### PR TITLE
Do not refresh all on observation

### DIFF
--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
-import { UserSession, UserSessionService } from '../shared/services/user-session.service';
-import { delay, filter, map, skip } from 'rxjs/operators';
+import { UserSessionService } from '../shared/services/user-session.service';
+import { delay, map, skip } from 'rxjs/operators';
 import { Observable, Subscription } from 'rxjs';
 import { CurrentContentService } from '../shared/services/current-content.service';
 import { AuthService, AuthServiceState } from '../shared/auth/auth.service';
@@ -37,10 +37,9 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     // each time there is a new user, refresh the page
-    this.subscription = this.sessionService.session$.pipe(
-      filter<UserSession|undefined, UserSession>((session):session is UserSession => !!session),
+    this.subscription = this.sessionService.user$.pipe(
       skip(1), // do not refresh when the first user is set
-    ).subscribe(_session => {
+    ).subscribe(_user => {
       // Navigate to the root with an ugly hack to make sure the full content is reloaded
       void this.router.navigateByUrl('/groups/me', { skipLocationChange: true }).then(() => this.router.navigateByUrl('/'));
     });

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, HostListener, OnDestroy, OnInit } from '@angular/core';
 import { UserSessionService } from '../shared/services/user-session.service';
-import { delay, map, skip } from 'rxjs/operators';
+import { delay, map, skip, switchMap } from 'rxjs/operators';
 import { Observable, Subscription } from 'rxjs';
 import { CurrentContentService } from '../shared/services/current-content.service';
 import { AuthService, AuthServiceState } from '../shared/auth/auth.service';
@@ -36,13 +36,11 @@ export class AppComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    // each time there is a new user, refresh the page
+    // if user changes, navigate back to the root
     this.subscription = this.sessionService.user$.pipe(
       skip(1), // do not refresh when the first user is set
-    ).subscribe(_user => {
-      // Navigate to the root with an ugly hack to make sure the full content is reloaded
-      void this.router.navigateByUrl('/groups/me', { skipLocationChange: true }).then(() => this.router.navigateByUrl('/'));
-    });
+      switchMap(() => this.router.navigateByUrl('/')),
+    ).subscribe();
   }
 
   ngOnDestroy(): void {

--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -3,7 +3,7 @@
   [styleClass]="'dark'"
   (onChange)="onSelectionChangedByIdx($event)"
   [(activeIndex)]="activeTabIndex"
-  *ngrxLet="session$ as session"
+  *ngIf="currentUser$|async as currentUser"
 >
 
   <p-tabPanel>
@@ -22,7 +22,7 @@
     </ng-template>
   </p-tabPanel>
 
-  <p-tabPanel *ngIf="activeTabIndex === 2 || (session && !session.user.tempUser)">
+  <p-tabPanel *ngIf="activeTabIndex === 2 || currentUser.tempUser">
     <ng-template pTemplate="header" tabindex="7">
       <span class="indicator dark"></span>
       <i class="fa fa-users"></i>

--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -22,7 +22,7 @@
     </ng-template>
   </p-tabPanel>
 
-  <p-tabPanel *ngIf="activeTabIndex === 2 || currentUser.tempUser">
+  <p-tabPanel *ngIf="activeTabIndex === 2 || !currentUser.tempUser">
     <ng-template pTemplate="header" tabindex="7">
       <span class="indicator dark"></span>
       <i class="fa fa-users"></i>

--- a/src/app/core/components/left-nav/left-nav.component.ts
+++ b/src/app/core/components/left-nav/left-nav.component.ts
@@ -29,7 +29,7 @@ export class LeftNavComponent implements OnInit, OnDestroy {
     new LeftNavSkillDataSource(this.itemNavigationService),
     new LeftNavGroupDataSource(this.groupNavigationService),
   ];
-  session$ = this.sessionService.session$.pipe(delay(0));
+  currentUser$ = this.sessionService.user$.pipe(delay(0));
 
   private subscription?: Subscription;
 

--- a/src/app/modules/group/pages/current-user/current-user.component.ts
+++ b/src/app/modules/group/pages/current-user/current-user.component.ts
@@ -1,15 +1,10 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { contentInfo } from 'src/app/shared/models/content/content-info';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
-import { CurrentUserHttpService, UserProfile } from 'src/app/shared/http-services/current-user.service';
-import { Observable } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
-import { UserSession, UserSessionService } from 'src/app/shared/services/user-session.service';
-import { isNotNullOrUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
+import { CurrentUserHttpService } from 'src/app/shared/http-services/current-user.service';
 import { ActionFeedbackService } from '../../../../shared/services/action-feedback.service';
 import { LocaleService } from '../../../../core/services/localeService';
-
-const currentUserBreadcrumbCat = $localize`Yourself`;
+import { UserSessionService } from 'src/app/shared/services/user-session.service';
 
 @Component({
   selector: 'alg-current-user',
@@ -17,7 +12,7 @@ const currentUserBreadcrumbCat = $localize`Yourself`;
   styleUrls: [ './current-user.component.scss' ],
 })
 export class CurrentUserComponent implements OnInit, OnDestroy {
-  currentUser$?: Observable<UserProfile>;
+  currentUser$ = this.userSessionService.user$;
 
   constructor(
     private currentContent: CurrentContentService,
@@ -25,15 +20,10 @@ export class CurrentUserComponent implements OnInit, OnDestroy {
     private currentUser: CurrentUserHttpService,
     private actionFeedbackService: ActionFeedbackService,
     private localeService: LocaleService,
-  ) {
-    this.currentContent.current.next(contentInfo({ breadcrumbs: { category: currentUserBreadcrumbCat, path: [], currentPageIdx: -1 } }));
-  }
+  ) {}
 
   ngOnInit(): void {
-    this.currentUser$ = this.userSessionService.session$.pipe(
-      filter(isNotNullOrUndefined),
-      map((session: UserSession) => session.user)
-    );
+    this.currentContent.current.next(contentInfo({ breadcrumbs: { category: $localize`Yourself`, path: [], currentPageIdx: -1 } }));
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/group/pages/current-user/current-user.component.ts
+++ b/src/app/modules/group/pages/current-user/current-user.component.ts
@@ -5,7 +5,7 @@ import { CurrentUserHttpService, UserProfile } from 'src/app/shared/http-service
 import { Observable } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { UserSession, UserSessionService } from 'src/app/shared/services/user-session.service';
-import { isNotNullOrUndefined } from 'src/app/shared/helpers/is-not-null-or-undefined';
+import { isNotNullOrUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { ActionFeedbackService } from '../../../../shared/services/action-feedback.service';
 import { LocaleService } from '../../../../core/services/localeService';
 

--- a/src/app/shared/helpers/is-not-null-or-undefined.ts
+++ b/src/app/shared/helpers/is-not-null-or-undefined.ts
@@ -1,3 +1,0 @@
-export function isNotNullOrUndefined<T>(input: null | undefined | T): input is T {
-  return input !== null && input !== undefined;
-}

--- a/src/app/shared/helpers/null-undefined-predicates.ts
+++ b/src/app/shared/helpers/null-undefined-predicates.ts
@@ -1,0 +1,12 @@
+
+export function isNotNullOrUndefined<T>(e: T|null|undefined): e is T {
+  return e !== null && e !== undefined;
+}
+
+export function isNotNull<T>(e: T|null): e is T {
+  return e !== null;
+}
+
+export function isNotUndefined<T>(e: T|undefined): e is T {
+  return e !== undefined;
+}

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { of, EMPTY, BehaviorSubject, Subscription } from 'rxjs';
 import { AuthService } from '../auth/auth.service';
-import { switchMap, catchError, distinctUntilChanged } from 'rxjs/operators';
+import { switchMap, catchError, distinctUntilChanged, map, filter } from 'rxjs/operators';
 import { CurrentUserHttpService, UserProfile } from '../http-services/current-user.service';
 import { Group } from 'src/app/modules/group/http-services/get-group-by-id.service';
+import { isNotUndefined } from '../helpers/null-undefined-predicates';
 
 export interface UserSession {
   user: UserProfile,
@@ -16,6 +17,13 @@ export interface UserSession {
 export class UserSessionService implements OnDestroy {
 
   session$ = new BehaviorSubject<UserSession|undefined>(undefined)
+
+  /** currently-connected user profile, temporary or not, excluding transient (undefined) states */
+  user$ = this.session$.pipe(
+    filter(isNotUndefined),
+    map(session => session.user),
+    distinctUntilChanged((u1, u2) => u1.groupId === u2.groupId)
+  );
 
   private subscription?: Subscription;
 


### PR DESCRIPTION
Currently, if we enable "observation" on a group, you are being redirected on the homepage of the platform. 
Improve the behavior by redirecting to home only if the user changes (and so on logout).
Was also the opportunity to reorganize a bit session/user observables.