### PR TITLE
Add layout service, sync headers display with menu

### DIFF
--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -40,7 +40,7 @@
     <div
       class="right"
       *ngrxLet="leftMenuAndHeaders$ as leftMenuAndHeaders"
-      [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders, 'with-mode-bar': currentMode !== 'normal' }"
+      [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders, 'with-mode-bar': currentMode !== 'normal', 'with-task': withTask$ | async }"
       >
       <div class="main-content">
         <router-outlet></router-outlet>

--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -40,7 +40,7 @@
     <div
       class="right"
       *ngrxLet="fullFrameContent$ as fullFrameContent"
-      [ngClass]="{ collapsed: !fullFrameContent, expanded: fullFrameContent, 'with-mode-bar': currentMode !== 'normal', 'with-footer': footer$ | async }"
+      [ngClass]="{ collapsed: !fullFrameContent, expanded: fullFrameContent, 'with-mode-bar': currentMode !== 'normal', 'with-footer': contentFooter$ | async }"
       >
       <div class="main-content">
         <router-outlet></router-outlet>

--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -1,22 +1,19 @@
 <div class="container" *ngrxLet="session$ as session">
-  <div class="left" [ngClass]="{ collapsed: !leftMenuDisplayed, expanded: leftMenuDisplayed }">
-    <alg-left-menu (hideLeftMenu)="toggleLeftMenuDisplay(false)"></alg-left-menu>
+  <div class="left" [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }">
+    <alg-left-menu></alg-left-menu>
   </div>
   <ng-container *ngIf="currentMode$ | async as currentMode">
-    <div class="top-bar" [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: !leftMenuDisplayed, expanded: leftMenuDisplayed }">
-      <alg-left-header
-        *ngIf="!leftMenuDisplayed"
-        (displayLeftMenu)="toggleLeftMenuDisplay($event)"
-        (displayHeaders)="toggleHeadersDisplay($event)"
-        [compactMode]="true"
-      ></alg-left-header>
+    <div class="top-bar"
+      [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }">
+      <alg-left-header *ngIf="!leftMenuAndHeaders" [compactMode]="true"></alg-left-header>
       <div class="top-right-bar" *ngrxLet="currentContent$ as currentContent">
         <alg-editor-bar *ngIf="currentMode === 'editing'" (cancel)="onEditCancel()"></alg-editor-bar>
-        <alg-observation-bar *ngIf="currentMode === 'watching'" [groupName]="session?.watchedGroup?.name || ''" (cancel)="onWatchCancel()"></alg-observation-bar>
-        <div class="breadcrumb-bar" *ngIf="headersDisplayed && !scrolled">
+        <alg-observation-bar *ngIf="currentMode === 'watching'" [groupName]="session?.watchedGroup?.name || ''"
+          (cancel)="onWatchCancel()"></alg-observation-bar>
+        <div class="breadcrumb-bar" *ngIf="leftMenuAndHeaders && !scrolled">
           <alg-breadcrumb [contentBreadcrumb]="currentContent?.breadcrumbs"></alg-breadcrumb>
         </div>
-        <div class="folded-top-bar" *ngIf="!headersDisplayed || scrolled">
+        <div class="folded-top-bar" *ngIf="!leftMenuAndHeaders || scrolled">
           <!--<alg-score-ring
             [displayedScore]="50"
             [currentScore]="60"
@@ -37,8 +34,9 @@
       </div>
       <alg-top-right-controls [drawLeftBorder]="currentMode === 'normal'"></alg-top-right-controls>
     </div>
-    <div class="right" [ngClass]="{ collapsed: !leftMenuDisplayed, expanded: leftMenuDisplayed, 'with-mode-bar': currentMode !== 'normal' }">
-      <div class="main-content" [ngClass]="{ folded: !headersDisplayed, unfolded: headersDisplayed }">
+    <div class="right"
+      [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders, 'with-mode-bar': currentMode !== 'normal' }">
+      <div class="main-content" [ngClass]="{ folded: !leftMenuAndHeaders, unfolded: leftMenuAndHeaders }">
         <router-outlet></router-outlet>
       </div>
     </div>
@@ -47,16 +45,10 @@
 <p-toast></p-toast>
 <p-confirmDialog></p-confirmDialog>
 <p-confirmPopup key="commonPopup"></p-confirmPopup>
