### PR TITLE
handle forbidden received from breadcrumb (wrong path or attempt)

### DIFF
--- a/src/app/shared/helpers/item-route.ts
+++ b/src/app/shared/helpers/item-route.ts
@@ -31,6 +31,15 @@ export function itemUrl(item: ItemRoute, page: 'edit'|'details'): RouterCommands
   params[pathParamName] = item.path;
   return [ 'items', 'by-id', item.id, params, page ];
 }
+
+/*
+ * Url to an item with missing path and attempt
+ * Build commands to be used with the `Router.navigate()` function
+ */
+export function incompleteItemUrl(itemId: string): RouterCommands {
+  return [ 'items', 'by-id', itemId ];
+}
+
 /*
  * Build commands to be used with the `Router.navigate()` function
  */


### PR DESCRIPTION
Handle forbidden received from the get-breadcrumbs service (wrong path or attempt): redirect to the url without path and attempt, so that path & attempt discovery service can be called.