### PR TITLE
group path: avoid failing when path from root fails

### DIFF
--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.html
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.html
@@ -1,7 +1,1 @@
-<router-outlet *ngIf="!navigationError; else error"></router-outlet>
-
-<ng-template #error>
-  <p i18n>Error while loading the item.</p>
-  <p><a [routerLink]="" (click)="reloadContent()" i18n>Retry loading it</a></p>
-</ng-template>
-
+<router-outlet></router-outlet>

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -69,10 +69,6 @@ export class GroupByIdComponent implements OnDestroy {
     this.subscriptions.forEach(s => s.unsubscribe());
   }
 
-  reloadContent(): void {
-    this.fetchGroupAtRoute(this.activatedRoute.snapshot.paramMap);
-  }
-
   private fetchGroupAtRoute(params: ParamMap): void {
     const route = groupRouteFromParams(params);
 

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -24,7 +24,6 @@ const GROUP_BREADCRUMB_CAT = $localize`Groups`;
 })
 export class GroupByIdComponent implements OnDestroy {
 
-  navigationError = false;
   private subscriptions: Subscription[] = []; // subscriptions to be freed up on destroy
   private hasRedirected = false;
 
@@ -99,7 +98,7 @@ export class GroupByIdComponent implements OnDestroy {
         this.groupRouter.navigateTo(groupRoute(groupId, path), { navExtras: { replaceUrl: true } });
       },
       error: () => {
-        this.navigationError = true;
+        this.groupRouter.navigateTo(groupRoute(groupId, []), { navExtras: { replaceUrl: true } });
       }
     });
   }


### PR DESCRIPTION
## Done

When the group `path-from-root` fails, redirect to same page with `path: []`
Note: for a content route to be displayed, the `path` is mandatory, that's why I pass an empty array rather than `undefined`. If this behavior is incorrect, please notice me :pray: 

## Tests

I did not find a group for which `path-from-root` fails, where can I find one :pray: ?