### PR TITLE
Feat: display group breadcrumbs

### DIFF
--- a/src/app/modules/group/http-services/get-group-breadcrumbs.service.ts
+++ b/src/app/modules/group/http-services/get-group-breadcrumbs.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import * as D from 'io-ts/Decoder';
+import { appConfig } from 'src/app/shared/helpers/config';
+import { GroupRoute } from 'src/app/shared/routing/group-route';
+import { decodeSnakeCase } from 'src/app/shared/operators/decode';
+
+const groupBreadcrumbDecoder = D.struct({
+  id: D.string,
+  name: D.string,
+  type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base'),
+});
+export type GroupBreadcrumb = D.TypeOf<typeof groupBreadcrumbDecoder>;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GetGroupBreadcrumbsService {
+
+  constructor(private http: HttpClient) {}
+
+  getBreadcrumbs(groupRoute: GroupRoute): Observable<GroupBreadcrumb[]> {
+    const groupIds = [ ...groupRoute.path, groupRoute.id ];
+
+    return this.http.get<unknown>(`${appConfig.apiUrl}/groups/${groupIds.join('/')}/breadcrumbs`).pipe(
+      decodeSnakeCase(D.array(groupBreadcrumbDecoder)),
+    );
+  }
+
+}

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.ts
@@ -44,12 +44,15 @@ export class GroupByIdComponent implements OnDestroy {
     this.subscriptions.push(
       this.groupDataSource.state$.pipe(
         readyData(),
-        map(({ group, route }): GroupInfo => groupInfo({
+        map(({ group, route, breadcrumbs }): GroupInfo => groupInfo({
           route: groupRoute(group.id, route.path),
           breadcrumbs: {
             category: GROUP_BREADCRUMB_CAT,
-            path: [{ title: group.name, navigateTo: (): UrlTree => this.groupRouter.url(route, 'details') }],
-            currentPageIdx: 0,
+            path: breadcrumbs.map(breadcrumb => ({
+              title: breadcrumb.name,
+              navigateTo: (): UrlTree => this.groupRouter.url(breadcrumb.route, 'details'),
+            })),
+            currentPageIdx: breadcrumbs.length - 1,
           },
           title: group.name,
         })),

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -15,6 +15,7 @@ export class GroupDetailsComponent {
   state$ = this.groupDataSource.state$.pipe(mapStateData(state => ({
     group: withManagementAdditions(state.group),
     route: state.route,
+    breadcrumbs: state.breadcrumbs,
   })));
   fullFrameContent$ = this.layoutService.fullFrameContent$;
 

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -13,10 +13,8 @@ import { LayoutService } from '../../../../shared/services/layout.service';
 export class GroupDetailsComponent {
 
   state$ = this.groupDataSource.state$.pipe(mapStateData(state => ({
+    ...state,
     group: withManagementAdditions(state.group),
-    route: state.route,
-    navigation: state.navigation,
-    breadcrumbs: state.breadcrumbs,
   })));
   fullFrameContent$ = this.layoutService.fullFrameContent$;
 

--- a/src/app/modules/group/services/group-datasource.service.ts
+++ b/src/app/modules/group/services/group-datasource.service.ts
@@ -1,11 +1,16 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { ReplaySubject, Subject } from 'rxjs';
+import { forkJoin, ReplaySubject, Subject } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { mapToFetchState } from 'src/app/shared/operators/state';
 import { GroupRoute } from 'src/app/shared/routing/group-route';
+import { GetGroupBreadcrumbsService, GroupBreadcrumb } from '../http-services/get-group-breadcrumbs.service';
 import { GetGroupByIdService, Group } from '../http-services/get-group-by-id.service';
 
-export interface GroupData { route: GroupRoute, group: Group }
+export interface GroupData {
+  route: GroupRoute,
+  group: Group,
+  breadcrumbs: GroupBreadcrumb[],
+}
 
 /**
  * A datasource which allows fetching a group using a proper state and sharing it among several components.
@@ -22,8 +27,11 @@ export class GroupDataSource implements OnDestroy {
   state$ = this.fetchOperation.pipe(
     // switchMap does cancel the previous ongoing processing if a new one comes
     // on new fetch operation to be done: set "fetching" state and fetch the data which will result in a ready or error state
-    switchMap(route => this.getGroupByIdService.get(route.id).pipe(
-      map(group => ({ route, group })),
+    switchMap(route => forkJoin({
+      group: this.getGroupByIdService.get(route.id),
+      breadcrumbs: this.getGroupBreadcrumbsService.getBreadcrumbs(route),
+    }).pipe(
+      map(({ group, breadcrumbs }) => ({ route, group, breadcrumbs })),
       mapToFetchState({ resetter: this.refresh$ }),
     )),
     shareReplay(1),
@@ -31,6 +39,7 @@ export class GroupDataSource implements OnDestroy {
 
   constructor(
     private getGroupByIdService: GetGroupByIdService,
+    private getGroupBreadcrumbsService: GetGroupBreadcrumbsService
   ) {}
 
   fetchGroup(route: GroupRoute): void {


### PR DESCRIPTION
## Done

- Create service `GetGroupBreadcrumbs`
- Add `breadcrumbs` property to `group-datasource` `GroupData` and fetch breadcrumbs when fetching a group
- Register breadcrumbs to display in component `group-by-id`

## Tests

- [x] When constructing a path manually by navigating in the app
:one: Wherever on the app ([production]() / [branch]()), click on `Groups` tab
:two: Navigate to groups: `4LTDI1819` > `Pixal` > `demo`
Then:
:arrow_right: You should see in the breadcrumbs `4LTDI1819`, `Pixal` and `demo`, `demo` should be selected
:arrow_right: Clicking on `Pixal` should redirect to the `Pixal` group, `4LTDI1819` remaining in the breadcrumbs
:arrow_right: Clicking on `4LTDI1819` should redirect to the group

- [x] When landing on a group with path constructed by backend by calling `path-from-root`:
:one: Copy-paste the direct url of this group `demo` group: [production](https://dev.algorea.org/en/#/groups/by-id/4603869706499321180/details) / [branch](https://dev.algorea.org/branch/feat/display-group-breadcrumbs/en/#/groups/by-id/4603869706499321180/details)
Then:
:arrow_right: You should see in the breadcrumbs `4LTDI1819`, `Pixal` and `demo`, `demo` should be selected
:arrow_right: Clicking on `Pixal` should redirect to the group with `4LTDI1819` remaining in the breadcrumbs
:arrow_right: Clicking on `4LTDI1819` should redirect to the group

