### PR TITLE
Items decoding

### DIFF
--- a/src/app/modules/item/components/chapter-children/chapter-children.component.ts
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.ts
@@ -10,7 +10,7 @@ import { typeCategoryOfItem } from 'src/app/shared/helpers/item-type';
 interface ItemChildAdditions {
   isLocked: boolean,
   result?: {
-    attempt_id: string,
+    attemptId: string,
     validated: boolean,
     score: number,
   },
@@ -40,7 +40,7 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
 
   click(child: ItemChild&ItemChildAdditions): void {
     if (!this.itemData || child.isLocked) return;
-    const attemptId = child.result?.attempt_id;
+    const attemptId = child.result?.attemptId;
     const parentAttemptId = this.itemData.currentResult?.attemptId;
     if (!parentAttemptId) return; // unexpected: children have been loaded, so we are sure this item has an attempt
     this.itemRouter.navigateTo({
@@ -65,9 +65,9 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
                 ...child,
                 isLocked: !canCurrentUserViewItemContent(child),
                 result: res === null ? undefined : {
-                  attempt_id: res.attempt_id,
+                  attemptId: res.attemptId,
                   validated: res.validated,
-                  score: res.score,
+                  score: res.scoreComputed,
                 },
               };
             });

--- a/src/app/modules/item/components/parent-skills/parent-skills.component.html
+++ b/src/app/modules/item/components/parent-skills/parent-skills.component.html
@@ -19,7 +19,7 @@
           style="width: 25%;"
           type="thick-horizontal"
           [bestScore]="item.bestScore"
-          [currentScore]="item.result.score"
+          [currentScore]="item.result.scoreComputed"
         ></alg-skill-progress>
       </div>
     </li>

--- a/src/app/modules/item/components/parent-skills/parent-skills.component.ts
+++ b/src/app/modules/item/components/parent-skills/parent-skills.component.ts
@@ -40,7 +40,7 @@ export class ParentSkillsComponent implements OnChanges, OnDestroy {
       contentType: typeCategoryOfItem(parent),
       id: parent.id,
       path: this.itemData.route.path.slice(0, -1),
-      attemptId: parent.result.attempt_id,
+      attemptId: parent.result.attemptId,
     });
   }
 

--- a/src/app/modules/item/components/sub-skills/sub-skills.component.ts
+++ b/src/app/modules/item/components/sub-skills/sub-skills.component.ts
@@ -11,7 +11,7 @@ import { ItemData } from '../../services/item-datasource.service';
 interface SubSkillAdditions {
   isLocked: boolean,
   result?: {
-    attempt_id: string,
+    attemptId: string,
     score: number,
   },
 }
