### PR TITLE
fetch group nav data in group datasource

### DIFF
--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -15,6 +15,7 @@ export class GroupDetailsComponent {
   state$ = this.groupDataSource.state$.pipe(mapStateData(state => ({
     group: withManagementAdditions(state.group),
     route: state.route,
+    navigation: state.navigation,
   })));
   fullFrameContent$ = this.layoutService.fullFrameContent$;
 


### PR DESCRIPTION
Fixes #653

## Done

- [x] add method `getGroupNavigation(groupId: string)` to `group-navigation` service
- [x] call `getGroupNavigation` in `group-datasource` service
- [x] update `state$` in `group-by-id` component

## Tests

1. Go to a group page (links below)
2. Check out the requests in the console

With the [branch app](https://dev.algorea.org/branch/feat/fetch-group-nav-data-in-group-datasource/en/#/groups/by-id/7650735426882403033;path=52767158366271444,672913018859223173/details), you should see 4 requests to navigation
With the [production app](https://dev.algorea.org/en/#/groups/by-id/7650735426882403033;path=52767158366271444,672913018859223173/details), you should see 3 requests to navigation