### PR TITLE
add group path to url when switching between edit and normal mode

### DIFF
--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -61,7 +61,7 @@ export class GroupByIdComponent implements OnDestroy {
       ).subscribe(action => {
         const currentInfo = this.currentContent.current();
         if (!isGroupInfo(currentInfo)) throw new Error('Unexpected: in group-by-id but the current content is not a group');
-        void this.router.navigate([ 'groups', 'by-id', currentInfo.route.id, action === ModeAction.StartEditing ? 'edit' : 'details' ]);
+        this.groupRouter.navigateTo(currentInfo.route, { page: action === ModeAction.StartEditing ? 'edit' : 'details' });
       })
     );
   }

--- a/src/app/modules/group/services/group-datasource.service.ts
+++ b/src/app/modules/group/services/group-datasource.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { ReplaySubject, Subject } from 'rxjs';
-import { map, share, switchMap } from 'rxjs/operators';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { mapToFetchState } from 'src/app/shared/operators/state';
 import { GroupRoute } from 'src/app/shared/routing/group-route';
 import { GetGroupByIdService, Group } from '../http-services/get-group-by-id.service';
@@ -24,7 +24,7 @@ export class GroupDataSource implements OnDestroy {
     // on new fetch operation to be done: set "fetching" state and fetch the data which will result in a ready or error state
     switchMap(route => this.getGroupByIdService.get(route.id).pipe(map(group => ({ route, group })))),
     mapToFetchState({ resetter: this.refresh$ }),
-    share(),
+    shareReplay(1),
   );
 
   constructor(

--- a/src/app/shared/routing/group-router.ts
+++ b/src/app/shared/routing/group-router.ts
@@ -15,7 +15,7 @@ export class GroupRouter {
    * Navigate to given group, on the path page.
    * If page is not given and we are currently on a group page, use the same page. Otherwise, default to 'details'.
    */
-  navigateTo(route: GroupRoute, options?: { page?: 'edit'|'details'; navExtras: NavigationExtras }): void {
+  navigateTo(route: GroupRoute, options?: { page?: 'edit'|'details'; navExtras?: NavigationExtras }): void {
     void this.router.navigateByUrl(this.url(route, options?.page), options?.navExtras);
   }
 


### PR DESCRIPTION
## Done

* Pass the path when switching between edit/normal mode on group by id page.
* Replay last state of group datasource state observable

## Tests

1. Go to a group
2. Click on the "edit" button
3. Click on the "exit edition" button

The path in the url remains, the url does not blink at steps 2) and 3), whereas it does blink in production.

Branch app example: [link](https://dev.algorea.org/branch/fix/edit-group-path/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)
Production app example: [link](https://dev.algorea.org/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)