### PR TITLE
fix group breadcrumb missing path in link

### DIFF
--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -5,7 +5,7 @@ import { filter, map } from 'rxjs/operators';
 import { GetGroupPathService } from 'src/app/modules/item/http-services/get-group-path';
 import { groupInfo, GroupInfo, isGroupInfo } from 'src/app/shared/models/content/group-info';
 import { readyData } from 'src/app/shared/operators/state';
-import { groupRoute, groupRouteFromParams, isGroupRouteError } from 'src/app/shared/routing/group-route';
+import { groupRoute, groupRouteFromParams, isGroupRouteError, urlArrayForGroupRoute } from 'src/app/shared/routing/group-route';
 import { GroupRouter } from 'src/app/shared/routing/group-router';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { ModeAction, ModeService } from 'src/app/shared/services/mode.service';
@@ -48,7 +48,7 @@ export class GroupByIdComponent implements OnDestroy {
           route: groupRoute(group.id, route.path),
           breadcrumbs: {
             category: GROUP_BREADCRUMB_CAT,
-            path: [{ title: group.name, navigateTo: this.router.createUrlTree([ 'groups', 'by-id', group.id, 'details' ]) }],
+            path: [{ title: group.name, navigateTo: this.router.createUrlTree(urlArrayForGroupRoute(route, 'details')) }],
             currentPageIdx: 0,
           },
           title: group.name,


### PR DESCRIPTION
## Done

Add path parameter in url provided to breadcrumbs

## Test it

1) Go to [this group page (branch app)](https://dev.algorea.org/branch/fix/group-breadcrumb-path/en/#/groups/by-id/672913018859223173;path=52767158366271444/details/members)
2) At the top, you'll the breadcrumb `Groups → Pixal`, **click** on the `Pixal` breadcrumb

With the [production app](https://dev.algorea.org/en/#/groups/by-id/672913018859223173;path=52767158366271444/details), you'll see the url blink
With the [branch app](https://dev.algorea.org/branch/fix/group-breadcrumb-path/en/#/groups/by-id/672913018859223173;path=52767158366271444/details/members), you'll see the url does not blink because the path is provided

Although it is not _that_ useful today, it will have an positive impact when the breadcrumbs will be fully implemented
