### PR TITLE
call the timeout interceptor before the token injector 

### DIFF
--- a/src/app/core/app.module.ts
+++ b/src/app/core/app.module.ts
@@ -72,12 +72,12 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
     },
     {
       provide: HTTP_INTERCEPTORS,
-      useClass: AuthTokenInjector,
+      useClass: TimeoutInterceptor,
       multi: true,
     },
     {
       provide: HTTP_INTERCEPTORS,
-      useClass: TimeoutInterceptor,
+      useClass: AuthTokenInjector,
       multi: true,
     },
     {


### PR DESCRIPTION
Call the timeout interceptor before the token injector so that the timeout covers the token injector interceptor. In this way, if the token inject gets stuck (may happen as it is waiting for a token to be defined to inject and propagate the request), the timeout interceptor will make it fail properly after a delay.