### PR TITLE
Fix right panel broken when clicking an item in chapter children list

### DIFF
--- a/src/app/modules/item/components/chapter-children/chapter-children.component.ts
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.ts
@@ -10,6 +10,7 @@ import { itemDetailsRoute } from 'src/app/shared/services/nav-types';
 interface ItemChildAdditions {
   isLocked: boolean,
   result?: {
+    attempt_id: string,
     validated: boolean,
     score: number,
   },
@@ -38,12 +39,13 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
   }
 
   click(child: ItemChild&ItemChildAdditions): void {
-    if (!this.itemData) return;
-    if (child.isLocked) return;
+    if (!this.itemData || child.isLocked) return;
+    const attempt_id = child.result?.attempt_id;
     void this.router.navigate(itemDetailsRoute({
       itemId: child.id,
       itemPath: this.itemData.nav.itemPath.concat([ this.itemData.item.id ]),
-      attemptId: this.itemData.currentResult?.attemptId,
+      attemptId: attempt_id,
+      parentAttemptId: attempt_id ? undefined : this.itemData.currentResult?.attemptId,
       }));
   }
 
@@ -61,6 +63,7 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
                 ...child,
                 isLocked: !canCurrentUserViewItemContent(child),
                 result: res === null ? undefined : {
+                  attempt_id: res.attempt_id,
                   validated: res.validated,
                   score: res.score,
                 },

--- a/src/app/modules/item/http-services/get-item-children.service.ts
+++ b/src/app/modules/item/http-services/get-item-children.service.ts
@@ -14,6 +14,7 @@ interface RawItemChild extends ItemPermissionsInfo {
   category: 'Undefined'|'Discovery'|'Application'|'Validation'|'Challenge',
   type: 'Chapter'|'Task'|'Course'|'Skill',
   results: {
+    attempt_id: string,
     latest_activity_at: string,
     started_at: string|null,
     score_computed: number,
@@ -30,6 +31,7 @@ export interface ItemChild extends ItemPermissionsInfo {
   category: 'Undefined'|'Discovery'|'Application'|'Validation'|'Challenge',
   type: 'Chapter'|'Task'|'Course'|'Skill',
   results: {
+    attempt_id: string,
     latestActivityAt: Date,
     startedAt: Date|null,
     score: number,
@@ -59,6 +61,7 @@ export class GetItemChildrenService {
           category: c.category,
           type: c.type,
           results: c.results.map(r => ({
+            attempt_id: r.attempt_id,
             latestActivityAt: new Date(r.latest_activity_at),
             startedAt: r.started_at === null ? null : new Date(r.started_at),
             score: r.score_computed,


### PR DESCRIPTION
The right panel is no longer broken but the left menu is when clicking on an item in chapter children list.
The left menu can be fixed by reloading the page though