### PR TITLE
bugfix: ensure we do not expect children on chapter with can_view=info perm 

### DIFF
--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -126,7 +126,7 @@ function createNavMenuItem(raw: {
   return {
     id: raw.id,
     title: raw.string.title ?? '',
-    hasChildren: raw.has_visible_children && raw.permissions.can_view !== 'none' && raw.permissions.can_view !== 'info',
+    hasChildren: raw.has_visible_children && ![ 'none', 'info' ].includes(raw.permissions.can_view),
     attemptId: currentResult?.attemptId ?? null,
     canViewContent: [ 'content','content_with_descendants','solution' ].includes(raw.permissions.can_view),
     bestScore: raw.no_score ? undefined : raw.best_score,

--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -126,7 +126,7 @@ function createNavMenuItem(raw: {
   return {
     id: raw.id,
     title: raw.string.title ?? '',
-    hasChildren: raw.has_visible_children,
+    hasChildren: raw.has_visible_children && raw.permissions.can_view !== 'none' && raw.permissions.can_view !== 'info',
     attemptId: currentResult?.attemptId ?? null,
     canViewContent: [ 'content','content_with_descendants','solution' ].includes(raw.permissions.can_view),
     bestScore: raw.no_score ? undefined : raw.best_score,


### PR DESCRIPTION
Fix a bug: infinite loading spinner in menu when the item has can_view:info but has children.

Add extra checks to prevent this issue (will also ask the backend this "fix" that)