### PR TITLE
display the 'groups' tab when it is active, even if it does not know yet whether the user is connected or not

### DIFF
--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -22,7 +22,7 @@
     </ng-template>
   </p-tabPanel>
 
-  <p-tabPanel *ngIf="session && !session.user.isTemp">
+  <p-tabPanel *ngIf="activeTabIndex === 2 || (session && !session.user.isTemp)">
     <ng-template pTemplate="header" tabindex="7">
       <span class="indicator" class="dark"></span>
       <i class="fa fa-users"></i>


### PR DESCRIPTION
Fix that when going on a group page and refresh the page, the left nav menu didn't have "group" tab selected (while the content of the tab was the group tree)