@@ -40,7 +40,7 @@ export class SubSkillsComponent implements OnChanges, OnDestroy {
 
   click(child: ItemChild&SubSkillAdditions): void {
     if (!this.itemData || child.isLocked) return;
-    const attemptId = child.result?.attempt_id;
+    const attemptId = child.result?.attemptId;
     const parentAttemptId = this.itemData.currentResult?.attemptId;
     if (!parentAttemptId) return; // unexpected: children have been loaded, so we are sure this item has an attempt
     this.itemRouter.navigateTo({
@@ -65,8 +65,8 @@ export class SubSkillsComponent implements OnChanges, OnDestroy {
                 ...child,
                 isLocked: !canCurrentUserViewItemContent(child),
                 result: res === null ? undefined : {
-                  attempt_id: res.attempt_id,
-                  score: res.score,
+                  attemptId: res.attemptId,
+                  score: res.scoreComputed,
                 },
               };
             })

--- a/src/app/modules/item/helpers/item-permissions.ts
+++ b/src/app/modules/item/helpers/item-permissions.ts
@@ -1,8 +1,15 @@
+import * as D from 'io-ts/Decoder';
+
+export const permissionsDecoder = D.struct({
+  canView: D.literal('none','info','content','content_with_descendants','solution'),
+  canEdit: D.literal('none','children','all','all_with_grant'),
+  canGrantView: D.literal('none','enter','content','content_with_descendants','solution','solution_with_grant'),
+});
+
+export type PermissionsInfo = D.TypeOf<typeof permissionsDecoder>;
 
 export interface ItemPermissionsInfo {
-  permissions: {
-    canView: 'none'|'info'|'content'|'content_with_descendants'|'solution',
-  }
+  permissions: PermissionsInfo
 }
 
 export function canCurrentUserViewItemContent(item: ItemPermissionsInfo): boolean {

--- a/src/app/modules/item/http-services/get-item-by-id.service.ts
+++ b/src/app/modules/item/http-services/get-item-by-id.service.ts
@@ -5,6 +5,7 @@ import { appConfig } from 'src/app/shared/helpers/config';
 import * as D from 'io-ts/Decoder';
 import { pipe } from 'fp-ts/lib/function';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
+import { permissionsDecoder } from '../helpers/item-permissions';
 
 export const itemDecoder = pipe(
   D.struct({
@@ -22,11 +23,7 @@ export const itemDecoder = pipe(
       )
     ),
     bestScore: D.number,
-    permissions: D.struct({
-      canView: D.literal('none','info','content','content_with_descendants','solution'),
-      canEdit: D.literal('none','children','all','all_with_grant'),
-      canGrantView: D.literal('none','enter','content','content_with_descendants','solution','solution_with_grant'),
-    }),
+    permissions: permissionsDecoder,
     type: D.literal('Chapter','Task','Course','Skill'),
     promptToJoinGroupByCode: D.boolean,
     textId: D.nullable(D.string),

--- a/src/app/modules/item/http-services/get-item-children.service.ts
+++ b/src/app/modules/item/http-services/get-item-children.service.ts
@@ -1,47 +1,32 @@
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { appConfig } from 'src/app/shared/helpers/config';
-import { ItemType } from 'src/app/shared/helpers/item-type';
-import { ItemPermissionsInfo } from '../helpers/item-permissions';
+import { permissionsDecoder } from '../helpers/item-permissions';
+import * as D from 'io-ts/Decoder';
+import { decodeSnakeCase } from 'src/app/shared/operators/decode';
+import { dateDecoder } from 'src/app/shared/helpers/decoders';
 
-interface RawItemChild extends ItemPermissionsInfo {
-  id: string,
-  best_score: number,
-  order: number,
-  string: {
-    title: string|null,
-  },
-  category: 'Undefined'|'Discovery'|'Application'|'Validation'|'Challenge',
-  type: ItemType,
-  results: {
-    attempt_id: string,
-    latest_activity_at: string,
-    started_at: string|null,
-    score_computed: number,
-    validated: boolean,
-  }[],
-}
+export const itemChildDecoder = D.struct({
+  id: D.string,
+  bestScore: D.number,
+  order: D.number,
+  string: D.struct({
+    title: D.nullable(D.string),
+  }),
+  category: D.literal('Undefined', 'Discovery', 'Application', 'Validation', 'Challenge'),
+  type: D.literal('Chapter','Task','Course','Skill'),
+  permissions: permissionsDecoder,
+  results: D.array(D.struct({
+    attemptId: D.string,
+    latestActivityAt: dateDecoder,
+    startedAt: D.nullable(dateDecoder),
+    scoreComputed: D.number,
+    validated: D.boolean,
+  }))
+});
 
-export interface ItemChild extends ItemPermissionsInfo {
-  id: string,
-  bestScore: number,
-  order: number,
-  string: {
-    title: string|null,
-  },
-  category: 'Undefined'|'Discovery'|'Application'|'Validation'|'Challenge',
-  type: ItemType,
-  results: {
-    attempt_id: string,
-    latestActivityAt: Date,
-    startedAt: Date|null,
-    score: number,
-    validated: boolean,
-  }[],
-}
-
+export type ItemChild = D.TypeOf<typeof itemChildDecoder>;
 
 @Injectable({
   providedIn: 'root'
@@ -54,24 +39,9 @@ export class GetItemChildrenService {
     let params = new HttpParams();
     params = params.set('attempt_id', attemptId);
     return this.http
-      .get<RawItemChild[]>(`${appConfig().apiUrl}/items/${id}/children`, { params: params })
+      .get<unknown[]>(`${appConfig().apiUrl}/items/${id}/children`, { params: params })
       .pipe(
-        map(children => children.map(c => ({
-          id: c.id,
-          bestScore: c.best_score,
-          order: c.order,
-          string: c.string,
-          category: c.category,
-          type: c.type,
-          results: c.results.map(r => ({
-            attempt_id: r.attempt_id,
-            latestActivityAt: new Date(r.latest_activity_at),
-            startedAt: r.started_at === null ? null : new Date(r.started_at),
-            score: r.score_computed,
-            validated: r.validated,
-          })),
-          permissions: c.permissions,
-        })))
+        decodeSnakeCase(D.array(itemChildDecoder))
       );
   }
 }

--- a/src/app/shared/helpers/decoders.ts
+++ b/src/app/shared/helpers/decoders.ts
@@ -1,0 +1,13 @@
+import { pipe } from 'fp-ts/lib/function';
+import * as D from 'io-ts/Decoder';
+
+/**
+ * Decoder for Date type
+ */
+export const dateDecoder: D.Decoder<unknown, Date> = pipe(
+  D.string,
+  D.parse(s => {
+    const date = Date.parse(s);
+    return isNaN(date) ? D.failure(s, "DateFromString") : D.success(new Date(date));
+  })
+);


### PR DESCRIPTION
Fixes #353 

After the PR #350, some consistency was lost in the naming of fiels (snake_case or CamelCase) which introduced bugs in other parts of the code, for example the `ItemPermissionsInfo` interface.
This broke the `ParentSkillsComponent` and `SubSkillsComponent` so I added decoding to the `get-item-children` and `get-item-parents` services to fix it.