### PR TITLE
Compiler lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ./
-      - run: ./node_modules/.bin/ng build --configuration ci --base-href ./
+      - run: ./node_modules/.bin/ng build algorea --configuration ci --base-href ./
       - persist_to_workspace:
           root: ./
           paths:

--- a/angular.json
+++ b/angular.json
@@ -304,6 +304,22 @@
                   "maximumError": "10kb"
                 }
               ]
+            },
+            "ci": {
+              "fileReplacements": [
+                {
+                  "replace": "projects/dev/src/environments/environment.ts",
+                  "with": "projects/dev/src/environments/environment.ci.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "extractCss": true,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true
             }
           }
         },

--- a/projects/core/src/lib/activity-picker/activity-picker.component.ts
+++ b/projects/core/src/lib/activity-picker/activity-picker.component.ts
@@ -18,7 +18,7 @@ export class ActivityPickerComponent implements OnInit {
 
   ngOnInit() {}
 
-  openDialog(e) {
+  openDialog(_e) {
     const dialogRef = this.dialog.open(MatDialogComponent, {
       maxHeight: '83rem',
       minWidth: '50rem',
@@ -29,6 +29,6 @@ export class ActivityPickerComponent implements OnInit {
       },
     });
 
-    dialogRef.afterClosed().subscribe((result) => {});
+    dialogRef.afterClosed().subscribe((_result) => {});
   }
 }

--- a/projects/core/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/projects/core/src/lib/breadcrumb/breadcrumb.component.ts
@@ -18,7 +18,7 @@ export class BreadcrumbComponent implements OnInit {
 
   ngOnInit() {}
 
-  onItemClick(e, item, idx) {
+  onItemClick(_e, item, idx) {
     this.items.selectedID = item.ID;
     this.selectedIdx = idx;
     this.itemClick.emit(item);

--- a/projects/core/src/lib/category-dropdown/category-dropdown.component.ts
+++ b/projects/core/src/lib/category-dropdown/category-dropdown.component.ts
@@ -20,5 +20,5 @@ export class CategoryDropdownComponent implements OnInit {
 
   ngOnInit() {}
 
-  handleChange(e) {}
+  handleChange(_e) {}
 }

--- a/projects/core/src/lib/chapter-grid/chapter-grid.component.ts
+++ b/projects/core/src/lib/chapter-grid/chapter-grid.component.ts
@@ -130,10 +130,10 @@ export class ChapterGridComponent implements OnInit {
       },
     });
 
-    ref.afterClosed().subscribe((result) => {});
+    ref.afterClosed().subscribe((_result) => {});
   }
 
-  menuSelected(e, idx, which) {
+  menuSelected(_e, idx, which) {
     switch (which) {
       case 0:
         this.icons[idx] = 'fa fa-eye-slash';
@@ -152,7 +152,7 @@ export class ChapterGridComponent implements OnInit {
     }
   }
 
-  lockMenuSelected(e, which) {
+  lockMenuSelected(_e, which) {
     this.lockState = which;
   }
 }

--- a/projects/core/src/lib/code-token/code-token.component.ts
+++ b/projects/core/src/lib/code-token/code-token.component.ts
@@ -16,5 +16,5 @@ export class CodeTokenComponent implements OnInit {
 
   ngOnInit() {}
 
-  refreshCode(e) {}
+  refreshCode(_e) {}
 }

--- a/projects/core/src/lib/dialogs/edit-user-dialog/edit-user-dialog.component.ts
+++ b/projects/core/src/lib/dialogs/edit-user-dialog/edit-user-dialog.component.ts
@@ -22,7 +22,7 @@ export class EditUserDialogComponent implements OnInit {
     this.dialogRef.close(e);
   }
 
-  onAttachClicked(e) {
+  onAttachClicked(_e) {
     const ref = this.dialog.open(AttachGroupDialogComponent, {
       maxHeight: '41rem',
       minWidth: '50rem',
@@ -36,10 +36,10 @@ export class EditUserDialogComponent implements OnInit {
       },
     });
 
-    ref.afterClosed().subscribe((result) => {});
+    ref.afterClosed().subscribe((_result) => {});
   }
 
-  onResetPassword(e) {
+  onResetPassword(_e) {
     const ref = this.dialog.open(ResetPasswordDialogComponent, {
       maxHeight: '41rem',
       minWidth: '50rem',
@@ -67,7 +67,7 @@ export class EditUserDialogComponent implements OnInit {
           },
         });
 
-        codeRef.afterClosed().subscribe((code) => {});
+        codeRef.afterClosed().subscribe((_code) => {});
       }
     });
   }

--- a/projects/core/src/lib/dialogs/generate-batch-user-dialog/generate-batch-user-dialog.component.ts
+++ b/projects/core/src/lib/dialogs/generate-batch-user-dialog/generate-batch-user-dialog.component.ts
@@ -27,7 +27,7 @@ export class GenerateBatchUserDialogComponent implements OnInit {
     this.prefix = e;
   }
 
-  onSuffixChange(e) {}
+  onSuffixChange(_e) {}
 
   onClose(e) {
     this.dialogRef.close(e);

--- a/projects/core/src/lib/grid-gear/grid-gear.component.ts
+++ b/projects/core/src/lib/grid-gear/grid-gear.component.ts
@@ -25,7 +25,7 @@ export class GridGearComponent implements OnInit {
 
   ngOnInit() {}
 
-  toggleGear(e) {
+  toggleGear(_e) {
     this.menuOpen = !this.menuOpen;
   }
 

--- a/projects/core/src/lib/grid/grid-filter/grid-filter.component.ts
+++ b/projects/core/src/lib/grid/grid-filter/grid-filter.component.ts
@@ -42,12 +42,12 @@ export class GridFilterComponent implements OnInit {
     this.onClose.emit(e);
   }
 
-  toggleMenu(e) {
+  toggleMenu(_e) {
     this.menuOpened = !this.menuOpened;
     this.onHide.emit(true);
   }
 
-  hideMenu(e) {
+  hideMenu(_e) {
     this.menuOpened = false;
     this.outsideClicked = false;
     this.onHide.emit(true);

--- a/projects/core/src/lib/grid/grid.component.ts
+++ b/projects/core/src/lib/grid/grid.component.ts
@@ -87,11 +87,11 @@ export class GridComponent implements OnInit, OnChanges {
   toShow = 0;
   expand = false;
 
-  onRowSelect(e) {
+  onRowSelect(_e) {
     this.selectionChange.emit(this.selectionValue);
   }
 
-  onRowUnselect(e) {
+  onRowUnselect(_e) {
     this.selectionChange.emit(this.selectionValue);
   }
 
@@ -109,17 +109,17 @@ export class GridComponent implements OnInit, OnChanges {
 
   ngOnInit() {}
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
     if (this.showGear) {
       this.detectSelected();
     }
   }
 
-  showColumns(e) {
+  showColumns(_e) {
     this.showColumnSelection = !this.showColumnSelection;
   }
 
-  showAll(e) {
+  showAll(_e) {
     this.selectedColumns = this.columns;
     this.toShow = 0;
     this.expand = !this.expand;
@@ -144,7 +144,7 @@ export class GridComponent implements OnInit, OnChanges {
     this.expandWholeWidth.emit(this.expand);
   }
 
-  handleChanges(e, item) {
+  handleChanges(_e, item) {
     this.selected[item.field] = !this.selected[item.field];
     const newSel = [];
     for (const col of this.columns) {
@@ -162,7 +162,7 @@ export class GridComponent implements OnInit, OnChanges {
     this.onSort.emit(event);
   }
 
-  onHeaderCheckbox(event) {
+  onHeaderCheckbox(_event) {
     this.selectionChange.emit(this.selectionValue);
   }
 

--- a/projects/core/src/lib/group-navigation-tree/group-navigation-tree.component.ts
+++ b/projects/core/src/lib/group-navigation-tree/group-navigation-tree.component.ts
@@ -31,7 +31,7 @@ export class GroupNavigationTreeComponent implements OnInit, OnChanges {
 
   ngOnInit() {}
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
     if (this.data) {
       if (!this.inGroup && this.data.length > 0) {
         this.data[0].root = true;
@@ -39,7 +39,7 @@ export class GroupNavigationTreeComponent implements OnInit, OnChanges {
     }
   }
 
-  nodeExpand(event, node) {
+  nodeExpand(_event, node) {
     if (!node.expanded) {
       node.expanded = true;
     } else {
@@ -58,7 +58,7 @@ export class GroupNavigationTreeComponent implements OnInit, OnChanges {
     });
   }
 
-  nodeCheck(e, node) {
+  nodeCheck(_e, node) {
     this._unCheckAll(this.data);
     if (!node.checked) {
       node.checked = true;
@@ -77,7 +77,7 @@ export class GroupNavigationTreeComponent implements OnInit, OnChanges {
     node.expanded = true;
   }
 
-  goToPage(e, node) {
+  goToPage(_e, node) {
     this.onNodeChange.emit(node);
   }
 

--- a/projects/core/src/lib/header-section/header-section.component.ts
+++ b/projects/core/src/lib/header-section/header-section.component.ts
@@ -15,7 +15,7 @@ export class HeaderSectionComponent implements OnInit {
 
   ngOnInit() {}
 
-  onCollapse(e) {
+  onCollapse(_e) {
     this.isCollapsed = !this.isCollapsed;
   }
 }

--- a/projects/core/src/lib/image-upload/image-upload.component.ts
+++ b/projects/core/src/lib/image-upload/image-upload.component.ts
@@ -28,12 +28,12 @@ export class ImageUploadComponent implements OnInit {
     const reader = new FileReader();
     this.imagePath = files;
     reader.readAsDataURL(files[0]);
-    reader.onload = (event) => {
+    reader.onload = (_event) => {
       this.imgURL = reader.result;
     };
   }
 
-  removeImage(e) {
+  removeImage(_e) {
     this.imgURL = null;
   }
 }

--- a/projects/core/src/lib/input/input.component.ts
+++ b/projects/core/src/lib/input/input.component.ts
@@ -30,7 +30,7 @@ export class InputComponent implements OnInit, OnChanges {
 
   ngOnInit() {}
 
-  ngOnChanges(changes: SimpleChanges) {}
+  ngOnChanges(_changes: SimpleChanges) {}
 
   onValueChange(e) {
     this.onChange.emit(e);

--- a/projects/core/src/lib/items-navigation-tree/items-navigation-tree.component.ts
+++ b/projects/core/src/lib/items-navigation-tree/items-navigation-tree.component.ts
@@ -30,7 +30,7 @@ export class ItemsNavigationTreeComponent implements OnInit, OnChanges {
 
   ngOnInit() {}
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
     if (this.data) {
       this.data.forEach((item) => {
         item.root = true;
@@ -40,7 +40,7 @@ export class ItemsNavigationTreeComponent implements OnInit, OnChanges {
     }
   }
 
-  nodeExpand(event, node) {
+  nodeExpand(_event, node) {
     if (!node.expanded) {
       node.expanded = true;
     } else {
@@ -73,7 +73,7 @@ export class ItemsNavigationTreeComponent implements OnInit, OnChanges {
     });
   }
 
-  nodeCheck(event, node) {
+  nodeCheck(_event, node) {
     this._unCheckAll(this.data);
     node.checked = true;
 
@@ -81,7 +81,7 @@ export class ItemsNavigationTreeComponent implements OnInit, OnChanges {
     this.onNodeSelect.emit(node);
   }
 
-  nodeSelect(e) {}
+  nodeSelect(_e) {}
 
   onKeyDown(e) {
     if (e.code === 'Space' || e.code === 'Enter') {

--- a/projects/core/src/lib/mat-dialog/mat-dialog.component.ts
+++ b/projects/core/src/lib/mat-dialog/mat-dialog.component.ts
@@ -14,7 +14,7 @@ export class MatDialogComponent implements OnInit {
 
   ngOnInit() {}
 
-  onClose(e) {
+  onClose(_e) {
     this.dialogRef.close();
   }
 }

--- a/projects/core/src/lib/pick-list/pick-list.component.ts
+++ b/projects/core/src/lib/pick-list/pick-list.component.ts
@@ -74,7 +74,7 @@ export class PickListComponent implements OnInit {
     e.dragData.data.list = listItem.ID;
   }
 
-  onListItemSelect(e, item, listID) {
+  onListItemSelect(_e, item, _listID) {
     this.activeID = item.ID;
     this.activeType = item.list;
   }
@@ -169,7 +169,7 @@ export class PickListComponent implements OnInit {
     }
   }
 
-  onClickOutside(e) {
+  onClickOutside(_e) {
     this.activeID = -1;
   }
 }

--- a/projects/core/src/lib/progress-section/progress-section.component.ts
+++ b/projects/core/src/lib/progress-section/progress-section.component.ts
@@ -13,15 +13,15 @@ export class ProgressSectionComponent implements OnInit {
 
   ngOnInit() {}
 
-  onCollapse(e) {
+  onCollapse(_e) {
     this.collapsed = !this.collapsed;
   }
 
-  onSwitchChange(e, item) {
+  onSwitchChange(_e, item) {
     item.checked = !item.checked;
   }
 
-  onSetActive(e, item, idx) {
+  onSetActive(_e, item, idx) {
     item.active_until = idx + 1;
   }
 }

--- a/projects/core/src/lib/score-ring/score-ring.component.ts
+++ b/projects/core/src/lib/score-ring/score-ring.component.ts
@@ -72,7 +72,7 @@ export class ScoreRingComponent implements OnInit, OnChanges {
     );
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
     if (this.scoreFill.length > 0) {
       this.displayFill = this.scoreFill;
       this.textFill = ScoreRingColor.darkText;

--- a/projects/core/src/lib/search-filter/search-filter.component.ts
+++ b/projects/core/src/lib/search-filter/search-filter.component.ts
@@ -22,11 +22,11 @@ export class SearchFilterComponent implements OnInit {
   ngOnInit() {
   }
 
-  toggleContent(e) {
+  toggleContent(_e) {
     this.showContent = !this.showContent;
   }
 
-  onItemSelect(e, i) {
+  onItemSelect(_e, i) {
     this.selected = i;
     this.showDropdown = false;
   }

--- a/projects/core/src/lib/search-input/search-input.component.ts
+++ b/projects/core/src/lib/search-input/search-input.component.ts
@@ -36,7 +36,7 @@ export class SearchInputComponent implements OnInit {
     this.onChange.emit(e);
   }
 
-  onFocus(e) {
+  onFocus(_e) {
     this.onChange.emit('');
     this.dirty = true;
   }

--- a/projects/core/src/lib/section-paragrah/section-paragraph.component.ts
+++ b/projects/core/src/lib/section-paragrah/section-paragraph.component.ts
@@ -33,7 +33,7 @@ export class SectionParagraphComponent implements OnInit {
     this.visible = this.collapsible;
   }
 
-  toggleContent(e) {
+  toggleContent(_e) {
     this.visible = !this.visible;
     this.onCollapse.emit(this.visible);
   }

--- a/projects/core/src/lib/select/select.component.ts
+++ b/projects/core/src/lib/select/select.component.ts
@@ -27,7 +27,7 @@ export class SelectComponent implements OnInit {
     this.onClick.emit(true);
   }
 
-  hideDropdown(e) {
+  hideDropdown(_e) {
     this.opened = false;
   }
 

--- a/projects/core/src/lib/selection-tree/selection-tree.component.ts
+++ b/projects/core/src/lib/selection-tree/selection-tree.component.ts
@@ -18,7 +18,7 @@ export class SelectionTreeComponent implements OnInit, OnChanges {
 
   ngOnInit() {}
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
     if (this.data) {
       while (this.data.length > 1) {
         this.data.pop();
@@ -30,7 +30,7 @@ export class SelectionTreeComponent implements OnInit, OnChanges {
     }
   }
 
-  nodeExpand(event, node) {
+  nodeExpand(_event, node) {
     if (!node.expanded) {
       node.expanded = true;
     } else {
@@ -38,7 +38,7 @@ export class SelectionTreeComponent implements OnInit, OnChanges {
     }
   }
 
-  nodeCheck(event, node) {
+  nodeCheck(_event, node) {
     if (!node.checked) {
       node.checked = true;
     } else {

--- a/projects/core/src/lib/selection/selection.component.ts
+++ b/projects/core/src/lib/selection/selection.component.ts
@@ -17,7 +17,7 @@ export class SelectionComponent implements OnInit {
 
   ngOnInit() {}
 
-  itemChanged(e, index) {
+  itemChanged(_e, index) {
     this.selected = index;
     this.onChange.emit(index);
   }

--- a/projects/core/src/lib/skill-activity-tabs/skill-activity-tabs.component.ts
+++ b/projects/core/src/lib/skill-activity-tabs/skill-activity-tabs.component.ts
@@ -26,7 +26,7 @@ export class SkillActivityTabsComponent implements OnInit, OnChanges {
 
   ngOnInit() {}
 
-  ngOnChanges(changes: SimpleChanges) {}
+  ngOnChanges(_changes: SimpleChanges) {}
 
   tabChanged(e) {
     this.tabChange.emit(e.index);

--- a/projects/core/src/lib/skill-progress/skill-progress.component.ts
+++ b/projects/core/src/lib/skill-progress/skill-progress.component.ts
@@ -70,7 +70,7 @@ export class SkillProgressComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
     if (this.displayedScore === 100) {
       this.displayColor = '#B8E986';
     } else {

--- a/projects/core/src/lib/switch/switch.component.ts
+++ b/projects/core/src/lib/switch/switch.component.ts
@@ -25,7 +25,7 @@ export class SwitchComponent implements OnInit, OnChanges {
 
   ngOnInit() {}
 
-  ngOnChanges(changes: SimpleChanges) {}
+  ngOnChanges(_changes: SimpleChanges) {}
 
   handleChange(e) {
     this.onChange.emit(e.checked);

--- a/projects/core/src/lib/time-picker/time-picker.component.ts
+++ b/projects/core/src/lib/time-picker/time-picker.component.ts
@@ -15,11 +15,11 @@ export class TimePickerComponent implements OnInit {
 
   ngOnInit() {}
 
-  timeChange(e) {
+  timeChange(_e) {
     this.prev = this.time;
   }
 
-  timeChanged(e) {
+  timeChanged(_e) {
     if (this.time > 999) {
       this.time = this.prev;
     }

--- a/projects/dev/src/app/app.component.ts
+++ b/projects/dev/src/app/app.component.ts
@@ -774,7 +774,7 @@ export class AppComponent {
   }
 
   @HostListener('window:scroll', ['$event'])
-  onScrollContent(e) {
+  onScrollContent(_e) {
     if (window.pageYOffset > 40 && !this.scrolled) {
       this.scrolled = true;
     } else if (window.pageYOffset <= 40 && this.scrolled) {
@@ -782,14 +782,14 @@ export class AppComponent {
     }
   }
 
-  onJoinGroupSelected(e) {
+  onJoinGroupSelected(_e) {
     this.selectedType = 3;
     this.userTitle = 'Groups you joined';
     this.updateService();
     this.router.navigate(['/dev/groups/memberships']);
   }
 
-  onManageGroupSelected(e) {
+  onManageGroupSelected(_e) {
     this.selectedType = 3;
     this.userTitle = 'Groups you manage';
     this.updateService();
@@ -808,33 +808,33 @@ export class AppComponent {
     }
   }
 
-  onEditPage(e) {
+  onEditPage(_e) {
     this.editing = true;
     this.updateService();
   }
 
-  onEditCancel(e) {
+  onEditCancel(_e) {
     this.editing = false;
     this.updateService();
   }
 
-  onNotify(e) {
+  onNotify(_e) {
 
   }
 
-  onSignInOut(e) {
+  onSignInOut(_e) {
 
   }
 
-  onSkillSelected(e) {
+  onSkillSelected(_e) {
 
   }
 
-  onActivitySelected(e) {
+  onActivitySelected(_e) {
 
   }
 
-  onYourselfSelected(e) {
+  onYourselfSelected(_e) {
 
   }
 }

--- a/projects/dev/src/app/group/group-content/group-content.component.ts
+++ b/projects/dev/src/app/group/group-content/group-content.component.ts
@@ -16,7 +16,7 @@ export class GroupContentComponent implements OnInit {
 
   ngOnInit() {}
 
-  onTabChange(e) {
+  onTabChange(_e) {
     const tabs = this.elementRef.nativeElement.querySelectorAll(
       '.mat-tab-labels .mat-tab-label'
     );

--- a/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
+++ b/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
@@ -34,7 +34,7 @@ export class GroupOverviewComponent implements OnInit {
 
   }
 
-  onExpandWidth(e) {
+  onExpandWidth(_e) {
 
   }
 

--- a/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
+++ b/projects/dev/src/app/group/group-content/group-overview/group-overview.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { GroupService } from '../../../shared/services/api/group.service';
 
 @Component({
   selector: 'app-group-overview',

--- a/projects/dev/src/app/group/group-header/group-header.component.ts
+++ b/projects/dev/src/app/group/group-header/group-header.component.ts
@@ -52,7 +52,7 @@ export class GroupHeaderComponent implements OnInit, OnChanges, AfterViewInit {
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
     if (this.data && this.data.grades) {
       this.grades = [];
       this.data.grades.forEach((grade) => {
@@ -62,9 +62,9 @@ export class GroupHeaderComponent implements OnInit, OnChanges, AfterViewInit {
   }
 
   @HostListener('window:resize', ['$event'])
-  onResized(e) {
+  onResized(_e) {
     this.checkVisibility();
   }
 
-  onExpandWidth(e) {}
+  onExpandWidth(_e) {}
 }

--- a/projects/dev/src/app/group/group-manage/group-manage.component.ts
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.ts
@@ -61,6 +61,6 @@ export class GroupManageComponent implements OnInit {
     });
   }
 
-  onExpandWidth(e) {
+  onExpandWidth(_e) {
   }
 }

--- a/projects/dev/src/app/group/group-manage/group-manage.component.ts
+++ b/projects/dev/src/app/group/group-manage/group-manage.component.ts
@@ -3,7 +3,6 @@ import { ActivatedRoute } from '@angular/router';
 import { StatusService } from '../../shared/services/status.service';
 import { GroupService } from '../../shared/services/api/group.service';
 import { Group } from '../../shared/models/group.model';
-import { Member } from '../../shared/models/member.model';
 
 @Component({
   selector: 'app-group-manage',
@@ -34,20 +33,6 @@ export class GroupManageComponent implements OnInit {
       columns: this.memberCols,
     },
   ];
-
-  private _setMemberData(members: Member[]) {
-    this.memberData = [];
-
-    for (const member of members) {
-      this.memberData.push({
-        member_since: member.member_since,
-        name: `${member.user.first_name} ${member.user.last_name}`,
-        'user.login': member.user.login,
-        'user.grade': member.user.grade,
-        id: member.id,
-      });
-    }
-  }
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/projects/dev/src/app/left-nav/left-nav.component.ts
+++ b/projects/dev/src/app/left-nav/left-nav.component.ts
@@ -29,10 +29,10 @@ export class LeftNavComponent implements OnInit, OnChanges {
   ngOnInit() {
   }
 
-  ngOnChanges(changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges) {
   }
 
-  onCollapse(e) {
+  onCollapse(_e) {
     this.collapsed = !this.collapsed;
     this.collapseEvent.emit(this.collapsed);
   }
@@ -69,11 +69,11 @@ export class LeftNavComponent implements OnInit, OnChanges {
     this.onNotify.emit(e);
   }
 
-  onSearchEvent(e) {
+  onSearchEvent(_e) {
     this.searchView = true;
   }
 
-  onSearchCloseEvent(e) {
+  onSearchCloseEvent(_e) {
     this.searchView = false;
   }
 

--- a/projects/dev/src/app/left-nav/navigation-tabs/navigation-tabs.component.ts
+++ b/projects/dev/src/app/left-nav/navigation-tabs/navigation-tabs.component.ts
@@ -62,7 +62,7 @@ export class NavigationTabsComponent implements OnInit, OnChanges {
     }
   }
 
-  toggleGroup(e) {
+  toggleGroup(_e) {
     this.groupShow = !this.groupShow;
     if (!this.groupShow) {
       this.stickyShow = false;
@@ -178,7 +178,7 @@ export class NavigationTabsComponent implements OnInit, OnChanges {
     this.statusService.setUser(this.currentUser);
   }
 
-  goBack(e) {
+  goBack(_e) {
     this.notified = false;
     this.esOb.notified = false;
     this.statusService.setValue(this.esOb);

--- a/projects/dev/src/app/left-nav/navigation-tabs/navigation-tabs.component.ts
+++ b/projects/dev/src/app/left-nav/navigation-tabs/navigation-tabs.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit, Input, OnChanges, SimpleChanges, ViewChild, NgZone, Output, EventEmitter } from '@angular/core';
 import { Location } from '@angular/common';
 import { StatusService } from '../../shared/services/status.service';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-navigation-tabs',

--- a/projects/dev/src/app/shared/services/api/group.service.spec.ts
+++ b/projects/dev/src/app/shared/services/api/group.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { GroupService } from './group.service';
 
 describe('GroupService', () => {

--- a/projects/dev/src/app/shared/services/api/group.service.ts
+++ b/projects/dev/src/app/shared/services/api/group.service.ts
@@ -3,7 +3,6 @@ import { environment } from '../../../../environments/environment';
 import {
   HttpClient,
   HttpErrorResponse,
-  HttpHeaders,
   HttpParams,
 } from '@angular/common/http';
 import { Observable, Subject, throwError } from 'rxjs';
@@ -27,7 +26,6 @@ export class GroupService {
   private baseGroupUrl = `${environment.apiUrl}/groups`;
   private baseCurrentUserUrl = `${environment.apiUrl}/current-user`;
 
-  private groupList = new Subject<Group>();
   private memberList = new Subject<Member[]>();
   private membershipHistoryList = new Subject<MembershipHistory[]>();
   private joinedGroupList = new Subject<GroupMembership[]>();

--- a/projects/dev/src/app/shared/services/api/group.service.ts
+++ b/projects/dev/src/app/shared/services/api/group.service.ts
@@ -63,7 +63,7 @@ export class GroupService {
   getGroupMembers(
     id,
     sort = [],
-    limit = DEFAULT_LIMIT
+    _limit = DEFAULT_LIMIT
   ): Observable<Member[]> {
     this.http
       .get(`${this.baseGroupUrl}/${id}/members`, {
@@ -117,7 +117,7 @@ export class GroupService {
 
   getPendingInvitations(
     sortBy = [],
-    limit = 500
+    _limit = 500
   ): Observable<MembershipHistory[]> {
     this.http
       .get(`${this.baseCurrentUserUrl}/group-memberships-history`, {

--- a/projects/dev/src/app/top-nav/top-nav.component.spec.ts
+++ b/projects/dev/src/app/top-nav/top-nav.component.spec.ts
@@ -43,5 +43,6 @@ describe('TopNavComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+    expect(router).toBeDefined();
   });
 });

--- a/projects/dev/src/app/top-nav/top-nav.component.ts
+++ b/projects/dev/src/app/top-nav/top-nav.component.ts
@@ -42,13 +42,13 @@ export class TopNavComponent implements OnInit {
   ngOnInit() {
   }
 
-  onCollapse(e) {
+  onCollapse(_e) {
     this.collapsed = !this.collapsed;
     this.collapseEvent.emit(this.collapsed);
     console.log(this.templateId);
   }
 
-  onFold(e) {
+  onFold(_e) {
     this.folded = !this.folded;
     this.foldEvent.emit(this.folded);
   }
@@ -59,7 +59,7 @@ export class TopNavComponent implements OnInit {
     this.onNotify.emit(e);
   }
 
-  signInOut(e) {
+  signInOut(_e) {
     this.signedIn = !this.signedIn;
     this.signInOutEvent.emit(this.signedIn);
     console.log(this.signedIn, this.templateId);

--- a/projects/dev/src/app/top-nav/top-nav.component.ts
+++ b/projects/dev/src/app/top-nav/top-nav.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Output, EventEmitter, Input, HostListener } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
 import { StatusService } from '../shared/services/status.service';
 import { Router } from '@angular/router';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
     // compiler linter checks
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,11 @@
         "dist/core/core",
         "dist/core"
       ]
-    }
+    },
+
+    // compiler linter checks
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
 
     // compiler linter checks
     "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true
+    "noImplicitReturns": true,
+    "noUnusedLocals": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,9 +27,7 @@
 
     // compiler linter checks
     "noFallthroughCasesInSwitch": true,
-    "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noImplicitReturns": true
   },
   "angularCompilerOptions": {
     "fullTemplateTypeCheck": true,


### PR DESCRIPTION
Trial to enable compiler lint to allow checking unused vars and some other checks (has to use compiler check as tslint has deprecated these rules).
"dev" and "app" package update to match these rules.

At the end,  these flags cannot be applied to only a part of the file (to disable them for "design"), so I had to disable the check for now. 

Probably we should switch to eslint for these kind for checks... to be seen later. Anyway the fix of this PR are still interesting to merge.