### PR TITLE
Fetch item navigation data in item-by-id

### DIFF
--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -7,7 +7,7 @@ import { isRouteWithSelfAttempt, FullItemRoute } from 'src/app/shared/routing/it
 import { appConfig } from 'src/app/shared/helpers/config';
 import { isASkill, isSkill, ItemType, ItemTypeCategory } from 'src/app/shared/helpers/item-type';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
-import { pipe } from 'fp-ts/lib/function';
+import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
 import { permissionsDecoder } from 'src/app/modules/item/helpers/item-permissions';
 import { dateDecoder } from 'src/app/shared/helpers/decoders';

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { concat, EMPTY, forkJoin, Observable, of, ReplaySubject, Subject, Subscription } from 'rxjs';
+import { EMPTY, forkJoin, Observable, of, ReplaySubject, Subject, Subscription } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { bestAttemptFromResults, implicitResultStart } from 'src/app/shared/helpers/attempts';
 import { isRouteWithSelfAttempt, FullItemRoute } from 'src/app/shared/routing/item-route';
@@ -10,6 +10,7 @@ import { GetItemByIdService, Item } from '../http-services/get-item-by-id.servic
 import { GetResultsService, Result } from '../http-services/get-results.service';
 import { canCurrentUserViewItemContent } from 'src/app/modules/item/helpers/item-permissions';
 import { mapToFetchState } from 'src/app/shared/operators/state';
+import { buildUp } from 'src/app/shared/operators/build-up';
 
 export interface ItemData { route: FullItemRoute, item: Item, breadcrumbs: BreadcrumbItem[], results?: Result[], currentResult?: Result}
 
@@ -62,22 +63,12 @@ export class ItemDataSource implements OnDestroy {
    * In parallel: breadcrumb and (in serial: get info and start result)
    */
   private fetchItemData(itemRoute: FullItemRoute): Observable<ItemData> {
-    return forkJoin([
-      this.getBreadcrumbService.getBreadcrumb(itemRoute),
-      this.getItemByIdService.get(itemRoute.id)
-    ]).pipe(
-      switchMap(([ breadcrumbs, item ]) => {
-        // emit immediately without results, then, if the perm allows it, fetch results
-        const initialData = { route: itemRoute, item: item, breadcrumbs: breadcrumbs };
-        if (canCurrentUserViewItemContent(item)) {
-          return concat(
-            of(initialData),
-            this.fetchResults(itemRoute, item).pipe(
-              map(r => ({ ...initialData, ...r }))
-            )
-          );
-        } else return of(initialData);
-      })
+    return forkJoin({
+      route: of(itemRoute),
+      item: this.getItemByIdService.get(itemRoute.id),
+      breadcrumbs: this.getBreadcrumbService.getBreadcrumb(itemRoute),
+    }).pipe(
+      buildUp(data => (canCurrentUserViewItemContent(data.item) ? this.fetchResults(data.route, data.item) : EMPTY))
     );
   }
 

--- a/src/app/shared/operators/build-up.spec.ts
+++ b/src/app/shared/operators/build-up.spec.ts
@@ -1,0 +1,85 @@
+/* eslint-disable no-multi-spaces */
+import { EMPTY, of } from 'rxjs';
+import { delay } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { buildUp } from './build-up';
+
+describe('progressiveListFromList operator', () => {
+
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual, expected) => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  it('should work as expected when the second service responds immediately', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source =   cold('---a------b---|', { a: { name: 'foo', childId: '4' }, b: { name: 'bar', childId: '6' } });
+      const expected = cold('---(xy)---(wz)|', {
+        x: { name: 'foo', childId: '4' },
+        y: { name: 'foo', childId: '4', childName: 'foo4' },
+        w: { name: 'bar', childId: '6' },
+        z: { name: 'bar', childId: '6', childName: 'bar6' },
+      });
+      const list = source.pipe(buildUp(s => of({ childName: s.name + s.childId })));
+      expectObservable(list).toEqual(expected);
+    });
+  });
+
+  it('should work as expected when the second service responds with a delay', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source =   cold('---a------b---|', { a: { name: 'foo', childId: '4' }, b: { name: 'bar', childId: '6' } });
+      const expected = cold('---x-y----w-z-|', {
+        x: { name: 'foo', childId: '4' },
+        y: { name: 'foo', childId: '4', childName: 'foo4' },
+        w: { name: 'bar', childId: '6' },
+        z: { name: 'bar', childId: '6', childName: 'bar6' },
+      });
+      const list = source.pipe(buildUp(s => of({ childName: s.name + s.childId }).pipe(delay(2))));
+      expectObservable(list).toEqual(expected);
+    });
+  });
+
+  it('should work as expected when the second call is cancelled by another emission from the source', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source =   cold('---a--b-----|', { a: { name: 'foo', childId: '4' }, b: { name: 'bar', childId: '6' } });
+      const expected = cold('---x--w---z-|', {
+        x: { name: 'foo', childId: '4' },
+        w: { name: 'bar', childId: '6' },
+        z: { name: 'bar', childId: '6', childName: 'bar6' },
+      });
+      const list = source.pipe(buildUp(s => of({ childName: s.name + s.childId }).pipe(delay(4))));
+      expectObservable(list).toEqual(expected);
+    });
+  });
+
+
+  it('should work as expected when the second service complete immediately', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source =   cold('---a------b---|', { a: { name: 'foo', childId: '4' }, b: { name: 'bar', childId: '6' } });
+      const expected = cold('---x------w---|', {
+        x: { name: 'foo', childId: '4' },
+        w: { name: 'bar', childId: '6' },
+      });
+      const list = source.pipe(buildUp(_ => EMPTY));
+      expectObservable(list).toEqual(expected);
+    });
+  });
+
+  it('should work as expected when keys are overridden', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source =   cold('---a------b---|', { a: { name: 'foo', childId: '4' }, b: { name: 'bar', childId: '6' } });
+      const expected = cold('---(xy)---(wz)|', {
+        x: { name: 'foo', childId: '4' },
+        y: { name: 'foo4', childId: '4' },
+        w: { name: 'bar', childId: '6' },
+        z: { name: 'bar6', childId: '6' },
+      });
+      const list = source.pipe(buildUp(s => of({ name: s.name + s.childId })));
+      expectObservable(list).toEqual(expected);
+    });
+  });
+
+});

