### PR TITLE
`mapToFetchState`: add previous data to fetching state

### DIFF
--- a/src/app/shared/helpers/state.ts
+++ b/src/app/shared/helpers/state.ts
@@ -1,15 +1,15 @@
 
-export type FetchState<T> = Ready<T>|Fetching|FetchError;
+export type FetchState<T> = Ready<T>|Fetching<T>|FetchError;
 export type Ready<T> = Readonly<{ tag: 'ready', isReady: true, data: T, isFetching: false, isError: false, error?: undefined }>;
-export type Fetching = Readonly<{ tag: 'fetching', isReady: false, data?: undefined, isFetching: true, isError: false, error?: undefined }>;
+export type Fetching<T> = Readonly<{ tag: 'fetching', isReady: false, data?: T, isFetching: true, isError: false, error?: undefined }>;
 export type FetchError = Readonly<{ tag: 'error', isReady: false, data?: undefined, isFetching: false, isError: true, error: Error }>;
 
 export function readyState<T>(data: T): Ready<T> {
   return { tag: 'ready', isReady: true, data: data, isFetching: false, isError: false };
 }
 
-export function fetchingState(): Fetching {
-  return { tag: 'fetching', isReady: false, isFetching: true, isError: false };
+export function fetchingState<T = undefined>(data?: T): Fetching<T> {
+  return { tag: 'fetching', isReady: false, data: data, isFetching: true, isError: false };
 }
 
 export function errorState(error: Error): FetchError {

--- a/src/app/shared/operators/state.spec.ts
+++ b/src/app/shared/operators/state.spec.ts
@@ -148,6 +148,62 @@ describe('mapToState', () => {
     });
   });
 
+  it('should allow several fetching states with no data', () => {
+    testScheduler.run(helpers => {
+      const { cold, expectObservable } = helpers;
+      const e1 =  cold('---1|');
+      const res = cold('-0------|'); // the values are not important for the resetter
+      const expected = 'ff--a---|';
+
+      expectObservable(e1.pipe(
+        mapToFetchState({ resetter: res }),
+        stateToLetter(),
+      )).toBe(expected);
+    });
+  });
+
+  it('should pass data between fetching states', () => {
+    testScheduler.run(helpers => {
+      const { cold, expectObservable } = helpers;
+      const e1 =  cold('--1|');
+      const res = cold('----00----|'); // the values are not important for the resetter
+      const expected = 'f-a-gg-a--|';
+
+      expectObservable(e1.pipe(
+        mapToFetchState({ resetter: res }),
+        stateToLetter(),
+      )).toBe(expected);
+    });
+  });
+
+  it('should not replay the last data after a failure', () => {
+    testScheduler.run(helpers => {
+      const { cold, expectObservable } = helpers;
+      const e1 =  cold('-1-#');
+      const res = cold('-------0------|');
+      const expected = 'fa-x---fa-x---|';
+
+      expectObservable(e1.pipe(
+        mapToFetchState({ resetter: res }),
+        stateToLetter(),
+      )).toBe(expected);
+    });
+  });
+
+  it('should change the data in state as expected', () => {
+    testScheduler.run(helpers => {
+      const { cold, expectObservable } = helpers;
+      const e1 =  cold('--1--2|');
+      const res = cold('----0------0-----|'); // the values are not important for the resetter
+      const expected = 'f-a-g-a--b-h-a--b|';
+
+      expectObservable(e1.pipe(
+        mapToFetchState({ resetter: res }),
+        stateToLetter(),
+      )).toBe(expected);
+    });
+  });
+
 });
 
 

--- a/src/app/shared/operators/state.spec.ts
+++ b/src/app/shared/operators/state.spec.ts
@@ -7,19 +7,26 @@ import { mapStateData, mapToFetchState, readyData } from './state';
 
 const stateToLetter = (): OperatorFunction<FetchState<string>, string> => pipe(
   map(state => {
-    if (state.isReady) return state.data;
-    if (state.isFetching) return 'f';
-    if (state.isError) return 'e';
-    return '?';
+    if (state.isReady && state.data === '1') return 'a';
+    if (state.isReady && state.data === '2') return 'b';
+    if (state.isFetching && !state.data) return 'f';
+    if (state.isFetching && state.data === '1') return 'g';
+    if (state.isFetching && state.data === '2') return 'h';
+    if (state.isError) return 'x';
+    throw new Error('encoding error');
   })
 );
 
 const letterToState = (): OperatorFunction<string, FetchState<string>> => pipe(
   map(l => {
     switch (l) {
+      case 'a': return readyState('1');
+      case 'b': return readyState('2');
       case 'f': return fetchingState();
-      case 'e': return errorState(new Error());
-      default: return readyState(l);
+      case 'g': return fetchingState('1');
+      case 'h': return fetchingState('2');
+      case 'x': return errorState(new Error());
+      default: throw new Error('decoding error');
     }
   })
 );
