### PR TITLE
No undefined-item history state

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -102,7 +102,7 @@ export class ItemByIdComponent implements OnDestroy {
       ).subscribe(action => {
         const current = this.currentContent.current();
         if (!isItemInfo(current)) throw new Error('Unexpected: in item-by-id but the current content is not an item');
-        this.itemRouter.navigateTo(current.route, action === ModeAction.StartEditing ? 'edit' : 'details');
+        this.itemRouter.navigateTo(current.route, { page: action === ModeAction.StartEditing ? 'edit' : 'details' });
       }),
     );
   }

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -151,7 +151,7 @@ export class ItemByIdComponent implements OnDestroy {
         );
       })
     ).subscribe({
-      next: itemRoute => this.itemRouter.navigateTo(itemRoute),
+      next: itemRoute => this.itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } }),
       error: err => {
         this.state = errorState(err);
       }

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Router, UrlTree } from '@angular/router';
+import { NavigationExtras, Router, UrlTree } from '@angular/router';
 import { ensureDefined } from '../helpers/null-undefined-predicates';
 import { itemCategoryFromPrefix, RawItemRoute, urlArrayForItemRoute } from './item-route';
 
@@ -16,8 +16,8 @@ export class ItemRouter {
    * Navigate to given item, on the path page.
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
-  navigateTo(item: RawItemRoute, page?: string|string[]): void {
-    void this.router.navigateByUrl(this.url(item, page));
+  navigateTo(item: RawItemRoute, options?: { page?: string|string[], navExtras?: NavigationExtras }): void {
+    void this.router.navigateByUrl(this.url(item, options?.page), options?.navExtras);
   }
 
   /**


### PR DESCRIPTION
Do not keep an extra state when there is quick redirection because an item has its path/attempt fetched.
This way, the user can use the browser previous/next button without strange behavior.