### PR TITLE
use the content result start instead of the menu one

### DIFF
--- a/src/app/core/common/item-nav-menu-data.ts
+++ b/src/app/core/common/item-nav-menu-data.ts
@@ -1,4 +1,5 @@
 import { ItemRoute } from 'src/app/shared/helpers/item-route';
+import { ItemDetails } from 'src/app/shared/services/current-content.service';
 import { NavMenuItem } from '../http-services/item-navigation.service';
 
 type Id = string;
@@ -24,14 +25,30 @@ export class ItemNavMenuData {
   }
 
   /**
-   * Return this with the element identified by id (at first level of `elements`) updated with the given data.
+   * Return this with the element identified by id (at first level of `elements`) updated with the given details.
    * If the element was not found, return this.
    */
-  withUpdatedElement(id: Id, data: Object): ItemNavMenuData {
+  withUpdatedDetails(id: Id, details: ItemDetails): ItemNavMenuData {
     const idx = this.elements.findIndex(i => i.id === id);
     if (idx === -1) return this;
     const elements = [ ...this.elements ];
-    elements[idx] = { ...this.elements[idx], ...data };
+    elements[idx].title = details.title;
+    elements[idx].attemptId = details.attemptId ?? null;
+    elements[idx].bestScore = details.bestScore;
+    elements[idx].currentScore = details.currentScore;
+    elements[idx].validated = details.validated;
+    return new ItemNavMenuData(elements, this.pathToElements, this.selectedElement, this.parent);
+  }
+
+   /**
+   * Return this with the element identified by id (at first level of `elements`) updated with info "self" and replaced children.
+   * If the element was not found, return this.
+   */
+  withUpdatedInfo(id: Id, info: NavMenuItem, children: NavMenuItem[]): ItemNavMenuData {
+    const idx = this.elements.findIndex(i => i.id === id);
+    if (idx === -1) return this;
+    const elements = [ ...this.elements ];
+    elements[idx] = { ...elements[idx], ...info, children: children };
     return new ItemNavMenuData(elements, this.pathToElements, this.selectedElement, this.parent);
   }
 

--- a/src/app/core/components/item-nav/item-nav.component.ts
+++ b/src/app/core/components/item-nav/item-nav.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Input, OnDestroy } from '@angular/core';
 import { ItemNavigationService, NavMenuRootItem } from '../../http-services/item-navigation.service';
 import { CurrentContentService, isItemInfo } from 'src/app/shared/services/current-content.service';
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
-import { of, Observable, merge, EMPTY, Subscription, concat } from 'rxjs';
+import { of, Observable, EMPTY, Subscription, concat } from 'rxjs';
 import { ItemNavMenuData } from '../../common/item-nav-menu-data';
 import { Ready, Fetching, FetchError, fetchingState, readyState, mapErrorToState, isReady, errorState } from 'src/app/shared/helpers/state';
 import { ItemRoute } from 'src/app/shared/helpers/item-route';
@@ -27,7 +27,7 @@ export class ItemNavComponent implements OnInit, OnDestroy {
   ) { }
 
   loadRootNav(): Observable<State> {
-    return merge(
+    return concat(
       of(fetchingState()), // first change items to loading
       this.itemNavService.getRoot(this.type).pipe(
         map(items => readyState(new ItemNavMenuData(items.items, [], undefined, items.parent))),
@@ -44,12 +44,12 @@ export class ItemNavComponent implements OnInit, OnDestroy {
     } else {
       dataFetcher = this.itemNavService.getRoot(this.type);
     }
-    return merge(
+    return concat(
       of(fetchingState()), // as the menu change completely, display the loader
       dataFetcher.pipe(
         map(items => new ItemNavMenuData(items.items, item.path, item, items.parent)), // the new items (only first level loaded)
         // already update the tree loaded with the first level, and if needed, load (async) children as well
-        switchMap(data => merge(of(readyState(data)), this.loadChildrenIfNeeded(data))),
+        switchMap(data => concat(of(readyState(data)), this.loadChildrenIfNeeded(data))),
         mapErrorToState(),
       )
     );

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -61,12 +61,13 @@ export class ItemByIdComponent implements OnDestroy {
           title: state.data.item.string.title === null ? undefined : state.data.item.string.title,
           data: {
             route: state.data.route,
-            result: state.data.currentResult ? {
-              attemptId: state.data.currentResult.attemptId,
+            details: {
+              title: state.data.item.string.title,
+              attemptId: state.data.currentResult?.attemptId,
               bestScore: state.data.item.best_score,
-              currentScore: state.data.currentResult.score,
-              validated: state.data.currentResult.validated,
-            } : undefined
+              currentScore: state.data.currentResult?.score,
+              validated: state.data.currentResult?.validated,
+            }
           },
         }))
       ).subscribe(p => this.currentContent.current.next(p)),

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -22,8 +22,17 @@ export interface ContentInfo {
 
 export interface ItemInfo extends ContentInfo {
   type: 'item',
-  data: { route: ItemRoute, result?: { attemptId: string, bestScore: number, currentScore: number, validated: boolean } }
+  data: { route: ItemRoute, details?: ItemDetails }
 }
+
+export interface ItemDetails {
+  title: string|null,
+  attemptId?: string,
+  bestScore?: number,
+  currentScore?: number,
+  validated?: boolean,
+}
+
 export interface GroupInfo extends ContentInfo { type: 'group' }
 
 export function isItemInfo(info: ContentInfo|null): info is ItemInfo {


### PR DESCRIPTION
Instead of letting the menu start a result on chapters, let the right content starts the result and load the children in the menu only when the attempt_id is known.
It fixes the navigation when it is done via the chapter children list.

Also: 
- fix the title that may be null
- pass the title in current content detail so that it can be updated (in edition)
- get rid of this 2nd subscription I didn't like in item nav comp