### PR TITLE
fixes #78

### DIFF
--- a/src/app/modules/group/http-services/get-requests.service.ts
+++ b/src/app/modules/group/http-services/get-requests.service.ts
@@ -30,7 +30,7 @@ export class GetRequestsService {
     sort: string[] = []
   ): Observable<PendingRequest[]> {
     let params = new HttpParams();
-    params.set('group_id', groupId);
+    params = params.set('group_id', groupId);
     if (sort.length > 0) {
       params = params.set('sort', sort.join(','));
     }


### PR DESCRIPTION
Fixes `group_id` filter not being added to the url params when looking for users requests.