### PR TITLE
Edit workflow step 1: saving

### DIFF
--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -20,11 +20,7 @@
         [templateId]="1"
       ></alg-top-nav>
       <div class="top-right-bar" *ngrxLet="currentContent$ as currentContent">
-        <alg-editor-bar
-          *ngIf="editState === 'editing' || editState === 'editing-noaction'"
-          (cancel)="onEditCancel()"
-          (save)="onEditSave()"
-        ></alg-editor-bar>
+        <alg-editor-bar *ngIf="editState === 'editing' || editState === 'editing-noaction'" (cancel)="onEditCancel()"></alg-editor-bar>
         <div class="breadcrumb-bar"
              *ngIf="!folded && !scrolled">
           <alg-breadcrumb [contentBreadcrumb]="currentContent?.breadcrumbs"></alg-breadcrumb>

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -75,10 +75,6 @@ export class AppComponent implements OnInit, OnDestroy {
     this.currentContent.editAction.next(EditAction.StopEditing);
   }
 
-  onEditSave(): void {
-    this.currentContent.editAction.next(EditAction.Save);
-  }
-
   login(): void {
     this.authService.startAuthLogin();
   }

--- a/src/app/modules/group/pages/group-edit/group-edit.component.html
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.html
@@ -24,7 +24,7 @@
       </div>
     </form>
 
-    <alg-floating-save *ngIf="groupForm.dirty" [saving]="groupForm.disabled" (save)="saveInput()" (cancel)="resetForm()"></alg-floating-save>
+    <alg-floating-save *ngIf="groupForm.dirty" [saving]="groupForm.disabled" (save)="save()" (cancel)="resetForm()"></alg-floating-save>
   </div>
 
 </ng-container>

--- a/src/app/modules/group/pages/group-edit/group-edit.component.html
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.html
@@ -23,6 +23,8 @@
         </div>
       </div>
     </form>
+
+    <alg-floating-save *ngIf="groupForm.dirty" [saving]="groupForm.disabled" (save)="saveInput()" (cancel)="resetForm()"></alg-floating-save>
   </div>
 
 </ng-container>

--- a/src/app/modules/group/pages/group-edit/group-edit.component.ts
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.ts
@@ -76,7 +76,7 @@ export class GroupEditComponent implements OnDestroy {
     };
   }
 
