### PR TITLE
Feature/dev group module

### DIFF
--- a/projects/design/src/app/left-nav/navigation-tabs/navigation-tabs.component.ts
+++ b/projects/design/src/app/left-nav/navigation-tabs/navigation-tabs.component.ts
@@ -45,7 +45,6 @@ export class NavigationTabsComponent implements OnInit, OnChanges {
     this.editService.getOb().subscribe(res => {
       this.notified = res.notified;
       this.esOb = res;
-      console.log('get', this.esOb);
     });
   }
 
@@ -59,7 +58,6 @@ export class NavigationTabsComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    console.log('navigation tabs', changes);
     if (this.items) {
       this.fetchUser();
     }
@@ -97,7 +95,6 @@ export class NavigationTabsComponent implements OnInit, OnChanges {
 
   _focusParent() {
     const elements = this.groupPanel.nativeElement.querySelectorAll('.ui-accordion-header a');
-    console.log(elements);
     for (const element of elements) {
       (element as HTMLElement).blur();
     }

--- a/projects/dev/src/app/app.component.ts
+++ b/projects/dev/src/app/app.component.ts
@@ -80,74 +80,16 @@ export class AppComponent {
     groups: {
       manage: [
         {
-          ID: 1,
-          title: "Big root",
-          type: "folder",
-          icons: "fa fa-home",
-          children: [
-            {
-              ID: 2,
-              title: "Big root1",
-              type: "folder",
-              progress: {
-                currentScore: 50,
-                displayedScore: 30
-              },
-              children: [
-                {
-                  ID: 3,
-                  title: "Documents",
-                  icons: "fa fa-folder",
-                  type: "folder"
-                },
-                {
-                  ID: 16,
-                  title: "Pictures",
-                  type: "folder"
-                }
-              ]
-            }
-          ]
+          ID: 50,
+          title: "Group 50",
+          type: "leaf",
+          icons: "fa fa-home"
         },
         {
-          ID: 22,
-          title: "Groups with requests",
-          type: "folder",
-          icons: "fa fa-home",
-          children: [
-            {
-              ID: 43,
-              title: "Group with grading requests",
-              type: "leaf",
-              ring: true,
-              state: "opened",
-              hasKey: true,
-              progress: {
-                displayedScore: 50,
-                currentScore: 30
-              },
-              category: {
-                icon: "fa fa-book-open",
-                type: 1
-              }
-            },
-            {
-              ID: 44,
-              title: "Groups as teams",
-              type: "leaf",
-              ring: true,
-              state: "opened",
-              hasKey: true,
-              progress: {
-                displayedScore: 50,
-                currentScore: 30
-              },
-              category: {
-                icon: "fa fa-book-open",
-                type: 1
-              }
-            }
-          ]
+          ID: 51,
+          title: "Group 51",
+          type: "leaf",
+          icons: "fa fa-home"
         }
       ],
       join: [

--- a/projects/dev/src/app/app.component.ts
+++ b/projects/dev/src/app/app.component.ts
@@ -803,7 +803,7 @@ export class AppComponent {
     this.updateService();
     console.log(e);
     if (e.src === 'managed') {
-      this.router.navigate(["/dev/groups/managed/50"]);
+      this.router.navigate([`/dev/groups/managed/${e.e.ID}`]);
     } else {
       this.router.navigate(["/dev/groups/memberships/11"]);
     }

--- a/projects/dev/src/app/group/group-content/group-content.component.html
+++ b/projects/dev/src/app/group/group-content/group-content.component.html
@@ -1,0 +1,35 @@
+<mat-tab-group mat-stretch-tabs (selectedTabChange)="onTabChange($event)">
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <i class="fa fa-chart-pie"></i>
+      Overview
+    </ng-template>
+    <ng-template matTabContent>
+      <app-group-overview></app-group-overview>
+    </ng-template>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <i class="fa fa-sitemap"></i>
+      Composition
+    </ng-template>
+    <ng-template matTabContent>
+    </ng-template>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <i class="fa fa-lock"></i>
+      Administration
+    </ng-template>
+    <ng-template matTabContent>
+    </ng-template>
+  </mat-tab>
+  <mat-tab>
+    <ng-template mat-tab-label>
+      <i class="fa fa-cog"></i>
+      Settings
+    </ng-template>
+    <ng-template matTabContent>
+    </ng-template>
+  </mat-tab>
+</mat-tab-group>

--- a/projects/dev/src/app/group/group-content/group-content.component.scss
+++ b/projects/dev/src/app/group/group-content/group-content.component.scss
@@ -1,0 +1,42 @@
+@import 'src/colors.scss';
+@import 'src/geometry.scss';
+
+.mat-tab-group {
+  font-family: inherit;
+}
+
+:host ::ng-deep .mat-tab-header {
+  border-bottom: none;
+  .mat-tab-label-container {
+    .mat-ink-bar {
+      display: none;
+    }
+
+    .mat-tab-labels {
+      .mat-tab-label {
+        @include main-tabs;
+
+        &.mat-tab-label-active {
+          @include main-tab-active;
+        }
+
+        .mat-tab-label-content {
+          i {
+            margin-right: 1.25rem;
+          }
+        }
+      }
+    }
+  }
+}
+
+:host ::ng-deep .mat-tab-body-wrapper {
+  .mat-tab-body {
+    background-color: white;
+    @include tab-content-radius;
+
+    &:last-child {
+      @include tab-content-radius;
+    }
+  }
+}

--- a/projects/dev/src/app/group/group-content/group-content.component.spec.ts
+++ b/projects/dev/src/app/group/group-content/group-content.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GroupContentComponent } from './group-content.component';
+
+describe('GroupContentComponent', () => {
+  let component: GroupContentComponent;
+  let fixture: ComponentFixture<GroupContentComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GroupContentComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/dev/src/app/group/group-content/group-content.component.ts
+++ b/projects/dev/src/app/group/group-content/group-content.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnInit, ElementRef, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-group-content',
+  templateUrl: './group-content.component.html',
+  styleUrls: ['./group-content.component.scss']
+})
+export class GroupContentComponent implements OnInit {
+
+  @Input() data;
+  @Input() empty;
+
+  @Output() expandWholeWidth = new EventEmitter<void>();
+
+  constructor(
+    private elementRef: ElementRef
+  ) { }
+
+  ngOnInit() {
+  }
+
+  onTabChange(e) {
+    const tabs = this.elementRef.nativeElement.querySelectorAll('.mat-tab-labels .mat-tab-label');
+    const activeTab = this.elementRef.nativeElement.querySelector('.mat-tab-labels .mat-tab-label.mat-tab-label-active');
+    tabs.forEach((tab) => {
+      tab.classList.remove('mat-tab-label-before-active');
+    });
+    
+    let i;
+
+    for (i = 0 ; i < tabs.length ; i++) {
+      if (tabs[i] === activeTab) {
+        break;
+      }
+    }
+
+    if (i > 0) {
+      tabs[i - 1].classList.add('mat-tab-label-before-active');
+    }
+  }
+
+  onExpandWidth(e) {
+    this.expandWholeWidth.emit(e);
+  }
+
+}

--- a/projects/dev/src/app/group/group-content/group-content.component.ts
+++ b/projects/dev/src/app/group/group-content/group-content.component.ts
@@ -25,14 +25,8 @@ export class GroupContentComponent implements OnInit {
     tabs.forEach((tab) => {
       tab.classList.remove('mat-tab-label-before-active');
     });
-    
-    let i;
 
-    for (i = 0 ; i < tabs.length ; i++) {
-      if (tabs[i] === activeTab) {
-        break;
-      }
-    }
+    const i = tabs.indexOf(activeTab);
 
     if (i > 0) {
       tabs[i - 1].classList.add('mat-tab-label-before-active');

--- a/projects/dev/src/app/group/group-content/group-overview/group-overview.component.html
+++ b/projects/dev/src/app/group/group-content/group-overview/group-overview.component.html
@@ -1,0 +1,58 @@
+<app-section icon="fa fa-users" label="Presentation">
+  <p>
+    Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
+  </p>
+</app-section>
+<app-section icon="fa fa-puzzle-piece" label="Recently solved tasks">
+  <app-grid
+    [selectedColumns]="columns"
+    [columns]="columns"
+    [data]="griddata"
+    sortMode="single"
+    scrollWhenExpanded="true"
+    [groupInfo]="panels"
+    (expandWholeWidth)="onExpandWidth($event)"
+  >
+    <ng-template #colgroupTemplate let-columns>
+      <colgroup>
+        <col style="width: 4rem;"/>
+        <col style="width: 100%;"/>
+        <col style="width: 100%;"/>
+        <col style="width: 9rem;"/>
+        <col style="width: 9rem;"/>
+      </colgroup>
+    </ng-template>
+    <ng-template #headerTemplate let-columns>
+      <tr>
+        <th style="width: 4rem;"></th>
+        <th *ngFor="let col of columns" [pSortableColumn]="col.field">
+          <div class="header-container"> 
+            {{ col.header }}
+            <p-sortIcon [field]="col.field"></p-sortIcon>
+          </div>
+        </th>
+      </tr>
+    </ng-template>
+    <ng-template
+      #bodyTemplate
+      let-rowData
+      let-columns="columns"
+      let-rowIndex="rowIndex"
+    >
+      <tr >
+        <td style="width: 4rem;"></td>
+        <ng-container *ngFor="let col of columns">
+          <td *ngIf="col.field === 'date'">
+            {{rowData[col.field] | date:'d/MM/y'}}
+          </td>
+          <td *ngIf="col.field === 'task'">
+            {{rowIndex+1}}) {{ rowData[col.field] }}
+          </td>
+          <td *ngIf="col.field === 'grade' || col.field === 'chapter'">
+            {{rowData[col.field]}}
+          </td>
+        </ng-container>
+      </tr>
+    </ng-template>
+  </app-grid>
+</app-section>

--- a/projects/dev/src/app/group/group-content/group-overview/group-overview.component.scss
+++ b/projects/dev/src/app/group/group-content/group-overview/group-overview.component.scss
@@ -1,0 +1,14 @@
+@import 'src/colors.scss';
+
+:host ::ng-deep app-section .ui-table .ui-table-tbody > tr > td {
+  border-right: .1rem solid #f0f0f0;
+
+  &:first-child {
+    border: none;
+  }
+}
+
+app-grid {
+  margin-right: -1.6667rem;
+  margin-left: -3.3333rem;
+}

--- a/projects/dev/src/app/group/group-content/group-overview/group-overview.component.spec.ts
+++ b/projects/dev/src/app/group/group-content/group-overview/group-overview.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GroupOverviewComponent } from './group-overview.component';
+
+describe('GroupOverviewComponent', () => {
+  let component: GroupOverviewComponent;
+  let fixture: ComponentFixture<GroupOverviewComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GroupOverviewComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupOverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
+++ b/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
@@ -1,0 +1,98 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-group-overview',
+  templateUrl: './group-overview.component.html',
+  styleUrls: ['./group-overview.component.scss']
+})
+export class GroupOverviewComponent implements OnInit {
+
+  griddata = [
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+    {
+      task: 'Espion etranger',
+      chapter: 'Chapter 1',
+      grade: 'Terminale',
+      date: new Date(2018, 4, 23)
+    },
+  ];
+
+  columns = [
+    { field: 'task', header: 'Task' },
+    { field: 'chapter', header: 'Chapter' },
+    { field: 'grade', header: 'Grade' },
+    { field: 'date', header: 'Date' }
+  ];
+
+  panels = [
+  ];
+
+  constructor() { }
+
+  ngOnInit() {
+    this.panels.push(
+      {
+        name: 'Group',
+        columns: this.columns
+      }
+    );
+  }
+
+  onExpandWidth(e) {
+
+  }
+
+}

--- a/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
+++ b/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
@@ -13,61 +13,7 @@ export class GroupOverviewComponent implements OnInit {
       chapter: 'Chapter 1',
       grade: 'Terminale',
       date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
-    {
-      task: 'Espion etranger',
-      chapter: 'Chapter 1',
-      grade: 'Terminale',
-      date: new Date(2018, 4, 23)
-    },
+    }
   ];
 
   columns = [

--- a/projects/dev/src/app/group/group-header/group-header.component.html
+++ b/projects/dev/src/app/group/group-header/group-header.component.html
@@ -1,0 +1,85 @@
+<div class="group-header-container">
+  <div
+    class="group-header"
+    [ngClass]="{ folded: isFolded, unfolded: !isFolded }"
+  >
+    <div class="user-image">
+      <img src="assets/images/_messi.jpg" style="width: 7.5rem; height: 7.5rem;"/>
+    </div>
+    <div class="user-info" (window:resize)="onResized($event)" #userInfo>
+      <div class="user-name" [ngStyle]="{ opacity: isScrolled ? 0 : 1 }">
+        <span>{{ data.name }}</span>
+      </div>
+      <div *ngIf="!isTwoColumn; then oneColumn; else twoColumn"></div>
+      <ng-template #oneColumn>
+        <span class="user-type" *ngIf="data.type">
+          <i class="fa fa-home"></i>
+          <span>{{ data.type }}</span>
+        </span>
+        <span class="user-site" *ngIf="data.website">
+          <i class="fa fa-external-link-alt"></i>
+          <a href="https://{{ data.website }}">{{ data.website }}</a>
+        </span>
+        <span class="user-location" *ngIf="data.location">
+          <i class="fa fa-map-marker-alt"></i>
+          <span title="{{ data.location }}">{{ data.location }}</span>
+        </span>
+      </ng-template>
+      <ng-template #twoColumn>
+        <div class="two-columns">
+          <span class="user-type" *ngIf="data.type">
+            <i class="fa fa-home"></i>
+            <span>{{ data.type }}</span>
+          </span>
+          <span class="user-site" *ngIf="data.website">
+            <i class="fa fa-external-link-alt"></i>
+            <a href="https://{{ data.website }}">{{ data.website }}</a>
+          </span>
+          <span class="user-location" *ngIf="data.location">
+            <i class="fa fa-map-marker-alt"></i>
+            <span title="{{ data.location }}">{{ data.location }}</span>
+          </span>
+          <span class="time" *ngIf="data.date">
+            <i class="fa fa-clock"></i>
+            <span>{{ data.date | date: "MMM d, y h:mm a" }}</span>
+          </span>
+          <span class="grade" *ngIf="data.grades">
+            <i class="fa fa-user-graduate"></i>
+            <span>Grades: {{ grades.join(", ") }}</span>
+          </span>
+          <span
+            class="join-method"
+            *ngIf="data.joinMethods && data.joinMethods.length > 0"
+          >
+            <i class="fa fa-sign-in-alt"></i>
+            <span>Join Methods: {{ data.joinMethods.join(", ") }}</span>
+          </span>
+          <span class="assoc-skill" *ngIf="data.assocSkill">
+            <i class="fa fa-link"></i>
+            <span class="no-wrap" *ngIf="visibleAssoc">Associated with: </span>
+            <a href="{{ data.assocSkill.link }}">{{ data.assocSkill.name }}</a>
+            <app-score-ring
+              *ngIf="data.assocSkill.progress"
+              [displayedScore]="data.assocSkill.progress.displayedScore"
+              [currentScore]="data.assocSkill.progress.currentScore"
+              diameter="24"
+            ></app-score-ring>
+          </span>
+          <span class="assoc-skill" *ngIf="data.assocActivity">
+            <i class="fa fa-link"></i>
+            <span class="no-wrap" *ngIf="visibleAssoc">Associated with: </span>
+            <a href="{{ data.assocActivity.link }}">{{
+              data.assocSkill.name
+            }}</a>
+            <app-skill-progress
+              *ngIf="data.assocActivity.progress"
+              [displayedScore]="data.assocActivity.progress.displayedScore"
+              [currentScore]="data.assocActivity.progress.currentScore"
+              style="width: 40%; margin-left: 1rem;"
+            ></app-skill-progress>
+          </span>
+        </div>
+      </ng-template>
+    </div>
+  </div>
+</div>

--- a/projects/dev/src/app/group/group-header/group-header.component.html
+++ b/projects/dev/src/app/group/group-header/group-header.component.html
@@ -3,14 +3,14 @@
     class="group-header"
     [ngClass]="{ folded: isFolded, unfolded: !isFolded }"
   >
-    <div class="user-image">
+    <!-- <div class="user-image">
       <img src="assets/images/_messi.jpg" style="width: 7.5rem; height: 7.5rem;"/>
-    </div>
+    </div> -->
     <div class="user-info" (window:resize)="onResized($event)" #userInfo>
       <div class="user-name" [ngStyle]="{ opacity: isScrolled ? 0 : 1 }">
         <span>{{ data.name }}</span>
       </div>
-      <div *ngIf="!isTwoColumn; then oneColumn; else twoColumn"></div>
+      <!-- <div *ngIf="!isTwoColumn; then oneColumn; else twoColumn"></div> -->
       <ng-template #oneColumn>
         <span class="user-type" *ngIf="data.type">
           <i class="fa fa-home"></i>

--- a/projects/dev/src/app/group/group-header/group-header.component.scss
+++ b/projects/dev/src/app/group/group-header/group-header.component.scss
@@ -1,0 +1,100 @@
+@import 'src/colors.scss';
+
+.group-header-container {
+  display: flex;
+  flex-direction: column;
+
+  .group-header {
+    display: flex;
+    align-items: center;
+    margin-right: 1.25rem;
+    margin-top: 1.6667rem;
+    margin-bottom: 2.5rem;
+    background-color: $base-bk-color;
+
+    &.small {
+      height: 3.5833rem;
+    }
+
+    .user-image {
+      border-radius: 9rem;
+
+      img {
+        border-radius: 9rem;
+      }
+    }
+
+    .user-info {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      margin-left: 1.6667rem;
+
+      .user-name {
+        display: flex;
+        align-items: center;
+        margin-bottom: 1rem;
+
+        span {
+          color: #4A4A4A;
+          font-size: 2rem;
+          line-height: 2rem;
+          margin-top: 0;
+          margin-right: 2rem;
+        }
+
+      }
+
+      .two-columns {
+        display: flex;
+        flex-wrap: wrap;
+
+        > span {
+          flex-basis: 50%;
+          min-width: 0;
+
+          &.assoc-skill {
+            app-score-ring {
+              margin-left: 1.6667rem;
+            }
+          }
+        }
+      }
+
+      span {
+        display: flex;
+        align-items: center;
+        color: $base-text-color;
+        // margin-bottom: 0.6667rem;
+        font-size: 1.2rem;
+        line-height: 2rem;
+        height: 2rem;
+        // overflow: hidden;
+        padding-right: 1rem;
+
+        i {
+          margin-right: 1rem;
+          width: 1rem;
+        }
+
+        span, a {
+          margin-bottom: 0;
+          display: inline-block;
+
+          min-width: 0;
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+
+          &.no-wrap {
+            overflow: unset;
+          }
+        }
+      }
+    }
+
+    .certificates {
+      margin-right: 2.0833rem;
+    }
+  }
+}

--- a/projects/dev/src/app/group/group-header/group-header.component.spec.ts
+++ b/projects/dev/src/app/group/group-header/group-header.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GroupHeaderComponent } from './group-header.component';
+
+describe('GroupHeaderComponent', () => {
+  let component: GroupHeaderComponent;
+  let fixture: ComponentFixture<GroupHeaderComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GroupHeaderComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/dev/src/app/group/group-header/group-header.component.ts
+++ b/projects/dev/src/app/group/group-header/group-header.component.ts
@@ -1,0 +1,102 @@
+import { Component, OnInit, Input, OnChanges, SimpleChanges, HostListener, ViewChild, AfterViewInit } from '@angular/core';
+import * as converter from 'number-to-words';
+
+@Component({
+  selector: 'app-group-header',
+  templateUrl: './group-header.component.html',
+  styleUrls: ['./group-header.component.scss']
+})
+export class GroupHeaderComponent implements OnInit, OnChanges, AfterViewInit {
+
+  @Input() isScrolled;
+  @Input() isFolded;
+  @Input() isStarted;
+  @Input() isCollapsed;
+  @Input() data;
+
+  @ViewChild('userInfo', { static: false }) userInfo;
+
+  isTwoColumn = false;
+  grades;
+  visibleAssoc = true;
+
+  gradingRequests = [
+    {
+      user: 'BorisKarlo',
+      subject: 'LoremIpsum'
+    },
+    {
+      user: 'PaulGogo',
+      subject: 'LoremIpsum'
+    },
+    {
+      user: 'Marionduv',
+      subject: 'LoremIpsum'
+    },
+    {
+      user: 'Bestof',
+      subject: 'LoremIpsum'
+    },
+    {
+      user: 'SimSim',
+      subject: 'LoremIpsum'
+    },
+    {
+      user: 'Mamaschmitt',
+      subject: 'LoremIpsum'
+    }
+  ];
+
+  rightsReminder = {
+    administrators: [
+      'Mathias HIRON',
+      'Melanie STORUP',
+      'Jean LUCAS'
+    ],
+    require_watch_approval: true,
+    require_personal_info_access_approval: 'edit',
+    require_lock_membership_approval_until: new Date(),
+    desc: 'Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry\'s standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.'
+  };
+
+  constructor() { }
+
+  ngOnInit() {
+    if (Object.keys(this.data).length > 3) {
+      this.isTwoColumn = true;
+    }
+  }
+
+  ngAfterViewInit() {
+    this.checkVisibility();
+  }
+
+  checkVisibility() {
+    let html = document.getElementsByTagName("html")[0] as HTMLElement;
+    const fontSize = window.getComputedStyle(html, null).getPropertyValue('font-size');
+    if (this.userInfo.nativeElement.offsetWidth / parseInt(fontSize) <= 60) {
+      this.visibleAssoc = false;
+    } else {
+      this.visibleAssoc = true;
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.data && this.data.grades) {
+      this.grades = [];
+      this.data.grades.forEach(grade => {
+        this.grades.push(converter.toWords(grade));
+      });
+    }
+  }
+
+  @HostListener('window:resize', ['$event'])
+  onResized(e) {
+    this.checkVisibility();
+  }
+
+  onExpandWidth(e) {
+    
+  }
+
+}

--- a/projects/dev/src/app/group/group-manage/group-manage.component.html
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.html
@@ -6,4 +6,9 @@
   [data]="groupdata"
   (expandWholeWidth)="onExpandWidth($event)"
 ></app-group-header>
-<app-group-content [data]="groupdata"></app-group-content>
+<app-pending-request
+  [id]="groupId"
+  (onAccept)="onAcceptRequest($event)"
+  (onReject)="onRejectRequest($event)"
+></app-pending-request>
+<!-- <app-group-content [data]="groupdata"></app-group-content> -->

--- a/projects/dev/src/app/group/group-manage/group-manage.component.html
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.html
@@ -1,0 +1,9 @@
+<app-group-header
+  [isScrolled]="status.scrolled"
+  [isFolded]="status.folded"
+  [isStarted]="status.isStarted"
+  [isCollapsed]="status.collapsed"
+  [data]="groupdata"
+  (expandWholeWidth)="onExpandWidth($event)"
+></app-group-header>
+<app-group-content [data]="groupdata"></app-group-content>

--- a/projects/dev/src/app/group/group-manage/group-manage.component.spec.ts
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { GroupManageComponent } from './group-manage.component';
+
+describe('GroupManageComponent', () => {
+  let component: GroupManageComponent;
+  let fixture: ComponentFixture<GroupManageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ GroupManageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupManageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/dev/src/app/group/group-manage/group-manage.component.ts
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.ts
@@ -58,7 +58,11 @@ export class GroupManageComponent implements OnInit {
 
   ngOnInit() {
     const id = this.activatedRoute.snapshot.params.id;
-    this.groupId = id;
+    
+    this.activatedRoute.params.subscribe(routeParams => {
+      this.groupId = routeParams.id;
+      console.log(this.groupId)
+    })
 
     this.groupService.getManagedGroup(id).subscribe((group: Group) => {
       this.groupdata = {

--- a/projects/dev/src/app/group/group-manage/group-manage.component.ts
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.ts
@@ -56,27 +56,25 @@ export class GroupManageComponent implements OnInit {
     private groupService: GroupService
   ) {}
 
-  ngOnInit() {
-    const id = this.activatedRoute.snapshot.params.id;
-    
+  ngOnInit() {    
     this.activatedRoute.params.subscribe(routeParams => {
       this.groupId = routeParams.id;
-      console.log(this.groupId)
+      console.log(this.groupId);
+
+      this.groupService.getManagedGroup(this.groupId).subscribe((group: Group) => {
+        this.groupdata = {
+          ID: group.id,
+          name: group.name,
+          type: group.type,
+          grades: [group.grade],
+          date: group.created_at,
+        };
+      });
+  
+      this.groupService.getGroupMembers(51).subscribe((members: Member[]) => {
+        this._setMemberData(members);
+      });
     })
-
-    this.groupService.getManagedGroup(id).subscribe((group: Group) => {
-      this.groupdata = {
-        ID: group.id,
-        name: group.name,
-        type: group.type,
-        grades: [group.grade],
-        date: group.created_at,
-      };
-    });
-
-    this.groupService.getGroupMembers(51).subscribe((members: Member[]) => {
-      this._setMemberData(members);
-    });
 
     this.statusService.getObservable().subscribe((res) => {
       this.status = res;

--- a/projects/dev/src/app/group/group-manage/group-manage.component.ts
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.ts
@@ -1,0 +1,43 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { StatusService } from '../../shared/services/status.service';
+import { GroupService } from '../../shared/services/api/group.service';
+import { Group } from '../../shared/models/group.model';
+
+@Component({
+  selector: 'app-group-manage',
+  templateUrl: './group-manage.component.html',
+  styleUrls: ['./group-manage.component.scss']
+})
+export class GroupManageComponent implements OnInit {
+
+  groupdata = {};
+  status;
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private statusService: StatusService,
+    private groupService: GroupService
+  ) { }
+
+  ngOnInit() {
+    const id = this.activatedRoute.snapshot.params.id;
+
+    console.log(id);
+
+    this.groupService.getManagedGroup(id).subscribe((group: Group) => {
+      this.groupdata = {
+        ID: group.id,
+        name: group.name,
+        type: group.type,
+        grades: [group.grade],
+        date: group.created_at
+      };
+    });
+
+    this.statusService.getObservable().subscribe(res => {
+      this.status = res;
+    });
+  }
+
+}

--- a/projects/dev/src/app/group/group-manage/group-manage.component.ts
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.ts
@@ -1,29 +1,64 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { StatusService } from '../../shared/services/status.service';
-import { GroupService } from '../../shared/services/api/group.service';
-import { Group } from '../../shared/models/group.model';
+import { Component, OnInit } from "@angular/core";
+import { ActivatedRoute } from "@angular/router";
+import { StatusService } from "../../shared/services/status.service";
+import { GroupService } from "../../shared/services/api/group.service";
+import { Group } from "../../shared/models/group.model";
+import { PendingRequest } from "../../shared/models/pending-request.model";
+import { Member } from "../../shared/models/member.model";
 
 @Component({
-  selector: 'app-group-manage',
-  templateUrl: './group-manage.component.html',
-  styleUrls: ['./group-manage.component.scss']
+  selector: "app-group-manage",
+  templateUrl: "./group-manage.component.html",
+  styleUrls: ["./group-manage.component.scss"],
 })
 export class GroupManageComponent implements OnInit {
-
   groupdata = {};
+  groupId;
   status;
+
+  memberData = [];
+  memberCols = [
+    { field: "id", header: "ID" },
+    { field: "name", header: "Name" },
+    { field: "user.login", header: "User name" },
+    { field: "user.grade", header: "Grade" },
+    { field: "member_since", header: "Member Since" },
+  ];
+  multiSortMeta = [
+    { field: "id", order: 1 },
+    { field: "member_since", order: -1 },
+  ];
+  prevSortMeta = "-member_since id";
+  memberPanel = [
+    {
+      name: "Group Info",
+      columns: this.memberCols,
+    },
+  ];
+
+  private _setMemberData(members: Member[]) {
+    this.memberData = [];
+
+    for (const member of members) {
+      this.memberData.push({
+        member_since: member.member_since,
+        name: `${member.user.first_name} ${member.user.last_name}`,
+        "user.login": member.user.login,
+        "user.grade": member.user.grade,
+        id: member.id,
+      });
+    }
+  }
 
   constructor(
     private activatedRoute: ActivatedRoute,
     private statusService: StatusService,
     private groupService: GroupService
-  ) { }
+  ) {}
 
   ngOnInit() {
     const id = this.activatedRoute.snapshot.params.id;
-
-    console.log(id);
+    this.groupId = id;
 
     this.groupService.getManagedGroup(id).subscribe((group: Group) => {
       this.groupdata = {
@@ -31,13 +66,25 @@ export class GroupManageComponent implements OnInit {
         name: group.name,
         type: group.type,
         grades: [group.grade],
-        date: group.created_at
+        date: group.created_at,
       };
     });
 
-    this.statusService.getObservable().subscribe(res => {
+    this.groupService.getGroupMembers(51).subscribe((members: Member[]) => {
+      this._setMemberData(members);
+    });
+
+    this.statusService.getObservable().subscribe((res) => {
       this.status = res;
     });
   }
 
+  onAcceptRequest(e) {
+  }
+
+  onRejectRequest(e) {
+  }
+
+  onExpandWidth(e) {
+  }
 }

--- a/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.html
+++ b/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.html
@@ -1,0 +1,126 @@
+<app-section-paragraph
+  *ngIf="requests.length"
+  icon="fa fa-check"
+  label="Pending requests"
+  [collapsible]="true"
+>
+  <ng-template #headerTemplate>
+    <div style="flex: 1; flex-direction: row-reverse; display: flex;">
+      <!-- <app-selection
+        [items]="groupSwitch"
+        style="width: 25rem;"
+      ></app-selection> -->
+    </div>
+  </ng-template>
+  <div class="pending-request-container">
+    <app-grid
+      [selectedColumns]="columns"
+      [columns]="columns"
+      [data]="requests"
+      [groupInfo]="panel"
+      [multiSortMeta]="multiSortMeta"
+      (onSort)="onCustomSort($event)"
+      (expandWholeWidth)="onExpandWidth($event)"
+    >
+      <ng-template #headerTemplate let-columns>
+        <tr>
+          <th style="width: 3.3333rem; background-color: #d3dbe7;"></th>
+          <ng-container *ngFor="let col of columns">
+            <th
+              *ngIf="col.field === 'at'"
+              [pSortableColumn]="col.field"
+              style="width: 13.3333rem; background-color: #d3dbe7;"
+            >
+              <div class="header-container">
+                {{ col.header }}
+                <p-sortIcon [field]="col.field"></p-sortIcon>
+              </div>
+            </th>
+            <th
+              *ngIf="col.field === 'member_id'"
+              [pSortableColumn]="col.field"
+              style="width: 5rem; background-color: #d3dbe7;"
+            >
+              <div class="header-container">
+                {{ col.header }}
+                <p-sortIcon [field]="col.field"></p-sortIcon>
+              </div>
+            </th>
+            <th
+              *ngIf="col.field === 'joining_user.login'"
+              [pSortableColumn]="col.field"
+              style="background-color: #d3dbe7;"
+            >
+              <div class="header-container">
+                {{ col.header }}
+                <p-sortIcon [field]="col.field"></p-sortIcon>
+              </div>
+            </th>
+          </ng-container>
+        </tr>
+      </ng-template>
+      <ng-template
+        #bodyTemplate
+        let-rowData
+        let-columns="columns"
+        let-rowIndex="rowIndex"
+      >
+        <tr [pSelectableRow]="rowData" [pSelectableRowIndex]="rowIndex">
+          <td style="width: 3.3333rem;">
+            <p-tableCheckbox [value]="rowData"></p-tableCheckbox>
+          </td>
+          <td *ngFor="let col of columns">
+            <ng-container *ngIf="col.field === 'member_id'">
+              {{ rowData.member_id }}
+            </ng-container>
+            <ng-container *ngIf="col.field === 'at'">
+              {{ rowData.at | date: "MM/d/y" }}
+            </ng-container>
+            <ng-container *ngIf="col.field === 'joining_user.login'">
+              <div class="grid-user-info-field">
+                <!-- <img
+                  src="{{ rowData.user.image }}"
+                  style="width: 7rem; height: 7rem;"
+                /> -->
+                <div class="user-info">
+                  <span class="user-info-name">{{ rowData[col.field] }}</span>
+                  <span class="user-info-activity" *ngIf="rowData.grade"
+                    ><em>Grade: {{ rowData.grade }}</em></span
+                  >
+                  <!-- <div class="user-info-content">
+                    {{ rowData.user.content }}
+                  </div> -->
+                </div>
+              </div>
+            </ng-container>
+          </td>
+        </tr>
+      </ng-template>
+      <ng-template #summaryTemplate let-table>
+        <div style="text-align: left; display: flex; align-items: center;">
+          <p-tableHeaderCheckbox></p-tableHeaderCheckbox>
+          <span
+            style="
+              margin-left: 2.1rem;
+              color: #9b9b9b;
+              flex: 1;
+              font-size: 1.2rem;
+            "
+          >
+            Select all
+          </span>
+          <div class="req-tools">
+            <span class="accept" (click)="onClickAccept($event)">
+              <span>Accept</span>
+              <i class="fa fa-check"></i>
+            </span>
+            <span class="reject" (click)="onClickReject($event)">
+              <span>Reject</span>
+              <i class="fa fa-times"></i>
+            </span>
+          </div>
+        </div>
+      </ng-template>
+    </app-grid>
+  </div>
+</app-section-paragraph>

--- a/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.scss
+++ b/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.scss
@@ -1,0 +1,93 @@
+@import "src/colors.scss";
+@import "src/geometry.scss";
+
+.pending-request-container {
+  margin-left: -4rem;
+  margin-right: -1.6667rem;
+
+  .grid-user-info-field {
+    display: flex;
+    align-items: center;
+    margin-left: 0.2rem;
+
+    img {
+      border-radius: 50%;
+      width: 7rem;
+      height: auto;
+      margin-right: 2rem;
+    }
+
+    .user-info {
+      display: flex;
+      flex-direction: column;
+      font-size: 1.2rem;
+      color: $base-text-color;
+
+      &-name {
+        font-weight: bold;
+        font-size: 1.2rem;
+      }
+
+      &-activity {
+        font-style: italic;
+      }
+
+      &-content {
+        white-space: normal;
+        margin-top: 1.2rem;
+        line-height: 1.5rem;
+      }
+    }
+  }
+
+  .req-tools {
+    display: flex;
+    align-items: center;
+    color: $base-color;
+    font-size: 1.2rem;
+
+    span {
+      margin-right: 1rem;
+      cursor: pointer;
+
+      span {
+        margin-right: 1rem;
+      }
+    }
+  }
+}
+
+:host ::ng-deep .pending-request-container .ui-table .ui-table-summary {
+  background-color: transparent;
+}
+
+:host ::ng-deep .pending-request-container .ui-table .ui-table-tbody > tr {
+  background-color: transparent;
+  height: 13rem;
+
+  > td {
+    border-bottom-color: $section-border-color;
+    font: 1rem;
+
+    &:last-child {
+      border-left: $border-filet;
+      text-align: center;
+    }
+  }
+
+  &:last-child {
+    border-bottom: 0.1rem solid $section-border-color;
+  }
+
+  &:nth-child(even) {
+    background-color: transparent;
+  }
+
+  &.ui-state-highlight {
+    background-color: $base-color;
+
+    .grid-user-info-field .user-info {
+      color: white;
+    }
+  }
+}

--- a/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.spec.ts
+++ b/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PendingRequestComponent } from './pending-request.component';
+
+describe('PendingRequestComponent', () => {
+  let component: PendingRequestComponent;
+  let fixture: ComponentFixture<PendingRequestComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PendingRequestComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PendingRequestComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.ts
+++ b/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.ts
@@ -1,0 +1,100 @@
+import { Component, OnInit, Input, EventEmitter, Output } from "@angular/core";
+import { GroupService } from "../../../shared/services/api/group.service";
+import { PendingRequest } from "../../../shared/models/pending-request.model";
+import { SortEvent } from "primeng/api/sortevent";
+
+@Component({
+  selector: "app-pending-request",
+  templateUrl: "./pending-request.component.html",
+  styleUrls: ["./pending-request.component.scss"],
+})
+export class PendingRequestComponent implements OnInit {
+  @Input() id;
+
+  columns = [
+    { field: "member_id", header: "ID" },
+    { field: "joining_user.login", header: "LOGIN" },
+    { field: "at", header: "REQUESTED ON" },
+  ];
+  requests = [];
+  panel = [];
+  multiSortMeta = [
+    { field: "at", order: -1 },
+    { field: "member_id", order: 1 },
+  ];
+  prevSortMeta = "-at member_id";
+
+  @Output() onAccept = new EventEmitter<any>();
+  @Output() onReject = new EventEmitter<any>();
+
+  groupSwitch = [
+    {
+      label: "This group only",
+    },
+    {
+      label: "All subgroups",
+    },
+  ];
+
+  _setRequestData(reqs: PendingRequest[]) {
+    this.requests = [];
+
+    for (const req of reqs) {
+      this.requests.push({
+        member_id: req.member_id,
+        "joining_user.login": `${req.joining_user.first_name || ""} ${
+          req.joining_user.last_name || ""
+        } (${req.joining_user.login || ""})`,
+        "grade": req.joining_user && req.joining_user.grade ? req.joining_user.grade : null,
+        at: req.at,
+      });
+    }
+  }
+
+  constructor(private groupService: GroupService) {}
+
+  ngOnInit() {
+    this.panel.push({
+      name: "Pending Requests",
+      columns: this.columns,
+    });
+    this.groupService
+      .getManagedRequests(50)
+      .subscribe((reqs: PendingRequest[]) => {
+        this._setRequestData(reqs);
+      });
+  }
+
+  onExpandWidth(e) {}
+
+  onClickAccept(e) {
+    this.onAccept.emit(e);
+  }
+
+  onClickReject(e) {
+    this.onReject.emit(e);
+  }
+
+  onCustomSort(event: SortEvent) {
+    let diff = false;
+
+    const sortBy = event.multiSortMeta.map((meta) =>
+      meta.order === -1 ? `-${meta.field}` : meta.field
+    );
+
+    if (sortBy.sort().join(" ") !== this.prevSortMeta) {
+      diff = true;
+    }
+
+    if (!diff) {
+      return;
+    }
+
+    this.prevSortMeta = sortBy.sort().join(" ");
+    this.groupService
+      .getManagedRequests(this.id, sortBy)
+      .subscribe((reqs: PendingRequest[]) => {
+        this._setRequestData(reqs);
+      });
+  }
+}

--- a/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.ts
+++ b/projects/dev/src/app/group/group-manage/pending-request/pending-request.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input, EventEmitter, Output } from "@angular/core";
+import { Component, OnInit, Input, EventEmitter, Output, OnChanges, SimpleChanges } from "@angular/core";
 import { GroupService } from "../../../shared/services/api/group.service";
 import { PendingRequest } from "../../../shared/models/pending-request.model";
 import { SortEvent } from "primeng/api/sortevent";
@@ -8,7 +8,7 @@ import { SortEvent } from "primeng/api/sortevent";
   templateUrl: "./pending-request.component.html",
   styleUrls: ["./pending-request.component.scss"],
 })
-export class PendingRequestComponent implements OnInit {
+export class PendingRequestComponent implements OnInit, OnChanges {
   @Input() id;
 
   columns = [
@@ -59,7 +59,15 @@ export class PendingRequestComponent implements OnInit {
       columns: this.columns,
     });
     this.groupService
-      .getManagedRequests(50)
+      .getManagedRequests(this.id)
+      .subscribe((reqs: PendingRequest[]) => {
+        this._setRequestData(reqs);
+      });
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    this.groupService
+      .getManagedRequests(this.id)
       .subscribe((reqs: PendingRequest[]) => {
         this._setRequestData(reqs);
       });

--- a/projects/dev/src/app/group/group-routing.module.ts
+++ b/projects/dev/src/app/group/group-routing.module.ts
@@ -1,12 +1,19 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { GroupComponent } from './group.component';
+import { GroupManageComponent } from './group-manage/group-manage.component';
 
 
 const routes: Routes = [
   {
-    path: 'managed/:id',
-    component: GroupComponent
+    path: 'managed',
+    component: GroupComponent,
+    children: [
+      {
+        path: ':id',
+        component: GroupManageComponent
+      }
+    ]
   },
   {
     path: 'memberships/:id',

--- a/projects/dev/src/app/group/group.component.html
+++ b/projects/dev/src/app/group/group.component.html
@@ -1,8 +1,1 @@
-<app-group-header
-  [isScrolled]="status.scrolled"
-  [isFolded]="status.folded"
-  [isStarted]="status.isStarted"
-  [isCollapsed]="status.collapsed"
-  [data]="groupdata"
-  (expandWholeWidth)="onExpandWidth($event)"
-></app-group-header>
+<router-outlet></router-outlet>

--- a/projects/dev/src/app/group/group.component.html
+++ b/projects/dev/src/app/group/group.component.html
@@ -1,1 +1,8 @@
-<p>group works!</p>
+<app-group-header
+  [isScrolled]="status.scrolled"
+  [isFolded]="status.folded"
+  [isStarted]="status.isStarted"
+  [isCollapsed]="status.collapsed"
+  [data]="groupdata"
+  (expandWholeWidth)="onExpandWidth($event)"
+></app-group-header>

--- a/projects/dev/src/app/group/group.component.ts
+++ b/projects/dev/src/app/group/group.component.ts
@@ -12,7 +12,7 @@ import { StatusService } from '../shared/services/status.service';
 })
 export class GroupComponent implements OnInit {
 
-  groupdata;
+  groupdata = {};
   status;
 
   constructor(
@@ -47,7 +47,7 @@ export class GroupComponent implements OnInit {
           }
         },
         location: '46  Chemin Du Lavarin Sud Cachan Île-de-France France',
-        grades: group.grade,
+        grades: [group.grade],
         date: group.created_at,
         joinMethods: [
           JoinMethod.accessCode,
@@ -59,6 +59,10 @@ export class GroupComponent implements OnInit {
     this.statusService.getObservable().subscribe(res => {
       this.status = res;
     });
+  }
+
+  onExpandWidth(e) {
+    
   }
 
 }

--- a/projects/dev/src/app/group/group.component.ts
+++ b/projects/dev/src/app/group/group.component.ts
@@ -1,9 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
-import { GroupService } from '../shared/services/api/group.service';
-import { Group } from '../shared/models/group.model';
-import { JoinMethod } from '../shared/constants/group';
-import { StatusService } from '../shared/services/status.service';
 
 @Component({
   selector: 'app-group',
@@ -12,57 +7,10 @@ import { StatusService } from '../shared/services/status.service';
 })
 export class GroupComponent implements OnInit {
 
-  groupdata = {};
-  status;
-
   constructor(
-    private activatedRoute: ActivatedRoute,
-    private statusService: StatusService,
-    private groupService: GroupService
   ) { }
 
   ngOnInit() {
-    const id = this.activatedRoute.snapshot.paramMap.get('id');
-
-    this.groupService.getManagedGroup(50).subscribe((group: Group) => {
-      this.groupdata = {
-        ID: group.id,
-        name: group.name,
-        type: group.type,
-        website: 'www.lyceeloremipsum.com',
-        assocActivity: {
-          name: 'Concours castor 2019',
-          link: 'www.france-ioi.com',
-          progress: {
-            displayedScore: 80,
-            currentScore: 90
-          }
-        },
-        assocSkill: {
-          name: 'Concours castor 2018',
-          link: 'www.france-ioi.com',
-          progress: {
-            displayedScore: 80,
-            currentScore: 90
-          }
-        },
-        location: '46  Chemin Du Lavarin Sud Cachan Île-de-France France',
-        grades: [group.grade],
-        date: group.created_at,
-        joinMethods: [
-          JoinMethod.accessCode,
-          JoinMethod.invitation
-        ]
-      };
-    });
-
-    this.statusService.getObservable().subscribe(res => {
-      this.status = res;
-    });
-  }
-
-  onExpandWidth(e) {
-    
   }
 
 }

--- a/projects/dev/src/app/group/group.module.ts
+++ b/projects/dev/src/app/group/group.module.ts
@@ -1,18 +1,25 @@
-import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
 
-import { GroupRoutingModule } from './group-routing.module';
-import { GroupComponent } from './group.component';
-import { GroupHeaderComponent } from './group-header/group-header.component';
-import { CoreModule } from 'core';
+import { TableModule } from "primeng/table";
+import { CoreModule } from "core";
 
+import { GroupRoutingModule } from "./group-routing.module";
+
+import { GroupComponent } from "./group.component";
+import { GroupHeaderComponent } from "./group-header/group-header.component";
+import { GroupContentComponent } from "./group-content/group-content.component";
+import { GroupOverviewComponent } from "./group-content/group-overview/group-overview.component";
+import { GroupManageComponent } from "./group-manage/group-manage.component";
 
 @NgModule({
-  declarations: [GroupComponent, GroupHeaderComponent],
-  imports: [
-    CommonModule,
-    GroupRoutingModule,
-    CoreModule
-  ]
+  declarations: [
+    GroupComponent,
+    GroupHeaderComponent,
+    GroupContentComponent,
+    GroupOverviewComponent,
+    GroupManageComponent,
+  ],
+  imports: [CommonModule, GroupRoutingModule, TableModule, CoreModule],
 })
-export class GroupModule { }
+export class GroupModule {}

--- a/projects/dev/src/app/group/group.module.ts
+++ b/projects/dev/src/app/group/group.module.ts
@@ -11,6 +11,7 @@ import { GroupHeaderComponent } from "./group-header/group-header.component";
 import { GroupContentComponent } from "./group-content/group-content.component";
 import { GroupOverviewComponent } from "./group-content/group-overview/group-overview.component";
 import { GroupManageComponent } from "./group-manage/group-manage.component";
+import { PendingRequestComponent } from './group-manage/pending-request/pending-request.component';
 
 @NgModule({
   declarations: [
@@ -19,6 +20,7 @@ import { GroupManageComponent } from "./group-manage/group-manage.component";
     GroupContentComponent,
     GroupOverviewComponent,
     GroupManageComponent,
+    PendingRequestComponent,
   ],
   imports: [CommonModule, GroupRoutingModule, TableModule, CoreModule],
 })

--- a/projects/dev/src/app/group/group.module.ts
+++ b/projects/dev/src/app/group/group.module.ts
@@ -3,13 +3,16 @@ import { CommonModule } from '@angular/common';
 
 import { GroupRoutingModule } from './group-routing.module';
 import { GroupComponent } from './group.component';
+import { GroupHeaderComponent } from './group-header/group-header.component';
+import { CoreModule } from 'core';
 
 
 @NgModule({
-  declarations: [GroupComponent],
+  declarations: [GroupComponent, GroupHeaderComponent],
   imports: [
     CommonModule,
-    GroupRoutingModule
+    GroupRoutingModule,
+    CoreModule
   ]
 })
 export class GroupModule { }

--- a/projects/dev/src/app/shared/constants/api.ts
+++ b/projects/dev/src/app/shared/constants/api.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_LIMIT = 500;
-export const GROUP_API = {
-  sort: [
-    "-member_since",
-    "id"
-  ]
+export const GROUP_MEMBERS_API = {
+  sort: ["-member_since", "id"],
+};
+export const GROUP_REQUESTS_API = {
+  sort: ["-at", "member_id"],
 };

--- a/projects/dev/src/app/shared/services/api/group.service.ts
+++ b/projects/dev/src/app/shared/services/api/group.service.ts
@@ -1,141 +1,178 @@
-import { Injectable } from '@angular/core';
-import { environment } from '../../../../environments/environment';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { Observable, Subject, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Injectable } from "@angular/core";
+import { environment } from "../../../../environments/environment";
+import { HttpClient, HttpErrorResponse } from "@angular/common/http";
+import { Observable, Subject, throwError } from "rxjs";
+import { catchError } from "rxjs/operators";
 
-import { DEFAULT_LIMIT, GROUP_API } from '../../constants/api';
+import {
+  DEFAULT_LIMIT,
+  GROUP_MEMBERS_API,
+  GROUP_REQUESTS_API,
+} from "../../constants/api";
 
-import { Group } from '../../models/group.model';
-import { PendingRequest } from '../../models/pending-request.model';
-import { Member } from '../../models/member.model';
-import { MembershipHistory } from '../../models/membership-history.model';
-import { GroupMembership } from '../../models/group-membership.model';
+import { Group } from "../../models/group.model";
+import { PendingRequest } from "../../models/pending-request.model";
+import { Member } from "../../models/member.model";
+import { MembershipHistory } from "../../models/membership-history.model";
+import { GroupMembership } from "../../models/group-membership.model";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: "root",
 })
 export class GroupService {
-
   private baseGroupUrl = `${environment.apiUrl}/groups`;
   private baseCurrentUserUrl = `${environment.apiUrl}/current-user`;
-  
+
   private groupList = new Subject<Group>();
   private requestList = new Subject<PendingRequest[]>();
   private memberList = new Subject<Member[]>();
   private membershipHistoryList = new Subject<MembershipHistory[]>();
   private joinedGroupList = new Subject<GroupMembership[]>();
 
-  constructor(
-    private http: HttpClient
-  ) { }
+  constructor(private http: HttpClient) {}
 
   getManagedGroup(id): Observable<Group> {
-    this.http.get(`${this.baseGroupUrl}/${id}`)
-      .subscribe((group: Group) => this.groupList.next(group), this.handleError);
+    this.http
+      .get(`${this.baseGroupUrl}/${id}`)
+      .subscribe(
+        (group: Group) => this.groupList.next(group),
+        this.handleError
+      );
 
     return this.groupList;
   }
 
-  getManagedRequests(id): Observable<PendingRequest[]> {
-    this.http.get(`${this.baseGroupUrl}/${id}/requests`)
+  getManagedRequests(
+    id,
+    sort = GROUP_REQUESTS_API.sort,
+    limit = DEFAULT_LIMIT
+  ): Observable<PendingRequest[]> {
+    this.http
+      .get(`${this.baseGroupUrl}/${id}/requests`, {
+        params: {
+          sort: sort.join(","),
+        },
+      })
       .subscribe((requests: PendingRequest[]) => {
-        const newReqs = requests.filter((req: PendingRequest) => req.action === 'join_request_created');
+        const newReqs = requests.filter(
+          (req: PendingRequest) => req.action === "join_request_created"
+        );
         this.requestList.next(newReqs);
       }, this.handleError);
 
     return this.requestList;
   }
 
-  getGroupMembers(id, sort = GROUP_API.sort, limit = DEFAULT_LIMIT): Observable<Member[]> {
-    this.http.get(`${this.baseGroupUrl}/${id}/members`, {
-      params: {
-        sort: sort.join(',')
-      }
-    })
-      .subscribe((members: Member[]) => this.memberList.next(members), this.handleError);
+  getGroupMembers(
+    id,
+    sort = GROUP_MEMBERS_API.sort,
+    limit = DEFAULT_LIMIT
+  ): Observable<Member[]> {
+    this.http
+      .get(`${this.baseGroupUrl}/${id}/members`, {
+        params: {
+          sort: sort.join(","),
+        },
+      })
+      .subscribe(
+        (members: Member[]) => this.memberList.next(members),
+        this.handleError
+      );
 
     return this.memberList;
   }
 
   removeGroupMembers(id, user_ids): Observable<any> {
-    return this.http.delete(`${this.baseGroupUrl}/${id}/members`, {
-      params: {
-        user_ids: user_ids.join(',')
-      }
-    }).pipe(
-      catchError( this.handleError )
-    );
+    return this.http
+      .delete(`${this.baseGroupUrl}/${id}/members`, {
+        params: {
+          user_ids: user_ids.join(","),
+        },
+      })
+      .pipe(catchError(this.handleError));
   }
 
   acceptJoinRequest(id, group_ids) {
-    return this.http.post(`${this.baseGroupUrl}/${id}/join-requests/accept`, null, {
-      params: {
-        group_ids: group_ids.join(',')
-      }
-    }).pipe(
-      catchError( this.handleError )
-    );
+    return this.http
+      .post(`${this.baseGroupUrl}/${id}/join-requests/accept`, null, {
+        params: {
+          group_ids: group_ids.join(","),
+        },
+      })
+      .pipe(catchError(this.handleError));
   }
 
   rejectJoinRequest(id, group_ids) {
-    return this.http.post(`${this.baseGroupUrl}/${id}/join-requests/reject`, null, {
-      params: {
-        group_ids: group_ids.join(',')
-      }
-    }).pipe(
-      catchError( this.handleError )
-    );
+    return this.http
+      .post(`${this.baseGroupUrl}/${id}/join-requests/reject`, null, {
+        params: {
+          group_ids: group_ids.join(","),
+        },
+      })
+      .pipe(catchError(this.handleError));
   }
 
-  getPendingInvitations(sort_by = [], limit = 500) : Observable<MembershipHistory[]> {
-    this.http.get(`${this.baseCurrentUserUrl}/group-memberships-history`, {
-      params: {
-        sort: sort_by
-      }
-    })
-    .subscribe((memberships: MembershipHistory[]) => this.membershipHistoryList.next(memberships), this.handleError);
+  getPendingInvitations(
+    sort_by = [],
+    limit = 500
+  ): Observable<MembershipHistory[]> {
+    this.http
+      .get(`${this.baseCurrentUserUrl}/group-memberships-history`, {
+        params: {
+          sort: sort_by,
+        },
+      })
+      .subscribe(
+        (memberships: MembershipHistory[]) =>
+          this.membershipHistoryList.next(memberships),
+        this.handleError
+      );
 
     return this.membershipHistoryList;
   }
 
-  getJoinedGroups(sort_by = []) : Observable<GroupMembership[]> {
-    this.http.get(`${this.baseCurrentUserUrl}/group-memberships`, {
-      params: {
-        sort: sort_by
-      }
-    })
-    .subscribe((memberships: GroupMembership[]) => this.joinedGroupList.next(memberships), this.handleError);
+  getJoinedGroups(sort_by = []): Observable<GroupMembership[]> {
+    this.http
+      .get(`${this.baseCurrentUserUrl}/group-memberships`, {
+        params: {
+          sort: sort_by,
+        },
+      })
+      .subscribe(
+        (memberships: GroupMembership[]) =>
+          this.joinedGroupList.next(memberships),
+        this.handleError
+      );
 
     return this.joinedGroupList;
   }
 
   leaveGroup(id) {
-    return this.http.delete(`${this.baseCurrentUserUrl}/group-memberships/${id}`)
-            .pipe(
-              catchError( this.handleError )
-            );
+    return this.http
+      .delete(`${this.baseCurrentUserUrl}/group-memberships/${id}`)
+      .pipe(catchError(this.handleError));
   }
 
   joinGroupByCode(code, approvals = []) {
-    return this.http.post(`${this.baseCurrentUserUrl}/group-memberships/by-code`, {
-      params: {
-        code: code,
-        approvals: approvals.join(',')
-      }
-    })
-    .pipe(
-      catchError( this.handleError )
-    )
+    return this.http
+      .post(`${this.baseCurrentUserUrl}/group-memberships/by-code`, {
+        params: {
+          code: code,
+          approvals: approvals.join(","),
+        },
+      })
+      .pipe(catchError(this.handleError));
   }
 
   private handleError(error: HttpErrorResponse) {
     if (error.error instanceof ErrorEvent) {
-      console.error('An error occurred:', error.error.message);
+      console.error("An error occurred:", error.error.message);
     } else {
-      console.error(`Backend returned code ${error.status}, ` + `body was: ${error.error}`);
+      console.error(
+        `Backend returned code ${error.status}, ` + `body was: ${error.error}`
+      );
     }
 
-    return throwError('Something bad happened; please try again later.');
+    return throwError("Something bad happened; please try again later.");
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { DevAppModule } from 'projects/dev/src/app/app.module';
 const routes: Routes = [
   { path: 'design', loadChildren: () => import('projects/design/src/app/app.module').then(m => m.DesignAppModule) },
   { path: 'dev', loadChildren: () => import('projects/dev/src/app/app.module').then(m => m.DevAppModule) },
-  { path: '**', redirectTo: '/design' }
+  { path: '**', redirectTo: '/dev' }
 ];
 
 @NgModule({


### PR DESCRIPTION
- [x] in the menu, "groups you manage", add 2 groups: "group 50" and "group 51", with "blue arrow" linking respectively to `/groups/managed/50` and `/groups/managed/51` 
- page `/groups/managed/:id` shows:
  - [x] on the right pane (page excluding the left menu and the breadcrumb), only display components which can be implemented and show correct information.
  - [x] header: group name (so no link/img/url/address)
  - [x] between header and tabs:  the "pending requests" for this group:
    - [x] list requests (`GET /groups/50/requests`), **only keep** those with `action=="join_request_created"`
    - [x] if the list is empty, do not display the blue panel at all 
    - [x] remove picture, long text 
    - [x] if "grade" is not null for the joining_user, display "Grade: <value>" where "Terminale" is displayed in the designs
    - [x] Hide "this group only"/"all subgroups" 
    - [x] add sorting to this list (backend-side, cfr the `sort` in the API)