### PR TITLE
disallow backticks when not required

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,7 +82,7 @@ module.exports = {
     }],
     'quotes': ['error', 'single', {
       avoidEscape: true,
-      allowTemplateLiterals: true
+      allowTemplateLiterals: false
     }]
   },
   overrides: [


### PR DESCRIPTION
Does not allow backticks when they are not required. 
The name of this property was not clear but as "true", it allows to use backticks for any string.