-<p-dialog
-  *ngrxLet="fatalError$"
-  i18n-header="@@auth-error-modal-title" header="Error"
-  [visible]="true"
-  [style]="{width: '50vw'}"
-  [modal]="true"
-  [closeOnEscape]="false"
-  [closable]="false"
->
-  <p i18n="@@auth-error-modal-context">Oops, we are unable to make the site work properly. Are you connected to the Internet?</p>
+<p-dialog *ngrxLet="fatalError$" i18n-header="@@auth-error-modal-title" header="Error" [visible]="true"
+  [style]="{width: '50vw'}" [modal]="true" [closeOnEscape]="false" [closable]="false">
+  <p i18n="@@auth-error-modal-context">Oops, we are unable to make the site work properly. Are you connected to the
+    Internet?</p>
   <p i18n="@@auth-error-modal-todo">Try to refresh the page. If this problem persists, please contact us.</p>
 </p-dialog>
 <alg-language-mismatch></alg-language-mismatch>

--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -1,10 +1,13 @@
 <div class="container" *ngrxLet="session$ as session">
-  <div class="left" [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }">
+  <div class="left" *ngrxLet="leftMenuAndHeaders$ as leftMenuAndHeaders" [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }">
     <alg-left-menu></alg-left-menu>
   </div>
   <ng-container *ngIf="currentMode$ | async as currentMode">
-    <div class="top-bar"
-      [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }">
+    <div
+      class="top-bar"
+      *ngrxLet="leftMenuAndHeaders$ as leftMenuAndHeaders"
+      [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }"
+      >
       <alg-left-header *ngIf="!leftMenuAndHeaders" [compactMode]="true"></alg-left-header>
       <div class="top-right-bar" *ngrxLet="currentContent$ as currentContent">
         <alg-editor-bar *ngIf="currentMode === 'editing'" (cancel)="onEditCancel()"></alg-editor-bar>
@@ -34,9 +37,12 @@
       </div>
       <alg-top-right-controls [drawLeftBorder]="currentMode === 'normal'"></alg-top-right-controls>
     </div>
-    <div class="right"
-      [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders, 'with-mode-bar': currentMode !== 'normal' }">
-      <div class="main-content" [ngClass]="{ folded: !leftMenuAndHeaders, unfolded: leftMenuAndHeaders }">
+    <div
+      class="right"
+      *ngrxLet="leftMenuAndHeaders$ as leftMenuAndHeaders"
+      [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders, 'with-mode-bar': currentMode !== 'normal' }"
+      >
+      <div class="main-content">
         <router-outlet></router-outlet>
       </div>
     </div>
@@ -45,10 +51,16 @@
 <p-toast></p-toast>
 <p-confirmDialog></p-confirmDialog>
 <p-confirmPopup key="commonPopup"></p-confirmPopup>
-<p-dialog *ngrxLet="fatalError$" i18n-header="@@auth-error-modal-title" header="Error" [visible]="true"
-  [style]="{width: '50vw'}" [modal]="true" [closeOnEscape]="false" [closable]="false">
-  <p i18n="@@auth-error-modal-context">Oops, we are unable to make the site work properly. Are you connected to the
-    Internet?</p>
+<p-dialog
+  *ngrxLet="fatalError$"
+  i18n-header="@@auth-error-modal-title" header="Error"
+  [visible]="true"
+  [style]="{width: '50vw'}"
+  [modal]="true"
+  [closeOnEscape]="false"
+  [closable]="false"
+>
+  <p i18n="@@auth-error-modal-context">Oops, we are unable to make the site work properly. Are you connected to the Internet?</p>
   <p i18n="@@auth-error-modal-todo">Try to refresh the page. If this problem persists, please contact us.</p>
 </p-dialog>
 <alg-language-mismatch></alg-language-mismatch>

--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -1,22 +1,22 @@
 <div class="container" *ngrxLet="session$ as session">
-  <div class="left" *ngrxLet="leftMenuAndHeaders$ as leftMenuAndHeaders" [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }">
+  <div class="left" *ngrxLet="fullFrameContent$ as fullFrameContent" [ngClass]="{ collapsed: !fullFrameContent, expanded: fullFrameContent }">
     <alg-left-menu></alg-left-menu>
   </div>
   <ng-container *ngIf="currentMode$ | async as currentMode">
     <div
       class="top-bar"
-      *ngrxLet="leftMenuAndHeaders$ as leftMenuAndHeaders"
-      [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders }"
+      *ngrxLet="fullFrameContent$ as fullFrameContent"
+      [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: !fullFrameContent, expanded: fullFrameContent }"
       >
-      <alg-left-header *ngIf="!leftMenuAndHeaders" [compactMode]="true"></alg-left-header>
+      <alg-left-header *ngIf="!fullFrameContent" [compactMode]="true"></alg-left-header>
       <div class="top-right-bar" *ngrxLet="currentContent$ as currentContent">
         <alg-editor-bar *ngIf="currentMode === 'editing'" (cancel)="onEditCancel()"></alg-editor-bar>
         <alg-observation-bar *ngIf="currentMode === 'watching'" [groupName]="session?.watchedGroup?.name || ''"
           (cancel)="onWatchCancel()"></alg-observation-bar>
