### PR TITLE
Initial version of breadcrumbs

### DIFF
--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -59,9 +59,7 @@
       ></alg-editor-bar>
       <div class="breadcrumb-bar"
       *ngIf="!folded && !scrolled">
-        <alg-breadcrumb
-          [items]="breaddata"
-        ></alg-breadcrumb>
+        <alg-breadcrumb [pageInfo]="pageInfo$ | async"></alg-breadcrumb>
         <alg-page-navigator
           *ngIf="!editing"
           (edit)="onEditPage()"

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostListener, OnInit } from '@angular/core';
 import { CurrentUserService } from '../shared/services/current-user.service';
-import { filter, skip } from 'rxjs/operators';
+import { delay, filter, skip } from 'rxjs/operators';
 import { UserProfile } from '../shared/http-services/current-user.service';
 import { Observable } from 'rxjs';
 import { CurrentContentService, PageInfo } from '../shared/services/current-content.service';
@@ -12,7 +12,8 @@ import { CurrentContentService, PageInfo } from '../shared/services/current-cont
 })
 export class AppComponent implements OnInit {
 
-  pageInfo$: Observable<PageInfo|null>
+  // the delay(0) is used to prevent the UI to update itself (when the content is loaded) (ExpressionChangedAfterItHasBeenCheckedError)
+  pageInfo$: Observable<PageInfo|null>  = this.currentContent.pageInfo().pipe( delay(0) );
 
   editing = false;
   isStarted = true;
@@ -34,9 +35,7 @@ export class AppComponent implements OnInit {
   constructor(
     private currentUserService: CurrentUserService,
     private currentContent: CurrentContentService,
-  ) {
-    this.pageInfo$ = currentContent.pageInfo();
-  }
+  ) {}
 
   ngOnInit() {
    // each time there is a new user, refresh the page

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -2,6 +2,8 @@ import { Component, HostListener, OnInit } from '@angular/core';
 import { CurrentUserService } from '../shared/services/current-user.service';
 import { filter, skip } from 'rxjs/operators';
 import { UserProfile } from '../shared/http-services/current-user.service';
+import { Observable } from 'rxjs';
+import { CurrentContentService, PageInfo } from '../shared/services/current-content.service';
 
 @Component({
   selector: 'alg-root',
@@ -9,6 +11,9 @@ import { UserProfile } from '../shared/http-services/current-user.service';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent implements OnInit {
+
+  pageInfo$: Observable<PageInfo|null>
+
   editing = false;
   isStarted = true;
 
@@ -20,22 +25,6 @@ export class AppComponent implements OnInit {
     'Deutsch'
   ];
 
-  breaddata = {
-    selectedID: '42',
-    path: [
-      { ID: '1', label: 'Contest', separator: 'slash' },
-      {
-        ID: '42',
-        label: 'Personalized contest',
-        attempt: 12,
-        separator: 'arrow'
-      },
-      { ID: '43', label: 'Personalized contests', attempt: 12 },
-      { ID: '23', label: 'IOI Selection 2012', attempt: 2 },
-      { ID: '24', label: 'Individuals', separator: 'slash' }
-    ]
-  };
-
   collapsed = false;
   folded = false;
   scrolled = false;
@@ -44,7 +33,10 @@ export class AppComponent implements OnInit {
 
   constructor(
     private currentUserService: CurrentUserService,
-  ) {}
+    private currentContent: CurrentContentService,
+  ) {
+    this.pageInfo$ = currentContent.pageInfo();
+  }
 
   ngOnInit() {
    // each time there is a new user, refresh the page

--- a/src/app/core/components/breadcrumb/breadcrumb.component.html
+++ b/src/app/core/components/breadcrumb/breadcrumb.component.html
@@ -1,34 +1,25 @@
 <div class="breadcrumb-container">
-  <ul (resized)="onResize($event)">
+  <ul *ngIf="pageInfo"> <!-- TODO: handle "smart" ellipsis (as in https://codepen.io/shippin/pen/YrwrYa) -->
+
+    <!-- category -->
     <li class="home"><i class="fa fa-folder"></i></li>
-    <ng-container *ngFor="let item of items.path; index as idx;">
-      <ng-container *ngIf="idx > 0">
-        <li class="separator" [ngClass]="{'active': item.ID === items.selectedID}">
-          <ng-container *ngIf="item.separator === 'arrow'; then arrowBlock else slashBlock">
-          </ng-container>
-          <ng-template #arrowBlock>
-            <i class="fa fa-arrow-right"></i>
-          </ng-template>
-          <ng-template #slashBlock>
-            \
-          </ng-template>
-        </li>
-      </ng-container>
-      <ng-container *ngIf="maxWidths[idx] === 0">
-        <li [ngClass]="{'active': item.ID === items.selectedID}" (click)="onItemClick(item, idx)">...</li>
-      </ng-container>
-      <li
-        *ngIf="maxWidths[idx] > 0"
-        [ngClass]="{'active': item.ID === items.selectedID}"
-        (click)="onItemClick(item, idx)"
-        [ngStyle]="{'max-width.rem': maxWidths[idx]}"
-      >
-        <span class="label">
-          {{item.label}}
-        </span>
-        <span *ngIf="item.attempt && item.attempt > 0" class="attempt-badge">
-          {{item.attempt}}
-        </span>
+    <li><span class="label">{{ pageInfo.category }}</span></li>
+
+    <!-- elements -->
+    <ng-container *ngFor="let element of pageInfo.breadcrumb; index as idx;">
+      <li class="separator" [ngClass]="{'active': idx === pageInfo.currentPageIndex}">
+        <ng-container *ngIf="idx === 0; then arrowBlock else slashBlock">
+        </ng-container>
+        <ng-template #arrowBlock>
+          <i class="fa fa-arrow-right"></i>
+        </ng-template>
+        <ng-template #slashBlock>
+          \
+        </ng-template>
+      </li>
+      <li [ngClass]="{'active': idx === pageInfo.currentPageIndex}" (click)="onElementClick(element)">
+        <span class="label">{{element.title}}</span>
+        <span *ngIf="element.attemptOrder" class="attempt-badge">{{element.attemptOrder}}</span>
       </li>
     </ng-container>
   </ul>

--- a/src/app/core/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/core/components/breadcrumb/breadcrumb.component.spec.ts
@@ -5,21 +5,6 @@ import { BreadcrumbComponent } from './breadcrumb.component';
 describe('BreadcrumbComponent', () => {
   let component: BreadcrumbComponent;
   let fixture: ComponentFixture<BreadcrumbComponent>;
-  const mockItems = {
-    selectedID: '42',
-    path: [
-      { ID: '1', label: 'Contest', separator: 'slash' },
-      {
-        ID: '42',
-        label: 'Personalized contest',
-        attempt: 12,
-        separator: 'arrow'
-      },
-      { ID: '43', label: 'Personalized contests', attempt: 12 },
-      { ID: '23', label: 'IOI Selection 2012', attempt: 2 },
-      { ID: '24', label: 'Individuals', separator: 'slash' }
-    ]
-  };
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -31,7 +16,6 @@ describe('BreadcrumbComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(BreadcrumbComponent);
     component = fixture.componentInstance;
-    component.items = mockItems;
     fixture.detectChanges();
   });
 

--- a/src/app/core/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/core/components/breadcrumb/breadcrumb.component.ts
@@ -1,51 +1,17 @@
-import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
-import { ResizedEvent } from 'angular-resize-event';
-
-interface Item {
-  ID: string
-  label: string,
-  attempt?: number
-  separator?: string,
-} // FIXME: quick fix type, to be cleaned
+import { Component, Input } from '@angular/core';
+import { PageInfo } from 'src/app/shared/services/current-content.service';
 
 @Component({
   selector: 'alg-breadcrumb',
   templateUrl: './breadcrumb.component.html',
   styleUrls: ['./breadcrumb.component.scss'],
 })
-export class BreadcrumbComponent implements OnInit {
-  @Input() items: {
-    selectedID: string,
-    path: Item[]
-  }; // FIXME: quick fix type, to be cleaned
-  @Output() itemClick = new EventEmitter<any>();
+export class BreadcrumbComponent {
 
-  selectedIdx: number;
-  breadWidth: number;
+  @Input() pageInfo: PageInfo|null
 
-  maxWidths = [9, 10, 12, 13, 16, 20, 0];
-
-  constructor() {}
-
-  ngOnInit() {}
-
-  onItemClick(item: Item, idx: number) {
-    this.items.selectedID = item.ID;
-    this.selectedIdx = idx;
-    this.itemClick.emit(item);
-    this.maxWidths = this.itemMaxWidth();
+  onElementClick(_el: { title: string, attemptOrder?: number}) {
+    // to do go to path
   }
 
-  itemMaxWidth() {
-    const widths = [9, 9, 12, 13, 16, 20, 0];
-
-    widths[this.selectedIdx] = 13;
-
-    return widths;
-  }
-
-  onResize(e: ResizedEvent) {
-    this.breadWidth = e.newWidth;
-    this.maxWidths = this.itemMaxWidth();
-  }
 }

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { GroupTabService } from '../../services/group-tab.service';
 import { Group, GetGroupByIdService } from '../../http-services/get-group-by-id.service';
 import { ActivatedRoute } from '@angular/router';
 import { withManagementAdditions, ManagementAdditions } from '../../helpers/group-management';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 
 @Component({
   selector: 'alg-group-details',
@@ -10,7 +11,7 @@ import { withManagementAdditions, ManagementAdditions } from '../../helpers/grou
   styleUrls: ['./group-details.component.scss'],
   providers: [ GroupTabService ]
 })
-export class GroupDetailsComponent {
+export class GroupDetailsComponent implements OnDestroy {
 
   idFromRoute?: string;
   group?: Group & ManagementAdditions;
@@ -19,7 +20,8 @@ export class GroupDetailsComponent {
   constructor(
     private activatedRoute: ActivatedRoute,
     private groupTabService: GroupTabService,
-    private getGroupByIdService: GetGroupByIdService
+    private getGroupByIdService: GetGroupByIdService,
+    private currentContent: CurrentContentService,
   ) {
     groupTabService.refresh$.subscribe(() => this.fetchGroup());
     activatedRoute.paramMap.subscribe((params) => {
@@ -41,6 +43,11 @@ export class GroupDetailsComponent {
             this.group = withManagementAdditions(g);
             this.state = 'loaded';
             this.groupTabService.group$.next(g);
+            this.currentContent.setPageInfo({
+              category: 'Groups',
+              breadcrumb: [{ title: g.name }],
+              currentPageIndex: 0
+            });
           },
           (_error) => {
             this.state = 'error';
@@ -49,6 +56,10 @@ export class GroupDetailsComponent {
     } else {
       this.state = 'error';
     }
+  }
+
+  ngOnDestroy() {
+    this.currentContent.setPageInfo(null);
   }
 
 }

--- a/src/app/modules/item/http-services/get-breadcrumb.service.ts
+++ b/src/app/modules/item/http-services/get-breadcrumb.service.ts
@@ -1,5 +1,3 @@
-
-
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
@@ -29,12 +27,10 @@ export class ItemNavigationService {
   constructor(private http: HttpClient) {}
 
   getBreadcrumb(itemIdPath: string[], attemptId: string): Observable<BreadcrumbItem[]|'forbidden'> {
-
     return this.getBreadcrumbGeneric(itemIdPath, { attempt_id: attemptId });
   }
 
   getBreadcrumbWithParentAttempt(itemIdPath: string[], parentAttemptId: string): Observable<BreadcrumbItem[]|'forbidden'> {
-
       return this.getBreadcrumbGeneric(itemIdPath, { parent_attempt_id: parentAttemptId });
   }
 

--- a/src/app/modules/item/http-services/get-breadcrumb.service.ts
+++ b/src/app/modules/item/http-services/get-breadcrumb.service.ts
@@ -1,0 +1,68 @@
+
+
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { map, catchError } from 'rxjs/operators';
+
+interface RawBreadcrumbItem {
+  item_id: string,
+  title: string,
+  language_tag: string,
+  attempt_id?: string,
+  attempt_number?: string,
+}
+
+interface BreadcrumbItem {
+  itemId: string,
+  title: string
+  attemptId?: string,
+  attemptCnt?: number,
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ItemNavigationService {
+
+  constructor(private http: HttpClient) {}
+
+  getBreadcrumb(itemIdPath: string[], attemptId: string): Observable<BreadcrumbItem[]|'forbidden'> {
+
+    return this.getBreadcrumbGeneric(itemIdPath, { attempt_id: attemptId });
+  }
+
+  getBreadcrumbWithParentAttempt(itemIdPath: string[], parentAttemptId: string): Observable<BreadcrumbItem[]|'forbidden'> {
+
+      return this.getBreadcrumbGeneric(itemIdPath, { parent_attempt_id: parentAttemptId });
+  }
+
+  getBreadcrumbGeneric(itemIdPath: string[], parameters: {[param: string]: string}): Observable<BreadcrumbItem[]|'forbidden'> {
+    return this.http
+      .get<RawBreadcrumbItem[]>(`${environment.apiUrl}/items/${itemIdPath.join('/')}/breadcrumbs`, {
+        params: parameters
+      })
+      .pipe(
+        map((items) => {
+          return items.map((item) => {
+            return {
+              itemId: item.item_id,
+              title: item.title,
+              attemptId: item.attempt_id,
+              attemptCnt: item.attempt_number ? +item.attempt_number : undefined,
+            };
+          });
+        }),
+        // extract one specific kind of error (403) as this one needs to be handled separately
+        catchError((err) => {
+          if (err instanceof HttpErrorResponse && err.status === 403) {
+            return of<'forbidden'>('forbidden');
+          }
+          throw err;
+        })
+
+      );
+  }
+
+}

--- a/src/app/modules/item/pages/item-details/item-details.component.spec.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.spec.ts
@@ -15,7 +15,8 @@ describe('ItemDetailsComponent', () => {
       declarations: [ ItemDetailsComponent ],
       providers: [
         { provide: CurrentContentService, useValue: {
-          setCurrent: (_i: NavItem) => {}
+          setCurrent: (_i: NavItem) => {},
+          setPageInfo: (_p: any) => {},
         }},
         { provide: ActivatedRoute, useValue: {
           paramMap: of({

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { ActivatedRoute } from '@angular/router';
 import { itemFromDetailParams } from 'src/app/shared/services/nav-types';
@@ -8,7 +8,7 @@ import { itemFromDetailParams } from 'src/app/shared/services/nav-types';
   templateUrl: './item-details.component.html',
   styleUrls: ['./item-details.component.scss']
 })
-export class ItemDetailsComponent implements OnInit {
+export class ItemDetailsComponent implements OnInit, OnDestroy {
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -30,6 +30,10 @@ export class ItemDetailsComponent implements OnInit {
       ],
       currentPageIndex: 2
     });
+  }
+
+  ngOnDestroy() {
+    this.currentContent.setPageInfo(null);
   }
 
 }

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -21,6 +21,15 @@ export class ItemDetailsComponent implements OnInit {
   }
 
   ngOnInit() {
+    this.currentContent.setPageInfo({
+      category: 'Items',
+      breadcrumb: [
+        { title: 'RootChapter' },
+        { title: 'MyChapter', attemptOrder: 1 },
+        { title: 'Content' }
+      ],
+      currentPageIndex: 2
+    });
   }
 
 }

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -3,6 +3,15 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { map, distinctUntilChanged } from 'rxjs/operators';
 import { NavItem, NavGroup } from './nav-types';
 
+export interface PageInfo {
+  category: string,
+  breadcrumb: {
+    title: string,
+    attemptOrder?: number,
+  }[],
+  currentPageIndex?: number, // index of the current page in the breadcrumb array
+}
+
 /**
  * Use this service to track what's the current item display in the content (right) pane.
  */
@@ -11,11 +20,16 @@ import { NavItem, NavGroup } from './nav-types';
 })
 export class CurrentContentService {
   private currentContent = new BehaviorSubject<NavItem|NavGroup|null>(null);
+  private currentPageInfo = new BehaviorSubject<PageInfo|null>(null);
 
   constructor() { }
 
   setCurrent(item: NavItem) {
     this.currentContent.next(item);
+  }
+
+  setPageInfo(info: PageInfo) {
+    this.currentPageInfo.next(info);
   }
 
   item(): Observable<NavItem|null> {
@@ -26,5 +40,9 @@ export class CurrentContentService {
       }),
       distinctUntilChanged() // mainly to avoid sending multiple null
     );
+  }
+
+  pageInfo(): Observable<PageInfo|null> {
+    return this.currentPageInfo.asObservable();
   }
 }

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -28,7 +28,7 @@ export class CurrentContentService {
     this.currentContent.next(item);
   }
 
-  setPageInfo(info: PageInfo) {
+  setPageInfo(info: PageInfo|null) {
     this.currentPageInfo.next(info);
   }
 


### PR DESCRIPTION
Initial version of the bit-less-static breadcrumbs which can be modified by the pages displaying content.
To be reviewed commit per commit (easier).

(while the item breadcrumb service is implemented, it is still not used by the item details page, it will be for a future PR)