### PR TITLE
Replace auto-starting result by fetching results and start one if none 

### DIFF
--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -3,7 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import { map } from 'rxjs/operators';
-import { bestAttemptFromResults, Result } from 'src/app/shared/helpers/attempts';
+import { bestAttemptFromResults } from 'src/app/shared/helpers/attempts';
 import { canCurrentUserViewItemContent } from 'src/app/modules/item/helpers/item-permissions';
 
 interface ItemStrings {
@@ -21,13 +21,7 @@ interface ActivityOrSkill {
   permissions: {
     can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
   },
-  results: {
-    attempt_id: string,
-    latest_activity_at: string|null,
-    started_at: string|null,
-    score_computed: number,
-    validated: boolean,
-}[]
+  results: RawResult[]
 }
 
 interface RootActivity {
@@ -41,6 +35,15 @@ interface RootSkill {
   group_id: string,
   name: string,
   skill: ActivityOrSkill
+}
+
+interface RawResult {
+  attempt_id: string,
+  /* on 10/2020, the service defines latest_activity_at as nullable but this should be a mistake. The bug has been submitted. */
+  latest_activity_at: string,
+  started_at: string|null,
+  score_computed: number,
+  validated: boolean,
 }
 
 interface RawNavData {
@@ -58,17 +61,19 @@ interface RawNavData {
     permissions: {
       can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
     },
-    results: {
-      attempt_id: string,
-      latest_activity_at: string|null,
-      started_at: string|null,
-      score_computed: number,
-      validated: boolean,
-    }[],
+    results: RawResult[],
   }[]
 }
 
 export type ItemType = 'Chapter'|'Task'|'Course'|'Skill';
+
+interface Result {
+  attemptId: string,
+  latestActivityAt: Date,
+  startedAt: Date|null,
+  score: number,
+  validated: boolean,
+}
 
 // exported nav menu structure
 export interface NavMenuItem {
@@ -87,27 +92,37 @@ export interface NavMenuRootItem {
   items: NavMenuItem[]
 }
 
+function rawResultToResult(r: RawResult): Result {
+  return {
+    attemptId: r.attempt_id,
+    latestActivityAt: new Date(r.latest_activity_at),
+    startedAt: r.started_at === null ? null : new Date(r.started_at),
+    score: r.score_computed,
+    validated: r.validated,
+  };
+}
+
 function createNavMenuItem(raw: {
   id: string,
   string: ItemStrings,
   has_visible_children: boolean,
-  results?: Result[],
+  results?: RawResult[],
   no_score: boolean,
   best_score: number,
   permissions: {
     can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
   },
 }): NavMenuItem {
-  const currentResult = raw.results ? bestAttemptFromResults(raw.results) : undefined;
+  const currentResult = raw.results ? bestAttemptFromResults(raw.results.map(rawResultToResult)) : undefined;
   return {
     id: raw.id,
     title: raw.string.title,
     hasChildren: raw.has_visible_children,
-    attemptId: currentResult?.attempt_id || null,
+    attemptId: currentResult?.attemptId ?? null,
     canViewContent: canCurrentUserViewItemContent(raw),
     score: raw.no_score || !currentResult ? undefined : {
       best: raw.best_score,
-      current: currentResult.score_computed,
+      current: currentResult.score,
       validated: currentResult.validated
     }
   };

--- a/src/app/modules/item/components/chapter-children/chapter-children.component.ts
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.ts
@@ -23,11 +23,11 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
   }
 
   private reloadData() {
-    if (this.itemData.attemptId) {
+    if (this.itemData.currentResult) {
       this.state = 'loading';
       this.subscription?.unsubscribe();
       this.subscription = this.getItemChildrenService
-        .get(this.itemData.item.id, this.itemData.attemptId)
+        .get(this.itemData.item.id, this.itemData.currentResult.attemptId)
         .subscribe(
           children => {
             this.children = children;

--- a/src/app/modules/item/http-services/get-results.service.ts
+++ b/src/app/modules/item/http-services/get-results.service.ts
@@ -1,0 +1,48 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+import { map } from 'rxjs/operators';
+
+type Attempt = { attemptId: string } | { parentAttemptId: string };
+
+interface RawResult {
+  id: string, // attempt id
+  latest_activity_at: string,
+  started_at: string|null,
+  score_computed: number,
+  validated: boolean,
+}
+
+export interface Result {
+  attemptId: string,
+  latestActivityAt: Date,
+  startedAt: Date|null,
+  score: number,
+  validated: boolean,
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GetResultsService {
+
+  constructor(private http: HttpClient) {}
+
+  getResults(itemId: string, attempt: Attempt): Observable<Result[]> {
+    return this.http
+      .get<RawResult[]>(`${environment.apiUrl}/items/${itemId}/attempts`, {
+        params: 'parentAttemptId' in attempt ? { parent_attempt_id: attempt.parentAttemptId } : { attempt_id: attempt.attemptId }
+      })
+      .pipe(
+        map(results => results.map(r => ({
+          attemptId: r.id,
+          latestActivityAt: new Date(r.latest_activity_at),
+          startedAt: r.started_at === null ? null : new Date(r.started_at),
+          score: r.score_computed,
+          validated: r.validated,
+        }))),
+      );
+  }
+
+}

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="itemData$ | async as itemData">
-  <ng-container *ngIf="itemData.attemptId">
+  <ng-container *ngIf="itemData.currentResult">
 
     <alg-section icon="fa fa-book" label="Description" *ngIf="itemData.item.string.description">
       <p>{{ itemData.item.string.description }} </p>

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -1,14 +1,16 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, concat, EMPTY, forkJoin, Observable, of, Subject } from 'rxjs';
 import { catchError, filter, map, mapTo, switchMap, tap } from 'rxjs/operators';
+import { bestAttemptFromResults, implicitResultStart } from 'src/app/shared/helpers/attempts';
 import { errorState, FetchError, Fetching, fetchingState, isReady, Ready, readyState } from 'src/app/shared/helpers/state';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { NavItem } from 'src/app/shared/services/nav-types';
 import { canCurrentUserViewItemContent } from '../helpers/item-permissions';
 import { BreadcrumbItem, GetBreadcrumbService } from '../http-services/get-breadcrumb.service';
 import { GetItemByIdService, Item } from '../http-services/get-item-by-id.service';
+import { GetResultsService, Result } from '../http-services/get-results.service';
 
-export interface ItemData { nav: NavItem, item: Item, breadcrumbs: BreadcrumbItem[], attemptId: string|null }
+export interface ItemData { nav: NavItem, item: Item, breadcrumbs: BreadcrumbItem[], results?: Result[], currentResult?: Result}
 
 /**
  * A datasource which allows fetching a item using a proper state and sharing it among several components.
@@ -34,6 +36,7 @@ export class ItemDataSource implements OnDestroy {
     private getBreadcrumbService: GetBreadcrumbService,
     private getItemByIdService: GetItemByIdService,
     private resultActionsService: ResultActionsService,
+    private getResultsService: GetResultsService,
   ) {
     this.fetchOperation.pipe(
 
@@ -68,13 +71,57 @@ export class ItemDataSource implements OnDestroy {
   private fetchItemData(navItem: NavItem): Observable<ItemData> {
     return forkJoin([
       this.getBreadcrumb(navItem),
-      this.getItemByIdService.get(navItem.itemId).pipe(
-        switchMap(item => this.startResultIfNeeded(navItem, item).pipe(map(a => ({ item: item, attemptId: a }))))
-      )
+      this.getItemByIdService.get(navItem.itemId)
     ]).pipe(
-      map(([breadcrumbs, {item: i, attemptId: a}]) => ({ item: i, breadcrumbs: breadcrumbs, attemptId: a, nav: navItem })),
+      switchMap(([breadcrumbs, item]) => {
+        // emit immediately without result, then fetch and add it
+        const initialData = { nav: navItem, item: item, breadcrumbs: breadcrumbs };
+        return concat(
+          of(initialData),
+          this.fetchResults(navItem, item).pipe(
+            map(r => ({ ...initialData, ...r}))
+          )
+        );
+      })
     );
   }
+
+  private fetchResults(nav: NavItem, item: Item): Observable<{ results: Result[], currentResult?: Result }> {
+    let attempt: { attemptId: string } | { parentAttemptId: string };
+    if (nav.parentAttemptId) attempt = { parentAttemptId: nav.parentAttemptId };
+    else if (nav.attemptId) attempt = { attemptId: nav.attemptId };
+    else return EMPTY; // unexpected
+
+    return this.getResultsService.getResults(nav.itemId, attempt).pipe(
+      switchMap(results => {
+        // 1) if attempt_id was given as arg, try to select the matching result
+        if (nav.attemptId) {
+          const currentResult = results.find(r => r.attemptId === nav.attemptId);
+          if (currentResult) return of({ results: results, currentResult: currentResult});
+        }
+        // 2) if there are already results on this item, select the best one
+        const currentResult = bestAttemptFromResults(results);
+        if (currentResult !== null) return of({ results: results, currentResult: currentResult});
+        // 3) if no suitable one and this item does not allow implicit result start or perms are not sufficent, continue without result
+        if (!implicitResultStart(item)) return of({ results: results });
+        // 4) otherwise, start a result
+        const attemptId  = nav.attemptId || nav.parentAttemptId;
+        if (!attemptId) return EMPTY; // unexpected
+        return this.resultActionsService.start(nav.itemPath.concat([nav.itemId]), attemptId).pipe(
+          // once a result has been created, fetch it
+          switchMap(() => this.getResultsService.getResults(nav.itemId, attempt).pipe(
+            map(results => {
+              // this time we are sure to have a started result as we just started it
+              const currentResult = bestAttemptFromResults(results);
+              if (currentResult === null) throw new Error('Unexpected: result just created not found');
+              return { results: results, currentResult: currentResult};
+            }),
+          )),
+        );
+      }),
+    );
+  }
+
 
   private startResultIfNeeded(navItem: NavItem, item: Item): Observable<string|null> { // observable of the result attempt_id
     const attemptId  = navItem.attemptId || navItem.parentAttemptId;

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -1,11 +1,10 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, concat, EMPTY, forkJoin, Observable, of, Subject } from 'rxjs';
-import { catchError, filter, map, mapTo, switchMap, tap } from 'rxjs/operators';
+import { catchError, filter, map, switchMap, tap } from 'rxjs/operators';
 import { bestAttemptFromResults, implicitResultStart } from 'src/app/shared/helpers/attempts';
 import { errorState, FetchError, Fetching, fetchingState, isReady, Ready, readyState } from 'src/app/shared/helpers/state';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { NavItem } from 'src/app/shared/services/nav-types';
-import { canCurrentUserViewItemContent } from '../helpers/item-permissions';
 import { BreadcrumbItem, GetBreadcrumbService } from '../http-services/get-breadcrumb.service';
 import { GetItemByIdService, Item } from '../http-services/get-item-by-id.service';
 import { GetResultsService, Result } from '../http-services/get-results.service';
@@ -119,17 +118,6 @@ export class ItemDataSource implements OnDestroy {
           )),
         );
       }),
-    );
-  }
-
-
-  private startResultIfNeeded(navItem: NavItem, item: Item): Observable<string|null> { // observable of the result attempt_id
-    const attemptId  = navItem.attemptId || navItem.parentAttemptId;
-    // if not allowed to start a result on this attempt, do not try
-    if (item.requires_explicit_entry || !canCurrentUserViewItemContent(item) || !attemptId) return of(null);
-    return this.resultActionsService.start(navItem.itemPath.concat([navItem.itemId]), attemptId).pipe(
-      mapTo(attemptId),
-      catchError(_e => of(null)) // if got an error, continue with no result
     );
   }
 

--- a/src/app/shared/helpers/attempts.ts
+++ b/src/app/shared/helpers/attempts.ts
@@ -15,3 +15,14 @@ export function bestAttemptFromResults<T extends Result>(results: T[]): T|null {
     return acc.latestActivityAt.getTime() < current.latestActivityAt.getTime() ? current : acc;
   }, null);
 }
+
+interface Item {
+  requires_explicit_entry: boolean
+  permissions: {
+    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
+  }
+}
+
+export function implicitResultStart(item: Item): boolean {
+  return item.permissions.can_view !== 'none' && !item.requires_explicit_entry;
+}

--- a/src/app/shared/helpers/attempts.ts
+++ b/src/app/shared/helpers/attempts.ts
@@ -1,20 +1,17 @@
 
-export interface Result {
-  attempt_id: string,
-  latest_activity_at: string|null,
-  started_at: string|null,
-  score_computed: number,
-  validated: boolean,
+interface Result {
+  latestActivityAt: Date,
+  startedAt: Date|null,
 }
 
-export function bestAttemptFromResults(results: Result[]): Result|null {
+export function bestAttemptFromResults<T extends Result>(results: T[]): T|null {
   if (!results || results.length === 0) {
     return null;
   }
   // pick the one which is started and with the greatest latest_activity_at
-  return results.reduce<Result|null>((acc, current) => {
-    if (current.started_at === null || current.latest_activity_at === null) return acc;
-    if (acc === null || acc.latest_activity_at === null) return current;
-    return new Date(acc.latest_activity_at).getTime() < new Date(current.latest_activity_at).getTime() ? current : acc;
+  return results.reduce<T|null>((acc, current) => {
+    if (current.startedAt === null) return acc;
+    if (acc === null) return current;
+    return acc.latestActivityAt.getTime() < current.latestActivityAt.getTime() ? current : acc;
   }, null);
 }


### PR DESCRIPTION
Replace in the item state the attempt_id by a detailed version of it a list of results and the current result, which allows to know the current score (and more)
So, instead of starting a result after fetching the item: fetch the list of results, find the more appropriate result and if none start a new one. 