### PR TITLE
Edit workflow step 3: stay on the same "subpage" when navigating from an item to another

### DIFF
--- a/src/app/core/components/breadcrumb/breadcrumb.component.ts
+++ b/src/app/core/components/breadcrumb/breadcrumb.component.ts
@@ -15,8 +15,11 @@ export class BreadcrumbComponent {
     private router: Router,
   ) {}
 
-  onElementClick(el: { navigateTo?: UrlTree }): void {
-    if (el.navigateTo) void this.router.navigateByUrl(el.navigateTo);
+  onElementClick(el: { navigateTo?: UrlTree|(() => UrlTree) }): void {
+    if (el.navigateTo) {
+      const dest = 'root' in el.navigateTo ? el.navigateTo : el.navigateTo();
+      void this.router.navigateByUrl(dest);
+    }
   }
 
 }

--- a/src/app/core/components/item-nav-tree/item-nav-tree.component.ts
+++ b/src/app/core/components/item-nav-tree/item-nav-tree.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { TreeNode } from 'primeng/api';
 import { NavMenuItem } from '../../http-services/item-navigation.service';
-import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { Router } from '@angular/router';
 import { ItemNavMenuData } from '../../common/item-nav-menu-data';
 import { itemDetailsUrl } from 'src/app/shared/helpers/item-route';