-  saveInput(): void {
+  save(): void {
     if (!this.initialFormData) return;
 
     if (this.groupForm.invalid) {

--- a/src/app/modules/group/pages/group-edit/group-edit.component.ts
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.ts
@@ -26,7 +26,7 @@ export class GroupEditComponent implements OnDestroy {
 
   state$ = this.groupDataSource.state$;
 
-  subscriptions: Subscription[] = [];
+  subscription?: Subscription;
 
   constructor(
     private currentContent: CurrentContentService,
@@ -37,18 +37,17 @@ export class GroupEditComponent implements OnDestroy {
   ) {
     this.currentContent.editState.next('editing');
 
-    this.subscriptions.push(
-      this.state$.pipe(filter<Ready<Group> | Fetching | FetchError, Ready<Group>>(isReady))
-        .subscribe(state => {
-          this.initialFormData = state.data;
-          this.resetFormWith(state.data);
-        }),
-    );
+    this.subscription = this.state$
+      .pipe(filter<Ready<Group> | Fetching | FetchError, Ready<Group>>(isReady))
+      .subscribe(state => {
+        this.initialFormData = state.data;
+        this.resetFormWith(state.data);
+      });
   }
 
   ngOnDestroy(): void {
     this.currentContent.editState.next('non-editable');
-    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+    this.subscription?.unsubscribe();
   }
 
   successToast(): void {

--- a/src/app/modules/item/components/item-children-edit/item-children-edit.component.ts
+++ b/src/app/modules/item/components/item-children-edit/item-children-edit.component.ts
@@ -74,4 +74,8 @@ export class ItemChildrenEditComponent implements OnChanges {
     this.childrenChanges.emit(this.data);
   }
 
+  reset(): void {
+    this.reloadData();
+  }
+
 }

--- a/src/app/modules/item/pages/item-edit-content/item-edit-content.component.html
+++ b/src/app/modules/item/pages/item-edit-content/item-edit-content.component.html
@@ -4,6 +4,6 @@
     <alg-textarea [parentForm]="parentForm" inputName="description"></alg-textarea>
   </alg-section>
 
-  <alg-item-children-edit (childrenChanges)="childrenChanges.emit($event)" [itemData]="itemData" *ngIf="['Chapter', 'Skill'].includes(itemData.item.type)"></alg-item-children-edit>
+  <alg-item-children-edit (childrenChanges)="childrenChanges.emit($event)" [itemData]="itemData" *ngIf="['Chapter', 'Skill'].includes(itemData.item.type)" #childrenEdit></alg-item-children-edit>
 
 </ng-container>

--- a/src/app/modules/item/pages/item-edit-content/item-edit-content.component.ts
+++ b/src/app/modules/item/pages/item-edit-content/item-edit-content.component.ts
@@ -1,7 +1,7 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ItemData } from '../../services/item-datasource.service';
-import { ChildData } from '../../components/item-children-edit/item-children-edit.component';
+import { ChildData, ItemChildrenEditComponent } from '../../components/item-children-edit/item-children-edit.component';
 
 @Component({
   selector: 'alg-item-edit-content',
@@ -14,6 +14,12 @@ export class ItemEditContentComponent {
 
   @Output() childrenChanges = new EventEmitter<ChildData[]>();
 
+  @ViewChild('childrenEdit') private childrenEdit?: ItemChildrenEditComponent;
+
   constructor() {}
+
+  reset(): void {
+    this.childrenEdit?.reset();
+  }
 
 }

--- a/src/app/modules/item/pages/item-edit/item-edit.component.html
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.html
@@ -22,7 +22,7 @@
       </nav>
 
       <div class="bg-white">
-        <alg-item-edit-content
+        <alg-item-edit-content #content
           *ngIf="rla1.isActive"
           [parentForm]="itemForm"
           [itemData]="itemData"
@@ -32,6 +32,7 @@
       </div>
 
     </form>
+    <alg-floating-save *ngIf="itemForm.dirty" [saving]="itemForm.disabled" (save)="save()" (cancel)="resetForm()"></alg-floating-save>
   </div>
 
 </ng-container>

--- a/src/app/modules/item/pages/item-edit/item-edit.component.ts
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.ts
@@ -29,7 +29,7 @@ export class ItemEditComponent implements OnDestroy {
   itemLoadingState$ = this.itemDataSource.state$;
   initialFormData?: Item;
 
-  subscriptions: Subscription[] = [];
+  subscription?: Subscription;
   itemChanges: ItemChanges = {};
 
   @ViewChild('content') private editContent?: ItemEditContentComponent;
@@ -43,18 +43,17 @@ export class ItemEditComponent implements OnDestroy {
     private messageService: MessageService
   ) {
     this.currentContent.editState.next('editing');
-    this.subscriptions.push(
-      this.itemLoadingState$.pipe(filter<Ready<ItemData> | Fetching | FetchError, Ready<ItemData>>(isReady))
-        .subscribe(state => {
-          this.initialFormData = state.data.item;
-          this.resetFormWith(state.data.item);
-        }),
-    );
+    this.subscription = this.itemLoadingState$
+      .pipe(filter<Ready<ItemData> | Fetching | FetchError, Ready<ItemData>>(isReady))
+      .subscribe(state => {
+        this.initialFormData = state.data.item;
+        this.resetFormWith(state.data.item);
+      });
   }
 
   ngOnDestroy(): void {
     this.currentContent.editState.next('non-editable');
-    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+    this.subscription?.unsubscribe();
   }
 
   successToast(): void {

--- a/src/app/modules/shared-components/components/button/button.component.scss
+++ b/src/app/modules/shared-components/components/button/button.component.scss
@@ -109,16 +109,6 @@ $danger-color: #ff001f;
     }
   }
 
-  &.p-button-danger {
-    background-color: $danger-color;
-    border-color: $danger-color;
-
-    &:enabled:focus {
-      outline: none;
-      box-shadow: none;
-    }
-  }
-
   &.p-top-rounded {
     border-radius: 0;
     border-top-left-radius: 0.6667rem;
@@ -132,22 +122,11 @@ $danger-color: #ff001f;
   }
 
   &.p-button-success {
-    background-color: white;
-    border-color: $base-color;
-    color: $base-color;
-
-    &:enabled:hover {
-      background-color: $base-color;
-      border-color: $base-color;
-      color: white;
-    }
-    &:enabled:focus {
-      outline: none;
-      box-shadow: none;
-    }
+    color: #ffffff;
+    background: #90C45F;
+    border: 1px solid #90C45F;
   }
-
-  }
+}
 
 :host ::ng-deep p-button {
   width: 100%;
@@ -160,10 +139,6 @@ $danger-color: #ff001f;
 
         &.p-button-rounded {
           border-radius: 1.5rem;
-        }
-
-        &.p-button-success {
-          background-color: transparent;
         }
     }
 }

--- a/src/app/modules/shared-components/components/editor-bar/editor-bar.component.html
+++ b/src/app/modules/shared-components/components/editor-bar/editor-bar.component.html
@@ -5,10 +5,7 @@
   <span class="edit-title">
     Edition Mode
   </span>
-  <span class="edit-save"  (click)="onValidateClick()">
-    <i class="fa fa-check"></i>
-  </span>
-  <span class="edit-cancel" (click)="onCancelClick()">
-    <i class="fa fa-times"></i>
-  </span>
+
+  <button pButton type="button" icon="pi pi-times" class="p-button-rounded" (click)="onCancelClick()"></button>
+
 </div>

--- a/src/app/modules/shared-components/components/editor-bar/editor-bar.component.ts
+++ b/src/app/modules/shared-components/components/editor-bar/editor-bar.component.ts
@@ -7,8 +7,6 @@ import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 })
 export class EditorBarComponent implements OnInit {
   @Output() cancel = new EventEmitter();
-  @Output() save = new EventEmitter();
-  @Output() reload = new EventEmitter();
 
   constructor() {}
 
@@ -16,10 +14,6 @@ export class EditorBarComponent implements OnInit {
 
   onCancelClick(): void {
     this.cancel.emit();
-  }
-
-  onValidateClick(): void {
-    this.save.emit();
   }
 
 }

--- a/src/app/modules/shared-components/components/floating-save/floating-save.component.html
+++ b/src/app/modules/shared-components/components/floating-save/floating-save.component.html
@@ -1,0 +1,2 @@
+<alg-button label="Save" class="p-button-rounded p-button-success save" (click)="onSave()" [disabled]="saving"></alg-button>
+<alg-button label="Cancel Changes" class="p-button-rounded p-button-outlined p-button-danger" [disabled]="saving" (click)="onCancel()"></alg-button>

--- a/src/app/modules/shared-components/components/floating-save/floating-save.component.scss
+++ b/src/app/modules/shared-components/components/floating-save/floating-save.component.scss
@@ -1,0 +1,14 @@
+
+:host {
+  position: fixed;
+  bottom: 0.2rem;
+  right: 1rem;
+  height: 4rem;
+  z-index: 900;
+  display: flex;
+
+  .save {
+    margin-right: 0.2rem;
+  }
+
+}

--- a/src/app/modules/shared-components/components/floating-save/floating-save.component.ts
+++ b/src/app/modules/shared-components/components/floating-save/floating-save.component.ts
@@ -1,0 +1,23 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'alg-floating-save',
+  templateUrl: './floating-save.component.html',
+  styleUrls: [ './floating-save.component.scss' ]
+})
+export class FloatingSaveComponent {
+
+  @Input() saving = false;
+  @Output() save = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  constructor() {}
+
+  onSave(): void {
+    this.save.emit();
+  }
+
+  onCancel(): void {
+    this.cancel.emit();
+  }
+}

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -51,6 +51,7 @@ import { FormErrorComponent } from './components/form-error/form-error.component
 import { UserPipe } from 'src/app/shared/pipes/userDisplay';
 import { SubSectionComponent } from './components/sub-section/sub-section.component';
 import { AddContentComponent } from './components/add-content/add-content.component';
