### PR TITLE
handle updated details and attempt availability for lev1 and lev2 navigation as it may happen with a race condition

### DIFF
--- a/src/app/core/components/item-nav/item-nav.component.ts
+++ b/src/app/core/components/item-nav/item-nav.component.ts
@@ -67,14 +67,16 @@ export class ItemNavComponent implements OnInit, OnChanges, OnDestroy {
 
             // CASE: the content is among the displayed items at the root of the tree -> select the right one (might load children)
             if (prevState.data.hasLevel1Element(itemData.route.id)) {
-              const newData = prevState.data.withSelection(itemData.route);
-              return of(readyState(newData));
+              let newData = prevState.data.withSelection(itemData.route);
+              if (itemData.details) newData = newData.withUpdatedDetails(itemData.route.id, itemData.details);
+              return concat(of(readyState(newData)), this.loadChildrenIfNeeded(newData));
             }
 
             // CASE: the content is a child of one item at the root of the tree -> shift the tree and select it (might load children)
             if (prevState.data.hasLevel2Element(itemData.route.id)) {
-              const newData = prevState.data.subNavMenuData(itemData.route);
-              return of(readyState(newData));
+              let newData = prevState.data.subNavMenuData(itemData.route);
+              if (itemData.details) newData = newData.withUpdatedDetails(itemData.route.id, itemData.details);
+              return concat(of(readyState(newData)), this.loadChildrenIfNeeded(newData));
             }
 
           } else /* not ready state */ if (!itemInfo) {


### PR DESCRIPTION
When navigating to siblings or children, check for details and children (attempt_id known). In normal case, they should not be available but if some requests are reordering they may be available.