### PR TITLE
Add missing columns of group manager list 

### DIFF
--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
@@ -41,8 +41,9 @@
               </div>
             </div>
           </th>
+          <th style="width: 110px;"></th>
       </tr>
-    </ng-template>
+      </ng-template>
 
       <ng-template
         #bodyTemplate
@@ -81,6 +82,7 @@
               <i *ngIf="rowData[rowData.can_watch_members]" class="fa fa-lock-open"></i>
             </span>
           </td>
+          <td style="width: 110px;"></td>
         </tr>
       </ng-template>
     </alg-grid>

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
@@ -11,37 +11,78 @@
     [scrollable]="true"
     class="slanted-grid"
     >
-
-    <ng-template #headerTemplate let-columns>
-      <tr style="border: none;">
-        <th style="min-width: 110px;">
-          <div class="slanted-header">
-            <div class="slanted-header-content">
-              Name
+      <ng-template #headerTemplate let-columns>
+        <tr style="border: none;">
+          <th style="width: 160px;">
+            <div class="slanted-header">
+              <div class="slanted-header-content">
+                Name
+              </div>
             </div>
-          </div>
-        </th>
-        <th style="width: 160px; transform: none;">
+          </th>
+          <th style="min-width: 110px;">
+            <div class="slanted-header">
+              <div class="slanted-header-content">
+                Can Manage
+              </div>
+            </div>
+          </th>
+          <th style="width: 5rem;">
+            <div class="slanted-header">
+              <div class="slanted-header-content">
+                Can grant group access
+              </div>
+            </div>
+          </th>
+          <th style="width: 5rem;">
+            <div class="slanted-header">
+              <div class="slanted-header-content">
+                Can watch members
+              </div>
+            </div>
+          </th>
       </tr>
     </ng-template>
 
-    <ng-template
-      #bodyTemplate
-      let-rowData
-      let-columns="columns"
-      let-rowIndex="rowIndex"
-    >
-      <tr [pSelectableRow]="rowData" [pSelectableRowIndex]="rowIndex">
-        <td
-          style="text-align: left;width: 160px;padding-left: 0.5rem;"
-          tooltipPosition="top"
-          tooltipStyleClass="tooltip-custom"
-        >
-          {{ rowData.name }}
-        </td>
-      </tr>
-    </ng-template>
-  </alg-grid>
-
+      <ng-template
+        #bodyTemplate
+        let-rowData
+        let-columns="columns"
+        let-rowIndex="rowIndex"
+      >
+        <tr [pSelectableRow]="rowData" [pSelectableRowIndex]="rowIndex">
+          <td
+            style="text-align: left;width: 160px;padding-left: 0.5rem;"
+            tooltipPosition="top"
+            tooltipStyleClass="tooltip-custom"
+          >
+            {{ rowData.name }}
+          </td>
+          <td style="min-width: 110px;">
+            {{ rowData.can_manage }}
+          </td>
+          <td style="width: 5rem;">
+            <span class="table-icon"
+              [ngClass]="{
+                locked: rowData[rowData.can_grant_group_access],
+                unlocked: !rowData[rowData.can_grant_group_access]
+              }">
+              <i *ngIf="!rowData[rowData.can_grant_group_access]" class="fa fa-lock"></i>
+              <i *ngIf="rowData[rowData.can_grant_group_access]" class="fa fa-lock-open"></i>
+            </span>
+          </td>
+          <td style="width: 5rem;">
+            <span class="table-icon"
+              [ngClass]="{
+                locked: rowData[rowData.can_watch_members],
+                unlocked: !rowData[rowData.can_watch_members]
+              }">
+              <i *ngIf="!rowData[rowData.can_watch_members]" class="fa fa-lock"></i>
+              <i *ngIf="rowData[rowData.can_watch_members]" class="fa fa-lock-open"></i>
+            </span>
+          </td>
+        </tr>
+      </ng-template>
+    </alg-grid>
   </alg-section>
 </ng-container>

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
@@ -60,7 +60,7 @@
             {{ rowData.name }}
           </td>
           <td style="min-width: 110px;">
-            {{ getManagerLevel(rowData) }}
+            {{ rowData.can_manage_as_text }}
           </td>
           <td style="width: 5rem;">
             <span class="table-icon"

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
@@ -68,8 +68,8 @@
                 locked: rowData[rowData.can_grant_group_access],
                 unlocked: !rowData[rowData.can_grant_group_access]
               }">
-              <i *ngIf="!rowData[rowData.can_grant_group_access]" class="fa fa-lock"></i>
-              <i *ngIf="rowData[rowData.can_grant_group_access]" class="fa fa-lock-open"></i>
+              <i *ngIf="!rowData[rowData.can_grant_group_access]" class="fa fa-times"></i>
+              <i *ngIf="rowData[rowData.can_grant_group_access]" class="fa fa-check"></i>
             </span>
           </td>
           <td style="width: 5rem;">
