### PR TITLE
Add "get group managers" service

### DIFF
--- a/src/app/modules/group/http-services/get-group-managers.service.spec.ts
+++ b/src/app/modules/group/http-services/get-group-managers.service.spec.ts
@@ -1,0 +1,21 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GetGroupManagersService } from './get-group-managers.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+
+describe('GetGroupManagersService', () => {
+  let service: GetGroupManagersService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule
+      ],
+    });
+    service = TestBed.inject(GetGroupManagersService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modules/group/http-services/get-group-managers.service.ts
+++ b/src/app/modules/group/http-services/get-group-managers.service.ts
@@ -1,0 +1,34 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+export interface Manager {
+  id: string,
+  name: string,
+
+  can_manage: string,
+  can_grant_group_access: boolean,
+  can_watch_members: boolean,
+}
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GetGroupManagersService {
+
+  constructor(private http: HttpClient) { }
+
+  getGroupManagers(
+    group_id: string,
+    sort: string[] = [],
+    ): Observable<Manager[]> {
+    let params = new HttpParams();
+    if (sort.length > 0) {
+      params = params.set('sort', sort.join(','));
+    }
+    return this.http
+      .get<Manager[]>(`${environment.apiUrl}/groups/${group_id}/managers`, { params: params });
+  }
+}


### PR DESCRIPTION
Added the http-service for the get-group-managers component.
This service is calling the [groupsMembersView](https://france-ioi.github.io/algorea-devdoc/api/#operation/groupsMembersView) in the Backend.