### PR TITLE
display task views as tabs

### DIFF
--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -1,9 +1,11 @@
 <div class="item-display" *ngIf="state$ | async as state">
-  <nav *ngIf="tabs.length > 1" class="nav-tab">
-    <a class="nav-tab-item" *ngFor="let tab of tabs" (click)="setActiveTab(tab)" [class.active]="activeTab === tab">
-      {{tab.name}}
-    </a>
-  </nav>
+  <ng-container *ngIf="tabs$ | async as tabs">
+    <nav *ngIf="tabs.length > 1" class="nav-tab">
+      <a class="nav-tab-item" *ngFor="let tab of tabs" (click)="setActiveTab(tab)" [class.active]="tab.view === (activeTabView$ | async)">
+        {{tab.name}}
+      </a>
+    </nav>
+  </ng-container>
   <div *ngIf="state.isError" i18n>Unable to load the task</div>
   <div class="iframe-container" [style.height.px]="iframeHeight$ | async" *ngIf="!state.isError">
     <iframe *ngIf="iframeSrc$ | async as iframeSrc" #iframe [src]="iframeSrc"></iframe>

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -26,7 +26,7 @@ export class ItemTaskService implements OnDestroy {
   views$ = merge(
     this.task$.pipe(switchMap(task => task.getViews())), // Load views once the task has been loaded
     this.display$.pipe(map(({ views }) => views), filter(isNotUndefined)), // listen to display updates
-  );
+  ).pipe(map(views => Object.entries(views).filter(([ , view ]) => !view.requires).map(([ name ]) => name)));
   activeView$ = new BehaviorSubject<string>('task');
   showViews$ = combineLatest([ this.task$, this.activeView$ ]).pipe(switchMap(([ task, view ]) => task.showViewsInTask({ [view]: true })));
 

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -28,7 +28,7 @@ export class ItemTaskService implements OnDestroy {
     this.display$.pipe(map(({ views }) => views), filter(isNotUndefined)), // listen to display updates
   ).pipe(map(views => Object.entries(views).filter(([ , view ]) => !view.requires).map(([ name ]) => name)));
   activeView$ = new BehaviorSubject<string>('task');
-  showViews$ = combineLatest([ this.task$, this.activeView$ ]).pipe(switchMap(([ task, view ]) => task.showViewsInTask({ [view]: true })));
+  showViews$ = combineLatest([ this.task$, this.activeView$ ]).pipe(switchMap(([ task, view ]) => task.showViews({ [view]: true })));
 
   initialized = false;
 
@@ -49,6 +49,10 @@ export class ItemTaskService implements OnDestroy {
       of({ minScore: -3, maxScore: 10, randomSeed: 0, noScore: 0, readOnly: false, options: {} }),
     updateDisplay: (display): Observable<void> => {
       this.displaySubject.next(display);
+      return EMPTY;
+    },
+    showView: (view): Observable<void> => {
+      this.activeView$.next(view);
       return EMPTY;
     },
   });

--- a/src/app/modules/item/task-communication/task-proxy.ts
+++ b/src/app/modules/item/task-communication/task-proxy.ts
@@ -102,7 +102,7 @@ export class Task {
     );
     this.chan.bind(
       'platform.showView',
-      view => platform.viewsShownByTask(decode(D.string)(view)),
+      view => platform.showView(decode(D.string)(view)),
     );
     this.chan.bind(
       'platform.askHint',
@@ -206,7 +206,7 @@ export class Task {
     }).pipe(map(([ taskViews ]) => decode(taskViewsDecoder)(taskViews)));
   }
 
-  showViewsInTask(views: Record<string, boolean>): Observable<unknown> {
+  showViews(views: Record<string, boolean>): Observable<unknown> {
     return this.chan.call({
       method: 'task.showViews',
       params: views,
@@ -250,7 +250,7 @@ export class TaskPlatform {
   validate(_mode: string): Observable<void> {
     return throwError(() => new Error('platform.validate is not defined'));
   }
-  viewsShownByTask(_views: unknown): Observable<void> {
+  showView(_views: string): Observable<void> {
     return throwError(() => new Error('platform.showView is not defined'));
   }
   askHint(_platformToken: string): Observable<void> {

--- a/src/app/shared/helpers/case_conversion.ts
+++ b/src/app/shared/helpers/case_conversion.ts
@@ -25,3 +25,7 @@ export function snakeToCamelKeys(input: unknown): unknown {
 
   return input;
 }
+
+export function capitalize(text: string): string {
+  return text.substring(0, 1).toUpperCase() + text.substring(1);
+}

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1943,15 +1943,9 @@
       </trans-unit>
       <trans-unit id="2577694282301310795" datatype="html">
         <source>Solution</source><target state="new">Solution</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context>
-          <context context-type="linenumber">40</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context>
-          <context context-type="linenumber">71</context>
-        </context-group>
-      </trans-unit>
+        
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">71</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">69</context></context-group></trans-unit>
       <trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="new"><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</target>
         <context-group purpose="location">
@@ -2354,25 +2348,31 @@
       </trans-unit>
       <trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
-          <context context-type="linenumber">7</context>
-        </context-group>
-      </trans-unit>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit>
       <trans-unit id="3894950702316166331" datatype="html">
         <source>Loading...</source><target state="new">Loading...</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
-          <context context-type="linenumber">10</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="3522561388766794803" datatype="html">
-        <source>No URL defined for this task.</source><target state="new">No URL defined for this task.</target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
+        <source>Editor</source><target state="new">Editor</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit><trans-unit id="1961103453220395122" datatype="html">
+        <source>Forum</source><target state="new">Forum</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+      </trans-unit><trans-unit id="4579430119993221119" datatype="html">
+        <source>Hints</source><target state="new">Hints</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit>
+      
       <trans-unit id="186460519743457757" datatype="html">
         <source>Global parameters</source><target state="new">Global parameters</target>
         <context-group purpose="location">
@@ -2945,11 +2945,8 @@
       </trans-unit>
       <trans-unit id="4578192247039196794" datatype="html">
         <source>Task</source><target state="new">Task</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context>
-          <context context-type="linenumber">14</context>
-        </context-group>
-      </trans-unit>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">71</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit>
       <trans-unit id="6361086178368013800" datatype="html">
         <source>A new task which users can try to solve.</source><target state="new">A new task which users can try to solve.</target>
         <context-group purpose="location">
@@ -2987,11 +2984,8 @@
       </trans-unit>
       <trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="new">Submission</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context>
-          <context context-type="linenumber">5</context>
-        </context-group>
-      </trans-unit>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">70</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">5</context></context-group></trans-unit>
       <trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="new">Submission (score: <x id="PH" equiv-text="score"/>)</target>
         <context-group purpose="location">


### PR DESCRIPTION
Can be tested [here](https://dev.algorea.org/branch/item-display/views/en/#/activities/by-id/1511229473173712830;path=1352246428241737349,1545709256713023530,1128536253570566326;attempId=0/details)

You should see a `Solution` tab

I could not test when the platform (aka the iframe) instructs the app to change the view. Is there a task on which I can test that ?