### PR TITLE
fix e2e tests by adopting retry+sleep strategy

### DIFF
--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -23,11 +23,12 @@ exports.config = {
     defaultTimeoutInterval: 30000,
     print: function() {}
   },
+  SELENIUM_PROMISE_MANAGER: false,
   onPrepare() {
     require('ts-node').register({
       project: require('path').join(__dirname, './tsconfig.json')
     });
-    browser.waitForAngularEnabled(false);
-    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
+    jasmine.getEnv().addReporter(new SpecReporter());
+    return browser.waitForAngularEnabled(false);
   }
 };

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,53 +1,54 @@
-/* eslint-disable @typescript-eslint/no-floating-promises */
 import { AppPage } from './app.po';
-import { browser, logging } from 'protractor';
+import { browser, ExpectedConditions, logging } from 'protractor';
+import { retry } from './helpers/retry';
 
 describe('Algorea Frontend', () => {
   let page: AppPage;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     page = new AppPage();
-    page.navigateTo();
+    await page.navigateTo();
   });
 
   describe('page static elements', () => {
-    it('should shows the title', () => {
-      page.waitForElement(page.getTitleElement());
-      expect(page.getTitleElement().getText()).toEqual('ALGOREA PLATFORM');
+    it('should shows the title', async () => {
+      await page.waitForElement(page.getTitleElement());
+      await expect(page.getTitleElement().getText()).toEqual('ALGOREA PLATFORM');
     });
 
-    it('should have a working item-detail', () => {
-      page.waitForElement(page.getFirstActivityElement());
+    it('should have a working item-detail', async () => {
+      await browser.wait(ExpectedConditions.elementToBeClickable(page.getFirstActivityElement()), 10000);
       // Check if the first item exists and is working
-      page.getFirstActivityElement().click();
-      page.waitForElement(page.getMainContentElement());
-      expect(page.getMainContentElement().getText()).toBeTruthy();
-      // expect(page.getMainContentElement().getText()).toEqual('item-details works!');
+      await retry(() => page.getFirstActivityElement().click());
+
+      await page.waitForElement(page.getMainContentElement());
+      await retry(() => expect(page.getMainContentElement().getText()).toBeTruthy());
+      // await expect(page.getMainContentElement().getText()).toEqual('item-details works!');
     });
 
-    it('should have a working collapse button', () => {
-      expect(page.getLeftElement().getAttribute('class')).toMatch('expanded');
-      expect(page.getTopBarElement().getAttribute('class')).toMatch('expanded');
-      expect(page.getRightElement().getAttribute('class')).toMatch('expanded');
+    it('should have a working collapse button', async () => {
+      await expect(page.getLeftElement().getAttribute('class')).toMatch('expanded');
+      await expect(page.getTopBarElement().getAttribute('class')).toMatch('expanded');
+      await expect(page.getRightElement().getAttribute('class')).toMatch('expanded');
 
-      page.getCollapseButtonElement().click();
+      await page.getCollapseButtonElement().click();
 
-      expect(page.getLeftElement().getAttribute('class')).toMatch('collapsed');
-      expect(page.getTopBarElement().getAttribute('class')).toMatch('collapsed');
-      expect(page.getRightElement().getAttribute('class')).toMatch('collapsed');
+      await expect(page.getLeftElement().getAttribute('class')).toMatch('collapsed');
+      await expect(page.getTopBarElement().getAttribute('class')).toMatch('collapsed');
+      await expect(page.getRightElement().getAttribute('class')).toMatch('collapsed');
     });
   });
 
   describe('activities elements', () => {
-    it('should shows the first element of the activity tree', () => {
-      page.waitForElement(page.getFirstActivityLabelElement());
-      expect(page.getFirstActivityLabelElement().getText()).toContain('Parcours officiels');
+    it('should shows the first element of the activity tree', async () => {
+      await browser.wait(ExpectedConditions.textToBePresentInElement(page.getFirstActivityLabelElement(), 'Parcours officiels'), 10000);
+      await retry(() => expect(page.getFirstActivityLabelElement().getText()).toContain('Parcours officiels'));
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     // Assert that there are no errors emitted from the browser
-    const logs = browser.manage().logs().get(logging.Type.BROWSER);
+    const logs = await browser.manage().logs().get(logging.Type.BROWSER);
     expect(logs).not.toContain(jasmine.objectContaining({
       level: logging.Level.SEVERE,
     } as logging.Entry));

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -1,12 +1,12 @@
 import { browser, by, element, ElementFinder, ExpectedConditions } from 'protractor';
 
 export class AppPage {
-  navigateTo() {
-    return browser.get(browser.baseUrl) as Promise<any>;
+  async navigateTo() {
+    await browser.get(browser.baseUrl) as Promise<any>;
   }
 
-  waitForElement(element: ElementFinder) {
-    return browser.wait(ExpectedConditions.visibilityOf(element), 10000, 'Element taking too long to appear in the DOM');
+  async waitForElement(element: ElementFinder) {
+    await browser.wait(ExpectedConditions.visibilityOf(element), 10000, 'Element taking too long to appear in the DOM');
   }
 
   getTitleElement() {

--- a/e2e/src/helpers/retry.ts
+++ b/e2e/src/helpers/retry.ts
@@ -1,0 +1,28 @@
+import { browser } from 'protractor';
+
+/**
+ * Helper to mitigate protractor notorious flakyness:
+ * - https://duckduckgo.com/?q=protractor+tests+are+flaky&t=canonical&ia=web
+ * - https://www.google.com/search?q=protractor+tests+are+flaky
+ * Although some tools exist, I tried protractor-errors and protractor-retry without success, so I got inspired from
+ * that blog post: https://christianlydemann.com/life-saving-protractor-utilities-to-fix-flaky-end-to-end-tests/
+ */
+
+export async function retry(
+  fn: () => unknown | Promise<unknown>,
+  pollInMs = 500,
+  maxTries = 20,
+  currentTry = 1,
+): Promise<unknown> {
+  if (currentTry > 1) console.info('retry', currentTry - 1);
+  if (currentTry > maxTries) throw new Error('should not happen');
+  if (currentTry === maxTries) return fn();
+  try {
+    // NOTE: to catch the error properly, we need to await the result and not return directly
+    const result = await fn();
+    return result;
+  } catch (error) {
+    await browser.sleep(pollInMs);
+    return retry(fn, pollInMs, maxTries, currentTry + 1);
+  }
+}


### PR DESCRIPTION
Fixes #605

Tests were run an another branch to keep a history:
- [GitHub](https://github.com/France-ioi/AlgoreaFrontend/pull/643)
- [CircleCI](https://app.circleci.com/pipelines/github/France-ioi/AlgoreaFrontend?branch=chore%2Fe2e-async-await)