### PR TITLE
Introduce a resetter for mapToFetchState and rewrite a fetching workflow with sort

### DIFF
--- a/src/app/core/http-services/joined-groups.service.ts
+++ b/src/app/core/http-services/joined-groups.service.ts
@@ -1,8 +1,9 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpParams } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { appConfig } from 'src/app/shared/helpers/config';
+import { SortOptions, sortOptionsToHTTP } from 'src/app/shared/helpers/sort-options';
 
 interface RawJoinedGroup{
   action: 'invitation_accepted' | 'join_request_accepted' | 'joined_by_code' | 'added_directly',
@@ -33,13 +34,9 @@ export class JoinedGroupsService {
 
   constructor(private http: HttpClient) {}
 
-  getJoinedGroups(
-    sort: string[] = [],
-  ): Observable<JoinedGroup[]> {
-    let params = new HttpParams();
-    if (sort.length > 0) params = params.set('sort', sort.join(','));
+  getJoinedGroups(sort: SortOptions): Observable<JoinedGroup[]> {
     return this.http
-      .get<RawJoinedGroup[]>(`${appConfig().apiUrl}/current-user/group-memberships`, { params: params })
+      .get<RawJoinedGroup[]>(`${appConfig().apiUrl}/current-user/group-memberships`, { params: sortOptionsToHTTP(sort) })
       .pipe(
         map(groups => groups.map(g => ({
           action: g.action,

--- a/src/app/modules/group/components/joined-group-list/joined-group-list.component.html
+++ b/src/app/modules/group/components/joined-group-list/joined-group-list.component.html
@@ -1,42 +1,44 @@
-<p *ngIf="state === 'error';else noError" class="alg-error-message">
-  <i class="fa fa-exclamation-triangle"></i>
-  <span i18n> Error while loading the group you joined</span>
-</p>
+<ng-container *ngIf="state$ | async as state">
+  <p *ngIf="state.isError" class="alg-error-message">
+    <i class="fa fa-exclamation-triangle"></i>
+    <span i18n> Error while loading the group you joined</span>
+  </p>
 
-<ng-template #noError>
-  <p-table #table
+  <p-table
+    *ngIf="!state.isError"
     class="alg-table --joined-group-list"
-    [value]="data"
+    [value]="state.data || []"
     [customSort]="true"
     sortMode="multiple"
     (sortFunction)="onCustomSort($event)"
-    [loading]="state === 'fetching'"
+    [loading]="state.isFetching"
   >
-  <ng-template pTemplate="header" let-columns>
-    <tr *ngIf="data.length > 0">
-        <th i18n>Name</th>
-        <th i18n>Type</th>
-        <th pSortableColumn="member_since">
-          <span i18n>Joined On</span>
-          <p-sortIcon field="member_since"></p-sortIcon>
-        </th>
-    </tr>
-  </ng-template>
+    <ng-template pTemplate="header" let-columns>
+      <tr *ngIf="state.isReady && state.data.length > 0">
+          <th i18n>Name</th>
+          <th i18n>Type</th>
+          <th pSortableColumn="member_since">
+            <span i18n>Joined On</span>
+            <p-sortIcon field="member_since"></p-sortIcon>
+          </th>
+      </tr>
+    </ng-template>
 
-  <ng-template pTemplate="body" let-group>
-    <tr>
-      <td>{{ group.group.name }}</td>
-      <td>{{ group.group.type }}</td>
-      <td>{{ group.memberSince | date:'short' }}</td>
-    </tr>
-  </ng-template>
+    <ng-template pTemplate="body" let-group>
+      <tr>
+        <td>{{ group.group.name }}</td>
+        <td>{{ group.group.type }}</td>
+        <td>{{ group.memberSince | date:'short' }}</td>
+      </tr>
+    </ng-template>
 
-  <ng-template pTemplate="emptymessage" let-columns>
-    <tr>
-      <td [attr.colspan]="columns.length">
-        <p class="empty-message" i18n>This list is empty.</p>
-      </td>
-    </tr>
-  </ng-template>
-</p-table>
-</ng-template>
+    <ng-template pTemplate="emptymessage" let-columns>
+      <tr>
+        <td [attr.colspan]="columns.length">
+          <p class="empty-message" i18n>This list is empty.</p>
+        </td>
+      </tr>
+    </ng-template>
+  </p-table>
+
+</ng-container>

--- a/src/app/modules/group/components/joined-group-list/joined-group-list.component.ts
+++ b/src/app/modules/group/components/joined-group-list/joined-group-list.component.ts
@@ -1,56 +1,35 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { Component, OnDestroy } from '@angular/core';
 import { SortEvent } from 'primeng/api';
-import { merge, of, Subject } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
-import { JoinedGroup, JoinedGroupsService } from 'src/app/core/http-services/joined-groups.service';
-import { fetchingState, readyState } from 'src/app/shared/helpers/state';
+import { ReplaySubject } from 'rxjs';
+import { distinctUntilChanged, startWith, switchMap } from 'rxjs/operators';
+import { JoinedGroupsService } from 'src/app/core/http-services/joined-groups.service';
+import { NO_SORT, sortEquals, multisortEventToOptions, SortOptions } from 'src/app/shared/helpers/sort-options';
+import { mapToFetchState } from 'src/app/shared/operators/state';
 
 @Component({
   selector: 'alg-joined-group-list',
   templateUrl: './joined-group-list.component.html',
   styleUrls: [ './joined-group-list.component.scss' ]
 })
-export class JoinedGroupListComponent implements OnDestroy, OnInit {
+export class JoinedGroupListComponent implements OnDestroy {
 
-  state: 'error' | 'ready' | 'fetching' = 'fetching';
-  currentSort: string[] = [];
+  private readonly sort$ = new ReplaySubject<SortOptions>(1);
+  readonly state$ = this.sort$.pipe(
+    startWith(NO_SORT),
+    distinctUntilChanged(sortEquals),
+    switchMap(sort => this.joinedGroupsService.getJoinedGroups(sort)),
+    mapToFetchState(),
+  );
 
-  data: JoinedGroup[] = [];
-
-  private dataFetching = new Subject<{ sort: string[] }>();
-
-  constructor(private joinedGroupsService:JoinedGroupsService) {
-    this.dataFetching.pipe(
-      switchMap(params =>
-        merge(
-          of(fetchingState()),
-          this.joinedGroupsService.getJoinedGroups(params.sort).pipe(map(readyState)),
-        )
-      )
-    ).subscribe(
-      state => {
-        this.state = state.tag;
-        if (state.isReady) this.data = state.data;
-      },
-      _err => this.state = 'error'
-    );
-  }
-
-  ngOnInit(): void {
-    this.dataFetching.next({ sort: this.currentSort });
-  }
+  constructor(private joinedGroupsService:JoinedGroupsService) {}
 
   ngOnDestroy(): void {
-    this.dataFetching.complete();
+    this.sort$.complete();
   }
 
   onCustomSort(event: SortEvent): void {
-    const sortMeta = event.multiSortMeta?.map(meta => (meta.order === -1 ? `-${meta.field}` : meta.field));
-
-    if (sortMeta && JSON.stringify(sortMeta) !== JSON.stringify(this.currentSort)) {
-      this.currentSort = sortMeta;
-      this.dataFetching.next({ sort: this.currentSort });
-    }
+    const sort = multisortEventToOptions(event);
+    if (sort) this.sort$.next(sort);
   }
 
 }

--- a/src/app/shared/helpers/sort-options.ts
+++ b/src/app/shared/helpers/sort-options.ts
@@ -1,0 +1,26 @@
+import { HttpParams } from "@angular/common/http";
+import { SortEvent } from "primeng/api";
+
+export interface SortOption {
+  field: string;
+  ascending: boolean;
+}
+export type SortOptions = readonly SortOption[];
+
+export const NO_SORT: SortOptions = [];
+
+export function multisortEventToOptions(event: SortEvent): SortOptions|undefined {
+  return event.multiSortMeta?.map(meta => ({ field: meta.field, ascending: meta.order >= 0 }));
+}
+
+export function sortEquals(sort1: SortOptions, sort2: SortOptions): boolean {
+  return JSON.stringify(sort1) === JSON.stringify(sort2);
+}
+
+export function sortOptionsToHTTP(opts: SortOptions): HttpParams {
+  let params = new HttpParams();
+  if (opts.length == 0) return params;
+  const apiFormatOpts = opts.map(opt => (opt.ascending ? opt.field : `-${opt.field}`));
+  params = params.set('sort', apiFormatOpts.join(','));
+  return params;
+}

--- a/src/app/shared/operators/state.spec.ts
+++ b/src/app/shared/operators/state.spec.ts
@@ -99,6 +99,48 @@ describe('mapToState', () => {
     });
   });
 
+  it('should retry work with a resetter not completing immediately', () => {
+    testScheduler.run(helpers => {
+      const { cold, expectObservable } = helpers;
+      const e1 =  cold('-a|');
+      const res = cold('----b----|');
+      const expected = 'fa--fa---|';
+
+      expectObservable(e1.pipe(
+        mapToFetchState({ resetter: res }),
+        stateToLetter(),
+      )).toBe(expected);
+    });
+  });
+
+  it('should retry work with multiple resets', () => {
+    testScheduler.run(helpers => {
+      const { cold, expectObservable } = helpers;
+      const e1 =  cold('-a|');
+      const res = cold('----b--b-----b|');
+      const expected = 'fa--fa-fa----fa|';
+
+      expectObservable(e1.pipe(
+        mapToFetchState({ resetter: res }),
+        stateToLetter(),
+      )).toBe(expected);
+    });
+  });
+
+  it('should retry even after a source failure', () => {
+    testScheduler.run(helpers => {
+      const { cold, expectObservable } = helpers;
+      const e1 =  cold('-e|');
+      const res = cold('----b--b--|');
+      const expected = 'fe--fe-fe-|';
+
+      expectObservable(e1.pipe(
+        mapToFetchState({ resetter: res }),
+        stateToLetter(),
+      )).toBe(expected);
+    });
+  });
+
 });
 
 


### PR DESCRIPTION
1. Introduce a resetter for mapToFetchState

So that is can be used for a upcoming feature. Should be useful refreshing after an action as well.
Basically it is used to reput the state to "fetching" and resubscribe (so re-run) to the service call.

2. Rewrite a fetching workflow with sort

It is already better (much simpler) but there are still some aspects I am not very happy with:
- This version keeps the current version displayed (not frozen) while fetching, which is actually ok for sorting. If I use the resetter to set it to fetching, as it has no data, it does not display data greyed-out while fetching which is less practical at the end.
- After reloading a sorted table, p-table call a second time the "onCustomSort" function with the same parameter. Which means that the distinctUntilChanged is required to prevent infinite looping... I find this quite error prone.
- If I use `sort$` as resetter, I need also to apply `distinctUntilChanged` on it, otherwise I get also a infinite reload. Not convenient.
- Maybe we should have an operator just to do a sort and generate fetchState... (left for later) 