### PR TITLE
enable explicit function return type + update all missing ones

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,7 @@ module.exports = {
     'key-spacing': ['error'],
     'keyword-spacing': ['error'],
     'no-eq-null': ['error'],
+    '@typescript-eslint/explicit-function-return-type': ['error'],
   },
   overrides: [
     {
@@ -69,6 +70,7 @@ module.exports = {
       rules: {
         '@typescript-eslint/no-floating-promises': 'off',
         '@typescript-eslint/unbound-method': 'off',
+        '@typescript-eslint/explicit-function-return-type': 'off',
       }
     },
   ],

--- a/src/app/core/app-routing.module.ts
+++ b/src/app/core/app-routing.module.ts
@@ -4,11 +4,11 @@ import { Routes, RouterModule } from '@angular/router';
 const routes: Routes = [
   {
     path: 'groups',
-    loadChildren: () => import('../modules/group/group.module').then(m => m.GroupModule)
+    loadChildren: (): Promise<any> => import('../modules/group/group.module').then(m => m.GroupModule)
   },
   {
     path: 'items',
-    loadChildren: () => import('../modules/item/item.module').then(m => m.ItemModule)
+    loadChildren: (): Promise<any> => import('../modules/item/item.module').then(m => m.ItemModule)
   },
 ];
 

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private currentContent: CurrentContentService,
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     // each time there is a new user, refresh the page
     this.subscription = this.currentUserService.currentUser$.pipe(
       filter<UserProfile|undefined, UserProfile>((user):user is UserProfile => !!user),
@@ -40,23 +40,23 @@ export class AppComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscription?.unsubscribe();
   }
 
-  onCollapse(e: boolean) {
+  onCollapse(e: boolean): void {
     this.collapsed = e;
     if (!this.collapsed) {
       this.folded = false;
     }
   }
 
-  onFold(folded: boolean) {
+  onFold(folded: boolean): void {
     this.folded = folded;
   }
 
   @HostListener('window:scroll', [ '$event' ])
-  onScrollContent() {
+  onScrollContent(): void{
     if (window.pageYOffset > 40 && !this.scrolled) {
       this.scrolled = true;
     } else if (window.pageYOffset <= 40 && this.scrolled) {
@@ -64,23 +64,23 @@ export class AppComponent implements OnInit, OnDestroy {
     }
   }
 
-  onEditPage() {
+  onEditPage(): void {
     this.currentContent.editAction.next(EditAction.StartEditing);
   }
 
-  onEditCancel() {
+  onEditCancel(): void {
     this.currentContent.editAction.next(EditAction.Cancel);
   }
 
-  onEditSave() {
+  onEditSave(): void {
     this.currentContent.editAction.next(EditAction.Save);
   }
 
-  login() {
+  login(): void {
     this.authService.startAuthLogin();
   }
 
-  logout() {
+  logout(): void {
     this.authService.logoutAuthUser();
   }
 

--- a/src/app/core/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/core/components/breadcrumb/breadcrumb.component.ts
@@ -15,7 +15,7 @@ export class BreadcrumbComponent {
     private router: Router,
   ) {}
 
-  onElementClick(el: { navigateTo?: any[] }) {
+  onElementClick(el: { navigateTo?: any[] }): void {
     if (el.navigateTo) void this.router.navigate(el.navigateTo);
   }
 

--- a/src/app/core/components/group-nav-tree/group-nav-tree.component.ts
+++ b/src/app/core/components/group-nav-tree/group-nav-tree.component.ts
@@ -26,7 +26,7 @@ export class GroupNavTreeComponent implements OnChanges {
 
   constructor(private router: Router) {}
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     this.nodes = this.groups.map(g => ({
       label: g.name,
       data: g,
@@ -36,11 +36,11 @@ export class GroupNavTreeComponent implements OnChanges {
     }));
   }
 
-  onSelect(node: GroupTreeNode) {
+  onSelect(node: GroupTreeNode): void {
     void this.router.navigate([ node.target ]);
   }
 
-  onKeyDown(e: KeyboardEvent) {
+  onKeyDown(e: KeyboardEvent): void {
     if (e.code === 'Space' || e.code === 'Enter') {
       e.stopPropagation();
       e.preventDefault();

--- a/src/app/core/components/group-nav/group-nav.component.ts
+++ b/src/app/core/components/group-nav/group-nav.component.ts
@@ -28,7 +28,7 @@ export class GroupNavComponent {
     private router: Router
   ) { }
 
-  onTabOpen(event: {index: number}) {
+  onTabOpen(event: {index: number}): void {
     this.focusOnGroupNav.emit();
     const service = event.index == joinGroupTabIdx ?
       this.joinedGroupsService.getJoinedGroups() : this.managedGroupService.getManagedGroups();
@@ -43,7 +43,7 @@ export class GroupNavComponent {
     });
   }
 
-  goToGroupManaged() {
+  goToGroupManaged(): void {
     void this.router.navigate([ 'groups', 'managed' ]);
   }
 

--- a/src/app/core/components/item-nav-tree/item-nav-tree.component.ts
+++ b/src/app/core/components/item-nav-tree/item-nav-tree.component.ts
@@ -52,11 +52,11 @@ export class ItemNavTreeComponent implements OnChanges {
     });
   }
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     this.nodes = this.data ? this.mapItemToNodes(this.data) : [];
   }
 
-  navigateToNode(node: ItemTreeNode, attemptId?: string) {
+  navigateToNode(node: ItemTreeNode, attemptId?: string): void {
     void this.router.navigate(itemDetailsRoute({
       itemId: node.data.id,
       itemPath: node.itemPath,
@@ -66,7 +66,7 @@ export class ItemNavTreeComponent implements OnChanges {
     }));
   }
 
-  navigateToParent() {
+  navigateToParent(): void {
     if (!this.data?.parent?.attemptId) return; // unexpected!
     void this.router.navigate(itemDetailsRoute({
       itemId: this.data.parent.id,
@@ -75,7 +75,7 @@ export class ItemNavTreeComponent implements OnChanges {
     }));
   }
 
-  selectNode(node: ItemTreeNode) {
+  selectNode(node: ItemTreeNode): void {
     this.selectedNode = node;
 
     // do not allow re-selecting a node with fetching in progress
@@ -109,7 +109,7 @@ export class ItemNavTreeComponent implements OnChanges {
     });
   }
 
-  onKeyDown(e: KeyboardEvent) {
+  onKeyDown(e: KeyboardEvent): void {
     if (e.code === 'Space' || e.code === 'Enter') {
       e.stopPropagation();
       e.preventDefault();

--- a/src/app/core/components/item-nav/item-nav.component.ts
+++ b/src/app/core/components/item-nav/item-nav.component.ts
@@ -70,7 +70,7 @@ export class ItemNavComponent implements OnInit, OnDestroy {
     );
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
 
     this.subscriptions.push(
 
@@ -129,7 +129,7 @@ export class ItemNavComponent implements OnInit, OnDestroy {
 
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscriptions.forEach(s => s.unsubscribe());
   }
 

--- a/src/app/core/components/left-nav/left-nav.component.ts
+++ b/src/app/core/components/left-nav/left-nav.component.ts
@@ -17,22 +17,22 @@ export class LeftNavComponent implements OnInit, OnChanges {
 
   constructor() { }
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
   }
 
-  onCollapse(collapsed: boolean) {
+  onCollapse(collapsed: boolean): void {
     this.collapsed = collapsed;
     this.collapse.emit(this.collapsed);
   }
 
-  onSearchEvent() {
+  onSearchEvent(): void {
     this.searchView = true;
   }
 
-  onSearchCloseEvent() {
+  onSearchCloseEvent(): void {
     this.searchView = false;
   }
 

--- a/src/app/core/components/navigation-tabs/navigation-tabs.component.ts
+++ b/src/app/core/components/navigation-tabs/navigation-tabs.component.ts
@@ -33,18 +33,18 @@ export class NavigationTabsComponent implements OnDestroy {
     ).subscribe(_i => this.groupShow = true);
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscription.unsubscribe();
   }
 
-  toggleGroup() {
+  toggleGroup(): void {
     this.groupShow = !this.groupShow;
     if (!this.groupShow) {
       this.stickyShow = false;
     }
   }
 
-  onResized(e: ResizedEvent) {
+  onResized(e: ResizedEvent): void {
     const directiveRef = this.scrollPanel?.directiveRef;
     if (!directiveRef) return;
     const boundaryHeight = (directiveRef.elementRef.nativeElement as HTMLElement).clientHeight - 50;
@@ -56,7 +56,7 @@ export class NavigationTabsComponent implements OnDestroy {
     }
   }
 
-  _updateStatus(e: HTMLElement) {
+  _updateStatus(e: HTMLElement): void {
     this.ngZone.run(() => {
       const scrollTop = e.scrollTop;
       const clientHeight = e.clientHeight - 50;
@@ -69,7 +69,7 @@ export class NavigationTabsComponent implements OnDestroy {
     });
   }
 
-  focusParent() {
+  focusParent(): void {
     if (this.groupPanel) {
       const elements = this.groupPanel.querySelectorAll('.ui-accordion-header a');
       elements.forEach(e => {
@@ -79,7 +79,7 @@ export class NavigationTabsComponent implements OnDestroy {
     }
   }
 
-  onScrollEvent(e: {srcElement: HTMLElement}) { /* guessed type, something cleaner would be nice */
+  onScrollEvent(e: {srcElement: HTMLElement}): void { /* guessed type, something cleaner would be nice */
     this._updateStatus(e.srcElement);
   }
 

--- a/src/app/core/components/top-nav/top-nav.component.ts
+++ b/src/app/core/components/top-nav/top-nav.component.ts
@@ -25,28 +25,28 @@ export class TopNavComponent implements OnInit {
     private authService: AuthService
   ) { }
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
-  onCollapse() {
+  onCollapse(): void {
     this.collapsed = !this.collapsed;
     this.collapse.emit(this.collapsed);
   }
 
-  onFold() {
+  onFold(): void {
     this.folded = !this.folded;
     this.fold.emit(this.folded);
   }
 
-  toggleNotification() {
+  toggleNotification(): void {
     this.showNotification = !this.showNotification;
   }
 
-  login() {
+  login(): void {
     this.authService.startAuthLogin();
   }
 
-  logout() {
+  logout(): void {
     this.authService.logoutAuthUser();
   }
 

--- a/src/app/modules/group/components/group-invite-users/group-invite-users.component.ts
+++ b/src/app/modules/group/components/group-invite-users/group-invite-users.component.ts
@@ -36,7 +36,7 @@ export class GroupInviteUsersComponent {
     ) {}
 
 
-  private processRequestError(_err: any) {
+  private processRequestError(_err: any): void {
     this.messageService.add({
       severity: 'error',
       summary: 'Error',
@@ -45,7 +45,7 @@ export class GroupInviteUsersComponent {
     });
   }
 
-  private displayResponse(response: Map<string, InvitationResult>) {
+  private displayResponse(response: Map<string, InvitationResult>): void {
 
     const sucessInvites: string[] = Array.from(response.entries()).filter(e => e[1] === InvitationResult.Success).map(e => e[0]);
     const alreadyInvited: string[] = Array.from(response.entries()).filter(e => e[1] === InvitationResult.AlreadyInvited).map(e => e[0]);
@@ -83,7 +83,7 @@ export class GroupInviteUsersComponent {
 
   /* events */
 
-  onTextChange(text:string) {
+  onTextChange(text:string): void {
     this.state = 'ready';
 
     const logins = text.split(',').filter(login => login.length > 0);
@@ -95,7 +95,7 @@ export class GroupInviteUsersComponent {
     }
   }
 
-  onInviteClicked() {
+  onInviteClicked(): void {
     if (!this.textArea || !this.group) return;
 
     // clear the messages

--- a/src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts
+++ b/src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts
@@ -31,11 +31,11 @@ export class GroupJoinByCodeComponent implements OnChanges {
     private codeActionsService: CodeActionsService,
   ) { }
 
-  ngOnChanges() {
+  ngOnChanges(): void {
     this.groupExt = this.group ? withCodeAdditions(this.group) : undefined;
   }
 
-  displaySuccess(msg: string) {
+  displaySuccess(msg: string): void {
     this.messageService.add({
       severity: 'success',
       summary: 'Success',
@@ -44,7 +44,7 @@ export class GroupJoinByCodeComponent implements OnChanges {
     });
   }
 
-  displayError() {
+  displayError(): void {
     this.messageService.add({
       severity: 'error',
       summary: 'Error',
@@ -55,7 +55,7 @@ export class GroupJoinByCodeComponent implements OnChanges {
 
   /* events */
 
-  generateNewCode() {
+  generateNewCode(): void {
     if (!this.group) return;
 
     // disable UI
@@ -77,7 +77,7 @@ export class GroupJoinByCodeComponent implements OnChanges {
       );
   }
 
-  changeValidity(newDuration: Duration) {
+  changeValidity(newDuration: Duration): void {
     if (!this.groupExt) return;
 
     // check valid state
@@ -102,7 +102,7 @@ export class GroupJoinByCodeComponent implements OnChanges {
       );
   }
 
-  removeCode() {
+  removeCode(): void {
     if (!this.group) return;
 
     // disable UI

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
@@ -18,7 +18,7 @@ export class GroupManagerListComponent implements OnChanges {
   constructor(private getGroupManagersService: GetGroupManagersService) {}
 
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     this.reloadData();
   }
 
@@ -33,7 +33,7 @@ export class GroupManagerListComponent implements OnChanges {
       }
   }
 
-  private reloadData() {
+  private reloadData(): void {
     if (!this.group) return;
     this.state = 'loading';
     this.getGroupManagersService

--- a/src/app/modules/group/components/group-no-permission/group-no-permission.component.ts
+++ b/src/app/modules/group/components/group-no-permission/group-no-permission.component.ts
@@ -9,7 +9,7 @@ export class GroupNoPermissionComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
 }

--- a/src/app/modules/group/components/pending-request/pending-request.component.ts
+++ b/src/app/modules/group/components/pending-request/pending-request.component.ts
@@ -72,20 +72,20 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     private messageService: MessageService
   ) {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.panel.push({
       columns: this.columns,
     });
     if (!this.showSwitch) this.columns = [ groupColumn ].concat(this.columns);
   }
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     this.selection = [];
     this.ongoingActivity = Activity.None;
     this.reloadData();
   }
 
-  private reloadData() {
+  private reloadData(): void {
     if (!this.groupId) return;
 
     this.status = 'loading';
@@ -114,7 +114,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     return res;
   }
 
-  private displayResponseToast(result: Result, verb: string, msg: string) {
+  private displayResponseToast(result: Result, verb: string, msg: string): void {
     if (result.countSuccess === result.countRequests) {
       this.messageService.add({
         severity: 'success',
@@ -139,7 +139,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     }
   }
 
-  private processRequestError(_err: any) {
+  private processRequestError(_err: any): void {
     this.messageService.add({
       severity: 'error',
       summary: 'Error',
@@ -148,7 +148,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     });
   }
 
-  processRequests(action: Action) {
+  processRequests(action: Action): Observable<Map<string, any>[]> {
     const requestMap = new Map<string, string[]>();
     this.selection.forEach(elm => {
       const groupID = elm.group.id;
@@ -166,7 +166,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     );
   }
 
-  onAcceptOrReject(action: Action) {
+  onAcceptOrReject(action: Action): void {
     if (this.selection.length === 0 || this.ongoingActivity !== Activity.None) {
       return;
     }
@@ -193,7 +193,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
       );
   }
 
-  onSelectAll() {
+  onSelectAll(): void {
     if (this.selection.length === this.requests.length) {
       this.selection = [];
     } else {
@@ -201,7 +201,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     }
   }
 
-  onCustomSort(event: SortEvent) {
+  onCustomSort(event: SortEvent): void {
     const sortMeta = event.multiSortMeta?.map(meta => (meta.order === -1 ? `-${meta.field}` : meta.field));
 
     if (sortMeta && JSON.stringify(sortMeta) !== JSON.stringify(this.currentSort)) {
@@ -211,7 +211,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     }
   }
 
-  onSubgroupSwitch(selectedIdx: number) {
+  onSubgroupSwitch(selectedIdx: number): void {
     this.includeSubgroup = this.subgroupSwitchItems[selectedIdx].includeSubgroup;
 
     this.columns = this.columns.filter(elm => elm !== groupColumn);

--- a/src/app/modules/group/pages/group-administration/group-administration.component.ts
+++ b/src/app/modules/group/pages/group-administration/group-administration.component.ts
@@ -17,7 +17,7 @@ export class GroupAdministrationComponent {
     private groupDataSource: GroupDataSource,
   ) {}
 
-  refreshGroupInfo() {
+  refreshGroupInfo(): void {
     this.groupDataSource.refetchGroup();
   }
 }

--- a/src/app/modules/group/pages/group-composition/group-composition.component.ts
+++ b/src/app/modules/group/pages/group-composition/group-composition.component.ts
@@ -17,7 +17,7 @@ export class GroupCompositionComponent {
     private groupDataSource: GroupDataSource,
   ) {}
 
-  refreshGroupInfo() {
+  refreshGroupInfo(): void {
     this.groupDataSource.refetchGroup();
   }
 

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -49,7 +49,7 @@ export class GroupDetailsComponent implements OnDestroy {
     ).subscribe(p => this.currentContent.current.next(p));
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.currentContent.current.next(null);
     this.subscription.unsubscribe();
   }

--- a/src/app/modules/group/services/group-datasource.service.ts
+++ b/src/app/modules/group/services/group-datasource.service.ts
@@ -43,18 +43,18 @@ export class GroupDataSource implements OnDestroy {
     ).subscribe(state => this.state.next(state));
   }
 
-  fetchGroup(id: GroupId) {
+  fetchGroup(id: GroupId): void {
     this.fetchOperation.next(id);
   }
 
   // If (and only if) a group is currently fetched (so we are not currently loading or in error), refetch it.
-  refetchGroup() {
+  refetchGroup(): void {
     if (isReady(this.state.value)) {
       this.fetchOperation.next(this.state.value.data.id);
     }
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.state.complete();
     this.fetchOperation.complete();
   }

--- a/src/app/modules/item/components/chapter-children/chapter-children.component.ts
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.ts
@@ -47,7 +47,7 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
       }));
   }
 
-  private reloadData() {
+  private reloadData(): void {
     if (this.itemData?.currentResult) {
       this.state = 'loading';
       this.subscription?.unsubscribe();
@@ -82,7 +82,7 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
     }
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscription?.unsubscribe();
   }
 }

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -92,7 +92,7 @@ export class ItemByIdComponent implements OnDestroy {
     );
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.currentContent.current.next(null);
     this.subscriptions.forEach(s => s.unsubscribe());
   }

--- a/src/app/modules/item/pages/item-current-situation/item-current-situation.component.ts
+++ b/src/app/modules/item/pages/item-current-situation/item-current-situation.component.ts
@@ -16,12 +16,12 @@ export class ItemCurrentSituationComponent implements OnInit {
 
   constructor() {}
 
-  onViewChanged(selectedIdx: number) {
+  onViewChanged(selectedIdx: number): void {
     // TODO :: Implement routing from alg-selection
     this.viewSelected = selectedIdx;
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     // TODO :: Implement routing from alg-selection
   }
 }

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -24,7 +24,7 @@ export class ItemDetailsComponent implements OnDestroy {
     );
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscription.unsubscribe();
     this.currentContent.editState.next('non-editable');
   }

--- a/src/app/modules/item/pages/item-edit/item-edit.component.ts
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.ts
@@ -30,7 +30,7 @@ export class ItemEditComponent implements OnDestroy {
     this.getCurrentItem();
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.currentContent.editState.next('non-editable');
     this.itemSubscription?.unsubscribe();
   }

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -9,7 +9,7 @@ export class ItemLogViewComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
 }

--- a/src/app/modules/item/pages/item-progress/item-progress.component.ts
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.ts
@@ -9,7 +9,7 @@ export class ItemProgressComponent implements OnDestroy {
 
   constructor() { }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
   }
 
 }

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -54,11 +54,11 @@ export class ItemDataSource implements OnDestroy {
     ).subscribe(state => this.state.next(state));
   }
 
-  fetchItem(navItem: NavItem) {
+  fetchItem(navItem: NavItem): void {
     this.fetchOperation.next(navItem);
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.state.complete();
     this.fetchOperation.complete();
   }

--- a/src/app/modules/shared-components/components/button/button.component.ts
+++ b/src/app/modules/shared-components/components/button/button.component.ts
@@ -16,9 +16,9 @@ export class ButtonComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  onClickEvent(event: any) {
+  onClickEvent(event: any): void {
     (event as Event).stopPropagation();
     this.click.emit();
   }

--- a/src/app/modules/shared-components/components/code-token/code-token.component.ts
+++ b/src/app/modules/shared-components/components/code-token/code-token.component.ts
@@ -15,13 +15,13 @@ export class CodeTokenComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  refreshCode() {
+  refreshCode(): void {
     this.refresh.emit();
   }
 
-  removeCode() {
+  removeCode(): void {
     this.remove.emit();
   }
 }

--- a/src/app/modules/shared-components/components/editor-bar/editor-bar.component.ts
+++ b/src/app/modules/shared-components/components/editor-bar/editor-bar.component.ts
@@ -12,13 +12,13 @@ export class EditorBarComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  onCancelClick() {
+  onCancelClick(): void {
     this.cancel.emit();
   }
 
-  onValidateClick() {
+  onValidateClick(): void {
     this.save.emit();
   }
 

--- a/src/app/modules/shared-components/components/grid/grid.component.ts
+++ b/src/app/modules/shared-components/components/grid/grid.component.ts
@@ -15,7 +15,7 @@ import { Table, TableService } from 'primeng/table';
 import { SortEvent } from 'primeng/api/sortevent';
 import { SortMeta } from 'primeng/api/sortmeta';
 
-export function tableFactory(wrapper: GridComponent) {
+export function tableFactory(wrapper: GridComponent): Table|undefined {
   return wrapper.table;
 }
 
@@ -88,20 +88,20 @@ export class GridComponent implements OnInit, OnChanges {
   toShow = 0;
   expand = false;
 
-  onSelectionChange(selection: any[]) {
+  onSelectionChange(selection: any[]): void {
     this.selection = selection;
     this.selectionChange.emit(this.selection ?? []);
   }
 
-  onRowSelect() {
+  onRowSelect(): void {
     this.selectionChange.emit(this.selection ?? []);
   }
 
-  onRowUnselect() {
+  onRowUnselect(): void {
     this.selectionChange.emit(this.selection ?? []);
   }
 
-  detectSelected() {
+  detectSelected(): void {
     const selectedCol = this.selectedColumns ?? [];
 
     for (const col of this.columns) {
@@ -115,19 +115,19 @@ export class GridComponent implements OnInit, OnChanges {
     this.toShow = this.columns.length - selectedCol.length;
   }
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     if (this.showGear) {
       this.detectSelected();
     }
   }
 
-  showColumns() {
+  showColumns(): void {
     this.showColumnSelection = !this.showColumnSelection;
   }
 
-  showAll() {
+  showAll(): void {
     this.selectedColumns = this.columns;
     this.toShow = 0;
     this.expand = !this.expand;
@@ -152,7 +152,7 @@ export class GridComponent implements OnInit, OnChanges {
     this.expandWholeWidth.emit(this.expand);
   }
 
-  handleColumnChanges(item: GridColumn) {
+  handleColumnChanges(item: GridColumn): void {
     this.selected[item.field] = !this.selected[item.field];
     const newSel: GridColumn[] = [];
     for (const col of this.columns) {
@@ -166,11 +166,11 @@ export class GridComponent implements OnInit, OnChanges {
     this.toShow = this.columns.length - this.selectedColumns.length;
   }
 
-  sortFunction(event: SortEvent) {
+  sortFunction(event: SortEvent): void {
     this.sort.emit(event);
   }
 
-  onHeaderCheckbox() {
+  onHeaderCheckbox(): void {
     this.selectionChange.emit(this.selection);
   }
 

--- a/src/app/modules/shared-components/components/input/input.component.ts
+++ b/src/app/modules/shared-components/components/input/input.component.ts
@@ -29,11 +29,11 @@ export class InputComponent implements OnInit, OnChanges {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  ngOnChanges(_changes: SimpleChanges) {}
+  ngOnChanges(_changes: SimpleChanges): void {}
 
-  onButtonClick() {
+  onButtonClick(): void {
     this.click.emit();
   }
 }

--- a/src/app/modules/shared-components/components/page-navigator/page-navigator.component.ts
+++ b/src/app/modules/shared-components/components/page-navigator/page-navigator.component.ts
@@ -12,10 +12,10 @@ export class PageNavigatorComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
-  editPage() {
+  editPage(): void {
     this.edit.emit();
   }
 }

--- a/src/app/modules/shared-components/components/score-ring/score-ring.component.ts
+++ b/src/app/modules/shared-components/components/score-ring/score-ring.component.ts
@@ -50,9 +50,9 @@ export class ScoreRingComponent implements OnInit, OnChanges {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  _pathFromScore(score: number) {
+  _pathFromScore(score: number): string {
     if (score === 0) {
       return 'M0, -30';
     }
@@ -66,7 +66,7 @@ export class ScoreRingComponent implements OnInit, OnChanges {
     return `M0,-30 A30,30 1 ${score > 50 ? 1 : 0},1 ${h},${w}`;
   }
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     if (this.scoreFillColor) {
       this.greyedFill = this.scoreFillColor;
       this.textFill = ScoreRingColor.darkText;

--- a/src/app/modules/shared-components/components/section-paragrah/section-paragraph.component.ts
+++ b/src/app/modules/shared-components/components/section-paragrah/section-paragraph.component.ts
@@ -30,10 +30,10 @@ export class SectionParagraphComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {
+  ngOnInit(): void {
   }
 
-  toggleContent() {
+  toggleContent(): void {
     this.collapsed = !this.collapsed;
     this.collapse.emit(this.collapsed);
   }

--- a/src/app/modules/shared-components/components/section/section.component.ts
+++ b/src/app/modules/shared-components/components/section/section.component.ts
@@ -12,5 +12,5 @@ export class SectionComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 }

--- a/src/app/modules/shared-components/components/select/select.component.ts
+++ b/src/app/modules/shared-components/components/select/select.component.ts
@@ -17,21 +17,21 @@ export class SelectComponent<T> implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.selected = this.items.length > 0 ? this.items[0] : undefined;
   }
 
-  toogleDropdown(e: Event) {
+  toogleDropdown(e: Event): void {
     this.opened = true;
     e.stopPropagation();
     this.click.emit();
   }
 
-  hideDropdown() {
+  hideDropdown(): void {
     this.opened = false;
   }
 
-  selectValue(v: T) {
+  selectValue(v: T): void {
     this.selected = v;
     this.opened = false;
     this.change.emit(v);

--- a/src/app/modules/shared-components/components/selection-tree/selection-tree.component.ts
+++ b/src/app/modules/shared-components/components/selection-tree/selection-tree.component.ts
@@ -22,9 +22,9 @@ export class SelectionTreeComponent implements OnInit, OnChanges {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     if (this.data) {
       while (this.data.length > 1) {
         this.data.pop();
@@ -36,7 +36,7 @@ export class SelectionTreeComponent implements OnInit, OnChanges {
     }
   }
 
-  nodeExpand(node: Node) {
+  nodeExpand(node: Node): void {
     if (!node.expanded) {
       node.expanded = true;
     } else {
@@ -44,7 +44,7 @@ export class SelectionTreeComponent implements OnInit, OnChanges {
     }
   }
 
-  nodeCheck(node: Node) {
+  nodeCheck(node: Node): void {
     if (!node.checked) {
       node.checked = true;
     } else {

--- a/src/app/modules/shared-components/components/selection/selection.component.ts
+++ b/src/app/modules/shared-components/components/selection/selection.component.ts
@@ -15,9 +15,9 @@ export class SelectionComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  itemChanged(index: number) {
+  itemChanged(index: number): void {
     this.selected = index;
     this.change.emit(index);
   }

--- a/src/app/modules/shared-components/components/skill-progress/skill-progress.component.ts
+++ b/src/app/modules/shared-components/components/skill-progress/skill-progress.component.ts
@@ -53,7 +53,7 @@ export class SkillProgressComponent implements OnInit, OnChanges {
     return score;
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     this._validateScore(this.currentScore);
     this._validateScore(this.bestScore);
 
@@ -65,7 +65,7 @@ export class SkillProgressComponent implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(_changes: SimpleChanges) {
+  ngOnChanges(_changes: SimpleChanges): void {
     if (this.currentScore === 100) {
       this.displayColor = '#B8E986';
     } else {

--- a/src/app/modules/shared-components/components/slider/slider.component.ts
+++ b/src/app/modules/shared-components/components/slider/slider.component.ts
@@ -30,12 +30,12 @@ export class SliderComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {
+  ngOnInit(): void {
     this.posStart = (this.ranges[0] * 100) / this.max;
     this.posEnd = (this.ranges[1] * 100) / this.max;
   }
 
-  handleChange() {
+  handleChange(): void {
     // const handles = this.slider.querySelectorAll('.ui-slider-handle');
     // this.posStart = parseFloat(handles.item(0)...asna.style.left);
     // this.posEnd = parseFloat(handles[1].style.left);

--- a/src/app/modules/shared-components/components/switch/switch.component.ts
+++ b/src/app/modules/shared-components/components/switch/switch.component.ts
@@ -22,11 +22,11 @@ export class SwitchComponent implements OnInit, OnChanges {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  ngOnChanges(_changes: SimpleChanges) {}
+  ngOnChanges(_changes: SimpleChanges): void {}
 
-  handleChange(checked: boolean) {
+  handleChange(checked: boolean): void {
     this.change.emit(checked);
   }
 }

--- a/src/app/modules/shared-components/components/textarea/textarea.component.ts
+++ b/src/app/modules/shared-components/components/textarea/textarea.component.ts
@@ -16,14 +16,14 @@ export class TextareaComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit(): void {}
 
-  setValue(text: string) {
+  setValue(text: string): void {
     this.value = text;
     this.onChange();
   }
 
-  onChange() {
+  onChange(): void {
     this.textChange.emit(this.value);
   }
 }

--- a/src/app/modules/shared-components/components/time-picker/time-picker.component.ts
+++ b/src/app/modules/shared-components/components/time-picker/time-picker.component.ts
@@ -17,7 +17,7 @@ export class TimePickerComponent implements OnChanges {
 
   constructor() {}
 
-  ngOnChanges() {
+  ngOnChanges(): void {
     if (this.initialValue) this.currentValue = this.initialValue.minutes();
   }
 
@@ -25,15 +25,15 @@ export class TimePickerComponent implements OnChanges {
     return Duration.fromHMS(0, this.currentValue, 0);
   }
 
-  onClickValidateButton() {
+  onClickValidateButton(): void {
     this.submit.emit(this.currentDuration());
   }
 
-  timeChange() {
+  timeChange(): void {
     // nothing for the moment
   }
 
-  timeChanged() {
+  timeChanged(): void {
     // nothing for the moment
   }
 }

--- a/src/app/shared/auth/access-token.ts
+++ b/src/app/shared/auth/access-token.ts
@@ -36,19 +36,19 @@ export class AccessToken {
     return new AccessToken(token, new Date(Date.now() + expiresIn*1000), type);
   }
 
-  static clearFromStorage() {
+  static clearFromStorage(): void {
     storage.removeItem(storageTokenKey);
     storage.removeItem(storageExpirationKey);
     storage.removeItem(storageTypeKey);
   }
 
-  saveToStorage() {
+  saveToStorage(): void {
     storage.setItem(storageTokenKey, this.accessToken);
     storage.setItem(storageExpirationKey, this.expiration.getTime().toString());
     storage.setItem(storageTypeKey, this.type);
   }
 
-  isValid() {
+  isValid(): boolean {
     if (!this.accessToken || this.accessToken.length === 0) return false;
     return this.expiration > new Date();
   }

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -8,7 +8,7 @@ import { AuthHttpService } from '../http-services/auth.http-service';
 
 // as auth can be complex to debug, enable this flag to print state logs
 const debugLogEnabled = true;
-function logState(msg: string) {
+function logState(msg: string): void {
   if (debugLogEnabled) {
     // eslint-disable-next-line no-console
     console.log(msg);
@@ -82,7 +82,7 @@ export class AuthService implements OnDestroy {
     });
   }
 
-  ngOnDestroy() {
+  ngOnDestroy(): void {
     this.subscription.unsubscribe();
   }
 
@@ -96,7 +96,7 @@ export class AuthService implements OnDestroy {
   /**
    * Start the auth session login workflow (i.e., redirect to login prompt)
    */
-  startAuthLogin() {
+  startAuthLogin(): void {
     logState('startLogin');
     if (this.isBusy() || this.authUserConnected()) {
       logState(`cannot startLogin if busy or already connected (${this.debugState()})`);
@@ -110,7 +110,7 @@ export class AuthService implements OnDestroy {
   /**
    * Log the authenticated user out and start a new temp session.
    */
-  logoutAuthUser() {
+  logoutAuthUser(): void {
     logState('endAuthSession');
     const currentToken = this.accessToken.value;
 
@@ -141,7 +141,7 @@ export class AuthService implements OnDestroy {
    * The token arg is the token which was used with the request that was considered as invalid, so that a more recent token which has been
    * added in the meantime is not dropped.
    */
-  invalidToken(invalidToken: string) {
+  invalidToken(invalidToken: string): void {
     const currentToken = this.accessToken.value;
     if (currentToken?.accessToken === invalidToken) {
 
@@ -168,7 +168,7 @@ export class AuthService implements OnDestroy {
     }
   }
 
-  private tokenChanged([ oldToken, newToken ]: [AccessToken|null, AccessToken|null]) {
+  private tokenChanged([ oldToken, newToken ]: [AccessToken|null, AccessToken|null]): void {
     logState('token changed');
 
     if (JSON.stringify(oldToken) === JSON.stringify(newToken)) return;

--- a/src/app/shared/auth/oauth.service.ts
+++ b/src/app/shared/auth/oauth.service.ts
@@ -25,7 +25,7 @@ export class OAuthService {
   /**
    * Init authorization code flow login anf redirect the user to the auth server login url.
    */
-  initCodeFlow() {
+  initCodeFlow(): void {
     const state = this.createNonce();
     const loginServerUri = environment.oauthServerUrl+'/oauth/authorize';
     const separationChar = loginServerUri.indexOf('?') > -1 ? '&' : '?';
@@ -71,7 +71,7 @@ export class OAuthService {
     );
   }
 
-  private loginRedirectUri() {
+  private loginRedirectUri(): string {
     return `${window.location.protocol}//${window.location.host}/#/`;
   }
 
@@ -89,7 +89,7 @@ export class OAuthService {
     return { nonce: nonce, userState: userState };
   }
 
-  private createNonce() {
+  private createNonce(): string {
     const unreserved = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
     let size = 45;
     let id = '';

--- a/src/app/shared/helpers/base64.ts
+++ b/src/app/shared/helpers/base64.ts
@@ -1,5 +1,5 @@
 
-export function base64UrlEncode(str: string) {
+export function base64UrlEncode(str: string): string {
     const base64 = btoa(str);
     return base64
         .replace(/\+/g, '-')

--- a/src/app/shared/helpers/url.ts
+++ b/src/app/shared/helpers/url.ts
@@ -47,7 +47,7 @@ export function getArgsFromUrl(): Map<string, string> {
   return parseQueryString(queryString);
 }
 
-export function clearHash(paramNames: string[]) {
+export function clearHash(paramNames: string[]): void {
   let href = location.href;
   for (const param of paramNames) {
     href = href.replace(new RegExp('[&\\?]'+param+'=[^&\\$]*'), '');


### PR DESCRIPTION
Enable explicit function return type in linter, so that the return type can be validated for every function.

In practice, it required to add many `: void` for all function not returning anything. 
A few functions non-returning void but without return type have been fixed as well.