### PR TITLE
require tests to pass before deploying master: to prevent a merging error to break everything

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,8 @@ workflows:
           requires:
             - build-master-en
             - build-master-fr
+            - tests
+            - e2e
           filters:
             branches:
               only: master


### PR DESCRIPTION
For branches, they are deployed and it's not a problem (it allows testing faster), but for the "master" branch, let's not deploy it if one one test fail. At worst, it is false negative (the tests need to be re-run) but that's better than breaking the platform.