### PR TITLE
Add "create group invitation" http-service

### DIFF
--- a/src/app/modules/group/http-services/create-group-invitations.service.spec.ts
+++ b/src/app/modules/group/http-services/create-group-invitations.service.spec.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import { CreateGroupInvitationsService } from './create-group-invitations.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('CreateGroupInvitationsService', () => {
   let service: CreateGroupInvitationsService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(CreateGroupInvitationsService);
   });
 

--- a/src/app/modules/group/http-services/create-group-invitations.service.spec.ts
+++ b/src/app/modules/group/http-services/create-group-invitations.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CreateGroupInvitationsService } from './create-group-invitations.service';
+
+describe('CreateGroupInvitationsService', () => {
+  let service: CreateGroupInvitationsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CreateGroupInvitationsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/group/http-services/create-group-invitations.service.ts
+++ b/src/app/modules/group/http-services/create-group-invitations.service.ts
@@ -2,9 +2,15 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { HttpClient } from '@angular/common/http';
-import { ActionResponse, successData, objectToMap } from 'src/app/shared/http-services/action-response';
+import { ActionResponse, successData } from 'src/app/shared/http-services/action-response';
 import { map } from 'rxjs/operators';
 
+export enum InvitationResult {
+  success,
+  error,
+  already_invited,
+  not_found,
+}
 
 @Injectable({
   providedIn: 'root'
@@ -16,7 +22,7 @@ export class CreateGroupInvitationsService {
   createInvitations(
     groupId: string,
     logins : string[]
-  ) : Observable<Map<string, any>>
+  ) : Observable<Map<string, InvitationResult>>
   {
     return this.http
       .post<ActionResponse<Object>>(
@@ -24,7 +30,16 @@ export class CreateGroupInvitationsService {
         {logins: logins}, {})
       .pipe(
         map(successData),
-        map(objectToMap)
+        map(function (data: Object): Map<string, InvitationResult> {
+          return new Map<string, InvitationResult>(
+            Object.entries(data).map(
+              ([key, value]) => {
+                const result = InvitationResult[value as keyof typeof InvitationResult];
+                if (result == undefined)
+                  throw new Error(`Invitation of user ${key} returned an unexpected result`);
+                return [key, value];
+          }));
+        })
       );
   }
 }

--- a/src/app/modules/group/http-services/create-group-invitations.service.ts
+++ b/src/app/modules/group/http-services/create-group-invitations.service.ts
@@ -34,7 +34,19 @@ export class CreateGroupInvitationsService {
           return new Map<string, InvitationResult>(
             Object.entries(data).map(
               ([key, value]) => {
+                switch (value) {
+                  case 'success':
+                    return [key, InvitationResult.Success];
+                  case 'unchanged':
+                    return [key, InvitationResult.AlreadyInvited];
+                  case 'not_found':
+                    return [key, InvitationResult.NotFound];
+                  case 'cycle':
+                  case 'invalid':
+                    return [key, InvitationResult.Error];
+                  default:
                     throw new Error(`Invitation of user ${key} returned an unexpected result (${JSON.stringify(value)})`);
+                }
           }));
         })
       );

--- a/src/app/modules/group/http-services/create-group-invitations.service.ts
+++ b/src/app/modules/group/http-services/create-group-invitations.service.ts
@@ -34,10 +34,7 @@ export class CreateGroupInvitationsService {
           return new Map<string, InvitationResult>(
             Object.entries(data).map(
               ([key, value]) => {
-                const result = InvitationResult[value as keyof typeof InvitationResult];
-                if (result == undefined)
-                  throw new Error(`Invitation of user ${key} returned an unexpected result`);
-                return [key, value];
+                    throw new Error(`Invitation of user ${key} returned an unexpected result (${JSON.stringify(value)})`);
           }));
         })
       );

--- a/src/app/modules/group/http-services/create-group-invitations.service.ts
+++ b/src/app/modules/group/http-services/create-group-invitations.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { HttpClient } from '@angular/common/http';
+import { ActionResponse, successData, objectToMap } from 'src/app/shared/http-services/action-response';
+import { map } from 'rxjs/operators';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CreateGroupInvitationsService {
+
+  constructor(private http: HttpClient) {}
+
+  createInvitations(
+    groupId: string,
+    logins : string[]
+  ) : Observable<Map<string, any>>
+  {
+    return this.http
+      .post<ActionResponse<Object>>(
+        `${environment.apiUrl}/groups/${groupId}/invitations`,
+        {logins: logins}, {})
+      .pipe(
+        map(successData),
+        map(objectToMap)
+      );
+  }
+}

--- a/src/app/modules/group/http-services/create-group-invitations.service.ts
+++ b/src/app/modules/group/http-services/create-group-invitations.service.ts
@@ -6,10 +6,10 @@ import { ActionResponse, successData } from 'src/app/shared/http-services/action
 import { map } from 'rxjs/operators';
 
 export enum InvitationResult {
-  success,
-  error,
-  already_invited,
-  not_found,
+  Success,
+  Error,
+  AlreadyInvited,
+  NotFound,
 }
 
 @Injectable({


### PR DESCRIPTION
Added the http-service for the group-invite-users component.
This service is calling the [groupInvitationsCreate](https://france-ioi.github.io/algorea-devdoc/api/#operation/groupInvitationsCreate) in the Backend.