@@ -31,7 +30,6 @@ export class ItemNavTreeComponent implements OnChanges {
 
   constructor(
     private router: Router,
-    private resultActionsService: ResultActionsService,
   ) {}
 
   mapItemToNodes(data: ItemNavMenuData): ItemTreeNode[] {

--- a/src/app/core/components/item-nav-tree/item-nav-tree.component.ts
+++ b/src/app/core/components/item-nav-tree/item-nav-tree.component.ts
@@ -1,11 +1,10 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { TreeNode } from 'primeng/api';
 import { NavMenuItem } from '../../http-services/item-navigation.service';
-import { Router } from '@angular/router';
 import { ItemNavMenuData } from '../../common/item-nav-menu-data';
-import { itemDetailsUrl } from 'src/app/shared/helpers/item-route';
 import { defaultAttemptId } from 'src/app/shared/helpers/attempts';
 import { ItemTypeCategory } from 'src/app/shared/helpers/item-type';
+import { ItemRouter } from 'src/app/shared/services/item-router';
 
 // ItemTreeNode is PrimeNG tree node with data forced to be an item
 interface ItemTreeNode extends TreeNode {
@@ -29,7 +28,7 @@ export class ItemNavTreeComponent implements OnChanges {
   selectedNode?: ItemTreeNode; // used to keep track after request that the selected is still the expected one
 
   constructor(
-    private router: Router,
+    private itemRouter: ItemRouter,
   ) {}
 
   mapItemToNodes(data: ItemNavMenuData): ItemTreeNode[] {
@@ -61,21 +60,21 @@ export class ItemNavTreeComponent implements OnChanges {
   navigateToNode(node: ItemTreeNode, attemptId?: string): void {
     const routeBase = { id: node.data.id, path: node.itemPath };
     if (attemptId) {
-      void this.router.navigateByUrl(itemDetailsUrl(this.router, { ...routeBase, attemptId: attemptId }));
+      this.itemRouter.navigateTo({ ...routeBase, attemptId: attemptId });
       return;
     }
     const parentAttemptId = this.parentAttemptForNode(node);
     if (!parentAttemptId) return; // unexpected
-    void this.router.navigateByUrl(itemDetailsUrl(this.router, { ...routeBase, parentAttemptId: parentAttemptId }));
+    this.itemRouter.navigateTo({ ...routeBase, parentAttemptId: parentAttemptId });
   }
 
   navigateToParent(): void {
     if (!this.data?.parent?.attemptId) return; // unexpected!
-    void this.router.navigateByUrl(itemDetailsUrl(this.router, {
+    this.itemRouter.navigateTo({
       id: this.data.parent.id,
       path: this.data.pathToElements.slice(0, -1),
       attemptId: this.data.parent.attemptId,
-    }));
+    });
   }
 
   selectNode(node: ItemTreeNode): void {

--- a/src/app/modules/item/components/chapter-children/chapter-children.component.ts
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.ts
@@ -4,8 +4,7 @@ import { canCurrentUserViewItemContent } from '../../helpers/item-permissions';
 import { GetItemChildrenService, ItemChild } from '../../http-services/get-item-children.service';
 import { ItemData } from '../../services/item-datasource.service';
 import { bestAttemptFromResults } from 'src/app/shared/helpers/attempts';
-import { Router } from '@angular/router';
-import { itemDetailsUrl } from 'src/app/shared/helpers/item-route';
+import { ItemRouter } from 'src/app/shared/services/item-router';
 
 interface ItemChildAdditions {
   isLocked: boolean,
@@ -29,7 +28,7 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
 
   constructor(
     private getItemChildrenService: GetItemChildrenService,
-    private router: Router,
+    private itemRouter: ItemRouter,
   ) {}
 
   private subscription?: Subscription;
@@ -43,11 +42,11 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
     const attemptId = child.result?.attempt_id;
     const parentAttemptId = this.itemData.currentResult?.attemptId;
     if (!parentAttemptId) return; // unexpected: children have been loaded, so we are sure this item has an attempt
-    void this.router.navigateByUrl(itemDetailsUrl(this.router, {
+    this.itemRouter.navigateTo({
       id: child.id,
       path: this.itemData.route.path.concat([ this.itemData.item.id ]),
       ...attemptId ? { attemptId: attemptId } : { parentAttemptId: parentAttemptId }
-    }));
+    });
   }
 
   private reloadData(): void {

--- a/src/app/modules/item/components/parent-skills/parent-skills.component.ts
+++ b/src/app/modules/item/components/parent-skills/parent-skills.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { itemDetailsUrl } from 'src/app/shared/helpers/item-route';
+import { ItemRouter } from 'src/app/shared/services/item-router';
 import { canCurrentUserViewItemContent } from '../../helpers/item-permissions';
 import { GetItemParentsService, ItemParent } from '../../http-services/get-item-parents.service';
 import { ItemData } from '../../services/item-datasource.service';
@@ -26,7 +25,7 @@ export class ParentSkillsComponent implements OnChanges, OnDestroy {
 
   constructor(
     private getItemParentsService: GetItemParentsService,
-    private router: Router,
+    private itemRouter: ItemRouter,
   ) {}
 
   ngOnChanges(_changes: SimpleChanges): void {
@@ -36,11 +35,11 @@ export class ParentSkillsComponent implements OnChanges, OnDestroy {
   click(parent: ItemParent&ParentSkillAdditions): void {
     if (!this.itemData || parent.isLocked) return;
 
-    void this.router.navigateByUrl(itemDetailsUrl(this.router, {
+    this.itemRouter.navigateTo({
       id: parent.id,
       path: this.itemData.route.path.slice(0, -1),
       attemptId: parent.result.attempt_id,
-    }));
+    });
   }
 
   private reloadData(): void {

--- a/src/app/modules/item/components/sub-skills/sub-skills.component.ts
+++ b/src/app/modules/item/components/sub-skills/sub-skills.component.ts
@@ -1,10 +1,9 @@
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { bestAttemptFromResults } from 'src/app/shared/helpers/attempts';
-import { itemDetailsUrl } from 'src/app/shared/helpers/item-route';
 import { isASkill } from 'src/app/shared/helpers/item-type';
+import { ItemRouter } from 'src/app/shared/services/item-router';
 import { canCurrentUserViewItemContent } from '../../helpers/item-permissions';
 import { GetItemChildrenService, ItemChild } from '../../http-services/get-item-children.service';
 import { ItemData } from '../../services/item-datasource.service';
@@ -32,7 +31,7 @@ export class SubSkillsComponent implements OnChanges, OnDestroy {
 
   constructor(
     private getItemChildrenService: GetItemChildrenService,
-    private router: Router,
+    private itemRouter: ItemRouter,
   ) {}
 
   ngOnChanges(_changes: SimpleChanges): void {
@@ -44,11 +43,11 @@ export class SubSkillsComponent implements OnChanges, OnDestroy {
     const attemptId = child.result?.attempt_id;
     const parentAttemptId = this.itemData.currentResult?.attemptId;
     if (!parentAttemptId) return; // unexpected: children have been loaded, so we are sure this item has an attempt
-    void this.router.navigateByUrl(itemDetailsUrl(this.router, {
+    this.itemRouter.navigateTo({
       id: child.id,
       path: this.itemData.route.path.concat([ this.itemData.item.id ]),
       ...attemptId ? { attemptId: attemptId } : { parentAttemptId: parentAttemptId }
-    }));
+    });
   }
 
   private reloadData(): void {

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, UrlTree } from '@angular/router';
 import { of, Subscription } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { defaultAttemptId } from 'src/app/shared/helpers/attempts';
@@ -64,7 +64,7 @@ export class ItemByIdComponent implements OnDestroy {
             path: state.data.breadcrumbs.map(el => ({
               title: el.title,
               hintNumber: el.attemptCnt,
-              navigateTo: itemRouter.url(el.route),
+              navigateTo: ():UrlTree => itemRouter.url(el.route),
             })),
             currentPageIdx: state.data.breadcrumbs.length - 1,
           },

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { of, Subscription } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import { defaultAttemptId } from 'src/app/shared/helpers/attempts';
-import { appDefaultItemRoute, isItemRouteError, itemDetailsUrl, itemRouteFromParams, itemUrl } from 'src/app/shared/helpers/item-route';
+import { appDefaultItemRoute, isItemRouteError, itemRouteFromParams } from 'src/app/shared/helpers/item-route';
 import { FetchError, Fetching, isReady, Ready } from 'src/app/shared/helpers/state';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { CurrentContentService, EditAction, isItemInfo, ItemInfo } from 'src/app/shared/services/current-content.service';
+import { ItemRouter } from 'src/app/shared/services/item-router';
 import { GetItemPathService } from '../../http-services/get-item-path';
 import { ItemDataSource, ItemData } from '../../services/item-datasource.service';
 
@@ -26,7 +27,7 @@ export class ItemByIdComponent implements OnDestroy {
   private subscriptions: Subscription[] = []; // subscriptions to be freed up on destroy
 
   constructor(
-    private router: Router,
+    private itemRouter: ItemRouter,
     private activatedRoute: ActivatedRoute,
     private currentContent: CurrentContentService,
     private itemDataSource: ItemDataSource,
@@ -63,7 +64,7 @@ export class ItemByIdComponent implements OnDestroy {
             path: state.data.breadcrumbs.map(el => ({
               title: el.title,
               hintNumber: el.attemptCnt,
-              navigateTo: itemDetailsUrl(this.router, el.route),
+              navigateTo: itemRouter.url(el.route),
             })),
             currentPageIdx: state.data.breadcrumbs.length - 1,
           },
@@ -87,9 +88,7 @@ export class ItemByIdComponent implements OnDestroy {
       ).subscribe(action => {
         const currentInfo = this.currentContent.current.value;
         if (isItemInfo(currentInfo)) {
-          void this.router.navigateByUrl(
-            itemUrl(this.router, currentInfo.data.route, action === EditAction.StartEditing ? 'edit' : 'details')
-          );
+          this.itemRouter.navigateTo(currentInfo.data.route, action === EditAction.StartEditing ? 'edit' : 'details');
         }
       })
     );
@@ -117,8 +116,8 @@ export class ItemByIdComponent implements OnDestroy {
         );
       })
     ).subscribe(
-      itemRoute => void this.router.navigateByUrl(itemDetailsUrl(this.router, itemRoute)),
-      _err => void this.router.navigateByUrl(itemDetailsUrl(this.router, appDefaultItemRoute()))
+      itemRoute => this.itemRouter.navigateTo(itemRoute),
+      _err => this.itemRouter.navigateTo(appDefaultItemRoute())
     );
   }
 

--- a/src/app/modules/item/pages/item-edit/item-edit.component.html
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.html
@@ -5,7 +5,7 @@
   <p *ngIf="state.tag === 'error'">Error while loading the item</p>
 
   <div *ngIf="state.tag === 'ready' && (itemData$ | async) as itemData" style="margin: 1rem 0 0.5rem 0">
-    <form [formGroup]="itemForm">
+    <form [formGroup]="itemForm" *ngIf="['all','all_with_grant'].includes(itemData.item.permissions.can_edit); else notAuthorized">
 
       <div class="header">
         <alg-input [parentForm]="itemForm" name="title" size="large" [isDark]='false'></alg-input>
@@ -33,6 +33,9 @@
 
     </form>
     <alg-floating-save *ngIf="itemForm.dirty" [saving]="itemForm.disabled" (save)="save()" (cancel)="resetForm()"></alg-floating-save>
+    <ng-template #notAuthorized>
+      <p>You do not have the permissions to edit this content.</p>
+    </ng-template>
   </div>
 
 </ng-container>

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -1,11 +1,11 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { Router } from '@angular/router';
 import { BehaviorSubject, concat, EMPTY, forkJoin, Observable, of, Subject, Subscription } from 'rxjs';
 import { catchError, filter, map, switchMap } from 'rxjs/operators';
 import { bestAttemptFromResults, implicitResultStart } from 'src/app/shared/helpers/attempts';
-import { isRouteWithAttempt, ItemRoute, incompleteItemUrl } from 'src/app/shared/helpers/item-route';
+import { isRouteWithAttempt, ItemRoute } from 'src/app/shared/helpers/item-route';
 import { errorState, FetchError, Fetching, fetchingState, isReady, Ready, readyState } from 'src/app/shared/helpers/state';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
+import { ItemRouter } from 'src/app/shared/services/item-router';
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { BreadcrumbItem, GetBreadcrumbService } from '../http-services/get-breadcrumb.service';
 import { GetItemByIdService, Item } from '../http-services/get-item-by-id.service';
@@ -40,7 +40,7 @@ export class ItemDataSource implements OnDestroy {
     private resultActionsService: ResultActionsService,
     private getResultsService: GetResultsService,
     private userSessionService: UserSessionService,
-    private router: Router,
+    private itemRouter: ItemRouter,
   ) {
     this.fetchOperation.pipe(
 
@@ -137,7 +137,7 @@ export class ItemDataSource implements OnDestroy {
         if (res === 'forbidden') {
           // clear the route & attempt and retry to visit this item (path/attempt discovery will be called)
           // ideally routing should not be called inside the datasource and maximum number of tries should be allowed
-          void this.router.navigateByUrl(incompleteItemUrl(this.router, item.id));
+          this.itemRouter.navigateToIncompleteItem(item.id);
           throw new Error('unhandled forbidden');
         } else {
           return res;

--- a/src/app/shared/helpers/item-route.ts
+++ b/src/app/shared/helpers/item-route.ts
@@ -1,4 +1,4 @@
-import { ParamMap, Router, UrlTree } from '@angular/router';
+import { ParamMap } from '@angular/router';
 import { defaultAttemptId } from './attempts';
 import { appConfig } from './config';
 import { isSkill, ItemTypeCategory } from './item-type';
@@ -14,23 +14,12 @@ export type ItemRouteWithParentAttempt = ItemRouteCommon & { parentAttemptId: At
 export type ItemRoute = ItemRouteWithAttempt | ItemRouteWithParentAttempt;
 
 /* url parameter names */
-const parentAttemptParamName = 'parentAttempId';
-const attemptParamName = 'attempId';
-const pathParamName = 'path';
+export const parentAttemptParamName = 'parentAttempId';
+export const attemptParamName = 'attempId';
+export const pathParamName = 'path';
 
 export function isRouteWithAttempt(item: ItemRoute): item is ItemRouteWithAttempt {
   return 'attemptId' in item;
-}
-
-/**
- * Build, from an item route, an url for navigation
- */
-export function itemUrl(router: Router, item: ItemRoute, page: 'edit'|'details'): UrlTree {
-  const params: {[k: string]: any} = {};
-  if (isRouteWithAttempt(item)) params[attemptParamName] = item.attemptId;
-  else params[parentAttemptParamName] = item.parentAttemptId;
-  params[pathParamName] = item.path;
-  return router.createUrlTree([ 'items', 'by-id', item.id, params, page ]);
 }
 
 /**
@@ -45,13 +34,6 @@ export function appDefaultItemRoute(cat: ItemTypeCategory = 'activity'): ItemRou
 }
 
 /**
- * Build an url to an item with missing path and attempt
- */
-export function incompleteItemUrl(router: Router, itemId: string): UrlTree {
-  return router.createUrlTree([ 'items', 'by-id', itemId ]);
-}
-
-/**
  * Url (as string) of the details page for the given item route
  */
 export function itemStringUrl(item: ItemRoute): string {
@@ -60,14 +42,6 @@ export function itemStringUrl(item: ItemRoute): string {
     `${parentAttemptParamName}=${item.parentAttemptId}`;
 
   return `/items/by-id/${item.id};${attemptPart};${pathParamName}=${item.path.join(',')}/details`;
-}
-
-export function itemDetailsUrl(router: Router, item: ItemRoute): UrlTree {
-  return itemUrl(router, item, 'details');
-}
-
-export function itemEditUrl(router: Router, item: ItemRoute): UrlTree {
-  return itemUrl(router, item, 'edit');
 }
 
 export interface ItemRouteError {

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -9,7 +9,7 @@ export interface ContentBreadcrumb {
   path: {
     title: string,
     hintNumber?: number,
-    navigateTo?: UrlTree,
+    navigateTo?: UrlTree|(() => UrlTree),
   }[],
   currentPageIdx: number, // index of the current page in the path array, -1 to select the category
 }

--- a/src/app/shared/services/item-router.ts
+++ b/src/app/shared/services/item-router.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRoute, Router, UrlTree } from '@angular/router';
+import { ItemRoute, isRouteWithAttempt, attemptParamName, parentAttemptParamName, pathParamName } from '../helpers/item-route';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ItemRouter {
+
+  constructor(
+    private router: Router,
+    private route: ActivatedRoute,
+  ) {}
+
+  /**
+   * Navigate to given item, on the path page.
+   * [not implemented yet] If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
+   */
+  navigateTo(item: ItemRoute, path?: 'edit'|'details'): void {
+    void this.router.navigateByUrl(this.url(item, path));
+  }
+
+  /**
+   * Navigate to an item with missing path and attempt
+   */
+  navigateToIncompleteItem(itemId: string): void {
+    void this.router.navigate([ 'items', 'by-id', itemId ]);
+  }
+
+  /**
+   * Return a url to given item, on the path page.
+   * [not implemented yet] If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
+   */
+  url(item: ItemRoute, path?: 'edit'|'details'): UrlTree {
+    const dest = path || 'details';
+    const params: {[k: string]: any} = {};
+    if (isRouteWithAttempt(item)) params[attemptParamName] = item.attemptId;
+    else params[parentAttemptParamName] = item.parentAttemptId;
+    params[pathParamName] = item.path;
+    return this.router.createUrlTree([ 'items', 'by-id', item.id, params, dest ]);
+  }
+
+}

--- a/src/app/shared/services/item-router.ts
+++ b/src/app/shared/services/item-router.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRoute, Router, UrlTree } from '@angular/router';
+import { Router, UrlTree } from '@angular/router';
 import { ItemRoute, isRouteWithAttempt, attemptParamName, parentAttemptParamName, pathParamName } from '../helpers/item-route';
 
 @Injectable({
@@ -9,12 +9,11 @@ export class ItemRouter {
 
   constructor(
     private router: Router,
-    private route: ActivatedRoute,
   ) {}
 
   /**
    * Navigate to given item, on the path page.
-   * [not implemented yet] If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
+   * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
   navigateTo(item: ItemRoute, path?: 'edit'|'details'): void {
     void this.router.navigateByUrl(this.url(item, path));
@@ -29,15 +28,27 @@ export class ItemRouter {
 
   /**
    * Return a url to given item, on the path page.
-   * [not implemented yet] If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
+   * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
   url(item: ItemRoute, path?: 'edit'|'details'): UrlTree {
-    const dest = path || 'details';
+    const dest = path ? [ path ] : (this.currentPage() || [ 'details' ]);
     const params: {[k: string]: any} = {};
     if (isRouteWithAttempt(item)) params[attemptParamName] = item.attemptId;
     else params[parentAttemptParamName] = item.parentAttemptId;
     params[pathParamName] = item.path;
-    return this.router.createUrlTree([ 'items', 'by-id', item.id, params, dest ]);
+    return this.router.createUrlTree([ 'items', 'by-id', item.id, params ].concat(dest));
+  }
+
+  /**
+   * Extract (bit hacky) the item sub-page of the current page.
+   * Return undefined if we are not on an "item" page
+   */
+  private currentPage(): string[]|undefined {
+    const currentPageUrlChildren = this.router.parseUrl(this.router.url).root.children;
+    if (!('primary' in currentPageUrlChildren)) return undefined;
+    const segments = currentPageUrlChildren['primary'].segments;
+    if (segments.length < 3 || segments[0].path !== 'items' || segments[1].path !== 'by-id') return undefined;
+    return segments.slice(3).map(segment => segment.path);
   }
 
 }


### PR DESCRIPTION
Edit workflow step 3: stay on the same "subpage" when navigating from an item to another
- Rewrite a bit item-route: create a new router service
- keep the same page
- Do not display the edit page if the perm does not allow it. Was not done before!!!