### PR TITLE
add path to group manager url in managers list

### DIFF
--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
@@ -59,7 +59,7 @@
             tooltipStyleClass="tooltip-custom"
           >
             <a class="alg-link"
-               [routerLink]="rowData.login ? [ '/', 'groups', 'users', rowData.id ] : [ '/', 'groups', 'by-id', rowData.id, 'details' ]"
+              [routerLink]="rowData.route | groupLink:!!rowData.login"
             >
               {{ rowData.login ? (rowData | userCaption) : rowData.name }}
             </a>

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { Group } from '../../http-services/get-group-by-id.service';
+import { GroupRoute, groupRoute } from 'src/app/shared/routing/group-route';
 import { GetGroupManagersService, Manager } from '../../http-services/get-group-managers.service';
+import { GroupData } from '../../services/group-datasource.service';
 
 @Component({
   selector: 'alg-group-manager-list',
@@ -9,9 +10,9 @@ import { GetGroupManagersService, Manager } from '../../http-services/get-group-
 })
 export class GroupManagerListComponent implements OnChanges {
 
-  @Input() group?: Group;
+  @Input() groupData?: GroupData;
 
-  managers: (Manager&{canManageAsText: string})[] = [];
+  managers: (Manager & { canManageAsText: string; route: GroupRoute })[] = [];
 
   state: 'loading' | 'ready' | 'error' = 'loading';
 
@@ -33,13 +34,18 @@ export class GroupManagerListComponent implements OnChanges {
   }
 
   private reloadData(): void {
-    if (!this.group) return;
+    if (!this.groupData) return;
+    const { route, group } = this.groupData;
     this.state = 'loading';
     this.getGroupManagersService
-      .getGroupManagers(this.group.id)
+      .getGroupManagers(group.id)
       .subscribe({
         next: (managers: Manager[]) => {
-          this.managers = managers.map(manager => ({ ...manager, canManageAsText: this.getManagerLevel(manager) }));
+          this.managers = managers.map(manager => ({
+            ...manager,
+            canManageAsText: this.getManagerLevel(manager),
+            route: groupRoute(manager.id, [ ...route.path, group.id ]),
+          }));
           this.state = 'ready';
         },
         error: _err => {

--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -61,7 +61,7 @@
     <div class="bg-white">
       <alg-group-overview *ngIf="overviewTab?.isActive || !overviewTab && group.currentUserManagership === 'none' && group.currentUserMembership === 'none'" [group]="group"></alg-group-overview>
       <alg-group-composition *ngIf="!!compositionTab?.isActive" [group]="group" (groupRefreshRequired)="onGroupRefreshRequired()"></alg-group-composition>
-      <alg-group-managers *ngIf="!!adminTab?.isActive" [group]="group"></alg-group-managers>
+      <alg-group-managers *ngIf="!!adminTab?.isActive" [groupData]="state.data"></alg-group-managers>
       <alg-group-settings *ngIf="!!settingsTab?.isActive" [group]="group" (groupRefreshRequired)="onGroupRefreshRequired()"></alg-group-settings>
     </div>
 

--- a/src/app/modules/group/pages/group-managers/group-managers.component.html
+++ b/src/app/modules/group/pages/group-managers/group-managers.component.html
@@ -1,6 +1,6 @@
 <alg-group-manager-list
-  [group]="group"
-  *ngIf="group?.isCurrentUserManager || group?.currentUserMembership !== 'none'; else noPermission"
+  [groupData]="groupData"
+  *ngIf="groupData?.group?.isCurrentUserManager || groupData?.group?.currentUserMembership !== 'none'; else noPermission"
 ></alg-group-manager-list>
 
 <ng-template #noPermission>

--- a/src/app/modules/group/pages/group-managers/group-managers.component.ts
+++ b/src/app/modules/group/pages/group-managers/group-managers.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
-import { Group } from '../../http-services/get-group-by-id.service';
 import { ManagementAdditions } from '../../helpers/group-management';
+import { GroupData } from '../../services/group-datasource.service';
 
 @Component({
   selector: 'alg-group-managers',
@@ -8,6 +8,6 @@ import { ManagementAdditions } from '../../helpers/group-management';
   styleUrls: [ './group-managers.component.scss' ],
 })
 export class GroupManagersComponent {
-  @Input() group?: Group & ManagementAdditions;
+  @Input() groupData?: GroupData & { group: GroupData['group'] & ManagementAdditions };
 }
 


### PR DESCRIPTION
## Done

Forward `groupData` to the managers list to provide access to current route, allowing to construct the path.

## Tests

1. Go to a group managers list
2. Hover a manager name

Now the path is included in the URL. Although it is not currently useful, it will when implementing breadcrumbs for users

Group example:
- [branch app](https://dev.algorea.org/branch/fix/group-managers-list-path/en/#/groups/by-id/672913018859223173;path=52767158366271444/details/managers)
- [production app](https://dev.algorea.org/en/#/groups/by-id/672913018859223173;path=52767158366271444/details/managers)