### PR TITLE
Improve "Item route" related files

### DIFF
--- a/src/app/core/app-routing.module.ts
+++ b/src/app/core/app-routing.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
-import { appDefaultItemRoute, urlStringForItemRoute } from '../shared/routing/item-route';
+import { urlStringFromArray } from '../shared/helpers/url';
+import { appDefaultItemRoute, urlArrayForItemRoute } from '../shared/routing/item-route';
 import { PageNotFoundComponent } from './pages/page-not-found/page-not-found.component';
 
 const routes: Routes = [
   {
     path: '',
-    redirectTo: urlStringForItemRoute(appDefaultItemRoute('activity')),
+    redirectTo: urlStringFromArray(urlArrayForItemRoute(appDefaultItemRoute('activity'))),
     pathMatch: 'full',
   },
   {

--- a/src/app/modules/group/components/associated-activity/associated-activity.component.ts
+++ b/src/app/modules/group/components/associated-activity/associated-activity.component.ts
@@ -3,7 +3,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Observable, of, ReplaySubject } from 'rxjs';
 import { catchError, distinct, map, switchMap } from 'rxjs/operators';
 import { GetItemByIdService } from 'src/app/modules/item/http-services/get-item-by-id.service';
-import { rawItemStringUrl } from 'src/app/shared/routing/item-route';
+import { urlArrayForRawItem } from 'src/app/shared/routing/item-route';
 import { SearchItemService } from 'src/app/modules/item/http-services/search-item.service';
 import { AddedContent } from 'src/app/modules/shared-components/components/add-content/add-content.component';
 import { ActivityType } from 'src/app/shared/helpers/item-type';
@@ -50,7 +50,7 @@ export class AssociatedActivityComponent implements ControlValueAccessor {
         this.getItemByIdService.get(id).pipe(map(item => item.string.title));
 
       return name.pipe(
-        map(name => ({ tag: 'existing-activity', id: id, name, path: rawItemStringUrl(id, 'activity') })),
+        map(name => ({ tag: 'existing-activity', id: id, name, path: urlArrayForRawItem(id, 'activity') })),
         catchError(err => {
           if (errorIsHTTPForbidden(err)) return of({
             tag: 'existing-activity', name: $localize`You don't have access to this activity.`, path: null

--- a/src/app/modules/group/components/associated-activity/associated-activity.component.ts
+++ b/src/app/modules/group/components/associated-activity/associated-activity.component.ts
@@ -3,7 +3,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Observable, of, ReplaySubject } from 'rxjs';
 import { catchError, distinct, map, switchMap } from 'rxjs/operators';
 import { GetItemByIdService } from 'src/app/modules/item/http-services/get-item-by-id.service';
-import { incompleteItemStringUrl } from 'src/app/shared/routing/item-route';
+import { rawItemStringUrl } from 'src/app/shared/routing/item-route';
 import { SearchItemService } from 'src/app/modules/item/http-services/search-item.service';
 import { AddedContent } from 'src/app/modules/shared-components/components/add-content/add-content.component';
 import { ActivityType } from 'src/app/shared/helpers/item-type';
@@ -50,7 +50,7 @@ export class AssociatedActivityComponent implements ControlValueAccessor {
         this.getItemByIdService.get(id).pipe(map(item => item.string.title));
 
       return name.pipe(
-        map(name => ({ tag: 'existing-activity', id: id, name, path: incompleteItemStringUrl(id, 'activity') })),
+        map(name => ({ tag: 'existing-activity', id: id, name, path: rawItemStringUrl(id, 'activity') })),
         catchError(err => {
           if (errorIsHTTPForbidden(err)) return of({
             tag: 'existing-activity', name: $localize`You don't have access to this activity.`, path: null

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -40,7 +40,7 @@
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
               </ng-container>
               <ng-container *ngSwitchCase="'item.string.title'">
-                <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | itemLink">
+                <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | rawItemLink">
                   {{ rowData.item.string.title }}
                 </a>
               </ng-container>

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -90,7 +90,7 @@ export class ItemByIdComponent implements OnDestroy {
           if (errorHasTag(state.error, breadcrumbServiceTag) && errorIsHTTPForbidden(state.error)) {
             if (this.hasRedirected) throw new Error('Too many redirections (unexpected)');
             this.hasRedirected = true;
-            this.itemRouter.navigateToIncompleteItemOfCurrentPage();
+            this.itemRouter.navigateToRawItemOfCurrentPage();
           }
           this.currentContent.clear();
         }

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -36,7 +36,7 @@ export class ItemByIdComponent implements OnDestroy {
   // to prevent looping indefinitely in case of bug in services (wrong path > item without path > fetch path > item with path > wrong path)
   hasRedirected = false;
 
-  readonly defaultItemRoute = this.itemRouter.urlArray(appDefaultItemRoute());
+  readonly defaultItemRoute = this.itemRouter.url(appDefaultItemRoute()).toString();
 
   private subscriptions: Subscription[] = []; // subscriptions to be freed up on destroy
 
@@ -70,7 +70,7 @@ export class ItemByIdComponent implements OnDestroy {
               path: state.data.breadcrumbs.map(el => ({
                 title: el.title,
                 hintNumber: el.attemptCnt,
-                navigateTo: ():UrlTree => itemRouter.urlTree(el.route),
+                navigateTo: ():UrlTree => itemRouter.url(el.route),
               })),
               currentPageIdx: state.data.breadcrumbs.length - 1,
             },

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -40,7 +40,7 @@
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
               </ng-container>
               <ng-container *ngSwitchCase="'item.string.title'">
-                <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | itemLink">
+                <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | rawItemLink">
                   {{ rowData.item.string.title }}
                 </a>
               </ng-container>

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -41,7 +41,7 @@ import { SectionParagraphComponent } from './components/section-paragrah/section
 import { MessageComponent } from './components/message/message.component';
 import { ProgressLevelComponent } from './components/progress-level/progress-level.component';
 import { FormErrorComponent } from './components/form-error/form-error.component';
-import { ItemLinkPipe } from 'src/app/shared/pipes/itemLink';
+import { RawItemLinkPipe } from 'src/app/shared/pipes/rawItemLink';
 import { SubSectionComponent } from './components/sub-section/sub-section.component';
 import { AddContentComponent } from './components/add-content/add-content.component';
 import { FloatingSaveComponent } from './components/floating-save/floating-save.component';
@@ -78,7 +78,7 @@ import { LogActionDisplayPipe } from '../../shared/pipes/logActionDisplay';
     MessageComponent,
     ProgressLevelComponent,
     FormErrorComponent,
-    ItemLinkPipe,
+    RawItemLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,
     SubSectionComponent,
@@ -142,7 +142,7 @@ import { LogActionDisplayPipe } from '../../shared/pipes/logActionDisplay';
     MessageComponent,
     ProgressLevelComponent,
     FormErrorComponent,
-    ItemLinkPipe,
+    RawItemLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,
     SubSectionComponent,

--- a/src/app/shared/helpers/type-checkers.ts
+++ b/src/app/shared/helpers/type-checkers.ts
@@ -1,0 +1,4 @@
+
+export function isString(value: any): value is string {
+  return typeof value === 'string' || value instanceof String;
+}

--- a/src/app/shared/helpers/url.spec.ts
+++ b/src/app/shared/helpers/url.spec.ts
@@ -1,0 +1,14 @@
+import { urlStringFromArray } from './url';
+
+describe('urlStringFromArray', () => {
+  fit('should convert correctly a complex absolute case', () => {
+    expect(urlStringFromArray([ '/', 'activities', 'by-id', '123', { attemptId: '99', path: [ '4','5','6' ] }, 'details' ]))
+      .toEqual('/activities/by-id/123;attemptId=99;path=4,5,6/details');
+  });
+
+  fit('should convert correctly a complex relative case', () => {
+    expect(urlStringFromArray([ 'by-id', '123', { attemptId: '99', path: [ '4','5','6' ] }, 'details' ]))
+      .toEqual('by-id/123;attemptId=99;path=4,5,6/details');
+  });
+
+});

--- a/src/app/shared/helpers/url.ts
+++ b/src/app/shared/helpers/url.ts
@@ -1,3 +1,4 @@
+import { isString } from './type-checkers';
 
 export function getHashFragmentParams(): Map<string, string>{
   let hash = window.location.hash;
@@ -53,5 +54,22 @@ export function clearHash(paramNames: string[]): void {
     href = href.replace(new RegExp('[&\\?]'+param+'=[^&\\$]*'), '');
   }
   history.replaceState(null, window.name, href);
+}
+
+/**
+ * Convert a valid url array (`commands` array) to the string url
+ */
+export function urlStringFromArray(urlAsArray: (string|{[k: string]: string|string[]})[]): string {
+  // do not try to understand the implementation, just check the tests
+  return urlAsArray.map((part, idx) => {
+    if (part === '/') return '';
+    else if (isString(part)) return (idx === 0 ? '' : '/') + part;
+    else return Object.keys(part).map(key => {
+      const val = part[key];
+      if (val === undefined) throw new Error('unexpected: cannot find key in a dict while iterating over keys');
+      const valStr = isString(val) ? val : val.join(',');
+      return ';' + key + '=' + valStr;
+    }).join('');
+  }).join('');
 }
 

--- a/src/app/shared/helpers/url.ts
+++ b/src/app/shared/helpers/url.ts
@@ -72,7 +72,7 @@ export function urlStringFromArray(urlAsArray: UrlCommand): string {
       const val = part[key];
       if (val === undefined) throw new Error('unexpected: cannot find key in a dict while iterating over keys');
       const valStr = isString(val) ? val : val.join(',');
-      return ';' + key + '=' + valStr;
+      return `;${ key }=${ valStr }`;
     }).join('');
   }).join('');
 }

--- a/src/app/shared/helpers/url.ts
+++ b/src/app/shared/helpers/url.ts
@@ -1,5 +1,9 @@
 import { isString } from './type-checkers';
 
+// Url array (`command` array used in some api of angular)
+export interface UrlCommandParameters { [k: string]: string|string[] }
+export type UrlCommand = (string|UrlCommandParameters)[];
+
 export function getHashFragmentParams(): Map<string, string>{
   let hash = window.location.hash;
   hash = decodeURIComponent(hash);
@@ -59,7 +63,7 @@ export function clearHash(paramNames: string[]): void {
 /**
  * Convert a valid url array (`commands` array) to the string url
  */
-export function urlStringFromArray(urlAsArray: (string|{[k: string]: string|string[]})[]): string {
+export function urlStringFromArray(urlAsArray: UrlCommand): string {
   // do not try to understand the implementation, just check the tests
   return urlAsArray.map((part, idx) => {
     if (part === '/') return '';

--- a/src/app/shared/pipes/itemLink.ts
+++ b/src/app/shared/pipes/itemLink.ts
@@ -1,10 +1,11 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ItemType, typeCategoryOfItem } from '../helpers/item-type';
-import { rawItemStringUrl } from '../routing/item-route';
+import { UrlCommand } from '../helpers/url';
+import { urlArrayForRawItem } from '../routing/item-route';
 
 @Pipe({ name: 'itemLink', pure: true })
 export class ItemLinkPipe implements PipeTransform {
-  transform({ id, type }: {id: string, type: ItemType}, page?: 'details' | 'edit'): string {
-    return rawItemStringUrl(id, typeCategoryOfItem({ type }), page);
+  transform({ id, type }: {id: string, type: ItemType}, page?: 'details' | 'edit'): UrlCommand {
+    return urlArrayForRawItem(id, typeCategoryOfItem({ type }), page);
   }
 }

--- a/src/app/shared/pipes/itemLink.ts
+++ b/src/app/shared/pipes/itemLink.ts
@@ -1,10 +1,10 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { ItemType, typeCategoryOfItem } from '../helpers/item-type';
-import { incompleteItemStringUrl } from '../routing/item-route';
+import { rawItemStringUrl } from '../routing/item-route';
 
 @Pipe({ name: 'itemLink', pure: true })
 export class ItemLinkPipe implements PipeTransform {
   transform({ id, type }: {id: string, type: ItemType}, page?: 'details' | 'edit'): string {
-    return incompleteItemStringUrl(id, typeCategoryOfItem({ type }), page);
+    return rawItemStringUrl(id, typeCategoryOfItem({ type }), page);
   }
 }

--- a/src/app/shared/pipes/rawItemLink.ts
+++ b/src/app/shared/pipes/rawItemLink.ts
@@ -9,7 +9,7 @@ import { urlArrayForRawItem } from '../routing/item-route';
  */
 @Pipe({ name: 'rawItemLink', pure: true })
 export class RawItemLinkPipe implements PipeTransform {
-  transform({ id, type }: {id: string, type: ItemType}, page?: 'details' | 'edit'): UrlCommand {
+  transform({ id, type }: {id: string, type: ItemType}, page?: string|string[]): UrlCommand {
     return urlArrayForRawItem(id, typeCategoryOfItem({ type }), page);
   }
 }

--- a/src/app/shared/pipes/rawItemLink.ts
+++ b/src/app/shared/pipes/rawItemLink.ts
@@ -3,8 +3,12 @@ import { ItemType, typeCategoryOfItem } from '../helpers/item-type';
 import { UrlCommand } from '../helpers/url';
 import { urlArrayForRawItem } from '../routing/item-route';
 
-@Pipe({ name: 'itemLink', pure: true })
-export class ItemLinkPipe implements PipeTransform {
+/**
+ * Functions using item route should always be preferred to raw item.
+ * Using raw item means further requests will be required to fetch path and attempt information.
+ */
+@Pipe({ name: 'rawItemLink', pure: true })
+export class RawItemLinkPipe implements PipeTransform {
   transform({ id, type }: {id: string, type: ItemType}, page?: 'details' | 'edit'): UrlCommand {
     return urlArrayForRawItem(id, typeCategoryOfItem({ type }), page);
   }

--- a/src/app/shared/routing/group-router.ts
+++ b/src/app/shared/routing/group-router.ts
@@ -23,7 +23,7 @@ export class GroupRouter {
    * Navigate to the current page without path if we are on a group page.
    * If we are not on an group page, do nothing.
    */
-  navigateToIncompleteGroupOfCurrentPage(): void {
+  navigateToRawGroupOfCurrentPage(): void {
     const currentPage = this.currentGroupPagePath();
     if (currentPage) void this.router.navigate(currentPage);
   }

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -49,7 +49,7 @@ export function appDefaultItemRoute(cat: ItemTypeCategory = 'activity'): ItemRou
  * Utility functions for finding the item route from router information
  * ********************************************************************************************************** */
 
- interface ItemRouteError {
+interface ItemRouteError {
   tag: 'error';
   contentType: ItemTypeCategory;
   id?: ItemId;

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -83,6 +83,8 @@ export function isItemRouteError(route: ItemRoute|ItemRouteError): route is Item
 
 /**
  * Url (as string) of the item route without attemptId or path (only item id)
+ * `urlArrayForItemRoute` should always be preferred to this one, using raw item means further requests will be required to fetch
+ * path and attempt information
 */
 export function urlArrayForRawItem(id: ItemId, cat: ItemTypeCategory, page: string|string[] = 'details'): UrlCommand {
   return urlArrayForItem(id, cat, {}, page);

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -48,18 +48,6 @@ export function incompleteItemStringUrl(id: ItemId, cat: ItemTypeCategory, page:
 }
 
 /**
- * Url (as string) of the details page for the given item route
- */
-export function urlStringForItemRoute(route: ItemRoute, page: string|string[] = 'details'): string {
-  const attemptPart = isRouteWithAttempt(route) ?
-    `${attemptParamName}=${route.attemptId}` :
-    `${parentAttemptParamName}=${route.parentAttemptId}`;
-  const prefix = itemTypeCategoryPrefix(route.contentType);
-  const pageAsStr = pageToPagePath(page).join('/');
-  return `/${prefix}/by-id/${route.id};${attemptPart};${pathParamName}=${route.path.join(',')}/${pageAsStr}`;
-}
-
-/**
  * Return a url array (`commands` array) to the given item, on the given page.
  */
 export function urlArrayForItemRoute(route: ItemRoute, page: string|string[] = 'details'): (string|{[k: string]: any})[] {

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -33,7 +33,7 @@ export const itemRoutePrefixes = [ activityPrefix, skillPrefix ];
  */
 export function appDefaultItemRoute(cat: ItemTypeCategory = 'activity'): ItemRouteWithParentAttempt {
   return {
-    contentType: 'activity',
+    contentType: cat,
     id: isSkill(cat) ? appConfig.defaultSkillId : appConfig.defaultActivityId,
     path: [],
     parentAttemptId: defaultAttemptId,

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -43,7 +43,7 @@ export function appDefaultItemRoute(cat: ItemTypeCategory = 'activity'): ItemRou
 /**
  * Url (as string) of the item route without attemptId or path (only item id)
 */
-export function incompleteItemStringUrl(id: ItemId, cat: ItemTypeCategory, page: string|string[] = 'details'): string {
+export function rawItemStringUrl(id: ItemId, cat: ItemTypeCategory, page: string|string[] = 'details'): string {
   return `/${itemTypeCategoryPrefix(cat)}/by-id/${id}/${pageToPagePath(page).join('/')}`;
 }
 

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -4,7 +4,7 @@ import { appConfig } from '../helpers/config';
 import { ContentRoute, pathParamName } from './content-route';
 import { isSkill, ItemTypeCategory } from '../helpers/item-type';
 import { isString } from '../helpers/type-checkers';
-import { UrlCommand } from '../helpers/url';
+import { UrlCommand, UrlCommandParameters } from '../helpers/url';
 
 // url parameter names
 const activityPrefix = 'activities';
@@ -44,19 +44,24 @@ export function appDefaultItemRoute(cat: ItemTypeCategory = 'activity'): ItemRou
 /**
  * Url (as string) of the item route without attemptId or path (only item id)
 */
-export function rawItemStringUrl(id: ItemId, cat: ItemTypeCategory, page: string|string[] = 'details'): string {
-  return `/${itemTypeCategoryPrefix(cat)}/by-id/${id}/${pageToPagePath(page).join('/')}`;
+export function urlArrayForRawItem(id: ItemId, cat: ItemTypeCategory, page: string|string[] = 'details'): UrlCommand {
+  return urlArrayForItem(id, cat, {}, page);
 }
 
 /**
  * Return a url array (`commands` array) to the given item, on the given page.
  */
 export function urlArrayForItemRoute(route: ItemRoute, page: string|string[] = 'details'): UrlCommand {
-  const params: {[k: string]: any} = {};
+  const params: UrlCommandParameters = {};
   if (isRouteWithAttempt(route)) params[attemptParamName] = route.attemptId;
   else params[parentAttemptParamName] = route.parentAttemptId;
   params[pathParamName] = route.path;
-  return [ '/', itemTypeCategoryPrefix(route.contentType), 'by-id', route.id, params, ...pageToPagePath(page) ];
+  return urlArrayForItem(route.id, route.contentType, params, page);
+}
+
+function urlArrayForItem(id: ItemId, cat: ItemTypeCategory, params: UrlCommandParameters, page: string|string[]):
+  UrlCommand {
+  return [ '/', itemTypeCategoryPrefix(cat), 'by-id', id, params, ...pageToPagePath(page) ];
 }
 
 interface ItemRouteError {

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -11,10 +11,15 @@ const activityPrefix = 'activities';
 const skillPrefix = 'skills';
 const parentAttemptParamName = 'parentAttempId';
 const attemptParamName = 'attempId';
+export const itemRoutePrefixes = [ activityPrefix, skillPrefix ];
 
 // alias for better readibility
 type ItemId = string;
 type AttemptId = string;
+
+/* **********************************************************************************************************
+ * Item Route: Object storing information required to navigate to an item without need for fetching a path
+ * ********************************************************************************************************** */
 
 interface ItemRouteBase extends ContentRoute {
   contentType: ItemTypeCategory;
@@ -26,8 +31,6 @@ export type ItemRoute = ItemRouteWithAttempt | ItemRouteWithParentAttempt;
 export function isRouteWithAttempt(item: ItemRoute): item is ItemRouteWithAttempt {
   return 'attemptId' in item;
 }
-
-export const itemRoutePrefixes = [ activityPrefix, skillPrefix ];
 
 /**
  * The route to the app default (see config) item
@@ -41,30 +44,12 @@ export function appDefaultItemRoute(cat: ItemTypeCategory = 'activity'): ItemRou
   };
 }
 
-/**
- * Url (as string) of the item route without attemptId or path (only item id)
-*/
-export function urlArrayForRawItem(id: ItemId, cat: ItemTypeCategory, page: string|string[] = 'details'): UrlCommand {
-  return urlArrayForItem(id, cat, {}, page);
-}
 
-/**
- * Return a url array (`commands` array) to the given item, on the given page.
- */
-export function urlArrayForItemRoute(route: ItemRoute, page: string|string[] = 'details'): UrlCommand {
-  const params: UrlCommandParameters = {};
-  if (isRouteWithAttempt(route)) params[attemptParamName] = route.attemptId;
-  else params[parentAttemptParamName] = route.parentAttemptId;
-  params[pathParamName] = route.path;
-  return urlArrayForItem(route.id, route.contentType, params, page);
-}
+/* **********************************************************************************************************
+ * Utility functions for finding the item route from router information
+ * ********************************************************************************************************** */
 
-function urlArrayForItem(id: ItemId, cat: ItemTypeCategory, params: UrlCommandParameters, page: string|string[]):
-  UrlCommand {
-  return [ '/', itemTypeCategoryPrefix(cat), 'by-id', id, params, ...pageToPagePath(page) ];
-}
-
-interface ItemRouteError {
+ interface ItemRouteError {
   tag: 'error';
   contentType: ItemTypeCategory;
   id?: ItemId;
@@ -91,10 +76,32 @@ export function isItemRouteError(route: ItemRoute|ItemRouteError): route is Item
   return 'tag' in route && route.tag === 'error';
 }
 
-function itemTypeCategoryPrefix(cat: ItemTypeCategory): string {
-  return cat === 'activity' ? activityPrefix : skillPrefix;
+
+/* **********************************************************************************************************
+ * Utility functions for converting item info to a navigable url command
+ * ********************************************************************************************************** */
+
+/**
+ * Url (as string) of the item route without attemptId or path (only item id)
+*/
+export function urlArrayForRawItem(id: ItemId, cat: ItemTypeCategory, page: string|string[] = 'details'): UrlCommand {
+  return urlArrayForItem(id, cat, {}, page);
 }
 
-function pageToPagePath(page: string|string[]): string[] {
-  return isString(page) ? [ page ] : page;
+/**
+ * Return a url array (`commands` array) to the given item, on the given page.
+ */
+export function urlArrayForItemRoute(route: ItemRoute, page: string|string[] = 'details'): UrlCommand {
+  const params: UrlCommandParameters = {};
+  if (isRouteWithAttempt(route)) params[attemptParamName] = route.attemptId;
+  else params[parentAttemptParamName] = route.parentAttemptId;
+  params[pathParamName] = route.path;
+  return urlArrayForItem(route.id, route.contentType, params, page);
+}
+
+function urlArrayForItem(id: ItemId, cat: ItemTypeCategory, params: UrlCommandParameters, page: string|string[]):
+  UrlCommand {
+  const prefix = cat === 'activity' ? activityPrefix : skillPrefix;
+  const pagePath = isString(page) ? [ page ] : page;
+  return [ '/', prefix, 'by-id', id, params, ...pagePath ];
 }

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -4,6 +4,7 @@ import { appConfig } from '../helpers/config';
 import { ContentRoute, pathParamName } from './content-route';
 import { isSkill, ItemTypeCategory } from '../helpers/item-type';
 import { isString } from '../helpers/type-checkers';
+import { UrlCommand } from '../helpers/url';
 
 // url parameter names
 const activityPrefix = 'activities';
@@ -50,7 +51,7 @@ export function rawItemStringUrl(id: ItemId, cat: ItemTypeCategory, page: string
 /**
  * Return a url array (`commands` array) to the given item, on the given page.
  */
-export function urlArrayForItemRoute(route: ItemRoute, page: string|string[] = 'details'): (string|{[k: string]: any})[] {
+export function urlArrayForItemRoute(route: ItemRoute, page: string|string[] = 'details'): UrlCommand {
   const params: {[k: string]: any} = {};
   if (isRouteWithAttempt(route)) params[attemptParamName] = route.attemptId;
   else params[parentAttemptParamName] = route.parentAttemptId;

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -24,7 +24,7 @@ export class ItemRouter {
    * Navigate to the current page without path and attempt if we are on an item page.
    * If we are not on an item page, do nothing.
    */
-  navigateToIncompleteItemOfCurrentPage(): void {
+  navigateToRawItemOfCurrentPage(): void {
     const currentPage = this.currentItemPagePath();
     if (currentPage) void this.router.navigate(currentPage);
   }

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -43,7 +43,6 @@ export class ItemRouter {
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
   urlArray(item: ItemRoute, page?: string|string[]): (string|{[k: string]: any})[] {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     return urlArrayForItemRoute(item, page ?? this.currentItemPage());
   }
 

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -16,7 +16,7 @@ export class ItemRouter {
    * Navigate to given item, on the path page.
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
-  navigateTo(item: ItemRoute, page?: 'edit'|'details'): void {
+  navigateTo(item: ItemRoute, page?: string|string[]): void {
     void this.router.navigateByUrl(this.urlTree(item, page));
   }
 
@@ -31,10 +31,10 @@ export class ItemRouter {
 
 
   /**
-   * Return a url to the given item, on the give page.
+   * Return a url to the given item, on the given page.
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
-  urlTree(item: ItemRoute, page?: 'edit'|'details'): UrlTree {
+  urlTree(item: ItemRoute, page?: string|string[]): UrlTree {
     return this.router.createUrlTree(this.urlArray(item, page));
   }
 
@@ -42,20 +42,18 @@ export class ItemRouter {
    * Return a url array (`commands` array) to the given item, on the given page.
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
-  urlArray(item: ItemRoute, page?: 'edit'|'details'): any[] {
+  urlArray(item: ItemRoute, page?: string|string[]): (string|{[k: string]: any})[] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return urlArrayForItemRoute(item, page ?? this.currentItemSubPage());
+    return urlArrayForItemRoute(item, page ?? this.currentItemPage());
   }
 
   /**
-   * Extract (bit hacky) the item sub-page of the current page.
+   * Extract (bit hacky) the item page from what is currently displayed.
    * Return undefined if we are not on an "item" page
    */
-  private currentItemSubPage(): 'edit'|'details'|undefined {
-    const subpagePart = this.currentItemPagePath()?.slice(3);
-    if (!subpagePart || subpagePart.length === 0) return undefined;
-    const page = subpagePart[0];
-    return page === 'edit' || page === 'details' ? page : undefined;
+  private currentItemPage(): string[]|undefined {
+    const page = this.currentItemPagePath()?.slice(3);
+    return page && page.length > 0 ? page : undefined;
   }
 
   private currentItemPagePath(): string[]|undefined {

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -17,7 +17,7 @@ export class ItemRouter {
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
   navigateTo(item: ItemRoute, page?: string|string[]): void {
-    void this.router.navigateByUrl(this.urlTree(item, page));
+    void this.router.navigateByUrl(this.url(item, page));
   }
 
   /**
@@ -34,16 +34,8 @@ export class ItemRouter {
    * Return a url to the given item, on the given page.
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
-  urlTree(item: ItemRoute, page?: string|string[]): UrlTree {
-    return this.router.createUrlTree(this.urlArray(item, page));
-  }
-
-  /**
-   * Return a url array (`commands` array) to the given item, on the given page.
-   * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
-   */
-  urlArray(item: ItemRoute, page?: string|string[]): (string|{[k: string]: any})[] {
-    return urlArrayForItemRoute(item, page ?? this.currentItemPage());
+  url(item: ItemRoute, page?: string|string[]): UrlTree {
+    return this.router.createUrlTree(urlArrayForItemRoute(item, page ?? this.currentItemPage()));
   }
 
   /**


### PR DESCRIPTION
Item route has been built by several unrelated updates and has become quite messy and inconsistent.
In order to prepare for the introduction of route for groups very soon, I tried to clean item route(r) and make utility function more consistent.

It is recommended to do this review commit per commit.