### PR TITLE
User pipe

### DIFF
--- a/src/app/core/components/navigation-tabs/navigation-tabs.component.html
+++ b/src/app/core/components/navigation-tabs/navigation-tabs.component.html
@@ -5,12 +5,7 @@
       <img src="assets/images/Male.svg" style="width: 7rem; height: auto;" />
     </div>
     <span class="group-title">
-      <ng-container *ngIf="(currentUser.firstname || currentUser.lastname); else noName">
-        {{ currentUser.firstname}} {{ currentUser.lastname}} ({{ currentUser.login }})
-      </ng-container>
-      <ng-template #noName>
-        {{currentUser.login}}
-      </ng-template>
+      {{ currentUser | user }}
     </span>
     <span class="group-toggle" (click)="toggleGroup()">
       <i class="fa fa-users"></i>

--- a/src/app/core/components/navigation-tabs/navigation-tabs.component.spec.ts
+++ b/src/app/core/components/navigation-tabs/navigation-tabs.component.spec.ts
@@ -66,28 +66,28 @@ describe('NavigationTabsComponent', () => {
       expect(userString()).toEqual('Loading...');
     });
 
-    it('should display the full information correctly when firstname is null', () => {
-      component.currentUser = { id: '1', login: 'mylogin', firstname: null, lastname: 'myname', isTemp: false };
+    it('should display the full information correctly when firstame is null', () => {
+      component.currentUser = { id: '1', login: 'mylogin', firstName: null, lastName: 'myname', isTemp: false };
       expect(userString()).toEqual('myname (mylogin)');
     });
 
     it('should display the full information correctly when lastname is null', () => {
-      component.currentUser = { id: '1', login: 'mylogin', firstname: 'myfirst', lastname: null, isTemp: false };
+      component.currentUser = { id: '1', login: 'mylogin', firstName: 'myfirst', lastName: null, isTemp: false };
       expect(userString()).toEqual('myfirst (mylogin)');
     });
 
     it('should display the full information correctly when firstname is empty', () => {
-      component.currentUser = { id: '1', login: 'mylogin', firstname: '', lastname: 'myname', isTemp: false };
+      component.currentUser = { id: '1', login: 'mylogin', firstName: '', lastName: 'myname', isTemp: false };
       expect(userString()).toEqual('myname (mylogin)');
     });
 
     it('should display only login when both firstname and lastname are null', () => {
-      component.currentUser = { id: '1', login: 'mylogin', firstname: null, lastname: null, isTemp: false };
+      component.currentUser = { id: '1', login: 'mylogin', firstName: null, lastName: null, isTemp: false };
       expect(userString()).toEqual('mylogin');
     });
 
     it('should display only login when both firstname and lastname are empty', () => {
-      component.currentUser = { id: '1', login: 'mylogin', firstname: '', lastname: '', isTemp: false };
+      component.currentUser = { id: '1', login: 'mylogin', firstName: '', lastName: '', isTemp: false };
       expect(userString()).toEqual('mylogin');
     });
   });

--- a/src/app/modules/group/components/pending-request/pending-request.component.html
+++ b/src/app/modules/group/components/pending-request/pending-request.component.html
@@ -67,13 +67,7 @@
                 /> -->
                 <div class="user-info">
                   <span class="user-info-name">
-                    <ng-container *ngIf="!rowData.user.first_name && !rowData.user.last_name; else fullInfo">
-                      {{ rowData.user.login }}
-                    </ng-container>
-                    <ng-template #fullInfo>
-                      {{ rowData.user.first_name || "" }} {{ rowData.user.last_name || "" }}
-                      ({{ rowData.user.login }})
-                    </ng-template>
+                    {{ rowData.user | user }}
                   </span>
                   <span class="user-info-activity" *ngIf="rowData.user.grade">
                     <em>Grade: {{ rowData.user.grade }}</em>

