### PR TITLE
fix problem with auth by cookie when cross site

### DIFF
--- a/src/app/core/app.module.ts
+++ b/src/app/core/app.module.ts
@@ -17,6 +17,7 @@ import { BreadcrumbComponent } from './components/breadcrumb/breadcrumb.componen
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 
 import { AuthTokenInjector } from '../shared/interceptors/auth_token_injector.interceptor';
+import { CredentialsInterceptor } from '../shared/interceptors/credentials.interceptor';
 import {
   TimeoutInterceptor,
   DEFAULT_TIMEOUT,
@@ -97,6 +98,11 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
     {
       provide: HTTP_INTERCEPTORS,
       useClass: AuthTokenInjector,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: CredentialsInterceptor,
       multi: true,
     },
     {

--- a/src/app/shared/interceptors/credentials.interceptor.ts
+++ b/src/app/shared/interceptors/credentials.interceptor.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpRequest,
+  HttpHandler,
+  HttpEvent,
+  HttpInterceptor
+} from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { appConfig } from '../helpers/config';
+
+@Injectable()
+export class CredentialsInterceptor implements HttpInterceptor {
+
+  constructor() {}
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    if (!req.url.toLowerCase().startsWith(appConfig.apiUrl)) {
+      return next.handle(req);
+    }
+
+    return next.handle(req.clone({ withCredentials: appConfig.authType === 'cookies' }));
+  }
+}

--- a/src/app/shared/interceptors/credentials.interceptor.ts
+++ b/src/app/shared/interceptors/credentials.interceptor.ts
@@ -18,6 +18,6 @@ export class CredentialsInterceptor implements HttpInterceptor {
       return next.handle(req);
     }
 
-    return next.handle(req.clone({ withCredentials: appConfig.authType === 'cookies' }));
+    return next.handle(req.clone({ withCredentials: appConfig.authType === 'cookies' && !appConfig.sameSite }));
   }
 }


### PR DESCRIPTION
Fixes #507

## Solution

Under the hood, Angular uses `XMLHttpRequest`. When the app is configured to be deployed under another domain, setting [withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials) option to `true` allows the server to set third party cookies.
The app configuration properties which pilot this behavior are `authType` and `sameSite`. When `authType === 'cookies' && sameSite === false`, credentials are enabled.

If authentication still doesn't work for algorea apps with another domain, it means that the user's browser is configured to block third party cookies, s⋅he will have to change to browser configuration.
