### PR TITLE
handle 'open url' platform operation

### DIFF
--- a/src/app/modules/item/task-communication/task-proxy.ts
+++ b/src/app/modules/item/task-communication/task-proxy.ts
@@ -10,6 +10,8 @@ import { delay, map, retryWhen, switchMap, take } from 'rxjs/operators';
 import { rxBuild, RxMessagingChannel } from './rxjschannel';
 import * as D from 'io-ts/Decoder';
 import {
+  OpenUrlParams,
+  openUrlParamsDecoder,
   TaskGrade,
   taskGradeDecoder,
   TaskLog,
@@ -114,7 +116,7 @@ export class Task {
     );
     this.chan.bind(
       'platform.openUrl',
-      url => platform.openUrl(decode(D.string)(url)),
+      url => platform.openUrl(decode(openUrlParamsDecoder)(url)),
     );
     this.chan.bind(
       'platform.log',
@@ -262,7 +264,7 @@ export class TaskPlatform {
   updateDisplay(_data: UpdateDisplayParams): Observable<void> {
     return throwError(() => new Error('platform.updateDisplay is not defined!'));
   }
-  openUrl(_url: string): Observable<void> {
+  openUrl(_url: OpenUrlParams): Observable<void> {
     return throwError(() => new Error('platform.openUrl is not defined!'));
   }
   log(_data: TaskLog): Observable<void> {

--- a/src/app/modules/item/task-communication/types.ts
+++ b/src/app/modules/item/task-communication/types.ts
@@ -1,5 +1,6 @@
 /** Types and decoders for types used in platform-task communication */
 
+import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
 
 
@@ -54,7 +55,6 @@ export type TaskGrade = D.TypeOf<typeof taskGradeDecoder>;
 export type TaskScore = NonNullable<TaskGrade['score']>;
 export type TaskScoreToken = NonNullable<TaskGrade['scoreToken']>;
 
-
 // Parameters sent by the task to platform.updateDisplay
 export const updateDisplayParamsDecoder = D.partial({
   height: D.number,
@@ -70,3 +70,17 @@ export type TaskLog = D.TypeOf<typeof taskLogDecoder>;
 // Currently unused
 export type TaskMetaData = unknown;
 export type TaskResources = unknown;
+
+export const openUrlParamsDecoder = D.union(
+  D.string,
+  pipe(
+    D.struct({ path: D.string }),
+    D.intersect(D.partial({ newTab: D.boolean }))
+  ),
+  pipe(
+    D.struct({ url: D.string }),
+    D.intersect(D.partial({ newTab: D.boolean }))
+  ),
+);
+
+export type OpenUrlParams = D.TypeOf<typeof openUrlParamsDecoder>;

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -43,6 +43,9 @@ export function isRouteWithSelfAttempt(item: FullItemRoute): item is ItemRouteWi
 export function rawItemRoute(contentType: ItemTypeCategory, id: ItemId): RawItemRoute {
   return { contentType, id };
 }
+export function itemRoute(contentType: ItemTypeCategory, id: ItemId, path: string[]): ItemRoute {
+  return { ...rawItemRoute(contentType, id), path };
+}
 
 /**
  * The route to the app default (see config) item


### PR DESCRIPTION
Although `OpenUrlParams` has 3 shapes
1. `string`
2. `{ path: string, newTab?: boolean }`
3. `{ url: string, newTab?: boolean }`

I could test only the second use case.