### PR TITLE
Load item breadcrumbs

### DIFF
--- a/src/app/modules/item/http-services/get-breadcrumb.service.ts
+++ b/src/app/modules/item/http-services/get-breadcrumb.service.ts
@@ -12,7 +12,7 @@ interface RawBreadcrumbItem {
   attempt_number?: string,
 }
 
-interface BreadcrumbItem {
+export interface BreadcrumbItem {
   itemId: string,
   title: string
   attemptId?: string,
@@ -22,7 +22,7 @@ interface BreadcrumbItem {
 @Injectable({
   providedIn: 'root'
 })
-export class ItemNavigationService {
+export class GetBreadcrumbService {
 
   constructor(private http: HttpClient) {}
 
@@ -34,7 +34,7 @@ export class ItemNavigationService {
       return this.getBreadcrumbGeneric(itemIdPath, { parent_attempt_id: parentAttemptId });
   }
 
-  getBreadcrumbGeneric(itemIdPath: string[], parameters: {[param: string]: string}): Observable<BreadcrumbItem[]|'forbidden'> {
+  private getBreadcrumbGeneric(itemIdPath: string[], parameters: {[param: string]: string}): Observable<BreadcrumbItem[]|'forbidden'> {
     return this.http
       .get<RawBreadcrumbItem[]>(`${environment.apiUrl}/items/${itemIdPath.join('/')}/breadcrumbs`, {
         params: parameters

--- a/src/app/modules/item/pages/item-details/item-details.component.spec.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.spec.ts
@@ -5,6 +5,7 @@ import { CurrentContentService } from 'src/app/shared/services/current-content.s
 import { NavItem } from 'src/app/shared/services/nav-types';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
+import { GetBreadcrumbService } from '../../http-services/get-breadcrumb.service';
 
 describe('ItemDetailsComponent', () => {
   let component: ItemDetailsComponent;
@@ -21,7 +22,17 @@ describe('ItemDetailsComponent', () => {
         { provide: ActivatedRoute, useValue: {
           paramMap: of({
             get: (_s: string) => '30'
-          })
+          }),
+          snapshot: {
+            paramMap: {
+              get: (_s: string) => '30',
+              has: (_s: string) => true,
+            }
+          }
+        }},
+        { provide: GetBreadcrumbService, useValue: {
+          getBreadcrumb: (_p: any, _a: any) => of([]),
+          getBreadcrumbWithParentAttempt: (_p: any, _a: any) => of([]),
         }}
       ]
     })

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -1,39 +1,81 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
-import { CurrentContentService } from 'src/app/shared/services/current-content.service';
+import { Component, OnDestroy } from '@angular/core';
+import { CurrentContentService, PageInfo } from 'src/app/shared/services/current-content.service';
 import { ActivatedRoute } from '@angular/router';
-import { itemFromDetailParams } from 'src/app/shared/services/nav-types';
+import { itemFromDetailParams, NavItem, pathGiven } from 'src/app/shared/services/nav-types';
+import { GetBreadcrumbService, BreadcrumbItem } from 'src/app/modules/item/http-services/get-breadcrumb.service';
+import { EMPTY, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'alg-item-details',
   templateUrl: './item-details.component.html',
   styleUrls: ['./item-details.component.scss']
 })
-export class ItemDetailsComponent implements OnInit, OnDestroy {
+export class ItemDetailsComponent implements OnDestroy {
 
   constructor(
     private activatedRoute: ActivatedRoute,
     private currentContent: CurrentContentService,
+    private getBreadcrumbService: GetBreadcrumbService,
   ) {
     activatedRoute.paramMap.subscribe((params) => {
-      const item = itemFromDetailParams(params);
-      if (item) currentContent.setCurrent(item);
-    });
-  }
-
-  ngOnInit() {
-    this.currentContent.setPageInfo({
-      category: 'Items',
-      breadcrumb: [
-        { title: 'RootChapter' },
-        { title: 'MyChapter', attemptOrder: 1 },
-        { title: 'Content' }
-      ],
-      currentPageIndex: 2
+      const navItem = itemFromDetailParams(params);
+      if (navItem) {
+        currentContent.setCurrent(navItem);
+        this.fetchItem();
+      }
     });
   }
 
   ngOnDestroy() {
     this.currentContent.setPageInfo(null);
+  }
+
+  private fetchItem() {
+    if (!pathGiven(this.activatedRoute.snapshot.paramMap)) {
+      // TODO: handle no path given
+      return;
+    }
+    const navItem = itemFromDetailParams(this.activatedRoute.snapshot.paramMap);
+    if (!navItem) return; // unexpected anyway
+    if (!navItem.attemptId && !navItem.parentAttemptId) {
+      // TODO: handle no attempt given
+      return;
+    }
+    this.breadcumbRequest(navItem).subscribe((pageInfo) => {
+      this.currentContent.setPageInfo(pageInfo);
+    });
+  }
+
+  private breadcumbRequest(navItem: NavItem): Observable<PageInfo> {
+    const service = this.breadcrumbService(navItem);
+    if (!service) return EMPTY; // unexpected as it should verified by the caller of this function
+    return service.pipe(
+      map((res) => {
+        // TODO: handle forbidden currently (handle like no path given) -- while not handled: consider as the other errors
+        if (res === 'forbidden') throw new Error('unhandled forbidden');
+        return {
+          category: 'Items',
+          breadcrumb: res.map((el) => {
+            return {
+              title: el.title,
+              attemptOrder: el.attemptCnt
+            };
+          }),
+          currentPageIndex: res.length - 1
+        };
+      })
+    );
+  }
+
+  /**
+   * Return the observable to the suitable breadcrumb service depending on the navitem, or undefined if no attempt is given.
+   */
+  private breadcrumbService(navItem: NavItem): Observable<BreadcrumbItem[]|'forbidden'>|undefined {
+    const fullPath = navItem.itemPath.concat([navItem.itemId]);
+    if (navItem.attemptId) return this.getBreadcrumbService.getBreadcrumb(fullPath, navItem.attemptId);
+    else if (navItem.parentAttemptId) return this.getBreadcrumbService.getBreadcrumbWithParentAttempt(fullPath, navItem.parentAttemptId);
+    else return undefined;
   }
 
 }

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy } from '@angular/core';
 import { CurrentContentService, PageInfo } from 'src/app/shared/services/current-content.service';
 import { ActivatedRoute } from '@angular/router';
-import { itemFromDetailParams, NavItem, pathGiven } from 'src/app/shared/services/nav-types';
+import { itemFromDetailParams, NavItem, isPathGiven } from 'src/app/shared/services/nav-types';
 import { GetBreadcrumbService, BreadcrumbItem } from 'src/app/modules/item/http-services/get-breadcrumb.service';
 import { EMPTY, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -32,7 +32,7 @@ export class ItemDetailsComponent implements OnDestroy {
   }
 
   private fetchItem() {
-    if (!pathGiven(this.activatedRoute.snapshot.paramMap)) {
+    if (!isPathGiven(this.activatedRoute.snapshot.paramMap)) {
       // TODO: handle no path given
       return;
     }

--- a/src/app/shared/services/nav-types.ts
+++ b/src/app/shared/services/nav-types.ts
@@ -39,3 +39,7 @@ export function itemFromDetailParams(params: ParamMap): NavItem|undefined {
     itemPath: pathAsString === null || pathAsString.length === 0 ? [] : pathAsString.split(','),
   };
 }
+
+export function pathGiven(params: ParamMap): boolean {
+  return params.has(pathParamName);
+}

--- a/src/app/shared/services/nav-types.ts
+++ b/src/app/shared/services/nav-types.ts
@@ -40,6 +40,6 @@ export function itemFromDetailParams(params: ParamMap): NavItem|undefined {
   };
 }
 
-export function pathGiven(params: ParamMap): boolean {
+export function isPathGiven(params: ParamMap): boolean {
   return params.has(pathParamName);
 }


### PR DESCRIPTION
Replace static breadcrumbs for items to the service call.

Note that: 
* 3 errors are still not well handled (requires services being implemented on the backend)
* `breadcumbRequest` is a separate fct (and not in fetchItem) as the next step is to add other parallel calls


(note the first commit is things that may have been noticed by the previous review)