+import { FloatingSaveComponent } from './components/floating-save/floating-save.component';
 
 @NgModule({
   declarations: [
@@ -78,6 +79,7 @@ import { AddContentComponent } from './components/add-content/add-content.compon
     UserPipe,
     SubSectionComponent,
     AddContentComponent,
+    FloatingSaveComponent,
   ],
   imports: [
     CommonModule,
@@ -138,6 +140,7 @@ import { AddContentComponent } from './components/add-content/add-content.compon
     UserPipe,
     SubSectionComponent,
     AddContentComponent,
+    FloatingSaveComponent,
   ],
   providers: [
     { provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: { hasBackdrop: true } }

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -51,7 +51,7 @@ export function isGroupInfo(info: ContentInfo|null): info is GroupInfo {
 }
 
 export type EditState = 'non-editable'|'editable'|'editing'|'editing-noaction'; // editingNoAction is for temporary disabled actions
-export enum EditAction { StartEditing, Save, StopEditing }
+export enum EditAction { StartEditing, StopEditing }
 
 /**
  * Use this service to track what's the current item display in the content (right) pane.


### PR DESCRIPTION
Update the saving workflow: 
- the top bar is only used for exiting save mode
- when there is a change save/cancel buttons are shown floating on the bottom right
- "cancel" reset the form to its initial value

Other improvements yet to be done for future PRs: 
- cancel / exiting editing should ask for confirmation
- navigating while in edit mode should stay in edit mode