### PR TITLE
Always fetching on refresh

### DIFF
--- a/src/app/modules/group/services/group-datasource.service.ts
+++ b/src/app/modules/group/services/group-datasource.service.ts
@@ -28,18 +28,19 @@ export class GroupDataSource implements OnDestroy {
     private getGroupByIdService: GetGroupByIdService,
   ) {
     this.fetchOperation.pipe(
-      // switchMap does cancel the previous ongoing processing if a new one comes
-      switchMap(id => {
-        const dataFetch = this.getGroupByIdService.get(id).pipe(
-          map(res => readyState(res)),
-          catchError(e => of(errorState(e)))
-        );
 
-        // if the fetched group is the same as the current one, do not change state to "loading" (silent refresh)
-        const currentState = this.state.value;
-        if (isReady(currentState) && currentState.data.id === id) return dataFetch;
-        else return concat(of(fetchingState()), dataFetch);
-      })
+      // switchMap does cancel the previous ongoing processing if a new one comes
+      // on new fetch operation to be done: set "fetching" stae and fetch the data which will result in a ready or error state
+      switchMap(id =>
+        concat(
+          of(fetchingState()),
+          this.getGroupByIdService.get(id).pipe(
+            map(res => readyState(res)),
+            catchError(e => of(errorState(e)))
+          )
+        )
+      ),
+
     ).subscribe(state => this.state.next(state));
   }
 

--- a/src/app/modules/group/services/group-datasource.service.ts
+++ b/src/app/modules/group/services/group-datasource.service.ts
@@ -30,7 +30,7 @@ export class GroupDataSource implements OnDestroy {
     this.fetchOperation.pipe(
 
       // switchMap does cancel the previous ongoing processing if a new one comes
-      // on new fetch operation to be done: set "fetching" stae and fetch the data which will result in a ready or error state
+      // on new fetch operation to be done: set "fetching" state and fetch the data which will result in a ready or error state
       switchMap(id =>
         concat(
           of(fetchingState()),

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -42,16 +42,16 @@ export class ItemDataSource implements OnDestroy {
     this.fetchOperation.pipe(
 
       // switchMap does cancel the previous ongoing processing if a new one comes
-      switchMap(item => {
-        const dataFetch = this.fetchItemData(item).pipe(
-          map(res => readyState(res)),
-          catchError(e => of(errorState(e)))
-        );
-        // if the fetched item is the same as the current one, do not change state to "loading" (silent refresh)
-        const currentState = this.state.value;
-        if (isReady(currentState) && currentState.data.item.id === item.id) return dataFetch;
-        else return concat(of(fetchingState()), dataFetch);
-      }),
+      // on new fetch operation to be done: set "fetching" stae and fetch the data which will result in a ready or error state
+      switchMap(item =>
+        concat(
+          of(fetchingState()),
+          this.fetchItemData(item).pipe(
+            map(res => readyState(res)),
+            catchError(e => of(errorState(e)))
+          )
+        )
+      ),
 
     ).subscribe(state => this.state.next(state));
   }


### PR DESCRIPTION
I find this "optimization" quite confusing as, on return from editing, the former content was displayed while the refresh is on progress.
Now the loading spinner is displayed while refreshing, even the content is the same.