### PR TITLE
Retry once on 401 errors

### DIFF
--- a/src/app/shared/interceptors/auth_token_injector.interceptor.ts
+++ b/src/app/shared/interceptors/auth_token_injector.interceptor.ts
@@ -1,9 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpErrorResponse } from '@angular/common/http';
+import { Observable, of, throwError } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { AuthService } from '../auth/auth.service';
-import { switchMap, filter, take } from 'rxjs/operators';
+import { switchMap, filter, take, retryWhen, mergeMap } from 'rxjs/operators';
 import { AccessToken } from '../auth/access-token';
 import { headersForAuth } from '../helpers/auth';
 
@@ -29,6 +29,11 @@ export class AuthTokenInjector implements HttpInterceptor {
         take(1), // complete after emitting the first non-null token
         switchMap(token => next.handle(
           req.clone({ setHeaders: headersForAuth(token.accessToken) })
+        )),
+        // when we get a 401 - we retry once (as the token should have been replaced)
+        retryWhen(errors => errors.pipe(
+          mergeMap((err, idx) => (idx === 0 && err instanceof HttpErrorResponse && err.status === 401 &&
+            req.url.toLowerCase().startsWith(environment.apiUrl) ? of(err) : throwError(err)))
         ))
       );
   }


### PR DESCRIPTION
When a request receives a 401 response (invalid token), the process of renewing the token is triggered (already done). 
But instead of forwarding the error to the subscriber (the component using the service), wait for the new token to arrive and retry the request. This way the subscriber does not see any error at all.
"Once" because if it fails several time, the problem is probably different, and we cannot keep trying again and again. 

It solves the problem that when loading the website and the token is invalid/expired, all services called at load (the menu, the content) do not fail and so do not display an error.