-        <div class="breadcrumb-bar" *ngIf="leftMenuAndHeaders && !scrolled">
+        <div class="breadcrumb-bar" *ngIf="fullFrameContent && !scrolled">
           <alg-breadcrumb [contentBreadcrumb]="currentContent?.breadcrumbs"></alg-breadcrumb>
         </div>
-        <div class="folded-top-bar" *ngIf="!leftMenuAndHeaders || scrolled">
+        <div class="folded-top-bar" *ngIf="!fullFrameContent || scrolled">
           <!--<alg-score-ring
             [displayedScore]="50"
             [currentScore]="60"
@@ -39,8 +39,8 @@
     </div>
     <div
       class="right"
-      *ngrxLet="leftMenuAndHeaders$ as leftMenuAndHeaders"
-      [ngClass]="{ collapsed: !leftMenuAndHeaders, expanded: leftMenuAndHeaders, 'with-mode-bar': currentMode !== 'normal', 'with-task': withTask$ | async }"
+      *ngrxLet="fullFrameContent$ as fullFrameContent"
+      [ngClass]="{ collapsed: !fullFrameContent, expanded: fullFrameContent, 'with-mode-bar': currentMode !== 'normal', 'with-footer': footer$ | async }"
       >
       <div class="main-content">
         <router-outlet></router-outlet>

--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -1,22 +1,22 @@
 <div class="container" *ngrxLet="session$ as session">
-  <div class="left" *ngrxLet="fullFrameContent$ as fullFrameContent" [ngClass]="{ collapsed: !fullFrameContent, expanded: fullFrameContent }">
+  <div class="left" *ngrxLet="fullFrameContent$ as fullFrameContent" [ngClass]="{ collapsed: fullFrameContent, expanded: !fullFrameContent }">
     <alg-left-menu></alg-left-menu>
   </div>
   <ng-container *ngIf="currentMode$ | async as currentMode">
     <div
       class="top-bar"
       *ngrxLet="fullFrameContent$ as fullFrameContent"
-      [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: !fullFrameContent, expanded: fullFrameContent }"
+      [ngClass]="{ 'with-mode-bar': currentMode !== 'normal', collapsed: fullFrameContent, expanded: !fullFrameContent }"
       >
-      <alg-left-header *ngIf="!fullFrameContent" [compactMode]="true"></alg-left-header>
+      <alg-left-header *ngIf="fullFrameContent" [compactMode]="true"></alg-left-header>
       <div class="top-right-bar" *ngrxLet="currentContent$ as currentContent">
         <alg-editor-bar *ngIf="currentMode === 'editing'" (cancel)="onEditCancel()"></alg-editor-bar>
         <alg-observation-bar *ngIf="currentMode === 'watching'" [groupName]="session?.watchedGroup?.name || ''"
           (cancel)="onWatchCancel()"></alg-observation-bar>
-        <div class="breadcrumb-bar" *ngIf="fullFrameContent && !scrolled">
+        <div class="breadcrumb-bar" *ngIf="!fullFrameContent && !scrolled">
           <alg-breadcrumb [contentBreadcrumb]="currentContent?.breadcrumbs"></alg-breadcrumb>
         </div>
-        <div class="folded-top-bar" *ngIf="!fullFrameContent || scrolled">
+        <div class="folded-top-bar" *ngIf="fullFrameContent || scrolled">
           <!--<alg-score-ring
             [displayedScore]="50"
             [currentScore]="60"
@@ -40,7 +40,7 @@
     <div
       class="right"
       *ngrxLet="fullFrameContent$ as fullFrameContent"
-      [ngClass]="{ collapsed: !fullFrameContent, expanded: fullFrameContent, 'with-mode-bar': currentMode !== 'normal', 'with-footer': contentFooter$ | async }"
+      [ngClass]="{ collapsed: fullFrameContent, expanded: !fullFrameContent, 'with-mode-bar': currentMode !== 'normal', 'with-footer': contentFooter$ | async }"
       >
       <div class="main-content">
         <router-outlet></router-outlet>

--- a/src/app/core/app.component.scss
+++ b/src/app/core/app.component.scss
@@ -216,6 +216,10 @@ a:hover {
       }
     }
 