@@ -37,7 +44,7 @@ describe('mapToState', () => {
   it('should work with 1 event', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e1 =  cold('---a---|');
+      const e1 =  cold('---1---|');
       const expected = 'f--a---|';
 
       expectObservable(e1.pipe(
@@ -63,7 +70,7 @@ describe('mapToState', () => {
   it('should work with several events', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e1 =  cold('--a-b--|');
+      const e1 =  cold('--1-2--|');
       const expected = 'f-a-b--|';
 
       expectObservable(e1.pipe(
@@ -77,7 +84,7 @@ describe('mapToState', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
       const e1 =  cold('------- #');
-      const expected = 'f------(e|)';
+      const expected = 'f------(x|)';
 
       expectObservable(e1.pipe(
         mapToFetchState(),
@@ -89,8 +96,8 @@ describe('mapToState', () => {
   it('should work with an event followed by an error', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e1 =  cold('---a--- #');
-      const expected = 'f--a---(e|)';
+      const e1 =  cold('---1--- #');
+      const expected = 'f--a---(x|)';
 
       expectObservable(e1.pipe(
         mapToFetchState(),
@@ -102,9 +109,9 @@ describe('mapToState', () => {
   it('should retry work with a resetter not completing immediately', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e1 =  cold('-a|');
-      const res = cold('----b----|');
-      const expected = 'fa--fa---|';
+      const e1 =  cold('-1|');
+      const res = cold('----0----|'); // the values are not important for the resetter
+      const expected = 'fa--ga---|';
 
       expectObservable(e1.pipe(
         mapToFetchState({ resetter: res }),
@@ -116,9 +123,9 @@ describe('mapToState', () => {
   it('should retry work with multiple resets', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e1 =  cold('-a|');
-      const res = cold('----b--b-----b|');
-      const expected = 'fa--fa-fa----fa|';
+      const e1 =  cold('-1|');
+      const res = cold('----0--0-----0|'); // the values are not important for the resetter
+      const expected = 'fa--ga-ga----ga|';
 
       expectObservable(e1.pipe(
         mapToFetchState({ resetter: res }),
@@ -130,9 +137,9 @@ describe('mapToState', () => {
   it('should retry even after a source failure', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e1 =  cold('-e|');
-      const res = cold('----b--b--|');
-      const expected = 'fe--fe-fe-|';
+      const e1 =  cold('-#|');
+      const res = cold('----0--0--|');
+      const expected = 'fx--fx-fx-|';
 
       expectObservable(e1.pipe(
         mapToFetchState({ resetter: res }),
@@ -157,8 +164,8 @@ describe('readyData', () => {
   it('should keep only ready events (and not to skip some)', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e =   cold('-f-a-b-f-e-#');
-      const expected = '---a-b-----#';
+      const e =   cold('-f-a-b-f-g-x-#');
+      const expected = '---1-2-------#';
 
       expectObservable(e.pipe(
         letterToState(),
@@ -183,12 +190,12 @@ describe('mapStateData', () => {
   it('should work as expected', () => {
     testScheduler.run(helpers => {
       const { cold, expectObservable } = helpers;
-      const e =   cold('-f-a-b-f-e-#');
-      const expected = '-f-z-z-f-e-#';
+      const e =   cold('-f-a-b-g-x-#');
+      const expected = '-f-b-b-h-x-#';
 
       expectObservable(e.pipe(
         letterToState(),
-        mapStateData(_x => 'z'),
+        mapStateData(_x => '2'),
         stateToLetter(),
       )).toBe(expected);
     });

--- a/src/app/shared/operators/state.spec.ts
+++ b/src/app/shared/operators/state.spec.ts
@@ -144,7 +144,7 @@ describe('mapToState', () => {
 });
 
 
-describe('readyState', () => {
+describe('readyData', () => {
 
   let testScheduler: TestScheduler;
 


### PR DESCRIPTION
Until now, using `mapToFetchState` did not allow to know the latest ready data when refetching. This is useful to reload while showing (even greyed out) the former data. For instance, not to have the full table emptying then back full when updating the members of a group.
This PR add to the "fetching state" the latest data, if any.

Better reviewed at a whole as I changed the way to proceed on the last commit as the first implementation was not fully working in any case.

I have still to update at least one place (group member remove) where the component had to handle that itself. But I'll do it in a separated PR.