@@ -78,8 +78,8 @@
                 locked: rowData[rowData.can_watch_members],
                 unlocked: !rowData[rowData.can_watch_members]
               }">
-              <i *ngIf="!rowData[rowData.can_watch_members]" class="fa fa-lock"></i>
-              <i *ngIf="rowData[rowData.can_watch_members]" class="fa fa-lock-open"></i>
+              <i *ngIf="!rowData[rowData.can_watch_members]" class="fa fa-times"></i>
+              <i *ngIf="rowData[rowData.can_watch_members]" class="fa fa-check"></i>
             </span>
           </td>
           <td style="width: 110px;"></td>

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
@@ -60,7 +60,7 @@
             {{ rowData.name }}
           </td>
           <td style="min-width: 110px;">
-            {{ rowData.can_manage }}
+            {{ getManagerLevel(rowData) }}
           </td>
           <td style="width: 5rem;">
             <span class="table-icon"

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
@@ -49,7 +49,7 @@
       }
     }
 
-    &:nth-child(even) {
+    &:nth-child(odd) {
       background-color: white;
     }
 
@@ -64,7 +64,7 @@
     text-align: center;
     font-size: 1.2rem;
 
-    &:nth-child(even) {
+    &:nth-child(odd) {
       background-color: white;
       text-align: center;
     }

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
@@ -77,7 +77,6 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      cursor: pointer;
 
       i {
         font-size: 1.2rem;

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
@@ -22,15 +22,28 @@ export class GroupManagerListComponent implements OnChanges {
     this.reloadData();
   }
 
+  private convertText(can_manage: string): string {
+    switch(can_manage) {
+      case 'none':
+        return 'Read-only';
+      case 'memberships':
+        return 'Memberships';
+      case 'memberships_and_group':
+        return 'Memberships and group';
+      default:
+        return '';
+      }
+  }
+
   private reloadData() {
     this.state = 'loading';
     this.getGroupManagersService
       .getGroupManagers(this.group.id)
-      .subscribe(
-        (managers: Manager[]) => {
-          this.managers = managers;
-          this.state = 'ready';
-        },
+      .subscribe((managers: Manager[]) => {
+        this.managers = managers;
+        this.managers.forEach(manager => manager.can_manage = this.convertText(manager.can_manage));
+        this.state = 'ready';
+      },
         _err => {
           this.state = 'error';
         });

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
@@ -11,7 +11,7 @@ export class GroupManagerListComponent implements OnChanges {
 
   @Input() group: Group;
 
-  managers: Manager[] = [];
+  managers: (Manager&{can_manage_as_text: string})[] = [];
 
   state: 'loading' | 'ready' | 'error' = 'loading';
 
@@ -22,7 +22,7 @@ export class GroupManagerListComponent implements OnChanges {
     this.reloadData();
   }
 
-  public getManagerLevel(manager: Manager): string {
+  private getManagerLevel(manager: Manager): string {
     switch(manager.can_manage) {
       case 'none':
         return 'Read-only';
@@ -38,7 +38,7 @@ export class GroupManagerListComponent implements OnChanges {
     this.getGroupManagersService
       .getGroupManagers(this.group.id)
       .subscribe((managers: Manager[]) => {
-        this.managers = managers;
+        this.managers = managers.map(manager => ({...manager, can_manage_as_text: this.getManagerLevel(manager)}));
         this.state = 'ready';
       },
         _err => {

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
@@ -22,16 +22,14 @@ export class GroupManagerListComponent implements OnChanges {
     this.reloadData();
   }
 
-  private convertText(can_manage: string): string {
-    switch(can_manage) {
+  public getManagerLevel(manager: Manager): string {
+    switch(manager.can_manage) {
       case 'none':
         return 'Read-only';
       case 'memberships':
         return 'Memberships';
       case 'memberships_and_group':
         return 'Memberships and group';
-      default:
-        return '';
       }
   }
 
@@ -41,7 +39,6 @@ export class GroupManagerListComponent implements OnChanges {
       .getGroupManagers(this.group.id)
       .subscribe((managers: Manager[]) => {
         this.managers = managers;
-        this.managers.forEach(manager => manager.can_manage = this.convertText(manager.can_manage));
         this.state = 'ready';
       },
         _err => {

--- a/src/app/modules/group/http-services/get-group-managers.service.ts
+++ b/src/app/modules/group/http-services/get-group-managers.service.ts
@@ -7,7 +7,7 @@ export interface Manager {
   id: string,
   name: string,
 
-  can_manage: string,
+  can_manage: 'none' | 'memberships' | 'memberships_and_group',
   can_grant_group_access: boolean,
   can_watch_members: boolean,
 }


### PR DESCRIPTION
Fixes #23 
Add the 3 missing columns of the manager list.
The 'Can Manage' column have an additional widget sometimes (the progress-level) but I'm not sure if this is really necessary.
The other 2 columns are represented by an open or closed lock