--- a/src/app/modules/group/components/pending-request/pending-request.component.spec.ts
+++ b/src/app/modules/group/components/pending-request/pending-request.component.spec.ts
@@ -10,17 +10,17 @@ import { RequestActionsService } from '../../http-services/request-actions.servi
 const MOCK_RESPONSE: PendingRequest[] = [
   {
     at: null,
-    user: { group_id: '11', login: 'MadameSoso', first_name: 'Marie-Sophie', last_name: 'Denis', grade: 3 },
+    user: { groupId: '11', login: 'MadameSoso', firstName: 'Marie-Sophie', lastName: 'Denis', grade: 3 },
     group: { id: '50', name: 'Dojo 50' }
   },
   {
     at: null,
-    user: { group_id: '12', login: 'FredGast', first_name: 'Frederique', last_name: 'Gastard', grade: 2 },
+    user: { groupId: '12', login: 'FredGast', firstName: 'Frederique', lastName: 'Gastard', grade: 2 },
     group: { id: '50', name: 'Dojo 50' }
   },
   {
     at: null,
-    user: { group_id: '10', login: 'Jeandu88', first_name: 'Jean', last_name: 'Dujardin', grade: 3 },
+    user: { groupId: '10', login: 'Jeandu88', firstName: 'Jean', lastName: 'Dujardin', grade: 3 },
     group: { id: '50', name: 'Dojo 50' }
   }
 

--- a/src/app/modules/group/components/pending-request/pending-request.component.ts
+++ b/src/app/modules/group/components/pending-request/pending-request.component.ts
@@ -139,7 +139,7 @@ export class PendingRequestComponent implements OnInit, OnChanges {
     const requestMap = new Map<string, string[]>();
     this.selection.forEach(elm => {
       const groupID = elm.group.id;
-      const memberID = elm.user.group_id;
+      const memberID = elm.user.groupId;
 
       const value = requestMap.get(groupID);
       if (value) requestMap.set(groupID, value.concat([ memberID ]));

--- a/src/app/modules/group/http-services/get-requests.service.ts
+++ b/src/app/modules/group/http-services/get-requests.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { appConfig } from 'src/app/shared/helpers/config';
+import { map } from 'rxjs/operators';
 
-export interface PendingRequest {
+interface RawPendingRequest {
   at: string|null;
   group: {
     id: string;
@@ -14,6 +15,21 @@ export interface PendingRequest {
     login: string;
     first_name: string|null;
     last_name: string|null;
+    grade: number|null;
+  }
+}
+
+export interface PendingRequest {
+  at: Date|null;
+  group: {
+    id: string;
+    name: string;
+  };
+  user: {
+    groupId: string;
+    login: string;
+    firstName: string|null;
+    lastName: string|null;
     grade: number|null;
   }
 }
@@ -39,7 +55,20 @@ export class GetRequestsService {
       params = params.set('sort', sort.join(','));
     }
     return this.http
-      .get<PendingRequest[]>(`${appConfig().apiUrl}/groups/user-requests`, { params: params });
+      .get<RawPendingRequest[]>(`${appConfig().apiUrl}/groups/user-requests`, { params: params })
+      .pipe(
+        map(pendingRequests => pendingRequests.map(r => ({
+          at: r.at === null ? null : new Date(r.at),
+          group: r.group,
+          user: {
+            groupId: r.user.group_id,
+            login: r.user.login,
+            firstName: r.user.first_name,
+            lastName: r.user.last_name,
+            grade: r.user.grade,
+          }
+        })))
+      );
   }
 
 }

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -49,6 +49,7 @@ import { SectionParagraphComponent } from './components/section-paragrah/section
 import { MessageComponent } from './components/message/message.component';
 import { ProgressLevelComponent } from './components/progress-level/progress-level.component';
 import { FormErrorComponent } from './components/form-error/form-error.component';
+import { UserPipe } from 'src/app/shared/pipes/userDisplay';
 
 @NgModule({
   declarations: [
@@ -73,6 +74,7 @@ import { FormErrorComponent } from './components/form-error/form-error.component
     MessageComponent,
     ProgressLevelComponent,
     FormErrorComponent,
+    UserPipe,
   ],
   imports: [
     CommonModule,
@@ -131,6 +133,7 @@ import { FormErrorComponent } from './components/form-error/form-error.component
     MessageComponent,
     ProgressLevelComponent,
     FormErrorComponent,
+    UserPipe,
   ],
   providers: [
     { provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: { hasBackdrop: true } }

--- a/src/app/shared/http-services/current-user.service.ts
+++ b/src/app/shared/http-services/current-user.service.ts
@@ -17,8 +17,8 @@ interface RawUserProfile {
 export interface UserProfile {
   id: string,
   login: string
-  firstname: string|null,
-  lastname: string|null,
+  firstName: string|null,
+  lastName: string|null,
   isTemp: boolean,
 }
 
@@ -36,8 +36,8 @@ export class CurrentUserHttpService {
         map(raw => ({
           id: raw.group_id,
           login: raw.login,
-          firstname: raw.first_name,
-          lastname: raw.last_name,
+          firstName: raw.first_name,
+          lastName: raw.last_name,
           isTemp: raw.temp_user,
         }))
       );

--- a/src/app/shared/pipes/userDisplay.ts
+++ b/src/app/shared/pipes/userDisplay.ts
@@ -1,0 +1,22 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+interface UserInfos {
+  login: string,
+  firstName: string|null,
+  lastName: string|null,
+}
+
+@Pipe({ name: 'user' })
+export class UserPipe implements PipeTransform {
+  transform<T extends UserInfos>(userInfos: T) : string {
+    if (userInfos.firstName !== null && userInfos.firstName !== '' && userInfos.lastName !== null && userInfos.lastName !== '') {
+      return `${userInfos.firstName} ${userInfos.lastName} (${userInfos.login})`;
+    } else if (userInfos.firstName !== null && userInfos.firstName !== '') {
+      return `${userInfos.firstName} (${userInfos.login})`;
+    } else if (userInfos.lastName !== null && userInfos.lastName !== '') {
+      return `${userInfos.lastName} (${userInfos.login})`;
+    } else {
+      return userInfos.login;
+    }
+  }
+}


### PR DESCRIPTION
Add the `user` pipe to display the first and last name of a user and the login if the first and last name are null.
For this pipe to be used in the group pending requests grid, and the navigation tab component, some refactoring was done.
this pipe will be used in the group user list component also, but only after the merge in master.