--- a/src/app/shared/operators/build-up.spec.ts
+++ b/src/app/shared/operators/build-up.spec.ts
@@ -4,7 +4,7 @@ import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { buildUp } from './build-up';
 
-describe('progressiveListFromList operator', () => {
+describe('buildUp operator', () => {
 
   let testScheduler: TestScheduler;
 

--- a/src/app/shared/operators/build-up.ts
+++ b/src/app/shared/operators/build-up.ts
@@ -1,0 +1,26 @@
+
+import { OperatorFunction, pipe, concat, of, Observable } from 'rxjs';
+import { switchMap, map } from 'rxjs/operators';
+
+interface ObjectT { [k: string]: any }
+
+/**
+ * RxOperator which, for each input, first emits the raw input and then emits the raw input extended with the emission of an another
+ * observable based on this input.
+ * It is intended to be used to build up data from several async services. So it emits first the input (typically the output from another
+ * service) and then uses this input for another call (e.g. request more now we know this initial info) and finally emits the merge of
+ * the initial input with the output of the other call.
+ * For instance, it emits `{ name: 'foo', childId: 4 }` and then `{ name: 'foo', childId: 4, childName: 'bar' }` when the child name has
+ * been fetched.
+ * Note that this operator uses `switchMap`, so if the source re-emits, the subrequest is cancelled.
+ */
+export function buildUp<T extends ObjectT, U extends ObjectT>(project: (value: T) => Observable<U>): OperatorFunction<T, T | (T & U)> {
+  return pipe(
+    switchMap(initialValue => concat(
+      of(initialValue),
+      project(initialValue).pipe(
+        map(additionalValue => ({ ...initialValue, ...additionalValue }))
+      ),
+    ))
+  );
+}


### PR DESCRIPTION
Fetch the item navigation data in item-by-id when the result is known.
This makes a 3rd call to the navigation service when navigating on an item, but of course, the goal is remove this from the menu in a next stage, and then remove it from the navigator as well. It will be done by publishing the nav data to the current content info.