+    &.with-task {
+      padding-bottom: 0;
+    }
+
     .main-content {
       padding-left: 1.6667rem;
       // background-color: $base-bk-color;

--- a/src/app/core/app.component.scss
+++ b/src/app/core/app.component.scss
@@ -202,7 +202,8 @@ a:hover {
   .right {
     margin-left: 34rem;
     padding-top: 3.75rem;
-    padding-bottom: 5rem;
+    padding-bottom: 0;
+
     // background-color: $base-bk-color;
     position: relative;
 
@@ -216,8 +217,8 @@ a:hover {
       }
     }
 
-    &.with-task {
-      padding-bottom: 0;
+    &.with-footer {
+      padding-bottom: 5rem;
     }
 
     .main-content {

--- a/src/app/core/app.component.scss
+++ b/src/app/core/app.component.scss
@@ -2,9 +2,8 @@
 @import "src/geometry.scss";
 
 :host {
-  font-family: "titillium", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
-    "Segoe UI Symbol";
+  font-family: "titillium", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   font-size: 1.2rem;
   color: #333;
   box-sizing: border-box;
@@ -77,7 +76,7 @@ a:hover {
     height: 3.75rem;
     display: flex;
     align-items: flex-start;
-    border-bottom: .1rem solid #e0e1e5;
+    border-bottom: 0.1rem solid #e0e1e5;
     background-color: $base-bk-color;
     z-index: 900;
 
@@ -217,12 +216,25 @@ a:hover {
       }
     }
 
+    .main-content {
+      padding-left: 1.6667rem;
+      // background-color: $base-bk-color;
+    }
+
     &.collapsed {
       margin-left: 0;
       transition: margin-left 1s;
       -webkit-transition: margin-left 1s;
       -moz-transition: margin-left 1s;
       -o-transition: margin-left 1s;
+
+      .main-content {
+        margin-top: -12.0833rem;
+        transition: margin-top 1s;
+        -webkit-transition: margin-top 1s;
+        -moz-transition: margin-top 1s;
+        -o-transition: margin-top 1s;
+      }
     }
 
     &.expanded {
@@ -230,21 +242,8 @@ a:hover {
       -webkit-transition: margin-left 1s;
       -moz-transition: margin-left 1s;
       -o-transition: margin-left 1s;
-    }
 
-    .main-content {
-      padding-left: 1.6667rem;
-      // background-color: $base-bk-color;
-
-      &.folded {
-        margin-top: -12.0833rem;
-        transition: margin-top 1s;
-        -webkit-transition: margin-top 1s;
-        -moz-transition: margin-top 1s;
-        -o-transition: margin-top 1s;
-      }
-
-      &.unfolded {
+      .main-content {
         margin-top: 0 !important;
         transition: margin-top 1s;
         -webkit-transition: margin-top 1s;

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -27,8 +27,8 @@ export class AppComponent implements OnInit, OnDestroy {
     this.localeService.currentLangError$,
   );
 
-  leftMenuAndHeaders$ = this.layoutService.leftMenuAndHeadersDisplayed$;
-  withTask$ = this.layoutService.withTask$;
+  fullFrameContent$ = this.layoutService.fullFrameContent$;
+  footer$ = this.layoutService.footer$;
   scrolled = false;
 
   private subscription?: Subscription;

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -28,6 +28,7 @@ export class AppComponent implements OnInit, OnDestroy {
   );
 
   leftMenuAndHeaders$ = this.layoutService.leftMenuAndHeadersDisplayed$;
+  withTask$ = this.layoutService.withTask$;
   scrolled = false;
 
   private subscription?: Subscription;

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -27,8 +27,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.localeService.currentLangError$,
   );
 
-  leftMenuAndHeaders = true;
-  leftMenuAndHeadersSubscription? : Subscription;
+  leftMenuAndHeaders$ = this.layoutService.leftMenuAndHeadersDisplayed$;
   scrolled = false;
 
   private subscription?: Subscription;
@@ -41,11 +40,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private modeService: ModeService,
     private localeService: LocaleService,
     private layoutService: LayoutService,
-  ) {
-    this.leftMenuAndHeadersSubscription = this.layoutService.leftMenuAndHeadersDisplayed$.subscribe(shown => {
-      this.leftMenuAndHeaders = shown;
-    });
-  }
+  ) {}
 
   ngOnInit(): void {
     // if user changes, navigate back to the root
@@ -56,7 +51,6 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscription?.unsubscribe();
-    this.leftMenuAndHeadersSubscription?.unsubscribe();
   }
 
   @HostListener('window:scroll', [ '$event' ])

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -28,7 +28,7 @@ export class AppComponent implements OnInit, OnDestroy {
   );
 
   fullFrameContent$ = this.layoutService.fullFrameContent$;
-  footer$ = this.layoutService.footer$;
+  contentFooter$ = this.layoutService.contentFooter$;
   scrolled = false;
 
   private subscription?: Subscription;

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -8,6 +8,7 @@ import { Router } from '@angular/router';
 import { ModeAction, ModeService } from '../shared/services/mode.service';
 import { ContentInfo } from '../shared/models/content/content-info';
 import { LocaleService } from './services/localeService';
+import { LayoutService } from '../shared/services/layout.service';
 
 @Component({
   selector: 'alg-root',
@@ -26,8 +27,8 @@ export class AppComponent implements OnInit, OnDestroy {
     this.localeService.currentLangError$,
   );
 
-  leftMenuDisplayed = true;
-  headersDisplayed = true;
+  leftMenuAndHeaders = true;
+  leftMenuAndHeadersSubscription? : Subscription;
   scrolled = false;
 
   private subscription?: Subscription;
@@ -39,7 +40,12 @@ export class AppComponent implements OnInit, OnDestroy {
     private currentContent: CurrentContentService,
     private modeService: ModeService,
     private localeService: LocaleService,
-  ) {}
+    private layoutService: LayoutService,
+  ) {
+    this.leftMenuAndHeadersSubscription = this.layoutService.leftMenuAndHeadersDisplayed$.subscribe(shown => {
+      this.leftMenuAndHeaders = shown;
+    });
+  }
 
   ngOnInit(): void {
     // if user changes, navigate back to the root
@@ -50,15 +56,7 @@ export class AppComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscription?.unsubscribe();
-  }
-
-  toggleLeftMenuDisplay(shown: boolean): void {
-    this.leftMenuDisplayed = shown;
-    if (shown) this.headersDisplayed = true;
-  }
-
-  toggleHeadersDisplay(shown: boolean): void {
-    this.headersDisplayed = shown;
+    this.leftMenuAndHeadersSubscription?.unsubscribe();
   }
 
   @HostListener('window:scroll', [ '$event' ])

--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -1,8 +1,7 @@
 <div class="nav-header" *ngIf="!compactMode">
   <div class="nav-control">
     <span class="nav-collapse" (click)="hideLeftMenuAndHeaders()" tabindex="0">
-      <!-- <i class="fa fa-bars"></i> -->
-      <img src="assets/images/menu-open.svg" style="width: 2rem; height: 2rem;" />
+      <i class="fas fa-expand-arrows-alt" style="font-size: 2rem;"></i>
     </span>
     <span class="platform-info">
       <span class="platform-name" i18n>Algorea Platform</span>
@@ -12,6 +11,6 @@
 
 <div class="nav-control alt" *ngIf="compactMode">
   <span class="nav-collapse" (click)="showLeftMenuAndHeaders()" tabindex="0">
-    <img src="assets/images/menu-open.svg" style="width: 2rem; height: 2rem;" />
+    <i class="fas fa-compress-arrows-alt" style="font-size: 2rem;"></i>
   </span>
 </div>

--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -1,16 +1,16 @@
 <div class="nav-header" *ngIf="!compactMode">
   <div class="nav-control">
-    <span class="nav-collapse" (click)="setFullFrameContent()" tabindex="0">
-      <i class="fas fa-expand-arrows-alt" style="font-size: 2rem;"></i>
-    </span>
     <span class="platform-info">
       <span class="platform-name" i18n>Algorea Platform</span>
+    </span>
+    <span class="nav-collapse" (click)="setFullFrameContent()" tabindex="0">
+      <i class="fas fa-angle-double-left"></i>
     </span>
   </div>
 </div>
 
 <div class="nav-control alt" *ngIf="compactMode">
   <span class="nav-collapse" (click)="unsetFullFrameContent()" tabindex="0">
-    <i class="fas fa-compress-arrows-alt" style="font-size: 2rem;"></i>
+    <i class="fas fa-angle-double-right"></i>
   </span>
 </div>

--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -1,6 +1,6 @@
 <div class="nav-header" *ngIf="!compactMode">
   <div class="nav-control">
-    <span class="nav-collapse" (click)="hideLeftMenuAndHeaders()" tabindex="0">
+    <span class="nav-collapse" (click)="setFullFrameContent()" tabindex="0">
       <i class="fas fa-expand-arrows-alt" style="font-size: 2rem;"></i>
     </span>
     <span class="platform-info">
@@ -10,7 +10,7 @@
 </div>
 
 <div class="nav-control alt" *ngIf="compactMode">
-  <span class="nav-collapse" (click)="showLeftMenuAndHeaders()" tabindex="0">
+  <span class="nav-collapse" (click)="unsetFullFrameContent()" tabindex="0">
     <i class="fas fa-compress-arrows-alt" style="font-size: 2rem;"></i>
   </span>
 </div>

--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -4,13 +4,13 @@
       <span class="platform-name" i18n>Algorea Platform</span>
     </span>
     <span class="nav-collapse" (click)="setFullFrameContent()" tabindex="0">
-      <i class="fas fa-angle-double-left"></i>
+      <i class="fas fa-chevron-circle-left"></i>
     </span>
   </div>
 </div>
 
 <div class="nav-control alt" *ngIf="compactMode">
   <span class="nav-collapse" (click)="unsetFullFrameContent()" tabindex="0">
-    <i class="fas fa-angle-double-right"></i>
+    <i class="fas fa-chevron-circle-right"></i>
   </span>
 </div>

--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -1,6 +1,7 @@
 <div class="nav-header" *ngIf="!compactMode">
   <div class="nav-control">
-    <span class="nav-collapse" (click)="hideLeftMenu()" tabindex="0">
+    <span class="nav-collapse" (click)="hideLeftMenuAndHeaders()" tabindex="0">
+      <!-- <i class="fa fa-bars"></i> -->
       <img src="assets/images/menu-open.svg" style="width: 2rem; height: 2rem;" />
     </span>
     <span class="platform-info">
@@ -10,10 +11,7 @@
 </div>
 
 <div class="nav-control alt" *ngIf="compactMode">
-  <span class="nav-collapse" (click)="showLeftMenu()" tabindex="0">
-    <img src="assets/images/menu-open.svg" style="width: 2rem; height: 2rem;"/>
-  </span>
-  <span class="title-collapse" (click)="toggleHeadersDisplay()" [ngClass]="{down: !showHeaders}">
-    <img src="assets/images/header-open.svg" style="width: 1rem;"/>
+  <span class="nav-collapse" (click)="showLeftMenuAndHeaders()" tabindex="0">
+    <img src="assets/images/menu-open.svg" style="width: 2rem; height: 2rem;" />
   </span>
 </div>

--- a/src/app/core/components/left-header/left-header.component.scss
+++ b/src/app/core/components/left-header/left-header.component.scss
@@ -20,12 +20,6 @@ $nav-control-border: #5c5c5c;
   &.alt {
     background-color: $nav-bk-color;
 
-    .nav-collapse {
-      img {
-        transform: rotate(360deg);
-      }
-    }
-
     .notifications {
       margin-left: 0.4167rem;
       margin-right: 0;
@@ -42,8 +36,9 @@ $nav-control-border: #5c5c5c;
     display: flex;
     align-items: center;
     cursor: pointer;
-    img {
-      transform: rotate(180deg);
+
+    > i {
+      font-size: 2rem;
     }
   }
 

--- a/src/app/core/components/left-header/left-header.component.scss
+++ b/src/app/core/components/left-header/left-header.component.scss
@@ -8,7 +8,7 @@ $nav-control-border: #5c5c5c;
 
 .nav-control {
   color: white;
-  height: 4rem;
+  height: 3.75rem;
   padding-left: 1rem;
   padding-right: 1rem;
   border-bottom: 0.1rem solid $nav-control-border;

--- a/src/app/core/components/left-header/left-header.component.scss
+++ b/src/app/core/components/left-header/left-header.component.scss
@@ -11,7 +11,7 @@ $nav-control-border: #5c5c5c;
   height: 4rem;
   padding-left: 1rem;
   padding-right: 1rem;
-  border-bottom: .1rem solid $nav-control-border;
+  border-bottom: 0.1rem solid $nav-control-border;
   position: relative;
   text-align: center;
   display: flex;
@@ -26,20 +26,9 @@ $nav-control-border: #5c5c5c;
       }
     }
 
-    .title-collapse {
-      margin-left: 1rem;
-      margin-right: 1rem;
-      padding-left: 1rem;
-      padding-right: 1rem;
-      cursor: pointer;
-      display: flex;
-      align-items: center;
-      flex-direction: column;
-      justify-content: center;
-
-      &.down {
-        transform: rotate(180deg);
-      }
+    .notifications {
+      margin-left: 0.4167rem;
+      margin-right: 0;
     }
   }
 

--- a/src/app/core/components/left-header/left-header.component.scss
+++ b/src/app/core/components/left-header/left-header.component.scss
@@ -19,11 +19,6 @@ $nav-control-border: #5c5c5c;
 
   &.alt {
     background-color: $nav-bk-color;
-
-    .notifications {
-      margin-left: 0.4167rem;
-      margin-right: 0;
-    }
   }
 
   span {

--- a/src/app/core/components/left-header/left-header.component.ts
+++ b/src/app/core/components/left-header/left-header.component.ts
@@ -19,11 +19,11 @@ export class LeftHeaderComponent {
   ) { }
 
   setFullFrameContent(): void {
-    this.layoutService.toggleFullFrameContent(false);
+    this.layoutService.toggleFullFrameContent(true);
   }
 
   unsetFullFrameContent(): void {
-    this.layoutService.toggleFullFrameContent(true);
+    this.layoutService.toggleFullFrameContent(false);
   }
 
   login(): void {

--- a/src/app/core/components/left-header/left-header.component.ts
+++ b/src/app/core/components/left-header/left-header.component.ts
@@ -18,12 +18,12 @@ export class LeftHeaderComponent {
     private layoutService: LayoutService
   ) { }
 
-  hideLeftMenuAndHeaders(): void {
-    this.layoutService.toggleLeftMenuAndHeaders(false);
+  setFullFrameContent(): void {
+    this.layoutService.toggleFullFrameContent(false);
   }
 
-  showLeftMenuAndHeaders(): void {
-    this.layoutService.toggleLeftMenuAndHeaders(true);
+  unsetFullFrameContent(): void {
+    this.layoutService.toggleFullFrameContent(true);
   }
 
   login(): void {

--- a/src/app/core/components/left-header/left-header.component.ts
+++ b/src/app/core/components/left-header/left-header.component.ts
@@ -1,5 +1,6 @@
-import { Component, Output, EventEmitter, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { AuthService } from 'src/app/shared/auth/auth.service';
+import { LayoutService } from 'src/app/shared/services/layout.service';
 
 @Component({
   selector: 'alg-left-header',
@@ -10,26 +11,19 @@ export class LeftHeaderComponent {
 
   @Input() compactMode = false;
 
-  @Output() displayLeftMenu = new EventEmitter<boolean>();
-  @Output() displayHeaders = new EventEmitter<boolean>();
-
   showHeaders = true;
 
   constructor(
-    private authService: AuthService
+    private authService: AuthService,
+    private layoutService: LayoutService
   ) { }
 
-  hideLeftMenu(): void {
-    this.displayLeftMenu.emit(false);
+  hideLeftMenuAndHeaders(): void {
+    this.layoutService.toggleLeftMenuAndHeaders(false);
   }
 
-  showLeftMenu(): void {
-    this.displayLeftMenu.emit(true);
-  }
-
-  toggleHeadersDisplay(): void {
-    this.showHeaders = !this.showHeaders;
-    this.displayHeaders.emit(this.showHeaders);
+  showLeftMenuAndHeaders(): void {
+    this.layoutService.toggleLeftMenuAndHeaders(true);
   }
 
   login(): void {

--- a/src/app/core/components/left-menu/left-menu.component.html
+++ b/src/app/core/components/left-menu/left-menu.component.html
@@ -1,4 +1,4 @@
-<alg-left-header (displayLeftMenu)="toggleDisplay($event)"></alg-left-header>
+<alg-left-header></alg-left-header>
 <perfect-scrollbar class="left-nav-theme scrollbar" [ngClass]="{'dark': isNavThemeDark}">
   <alg-left-nav (themeChange)="onNavThemeChange($event)"></alg-left-nav>
 </perfect-scrollbar>

--- a/src/app/core/components/left-menu/left-menu.component.ts
+++ b/src/app/core/components/left-menu/left-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Output } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'alg-left-menu',
@@ -7,13 +7,7 @@ import { Component, EventEmitter, Output } from '@angular/core';
 })
 export class LeftMenuComponent {
 
-  @Output() hideLeftMenu = new EventEmitter<void>();
-
   isNavThemeDark = false;
-
-  toggleDisplay(shown: boolean): void {
-    if (!shown) this.hideLeftMenu.emit();
-  }
 
   onNavThemeChange(event: string | null): void {
     this.isNavThemeDark = event === 'dark';

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -8,17 +8,17 @@ import { delay } from 'rxjs/operators';
 export class LayoutService {
   // Service allowing modifications of the layout
 
-  private leftMenuAndHeadersDisplayed = new BehaviorSubject<boolean>(true);
-  leftMenuAndHeadersDisplayed$ = this.leftMenuAndHeadersDisplayed.asObservable().pipe(delay(0));
+  private fullFrameContent = new BehaviorSubject<boolean>(true);
+  fullFrameContent$ = this.fullFrameContent.asObservable().pipe(delay(0));
 
-  private withTask = new BehaviorSubject<boolean>(false);
-  withTask$ = this.withTask.asObservable().pipe(delay(0));
+  private footer = new BehaviorSubject<boolean>(false);
+  footer$ = this.footer.asObservable().pipe(delay(0));
 
-  toggleLeftMenuAndHeaders(shown: boolean): void {
-    this.leftMenuAndHeadersDisplayed.next(shown);
+  toggleFullFrameContent(shown: boolean): void {
+    this.fullFrameContent.next(shown);
   }
 
-  toggleWithTask(newState: boolean): void {
-    this.withTask.next(newState);
+  toggleWithFooter(shown: boolean): void {
+    this.footer.next(shown);
   }
 }

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -14,12 +14,8 @@ export class LayoutService {
   private withTask = new BehaviorSubject<boolean>(false);
   withTask$ = this.withTask.asObservable().pipe(delay(0));
 
-  toggleLeftMenuAndHeaders(shown?: boolean): void {
-    if (shown !== undefined) {
-      this.leftMenuAndHeadersDisplayed.next(shown);
-    } else {
-      this.leftMenuAndHeadersDisplayed.next(!this.leftMenuAndHeadersDisplayed.value);
-    }
+  toggleLeftMenuAndHeaders(shown: boolean): void {
+    this.leftMenuAndHeadersDisplayed.next(shown);
   }
 
   toggleWithTask(newState: boolean): void {

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LayoutService {
+  // Service allowing modifications of the layout
+
+  private leftMenuAndHeadersDisplayed = new BehaviorSubject<boolean>(true);
+  leftMenuAndHeadersDisplayed$ = this.leftMenuAndHeadersDisplayed.asObservable();
+
+  toggleLeftMenuAndHeaders(shown?: boolean): void {
+    if (shown !== undefined) {
+      this.leftMenuAndHeadersDisplayed.next(shown);
+    } else {
+      this.leftMenuAndHeadersDisplayed.next(!this.leftMenuAndHeadersDisplayed.value);
+    }
+  }
+}

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -11,11 +11,18 @@ export class LayoutService {
   private leftMenuAndHeadersDisplayed = new BehaviorSubject<boolean>(true);
   leftMenuAndHeadersDisplayed$ = this.leftMenuAndHeadersDisplayed.asObservable().pipe(delay(0));
 
+  private withTask = new BehaviorSubject<boolean>(false);
+  withTask$ = this.withTask.asObservable().pipe(delay(0));
+
   toggleLeftMenuAndHeaders(shown?: boolean): void {
     if (shown !== undefined) {
       this.leftMenuAndHeadersDisplayed.next(shown);
     } else {
       this.leftMenuAndHeadersDisplayed.next(!this.leftMenuAndHeadersDisplayed.value);
     }
+  }
+
+  toggleWithTask(newState: boolean): void {
+    this.withTask.next(newState);
   }
 }

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -13,7 +13,9 @@ export class LayoutService {
   fullFrameContent$ = this.fullFrameContent.asObservable().pipe(delay(0));
 
   private contentFooter = new BehaviorSubject<boolean>(true);
-  /** Adds a blank footer to the content area */
+  /**
+   * Adds a blank footer to the content area
+   * Disabled for instance for displaying a task, as the task iframe is set to fill the screen to the bottom */
   contentFooter$ = this.contentFooter.asObservable().pipe(delay(0));
 
   /** Set fullFrameContent, which expands the content by hiding the left menu and select headers */

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -8,17 +8,21 @@ import { delay } from 'rxjs/operators';
 export class LayoutService {
   // Service allowing modifications of the layout
 
-  private fullFrameContent = new BehaviorSubject<boolean>(true);
+  private fullFrameContent = new BehaviorSubject<boolean>(false);
+  /** Expands the content by hiding the left menu and select headers */
   fullFrameContent$ = this.fullFrameContent.asObservable().pipe(delay(0));
 
-  private footer = new BehaviorSubject<boolean>(false);
-  footer$ = this.footer.asObservable().pipe(delay(0));
+  private contentFooter = new BehaviorSubject<boolean>(true);
+  /** Adds a blank footer to the content area */
+  contentFooter$ = this.contentFooter.asObservable().pipe(delay(0));
 
+  /** Set fullFrameContent, which expands the content by hiding the left menu and select headers */
   toggleFullFrameContent(shown: boolean): void {
     this.fullFrameContent.next(shown);
   }
 
-  toggleWithFooter(shown: boolean): void {
-    this.footer.next(shown);
+  /** Set contentFooter, which adds a blank footer to the content side */
+  toggleContentFooter(shown: boolean): void {
+    this.contentFooter.next(shown);
   }
 }

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { delay } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
@@ -8,7 +9,7 @@ export class LayoutService {
   // Service allowing modifications of the layout
 
   private leftMenuAndHeadersDisplayed = new BehaviorSubject<boolean>(true);
-  leftMenuAndHeadersDisplayed$ = this.leftMenuAndHeadersDisplayed.asObservable();
+  leftMenuAndHeadersDisplayed$ = this.leftMenuAndHeadersDisplayed.asObservable().pipe(delay(0));
 
   toggleLeftMenuAndHeaders(shown?: boolean): void {
     if (shown !== undefined) {


### PR DESCRIPTION
Add a layout service allowing components to act on the layout (currently whether the left menu and headers are opened). This will be used by the item-display component, to close the left menu and headers automatically when displaying a task.

Also sync the display of the headers with the display of the left menu, as decided, to reduce the number of clicks.