### PR TITLE
bugfix: make sure the 'via group ... ' indication is indicated for every root item, even non-chapters

### DIFF
--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.html
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.html
@@ -132,6 +132,7 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.data.element.title }}
+              <span *ngIf="node.data.element.groupName">(via group "{{ node.data.element.groupName }}")</span>
             </span>
           </span>
           <alg-skill-progress
@@ -228,6 +229,7 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.data.element.title }}
+              <span *ngIf="node.data.element.groupName">(via group "{{ node.data.element.groupName }}")</span>
             </span>
           </span>
         </span>


### PR DESCRIPTION
The 'via group...' was not given for tasks, courses and leaf skills.