### PR TITLE
fix observation bar watched group link

### DIFF
--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,58 +1,53 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
 import { AppPage } from './app.po';
-import { browser, by, logging } from 'protractor';
+import { browser, logging } from 'protractor';
 
 describe('Algorea Frontend', () => {
   let page: AppPage;
 
-  beforeEach(async () => {
+  beforeEach(() => {
     page = new AppPage();
-    await page.navigateTo();
-    await page.waitForContent();
-    await browser.waitForAngular();
+    page.navigateTo();
   });
 
   describe('page static elements', () => {
-    it('should shows the title', async () => {
-      await expect(
-        page.getTitleElement().getText()).toEqual('ALGOREA PLATFORM');
+    it('should shows the title', () => {
+      page.waitForElement(page.getTitleElement());
+      expect(page.getTitleElement().getText()).toEqual('ALGOREA PLATFORM');
     });
 
-    it('should have a working item-detail', async () => {
+    it('should have a working item-detail', () => {
+      page.waitForElement(page.getFirstActivityElement());
       // Check if the first item exists and is working
-      await page.getFirstActivityElement().click();
-
-      await expect(page.getMainContentElement()).toBeTruthy();
-      //await expect(page.getMainContentElement().getText()).toEqual('item-details works!');
+      page.getFirstActivityElement().click();
+      page.waitForElement(page.getMainContentElement());
+      expect(page.getMainContentElement().getText()).toBeTruthy();
+      // expect(page.getMainContentElement().getText()).toEqual('item-details works!');
     });
 
-    it('should have a working collapse button', async () => {
+    it('should have a working collapse button', () => {
+      expect(page.getLeftElement().getAttribute('class')).toMatch('expanded');
+      expect(page.getTopBarElement().getAttribute('class')).toMatch('expanded');
+      expect(page.getRightElement().getAttribute('class')).toMatch('expanded');
 
-      await expect(page.getLeftElement().getAttribute('class')).toMatch('expanded');
-      await expect(page.getTopBarElement().getAttribute('class')).toMatch('expanded');
-      await expect(page.getRightElement().getAttribute('class')).toMatch('expanded');
+      page.getCollapseButtonElement().click();
 
-      await page.getCollapseButtonElement().click();
-
-      await expect(page.getLeftElement().getAttribute('class')).toMatch('collapsed');
-      await expect(page.getTopBarElement().getAttribute('class')).toMatch('collapsed');
-      await expect(page.getRightElement().getAttribute('class')).toMatch('collapsed');
+      expect(page.getLeftElement().getAttribute('class')).toMatch('collapsed');
+      expect(page.getTopBarElement().getAttribute('class')).toMatch('collapsed');
+      expect(page.getRightElement().getAttribute('class')).toMatch('collapsed');
     });
   });
 
   describe('activities elements', () => {
-    it('should shows the first element of the activity tree', async () => {
-      await expect(
-        page
-          .getFirstActivityElement()
-          .element(by.css('.node-label-title'))
-          .getText()
-      ).toContain('Parcours officiels');
+    it('should shows the first element of the activity tree', () => {
+      page.waitForElement(page.getFirstActivityLabelElement());
+      expect(page.getFirstActivityLabelElement().getText()).toContain('Parcours officiels');
     });
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     // Assert that there are no errors emitted from the browser
-    const logs = await browser.manage().logs().get(logging.Type.BROWSER);
+    const logs = browser.manage().logs().get(logging.Type.BROWSER);
     expect(logs).not.toContain(jasmine.objectContaining({
       level: logging.Level.SEVERE,
     } as logging.Entry));

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -7,7 +7,7 @@ describe('Algorea Frontend', () => {
   beforeEach(async () => {
     page = new AppPage();
     await page.navigateTo();
-    page.waitForContent();
+    await page.waitForContent();
   });
 
   describe('page static elements', () => {

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,48 +1,48 @@
-import {AppPage} from './app.po';
-import {browser, by, logging} from 'protractor';
+import { AppPage } from './app.po';
+import { browser, by, logging } from 'protractor';
 
 describe('Algorea Frontend', () => {
   let page: AppPage;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     page = new AppPage();
-    page.navigateTo();
+    await page.navigateTo();
     page.waitForContent();
   });
 
   describe('page static elements', () => {
-    it('should shows the title', () => {
-      void expect(
+    it('should shows the title', async () => {
+      await expect(
         page.getTitleElement().getText()).toEqual('ALGOREA PLATFORM');
     });
 
-    it('should have a working item-detail', () => {
+    it('should have a working item-detail', async () => {
       // Check if the first item exists and is working
-      void page.getFirstActivityElement().click();
+      await page.getFirstActivityElement().click();
 
-      void expect(page.getMainContentElement()).toBeTruthy();
-      //void expect(page.getMainContentElement().getText()).toEqual('item-details works!');
+      await expect(page.getMainContentElement()).toBeTruthy();
+      //await expect(page.getMainContentElement().getText()).toEqual('item-details works!');
     });
 
-    it('should have a working collapse button', () => {
+    it('should have a working collapse button', async () => {
 
-      void expect(page.getLeftElement().getAttribute('class')).toMatch('expanded');
-      void expect(page.getTopBarElement().getAttribute('class')).toMatch('expanded');
-      void expect(page.getRightElement().getAttribute('class')).toMatch('expanded');
+      await expect(page.getLeftElement().getAttribute('class')).toMatch('expanded');
+      await expect(page.getTopBarElement().getAttribute('class')).toMatch('expanded');
+      await expect(page.getRightElement().getAttribute('class')).toMatch('expanded');
 
-      void page.getCollapseButtonElement().click();
+      await page.getCollapseButtonElement().click();
 
-      void expect(page.getLeftElement().getAttribute('class')).toMatch('collapsed');
-      void expect(page.getTopBarElement().getAttribute('class')).toMatch('collapsed');
-      void expect(page.getRightElement().getAttribute('class')).toMatch('collapsed');
+      await expect(page.getLeftElement().getAttribute('class')).toMatch('collapsed');
+      await expect(page.getTopBarElement().getAttribute('class')).toMatch('collapsed');
+      await expect(page.getRightElement().getAttribute('class')).toMatch('collapsed');
     });
   });
 
   describe('activities elements', () => {
-    it('should shows the first element of the activity tree', () => {
-      void browser.waitForAngular();
+    it('should shows the first element of the activity tree', async () => {
+      await browser.waitForAngular();
 
-      void expect(
+      await expect(
         page
           .getFirstActivityElement()
           .element(by.css('.node-label-title'))

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -8,6 +8,7 @@ describe('Algorea Frontend', () => {
     page = new AppPage();
     await page.navigateTo();
     await page.waitForContent();
+    await browser.waitForAngular();
   });
 
   describe('page static elements', () => {
@@ -40,8 +41,6 @@ describe('Algorea Frontend', () => {
 
   describe('activities elements', () => {
     it('should shows the first element of the activity tree', async () => {
-      await browser.waitForAngular();
-
       await expect(
         page
           .getFirstActivityElement()

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -6,7 +6,7 @@ export class AppPage {
   }
 
   waitForContent() {
-    browser.wait(ExpectedConditions.presenceOf(this.getFirstActivityElement()), 10000, 'Element taking too long to appear in the DOM');
+    return browser.wait(ExpectedConditions.presenceOf(this.getFirstActivityElement()), 10000, 'Element taking too long to appear in the DOM');
   }
 
   getTitleElement() {

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -1,16 +1,12 @@
-import { browser, by, element, ExpectedConditions } from 'protractor';
+import { browser, by, element, ElementFinder, ExpectedConditions } from 'protractor';
 
 export class AppPage {
   navigateTo() {
     return browser.get(browser.baseUrl) as Promise<any>;
   }
 
-  waitForContent() {
-    return browser.wait(
-      ExpectedConditions.presenceOf(this.getFirstActivityElement()),
-      20000,
-      'Element taking too long to appear in the DOM',
-    );
+  waitForElement(element: ElementFinder) {
+    return browser.wait(ExpectedConditions.visibilityOf(element), 10000, 'Element taking too long to appear in the DOM');
   }
 
   getTitleElement() {
@@ -24,6 +20,10 @@ export class AppPage {
 
   getFirstActivityElement() {
     return element(by.css('.p-treenode-content'));
+  }
+
+  getFirstActivityLabelElement() {
+    return this.getFirstActivityElement().element(by.css('.node-label-title'));
   }
 
   getLeftElement() {

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -6,7 +6,11 @@ export class AppPage {
   }
 
   waitForContent() {
-    return browser.wait(ExpectedConditions.presenceOf(this.getFirstActivityElement()), 10000, 'Element taking too long to appear in the DOM');
+    return browser.wait(
+      ExpectedConditions.presenceOf(this.getFirstActivityElement()),
+      20000,
+      'Element taking too long to appear in the DOM',
+    );
   }
 
   getTitleElement() {

--- a/src/app/core/components/observation-bar/observation-bar.component.html
+++ b/src/app/core/components/observation-bar/observation-bar.component.html
@@ -7,7 +7,7 @@
     <ng-container *ngIf="watchedGroup.name">
       : <a
           class="modebar-link alg-link white-color hover-underline"
-          [routerLink]="watchedGroup.login ? [ '/', 'groups', 'users', watchedGroup.id ] : [ '/', 'groups', 'by-id', watchedGroup.id, 'details' ]">
+          [routerLink]="watchedGroup.link">
           {{ watchedGroup.name }}
         </a>
     </ng-container>

--- a/src/app/core/components/observation-bar/observation-bar.component.html
+++ b/src/app/core/components/observation-bar/observation-bar.component.html
@@ -7,7 +7,7 @@
     <ng-container *ngIf="watchedGroup.name">
       : <a
         class="modebar-link alg-link white-color hover-underline"
-        [routerLink]="watchedGroup.route | groupLink:{ isUser: !!watchedGroup.login }">
+        [routerLink]="watchedGroup.route | groupLink:!!watchedGroup.login">
         {{ watchedGroup.name }}
       </a>
     </ng-container>

--- a/src/app/core/components/observation-bar/observation-bar.component.html
+++ b/src/app/core/components/observation-bar/observation-bar.component.html
@@ -6,10 +6,10 @@
     <ng-container i18n>Observation Mode</ng-container>
     <ng-container *ngIf="watchedGroup.name">
       : <a
-          class="modebar-link alg-link white-color hover-underline"
-          [routerLink]="watchedGroup.link">
-          {{ watchedGroup.name }}
-        </a>
+        class="modebar-link alg-link white-color hover-underline"
+        [routerLink]="watchedGroup.route | groupLink:{ isUser: !!watchedGroup.login }">
+        {{ watchedGroup.name }}
+      </a>
     </ng-container>
   </span>
 

--- a/src/app/modules/group/components/group-header/group-header.component.html
+++ b/src/app/modules/group/components/group-header/group-header.component.html
@@ -2,7 +2,7 @@
   <div class="group-header unfolded">
     <div class="user-info">
       <div class="user-name">
-        <span>{{ group?.name }}</span>
+        <span>{{ groupData?.group?.name }}</span>
       </div>
     </div>
     <alg-page-navigator

--- a/src/app/modules/group/components/group-header/group-header.component.ts
+++ b/src/app/modules/group/components/group-header/group-header.component.ts
@@ -20,7 +20,7 @@ export class GroupHeaderComponent implements OnChanges {
 
   groupWithManagement?: Group & ManagementAdditions;
   isCurrentGroupWatched$ = this.userSessionService.watchedGroup$.pipe(
-    map(watchedGroup => !!(watchedGroup && watchedGroup.id === this.group?.id)),
+    map(watchedGroup => !!(watchedGroup && watchedGroup.route.id === this.group?.id)),
   );
 
   constructor(
@@ -38,8 +38,10 @@ export class GroupHeaderComponent implements OnChanges {
 
   onStartWatchButtonClicked(event: Event): void {
     if (!this.group) throw new Error("unexpected group not set in 'onWatchButtonClicked'");
+    if (!this.path) throw new Error('path must be defined');
     this.modeService.startObserving({
-      ...this.group,
+      route: { id: this.group.id, path: this.path },
+      name: this.groupData.group.name,
       link: urlArrayForGroup(this.group.id, this.path),
     });
     this.openSuggestionOfActivitiesOverlayPanel(event);

--- a/src/app/modules/group/components/group-header/group-header.component.ts
+++ b/src/app/modules/group/components/group-header/group-header.component.ts
@@ -5,7 +5,7 @@ import { withManagementAdditions, ManagementAdditions } from '../../helpers/grou
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { map } from 'rxjs/operators';
 import { OverlayPanel } from 'primeng/overlaypanel';
-import { pathAsParameter } from 'src/app/shared/routing/content-route';
+import { urlArrayForGroup } from 'src/app/shared/routing/group-route';
 
 @Component({
   selector: 'alg-group-header',
@@ -40,7 +40,7 @@ export class GroupHeaderComponent implements OnChanges {
     if (!this.group) throw new Error("unexpected group not set in 'onWatchButtonClicked'");
     this.modeService.startObserving({
       ...this.group,
-      link: [ '/', 'groups', 'by-id', this.group.id, this.path && pathAsParameter(this.path), 'details' ].filter(Boolean),
+      link: urlArrayForGroup(this.group.id, this.path),
     });
     this.openSuggestionOfActivitiesOverlayPanel(event);
   }

--- a/src/app/modules/group/components/group-header/group-header.component.ts
+++ b/src/app/modules/group/components/group-header/group-header.component.ts
@@ -5,7 +5,6 @@ import { withManagementAdditions, ManagementAdditions } from '../../helpers/grou
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { map } from 'rxjs/operators';
 import { OverlayPanel } from 'primeng/overlaypanel';
-import { urlArrayForGroup } from 'src/app/shared/routing/group-route';
 import { GroupData } from '../../services/group-datasource.service';
 
 @Component({
@@ -41,7 +40,6 @@ export class GroupHeaderComponent implements OnChanges {
     this.modeService.startObserving({
       route: this.groupData.route,
       name: this.groupData.group.name,
-      link: urlArrayForGroup(this.group.id, this.path),
     });
     this.openSuggestionOfActivitiesOverlayPanel(event);
   }

--- a/src/app/modules/group/components/group-header/group-header.component.ts
+++ b/src/app/modules/group/components/group-header/group-header.component.ts
@@ -5,6 +5,7 @@ import { withManagementAdditions, ManagementAdditions } from '../../helpers/grou
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { map } from 'rxjs/operators';
 import { OverlayPanel } from 'primeng/overlaypanel';
+import { pathAsParameter } from 'src/app/shared/routing/content-route';
 
 @Component({
   selector: 'alg-group-header',
@@ -13,6 +14,7 @@ import { OverlayPanel } from 'primeng/overlaypanel';
 })
 export class GroupHeaderComponent implements OnChanges {
   @Input() group?: Group;
+  @Input() path?: string[];
 
   @ViewChild('op') op?: OverlayPanel;
 
@@ -36,7 +38,10 @@ export class GroupHeaderComponent implements OnChanges {
 
   onStartWatchButtonClicked(event: Event): void {
     if (!this.group) throw new Error("unexpected group not set in 'onWatchButtonClicked'");
-    this.modeService.startObserving(this.group);
+    this.modeService.startObserving({
+      ...this.group,
+      link: [ '/', 'groups', 'by-id', this.group.id, this.path && pathAsParameter(this.path), 'details' ].filter(Boolean),
+    });
     this.openSuggestionOfActivitiesOverlayPanel(event);
   }
 

--- a/src/app/modules/group/components/group-header/group-header.component.ts
+++ b/src/app/modules/group/components/group-header/group-header.component.ts
@@ -6,6 +6,7 @@ import { UserSessionService } from 'src/app/shared/services/user-session.service
 import { map } from 'rxjs/operators';
 import { OverlayPanel } from 'primeng/overlaypanel';
 import { urlArrayForGroup } from 'src/app/shared/routing/group-route';
+import { GroupData } from '../../services/group-datasource.service';
 
 @Component({
   selector: 'alg-group-header',
@@ -13,14 +14,13 @@ import { urlArrayForGroup } from 'src/app/shared/routing/group-route';
   styleUrls: [ './group-header.component.scss' ],
 })
 export class GroupHeaderComponent implements OnChanges {
-  @Input() group?: Group;
-  @Input() path?: string[];
+  @Input() groupData?: GroupData;
 
   @ViewChild('op') op?: OverlayPanel;
 
   groupWithManagement?: Group & ManagementAdditions;
   isCurrentGroupWatched$ = this.userSessionService.watchedGroup$.pipe(
-    map(watchedGroup => !!(watchedGroup && watchedGroup.route.id === this.group?.id)),
+    map(watchedGroup => !!(watchedGroup && watchedGroup.route.id === this.groupData?.group?.id)),
   );
 
   constructor(
@@ -29,7 +29,7 @@ export class GroupHeaderComponent implements OnChanges {
   ) {}
 
   ngOnChanges(): void {
-    this.groupWithManagement = this.group ? withManagementAdditions(this.group) : undefined;
+    this.groupWithManagement = this.groupData?.group ? withManagementAdditions(this.groupData.group) : undefined;
   }
 
   onEditButtonClicked(): void {
@@ -37,10 +37,9 @@ export class GroupHeaderComponent implements OnChanges {
   }
 
   onStartWatchButtonClicked(event: Event): void {
-    if (!this.group) throw new Error("unexpected group not set in 'onWatchButtonClicked'");
-    if (!this.path) throw new Error('path must be defined');
+    if (!this.groupData?.group) throw new Error("unexpected group not set in 'onWatchButtonClicked'");
     this.modeService.startObserving({
-      route: { id: this.group.id, path: this.path },
+      route: this.groupData.route,
       name: this.groupData.group.name,
       link: urlArrayForGroup(this.group.id, this.path),
     });

--- a/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
+++ b/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
@@ -14,9 +14,9 @@ export class SuggestionOfActivitiesComponent {
   readonly state$ = this.sessionService.watchedGroup$.pipe(
     filter(isNotUndefined),
     switchMap(watchedGroup =>
-      this.itemNavigationService.getRootActivities(watchedGroup.id).pipe(
+      this.itemNavigationService.getRootActivities(watchedGroup.route.id).pipe(
         map((rootActivity: RootActivity[]) =>
-          rootActivity.sort(item => (item.group_id === watchedGroup.id ? -1 : 1)).slice(0, 4)
+          rootActivity.sort(item => (item.group_id === watchedGroup.route.id ? -1 : 1)).slice(0, 4)
         ),
       )
     ),

--- a/src/app/modules/group/components/user-header/user-header.component.ts
+++ b/src/app/modules/group/components/user-header/user-header.component.ts
@@ -33,6 +33,7 @@ export class UserHeaderComponent {
       id: this.user.groupId,
       name: formatUser(this.user),
       login: this.user.login,
+      link: [ '/', 'groups', 'users', this.user.groupId ],
     });
   }
 

--- a/src/app/modules/group/components/user-header/user-header.component.ts
+++ b/src/app/modules/group/components/user-header/user-header.component.ts
@@ -4,6 +4,7 @@ import { map } from 'rxjs/operators';
 import { UserSessionService } from '../../../../shared/services/user-session.service';
 import { ModeAction, ModeService } from '../../../../shared/services/mode.service';
 import { formatUser } from '../../../../shared/helpers/user';
+import { groupRoute } from 'src/app/shared/routing/group-route';
 
 @Component({
   selector: 'alg-user-header',
@@ -14,7 +15,7 @@ export class UserHeaderComponent {
   @Input() user?: User;
 
   isCurrentGroupWatched$ = this.userSessionService.watchedGroup$.pipe(
-    map(watchedGroup => !!(watchedGroup && watchedGroup.id === this.user?.groupId)),
+    map(watchedGroup => !!(watchedGroup && watchedGroup.route.id === this.user?.groupId)),
   );
 
   constructor(
@@ -30,7 +31,7 @@ export class UserHeaderComponent {
   onStartWatchButtonClicked(): void {
     if (!this.user) throw new Error("unexpected user not set in 'onWatchButtonClicked'");
     this.modeService.startObserving({
-      id: this.user.groupId,
+      route: groupRoute(this.user.groupId, []),
       name: formatUser(this.user),
       login: this.user.login,
       link: [ '/', 'groups', 'users', this.user.groupId ],

--- a/src/app/modules/group/components/user-header/user-header.component.ts
+++ b/src/app/modules/group/components/user-header/user-header.component.ts
@@ -34,7 +34,6 @@ export class UserHeaderComponent {
       route: groupRoute(this.user.groupId, []),
       name: formatUser(this.user),
       login: this.user.login,
-      link: [ '/', 'groups', 'users', this.user.groupId ],
     });
   }
 

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -49,7 +49,7 @@ export class GroupByIdComponent implements OnDestroy {
           route: groupRoute(group.id, route.path),
           breadcrumbs: {
             category: GROUP_BREADCRUMB_CAT,
-            path: [{ title: group.name, navigateTo: this.router.createUrlTree(urlArrayForGroup(route.id, route.path, 'details')) }],
+            path: [{ title: group.name, navigateTo: this.router.createUrlTree(urlArrayForGroup(route, 'details')) }],
             currentPageIdx: 0,
           },
           title: group.name,

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, ParamMap, Router } from '@angular/router';
+import { ActivatedRoute, ParamMap, Router, UrlTree } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { GetGroupPathService } from 'src/app/modules/item/http-services/get-group-path';
 import { groupInfo, GroupInfo, isGroupInfo } from 'src/app/shared/models/content/group-info';
 import { readyData } from 'src/app/shared/operators/state';
-import { groupRoute, groupRouteFromParams, isGroupRouteError, urlArrayForGroup } from 'src/app/shared/routing/group-route';
+import { groupRoute, groupRouteFromParams, isGroupRouteError } from 'src/app/shared/routing/group-route';
 import { GroupRouter } from 'src/app/shared/routing/group-router';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { ModeAction, ModeService } from 'src/app/shared/services/mode.service';
@@ -49,7 +49,7 @@ export class GroupByIdComponent implements OnDestroy {
           route: groupRoute(group.id, route.path),
           breadcrumbs: {
             category: GROUP_BREADCRUMB_CAT,
-            path: [{ title: group.name, navigateTo: this.router.createUrlTree(urlArrayForGroup(route, 'details')) }],
+            path: [{ title: group.name, navigateTo: (): UrlTree => this.groupRouter.url(route, 'details') }],
             currentPageIdx: 0,
           },
           title: group.name,

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy } from '@angular/core';
-import { ActivatedRoute, ParamMap, Router, UrlTree } from '@angular/router';
+import { ActivatedRoute, ParamMap, UrlTree } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 import { GetGroupPathService } from 'src/app/modules/item/http-services/get-group-path';
@@ -29,7 +29,6 @@ export class GroupByIdComponent implements OnDestroy {
   private hasRedirected = false;
 
   constructor(
-    private router: Router,
     private activatedRoute: ActivatedRoute,
     private currentContent: CurrentContentService,
     private modeService: ModeService,

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -5,7 +5,7 @@ import { filter, map } from 'rxjs/operators';
 import { GetGroupPathService } from 'src/app/modules/item/http-services/get-group-path';
 import { groupInfo, GroupInfo, isGroupInfo } from 'src/app/shared/models/content/group-info';
 import { readyData } from 'src/app/shared/operators/state';
-import { groupRoute, groupRouteFromParams, isGroupRouteError, urlArrayForGroupRoute } from 'src/app/shared/routing/group-route';
+import { groupRoute, groupRouteFromParams, isGroupRouteError, urlArrayForGroup } from 'src/app/shared/routing/group-route';
 import { GroupRouter } from 'src/app/shared/routing/group-router';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { ModeAction, ModeService } from 'src/app/shared/services/mode.service';
@@ -49,7 +49,7 @@ export class GroupByIdComponent implements OnDestroy {
           route: groupRoute(group.id, route.path),
           breadcrumbs: {
             category: GROUP_BREADCRUMB_CAT,
-            path: [{ title: group.name, navigateTo: this.router.createUrlTree(urlArrayForGroupRoute(route, 'details')) }],
+            path: [{ title: group.name, navigateTo: this.router.createUrlTree(urlArrayForGroup(route.id, route.path, 'details')) }],
             currentPageIdx: 0,
           },
           title: group.name,

--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -2,7 +2,7 @@
 
   <ng-container *ngIf="state.data?.group as group">
     <div *ngIf="state.isFetching" class="block-ui"></div>
-    <alg-group-header [group]="group" [path]="state.data?.path" *ngIf="!(fullFrameContent$ | async)"></alg-group-header>
+    <alg-group-header [groupData]="state.data" *ngIf="!(fullFrameContent$ | async)"></alg-group-header>
     <alg-pending-join-requests
         *ngIf="group.isCurrentUserManager && group.currentUserCanManage !== 'none'"
         [groupId]="group.id"

--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -1,8 +1,8 @@
 <ng-container *ngIf="state$ | async as state">
 
-  <ng-container *ngIf="state.data as group">
+  <ng-container *ngIf="state.data?.group as group">
     <div *ngIf="state.isFetching" class="block-ui"></div>
-    <alg-group-header [group]="group" *ngIf="!(fullFrameContent$ | async)"></alg-group-header>
+    <alg-group-header [group]="group" [path]="state.data?.path" *ngIf="!(fullFrameContent$ | async)"></alg-group-header>
     <alg-pending-join-requests
         *ngIf="group.isCurrentUserManager && group.currentUserCanManage !== 'none'"
         [groupId]="group.id"

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -12,7 +12,10 @@ import { LayoutService } from '../../../../shared/services/layout.service';
 })
 export class GroupDetailsComponent {
 
-  state$ = this.groupDataSource.state$.pipe(mapStateData(state => withManagementAdditions(state.group)));
+  state$ = this.groupDataSource.state$.pipe(mapStateData(state => ({
+    group: withManagementAdditions(state.group),
+    path: state.route.path,
+  })));
   fullFrameContent$ = this.layoutService.fullFrameContent$;
 
   // use of ViewChild required as these elements are shown under some conditions, so may be undefined

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -14,7 +14,7 @@ export class GroupDetailsComponent {
 
   state$ = this.groupDataSource.state$.pipe(mapStateData(state => ({
     group: withManagementAdditions(state.group),
-    path: state.route.path,
+    route: state.route,
   })));
   fullFrameContent$ = this.layoutService.fullFrameContent$;
 

--- a/src/app/modules/item/pages/chapter-group-progress/chapter-group-progress.component.ts
+++ b/src/app/modules/item/pages/chapter-group-progress/chapter-group-progress.component.ts
@@ -17,7 +17,7 @@ export class ChapterGroupProgressComponent {
 
   state$ = this.sessionService.watchedGroup$.pipe(
     filter(isNotUndefined),
-    switchMap(watchedGroup => this.getGroupByIdService.get(watchedGroup.id)),
+    switchMap(watchedGroup => this.getGroupByIdService.get(watchedGroup.route.id)),
     mapToFetchState(),
   );
 

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -60,7 +60,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy {
   }
 
   private getData$(item: Item, watchingGroup?: WatchedGroup): Observable<Data> {
-    return this.activityLogService.getActivityLog(item.id, watchingGroup?.id).pipe(
+    return this.activityLogService.getActivityLog(item.id, watchingGroup?.route.id).pipe(
       map((data: ActivityLog[]) => ({
         columns: this.getLogColumns(item.type, watchingGroup),
         rowData: data

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -42,6 +42,7 @@ import { MessageComponent } from './components/message/message.component';
 import { ProgressLevelComponent } from './components/progress-level/progress-level.component';
 import { FormErrorComponent } from './components/form-error/form-error.component';
 import { RawItemLinkPipe } from 'src/app/shared/pipes/rawItemLink';
+import { GroupLinkPipe } from 'src/app/shared/pipes/groupLink';
 import { SubSectionComponent } from './components/sub-section/sub-section.component';
 import { AddContentComponent } from './components/add-content/add-content.component';
 import { FloatingSaveComponent } from './components/floating-save/floating-save.component';
@@ -79,6 +80,7 @@ import { LogActionDisplayPipe } from '../../shared/pipes/logActionDisplay';
     ProgressLevelComponent,
     FormErrorComponent,
     RawItemLinkPipe,
+    GroupLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,
     SubSectionComponent,
@@ -143,6 +145,7 @@ import { LogActionDisplayPipe } from '../../shared/pipes/logActionDisplay';
     ProgressLevelComponent,
     FormErrorComponent,
     RawItemLinkPipe,
+    GroupLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,
     SubSectionComponent,

--- a/src/app/shared/pipes/groupLink.ts
+++ b/src/app/shared/pipes/groupLink.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import { UrlCommand } from '../helpers/url';
 import { GroupRoute } from '../routing/group-route';
-import { urlArrayForGroup } from '../routing/group-route';
+import { urlArrayForGroupRoute } from '../routing/group-route';
 
 /**
  * Functions using item route should always be preferred to raw item.
@@ -10,6 +10,6 @@ import { urlArrayForGroup } from '../routing/group-route';
 @Pipe({ name: 'groupLink', pure: true })
 export class GroupLinkPipe implements PipeTransform {
   transform(route: GroupRoute, isUser?: boolean): UrlCommand {
-    return urlArrayForGroup(route, 'details', isUser);
+    return urlArrayForGroupRoute(route, 'details', isUser);
   }
 }

--- a/src/app/shared/pipes/groupLink.ts
+++ b/src/app/shared/pipes/groupLink.ts
@@ -9,7 +9,7 @@ import { urlArrayForGroup } from '../routing/group-route';
  */
 @Pipe({ name: 'groupLink', pure: true })
 export class GroupLinkPipe implements PipeTransform {
-  transform(route: GroupRoute, options?: { page?: 'edit' | 'details'; isUser?: boolean }): UrlCommand {
-    return urlArrayForGroup(route.id, route.path, options?.page, options?.isUser);
+  transform(route: GroupRoute, isUser?: boolean): UrlCommand {
+    return urlArrayForGroup(route, 'details', isUser);
   }
 }

--- a/src/app/shared/pipes/groupLink.ts
+++ b/src/app/shared/pipes/groupLink.ts
@@ -1,0 +1,15 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { UrlCommand } from '../helpers/url';
+import { GroupRoute } from '../routing/group-route';
+import { urlArrayForGroup } from '../routing/group-route';
+
+/**
+ * Functions using item route should always be preferred to raw item.
+ * Using raw item means further requests will be required to fetch path and attempt information.
+ */
+@Pipe({ name: 'groupLink', pure: true })
+export class GroupLinkPipe implements PipeTransform {
+  transform(route: GroupRoute, options?: { page?: 'edit' | 'details'; isUser?: boolean }): UrlCommand {
+    return urlArrayForGroup(route.id, route.path ?? [], options?.page);
+  }
+}

--- a/src/app/shared/pipes/groupLink.ts
+++ b/src/app/shared/pipes/groupLink.ts
@@ -10,6 +10,6 @@ import { urlArrayForGroup } from '../routing/group-route';
 @Pipe({ name: 'groupLink', pure: true })
 export class GroupLinkPipe implements PipeTransform {
   transform(route: GroupRoute, options?: { page?: 'edit' | 'details'; isUser?: boolean }): UrlCommand {
-    return urlArrayForGroup(route.id, route.path ?? [], options?.page);
+    return urlArrayForGroup(route.id, route.path, options?.page, options?.isUser);
   }
 }

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -21,7 +21,7 @@ export function groupRoute(id: GroupId, path: string[]): GroupRoute {
 /**
  * Return a url array (`commands` array) to the given group, on the given page.
  */
-export function urlArrayForGroup(route: GroupRoute, page: 'edit' | 'details' = 'details', isUser = false): UrlCommand {
+export function urlArrayForGroupRoute(route: GroupRoute, page: 'edit' | 'details' = 'details', isUser = false): UrlCommand {
   return isUser
     ? [ '/', 'groups', 'users', route.id, pathAsParameter(route.path) ]
     : [ '/', 'groups', 'by-id', route.id, pathAsParameter(route.path), page ];

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -19,8 +19,8 @@ export function groupRoute(id: GroupId, path: string[]): GroupRoute {
 /**
  * Return a url array (`commands` array) to the given group, on the given page.
  */
-export function urlArrayForGroupRoute(route: GroupRoute, page: 'edit'|'details' = 'details'): any[] {
-  return [ '/', 'groups', 'by-id', route.id, pathAsParameter(route.path), page ];
+export function urlArrayForGroup(id: string, path?: string[], page: 'edit' | 'details' = 'details'): any[] {
+  return [ '/', 'groups', 'by-id', id, path && pathAsParameter(path), page ].filter(Boolean);
 }
 
 export function decodeGroupRouterParameters(params: ParamMap): { id: string | null; path: string | null } {

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -1,5 +1,4 @@
 import { ParamMap } from '@angular/router';
-import { isNotUndefined } from '../helpers/null-undefined-predicates';
 import { UrlCommand } from '../helpers/url';
 import { ContentRoute, pathAsParameter, pathFromRouterParameters } from './content-route';
 
@@ -22,10 +21,10 @@ export function groupRoute(id: GroupId, path: string[]): GroupRoute {
 /**
  * Return a url array (`commands` array) to the given group, on the given page.
  */
-export function urlArrayForGroup(id: string, path?: string[], page: 'edit' | 'details' = 'details', isUser = false): UrlCommand {
+export function urlArrayForGroup(route: GroupRoute, page: 'edit' | 'details' = 'details', isUser = false): UrlCommand {
   return isUser
-    ? [ '/', 'groups', 'users', id, path && pathAsParameter(path) ].filter(isNotUndefined)
-    : [ '/', 'groups', 'by-id', id, path && pathAsParameter(path), page ].filter(isNotUndefined);
+    ? [ '/', 'groups', 'users', route.id, pathAsParameter(route.path) ]
+    : [ '/', 'groups', 'by-id', route.id, pathAsParameter(route.path), page ];
 }
 
 export function decodeGroupRouterParameters(params: ParamMap): { id: string | null; path: string | null } {

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -1,4 +1,6 @@
 import { ParamMap } from '@angular/router';
+import { isNotUndefined } from '../helpers/null-undefined-predicates';
+import { UrlCommand } from '../helpers/url';
 import { ContentRoute, pathAsParameter, pathFromRouterParameters } from './content-route';
 
 type GroupId = string;
@@ -6,6 +8,7 @@ type GroupId = string;
 export interface GroupRoute extends ContentRoute {
   contentType: 'group';
 }
+
 export interface GroupRouteError {
   tag: 'error';
   path?: string[];
@@ -19,8 +22,8 @@ export function groupRoute(id: GroupId, path: string[]): GroupRoute {
 /**
  * Return a url array (`commands` array) to the given group, on the given page.
  */
-export function urlArrayForGroup(id: string, path?: string[], page: 'edit' | 'details' = 'details'): any[] {
-  return [ '/', 'groups', 'by-id', id, path && pathAsParameter(path), page ].filter(Boolean);
+export function urlArrayForGroup(id: string, path?: string[], page: 'edit' | 'details' = 'details', isUser = false): UrlCommand {
+  return [ '/', 'groups', isUser ? 'users' : 'by-id', id, path && pathAsParameter(path), page ].filter(isNotUndefined);
 }
 
 export function decodeGroupRouterParameters(params: ParamMap): { id: string | null; path: string | null } {

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -23,7 +23,9 @@ export function groupRoute(id: GroupId, path: string[]): GroupRoute {
  * Return a url array (`commands` array) to the given group, on the given page.
  */
 export function urlArrayForGroup(id: string, path?: string[], page: 'edit' | 'details' = 'details', isUser = false): UrlCommand {
-  return [ '/', 'groups', isUser ? 'users' : 'by-id', id, path && pathAsParameter(path), page ].filter(isNotUndefined);
+  return isUser
+    ? [ '/', 'groups', 'users', id, path && pathAsParameter(path) ].filter(isNotUndefined)
+    : [ '/', 'groups', 'by-id', id, path && pathAsParameter(path), page ].filter(isNotUndefined);
 }
 
 export function decodeGroupRouterParameters(params: ParamMap): { id: string | null; path: string | null } {

--- a/src/app/shared/routing/group-router.ts
+++ b/src/app/shared/routing/group-router.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { NavigationExtras, Router, UrlTree } from '@angular/router';
-import { GroupRoute, urlArrayForGroup } from './group-route';
+import { UrlCommand } from '../helpers/url';
+import { GroupRoute, urlArrayForGroupRoute } from './group-route';
 
 @Injectable({
   providedIn: 'root'
@@ -41,9 +42,9 @@ export class GroupRouter {
    * Return a url array (`commands` array) to the given group, on the `path` page.
    * If page is not given and we are currently on a group page, use the same page. Otherwise, default to 'details'.
    */
-  urlArray(route: GroupRoute, page?: 'edit'|'details'): any[] {
+  urlArray(route: GroupRoute, page?: 'edit'|'details'): UrlCommand {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return urlArrayForGroup(route, page ?? this.currentGroupSubPage());
+    return urlArrayForGroupRoute(route, page ?? this.currentGroupSubPage());
   }
 
 

--- a/src/app/shared/routing/group-router.ts
+++ b/src/app/shared/routing/group-router.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { NavigationExtras, Router, UrlTree } from '@angular/router';
-import { GroupRoute, urlArrayForGroupRoute } from './group-route';
+import { GroupRoute, urlArrayForGroup } from './group-route';
 
 @Injectable({
   providedIn: 'root'
@@ -43,7 +43,7 @@ export class GroupRouter {
    */
   urlArray(route: GroupRoute, page?: 'edit'|'details'): any[] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return urlArrayForGroupRoute(route, page ?? this.currentGroupSubPage());
+    return urlArrayForGroup(route.id, route.path, page ?? this.currentGroupSubPage());
   }
 
 

--- a/src/app/shared/routing/group-router.ts
+++ b/src/app/shared/routing/group-router.ts
@@ -43,7 +43,7 @@ export class GroupRouter {
    */
   urlArray(route: GroupRoute, page?: 'edit'|'details'): any[] {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return urlArrayForGroup(route.id, route.path, page ?? this.currentGroupSubPage());
+    return urlArrayForGroup(route, page ?? this.currentGroupSubPage());
   }
 
 

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -11,7 +11,6 @@ export interface WatchedGroup {
   route: GroupRoute,
   name: string,
   login?: string,
-  link?: any[] | string,
 }
 
 export interface UserSession {

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -5,9 +5,10 @@ import { switchMap, distinctUntilChanged, map, filter, mapTo, skip, shareReplay,
 import { CurrentUserHttpService, UpdateUserBody, UserProfile } from '../http-services/current-user.service';
 import { isNotUndefined } from '../helpers/null-undefined-predicates';
 import { repeatLatestWhen } from '../helpers/repeatLatestWhen';
+import { GroupRoute } from '../routing/group-route';
 
 export interface WatchedGroup {
-  id: string,
+  route: GroupRoute,
   name: string,
   login?: string,
   link?: any[] | string,

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -10,6 +10,7 @@ export interface WatchedGroup {
   id: string,
   name: string,
   login?: string,
+  link?: any[] | string,
 }
 
 export interface UserSession {


### PR DESCRIPTION
## Done

Add `path` to `watchedGroup` to be able to redirect to it with its tree/ancestors

## Tests

1) Go to [a group page (branch app)](https://dev.algorea.org/branch/fix/observation-bar-group-link/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)
2) Observe the group
3) You'll see at the top of the screen `"Observation mode: [group name]"`. Hover the group name link. You should see the path in the url, which is not the case in [production](https://dev.algorea.org/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)