### PR TITLE
Permission constraints

### DIFF
--- a/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html
+++ b/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html
@@ -28,7 +28,6 @@
       <form [formGroup]="form">
         <alg-collapsible-section
           [collapsible]="false"
-          [collapsed]="false"
           i18n-title title="Management level"
           icon="fa fa-users-cog"
         >
@@ -48,7 +47,6 @@
 
         <alg-collapsible-section
           [collapsible]="false"
-          [collapsed]="false"
           i18n-title title="Can grant access"
           icon="fa fa-key"
         >
@@ -65,7 +63,6 @@
 
         <alg-collapsible-section
           [collapsible]="false"
-          [collapsed]="false"
           i18n-title title="Can watch members"
           icon="fa fa-binoculars"
         >

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts
@@ -71,13 +71,11 @@ export function generateCanGrantViewValues(targetType: TypeFilter): ProgressSele
       value: 'solution',
       label: $localize`Solution`,
       comment: $localize`${targetTypeString} can also grant \'Can view: solution\' access`,
-      disabled: true
     },
     {
       value: 'solution_with_grant',
       label: $localize`Solution and grant`,
       comment: $localize`${targetTypeString} can also grant \'Can grant view\' access`,
-      disabled: true
     }
   ];
 }

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts
@@ -1,5 +1,7 @@
 import { ProgressSelectValue } from
   'src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component';
+import { GroupPermissions } from 'src/app/shared/http-services/group-permissions.service';
+import { permissionsInfoString } from '../../helpers/item-permissions';
 import { TypeFilter } from '../composition-filter/composition-filter.component';
 
 function getTargetTypeString(targetType: TypeFilter): string {
@@ -13,123 +15,133 @@ function getTargetTypeString(targetType: TypeFilter): string {
   }
 }
 
-export function generateCanViewValues(targetType: TypeFilter): ProgressSelectValue<string>[]{
+export function generateCanViewValues(
+  targetType: TypeFilter,
+): ProgressSelectValue<GroupPermissions['canView']>[]{
   const targetTypeString = getTargetTypeString(targetType);
   return [
     {
       value: 'none',
-      label: $localize`Nothing`,
+      label: permissionsInfoString.canView.none,
       comment: $localize`${targetTypeString} can\'t see the item`
     },
     {
       value: 'info',
-      label: $localize`Info`,
-      comment: $localize`${targetTypeString} can see the item title and description, but not its content`
+      label: permissionsInfoString.canView.info,
+      comment: $localize`${targetTypeString} can see the item title and description, but not its content`,
     },
     {
       value: 'content',
-      label: $localize`Content`,
-      comment: $localize`${targetTypeString} can see the content of this item`
+      label: permissionsInfoString.canView.content,
+      comment: $localize`${targetTypeString} can see the content of this item`,
     },
     {
       value: 'content_with_descendants',
-      label: $localize`Content and descendants`,
-      comment: $localize`${targetTypeString} can also see the content of this items descendants (when possible for this group)`
+      label: permissionsInfoString.canView.content_with_descendants,
+      comment: $localize`${targetTypeString} can also see the content of this items descendants (when possible for this group)`,
     },
     {
       value: 'solution',
-      label: $localize`Solution`,
-      comment: $localize`${targetTypeString} can also see the solution of this items and its descendants (when possible for this group)`
+      label: permissionsInfoString.canView.solution,
+      comment: $localize`${targetTypeString} can also see the solution of this items and its descendants (when possible for this group)`,
     }
   ];
 }
 
-export function generateCanGrantViewValues(targetType: TypeFilter): ProgressSelectValue<string>[]{
+export function generateCanGrantViewValues(
+  targetType: TypeFilter,
+): ProgressSelectValue<GroupPermissions['canGrantView']>[]{
   const targetTypeString = getTargetTypeString(targetType);
+
   return [
     {
       value: 'none',
-      label: $localize`Nothing`,
+      label: permissionsInfoString.canGrantView.none,
       comment: $localize`${targetTypeString} can\'t grant any access to this item`
     },
     {
       value: 'enter',
-      label: $localize`Info & enter`,
-      comment: $localize`${targetTypeString} can grant \'Can view: info\' and  \'Can enter\' access`
+      label: permissionsInfoString.canGrantView.enter,
+      comment: $localize`${targetTypeString} can grant \'Can view: info\' and  \'Can enter\' access`,
     },
     {
       value: 'content',
-      label: $localize`Content`,
-      comment: $localize`${targetTypeString} can also grant \'Can view: content\' access`
+      label: permissionsInfoString.canGrantView.content,
+      comment: $localize`${targetTypeString} can also grant \'Can view: content\' access`,
     },
     {
       value: 'content_with_descendants',
-      label: $localize`Content and descendants`,
-      comment: $localize`${targetTypeString} can also grant \'Can view: content and descendants\' access`
+      label: permissionsInfoString.canGrantView.content_with_descendants,
+      comment: $localize`${targetTypeString} can also grant \'Can view: content and descendants\' access`,
     },
     {
       value: 'solution',
-      label: $localize`Solution`,
+      label: permissionsInfoString.canGrantView.solution,
       comment: $localize`${targetTypeString} can also grant \'Can view: solution\' access`,
     },
     {
       value: 'solution_with_grant',
-      label: $localize`Solution and grant`,
+      label: permissionsInfoString.canGrantView.solution_with_grant,
       comment: $localize`${targetTypeString} can also grant \'Can grant view\' access`,
     }
   ];
 }
 
-
-export function generateCanWatchValues(targetType: TypeFilter): ProgressSelectValue<string>[]{
+export function generateCanWatchValues(
+  targetType: TypeFilter,
+): ProgressSelectValue<GroupPermissions['canWatch']>[]{
   const targetTypeString = getTargetTypeString(targetType);
+
   return [
     {
       value: 'none',
-      label: $localize`Nothing`,
+      label: permissionsInfoString.canWatch.none,
       comment: $localize`${targetTypeString} can\'t watch the activity of others on this item`
     },
     {
       value: 'result',
-      label: $localize`Result`,
+      label: permissionsInfoString.canWatch.result,
       comment:
-        $localize`${targetTypeString} can view information about submissions and scores of others on this item, but not their answers`
+        $localize`${targetTypeString} can view information about submissions and scores of others on this item, but not their answers`,
     },
     {
       value: 'answer',
-      label: $localize`Answer`,
-      comment: $localize`${targetTypeString} can also look at other people\'s answers on this item`
+      label: permissionsInfoString.canWatch.answer,
+      comment: $localize`${targetTypeString} can also look at other people\'s answers on this item`,
     },
     {
       value: 'answer_with_grant',
-      label: $localize`Answer and grant`,
-      comment: $localize`${targetTypeString} can also grant \'Can watch\' access to others`
+      label: permissionsInfoString.canWatch.answer_with_grant,
+      comment: $localize`${targetTypeString} can also grant \'Can watch\' access to others`,
     }
   ];
 }
 
-export function generateCanEditValues(targetType: TypeFilter): ProgressSelectValue<string>[]{
+export function generateCanEditValues(
+  targetType: TypeFilter,
+): ProgressSelectValue<GroupPermissions['canEdit']>[]{
   const targetTypeString = getTargetTypeString(targetType);
+
   return [
     {
       value: 'none',
-      label: $localize`Nothing`,
+      label: permissionsInfoString.canEdit.none,
       comment: $localize`${targetTypeString} can\'t make any changes to this item`
     },
     {
       value: 'children',
-      label: $localize`Children`,
-      comment: $localize`${targetTypeString} can add children to this item and edit how permissions propagate to them`
+      label: permissionsInfoString.canEdit.children,
+      comment: $localize`${targetTypeString} can add children to this item and edit how permissions propagate to them`,
     },
     {
       value: 'all',
-      label: $localize`All`,
-      comment: $localize`${targetTypeString} can also edit the content of the item itself, but may not delete it`
+      label: permissionsInfoString.canEdit.all,
+      comment: $localize`${targetTypeString} can also edit the content of the item itself, but may not delete it`,
     },
     {
       value: 'all_with_grant',
-      label: $localize`All and grant`,
-      comment: $localize`${targetTypeString} can also give \'Can edit\' access to others`
+      label: permissionsInfoString.canEdit.all_with_grant,
+      comment: $localize`${targetTypeString} can also give \'Can edit\' access to others`,
     }
   ];
 }

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
@@ -30,7 +30,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canView"
-              [values]="canViewValues"
+              [values]="progressSelectValues.canViewValues"
               [validationErrors]="form.errors?.canView"
             ></alg-progress-select>
           </ng-template>
@@ -52,7 +52,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canGrantView"
-              [values]="canGrantViewValues"
+              [values]="progressSelectValues.canGrantViewValues"
               [validationErrors]="form.errors?.canGrantView"
             ></alg-progress-select>
           </ng-template>
@@ -66,7 +66,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canWatch"
-              [values]="canWatchValues"
+              [values]="progressSelectValues.canWatchValues"
               [validationErrors]="form.errors?.canWatch"
             ></alg-progress-select>
           </ng-template>
@@ -80,7 +80,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canEdit"
-              [values]="canEditValues"
+              [values]="progressSelectValues.canEditValues"
               [validationErrors]="form.errors?.canEdit"
             ></alg-progress-select>
           </ng-template>

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
@@ -1,5 +1,5 @@
 <p-dialog
-  *ngIf="permissions"
+  *ngIf="permissions && giverPermissions"
   [visible]="visible"
   [modal]="true"
   [draggable]="false"
@@ -22,12 +22,16 @@
     <div class="dialog-content">
 
       <form [formGroup]="form">
-        <alg-collapsible-section i18n-title title="Can view" icon="fa fa-eye">
+        <alg-collapsible-section
+          i18n-title title="Can view" icon="fa fa-eye"
+          [collapsible]="!form.errors?.canView"
+        >
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canView"
               [values]="canViewValues"
+              [validationErrors]="form.errors?.canView"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
@@ -40,39 +44,58 @@
           <ng-template #label i18n>{{targetTypeString}} may enter this item (a contest or time-limited chapter)</ng-template>
         </alg-switch-field>-->
 
-        <alg-collapsible-section i18n-title title="Can grant view" icon="fa fa-key">
+        <alg-collapsible-section
+          i18n-title title="Can grant view" icon="fa fa-key"
+          [collapsible]="!form.errors?.canGrantView"
+        >
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canGrantView"
               [values]="canGrantViewValues"
+              [validationErrors]="form.errors?.canGrantView"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
 
-        <alg-collapsible-section i18n-title title="Can watch" icon="fa fa-binoculars">
+        <alg-collapsible-section
+          i18n-title title="Can watch" icon="fa fa-binoculars"
+          [collapsible]="!form.errors?.canWatch"
+        >
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canWatch"
               [values]="canWatchValues"
+              [validationErrors]="form.errors?.canWatch"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
 
-        <alg-collapsible-section i18n-title title="Can edit" icon="fa fa-pencil-alt">
+        <alg-collapsible-section
+          i18n-title title="Can edit" icon="fa fa-pencil-alt"
+          [collapsible]="!form.errors?.canEdit"
+        >
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canEdit"
               [values]="canEditValues"
+              [validationErrors]="form.errors?.canEdit"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
 
-        <alg-collapsible-section i18n-title title="Can attach official sessions" icon="fa fa-paperclip">
+        <alg-collapsible-section
+          i18n-title title="Can attach official sessions" icon="fa fa-paperclip"
+          [collapsible]="!form.errors?.canMakeSessionOfficial"
+        >
           <ng-template #content let-collapsed>
-            <alg-switch-field [collapsed]="collapsed" formControlName="canMakeSessionOfficial">
+            <alg-switch-field
+              [collapsed]="collapsed"
+              formControlName="canMakeSessionOfficial"
+              [validationErrors]="form.errors?.canMakeSessionOfficial"
+            >
               <ng-template #label>
                 <span i18n>{{targetTypeString}} may attach official sessions to this item, that will be visible to everyone in the content tab of the item</span>
               </ng-template>
@@ -80,9 +103,16 @@
           </ng-template>
         </alg-collapsible-section>
 
-        <alg-collapsible-section i18n-title title="Is owner" icon="fa fa-user-tie">
+        <alg-collapsible-section
+          i18n-title title="Is owner" icon="fa fa-user-tie"
+          [collapsible]="!form.errors?.isOwner"
+        >
           <ng-template #content let-collapsed>
-            <alg-switch-field [collapsed]="collapsed" formControlName="isOwner">
+            <alg-switch-field
+              [collapsed]="collapsed"
+              formControlName="isOwner"
+              [validationErrors]="form.errors?.isOwner"
+            >
               <ng-template #label>
                 <span i18n>{{targetTypeString}} own this item, and get the maximum access in all categories above, and may also delete this item</span>
               </ng-template>
@@ -90,7 +120,6 @@
           </ng-template>
         </alg-collapsible-section>
       </form>
-
     </div>
   </div>
 
@@ -107,7 +136,7 @@
         i18n-label label="Proceed"
         class="p-button-rounded"
         (click)="onAccept()"
-        [disabled]="!form.dirty"
+        [disabled]="!form.dirty || form.invalid"
       ></alg-button>
     </div>
   </p-footer>

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -3,6 +3,8 @@ import { FormBuilder } from '@angular/forms';
 import { ProgressSelectValue } from
   'src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component';
 import { GroupPermissions } from 'src/app/shared/http-services/group-permissions.service';
+import { PermissionsInfo } from '../../helpers/item-permissions';
+import { permissionsConstraintsValidator } from '../../helpers/item-permissions-constraints';
 import { TypeFilter } from '../composition-filter/composition-filter.component';
 import { generateCanEditValues, generateCanGrantViewValues,
   generateCanViewValues, generateCanWatchValues } from './permissions-edit-dialog-texts';
@@ -17,6 +19,7 @@ export class PermissionsEditDialogComponent implements OnChanges {
   @Input() visible?: boolean;
   @Input() title?: string;
   @Input() permissions?: GroupPermissions;
+  @Input() giverPermissions?: PermissionsInfo;
   @Input() targetType: TypeFilter = 'Users';
   @Output() close = new EventEmitter<void>();
   @Output() save = new EventEmitter<Partial<GroupPermissions>>();
@@ -47,7 +50,9 @@ export class PermissionsEditDialogComponent implements OnChanges {
       this.canEditValues = generateCanEditValues(this.targetType);
     }
 
-    if (this.permissions) {
+    if (this.permissions && this.giverPermissions) {
+      this.form.setValidators(permissionsConstraintsValidator(this.permissions, this.giverPermissions));
+      this.form.updateValueAndValidity();
       this.form.reset({ ...this.permissions }, { emitEvent: false });
     }
   }
@@ -57,6 +62,8 @@ export class PermissionsEditDialogComponent implements OnChanges {
   }
 
   onAccept(): void {
+    if (!this.form.dirty || this.form.invalid) return;
+
     const groupPermissions: Partial<GroupPermissions> = {
       canView: this.form.get('canView')?.value as GroupPermissions['canView'],
       canGrantView: this.form.get('canGrantView')?.value as GroupPermissions['canGrantView'],

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 import { FormBuilder } from '@angular/forms';
 import { ProgressSelectValue } from
   'src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component';
-import { Permissions } from 'src/app/shared/http-services/group-permissions.service';
+import { GroupPermissions } from 'src/app/shared/http-services/group-permissions.service';
 import { TypeFilter } from '../composition-filter/composition-filter.component';
 import { generateCanEditValues, generateCanGrantViewValues,
   generateCanViewValues, generateCanWatchValues } from './permissions-edit-dialog-texts';
@@ -16,10 +16,10 @@ export class PermissionsEditDialogComponent implements OnChanges {
 
   @Input() visible?: boolean;
   @Input() title?: string;
-  @Input() permissions?: Permissions;
+  @Input() permissions?: GroupPermissions;
   @Input() targetType: TypeFilter = 'Users';
   @Output() close = new EventEmitter<void>();
-  @Output() save = new EventEmitter<Permissions>();
+  @Output() save = new EventEmitter<Partial<GroupPermissions>>();
 
   targetTypeString = '';
 
@@ -48,14 +48,7 @@ export class PermissionsEditDialogComponent implements OnChanges {
     }
 
     if (this.permissions) {
-      this.form.reset({
-        canView: this.permissions.can_view,
-        canGrantView: this.permissions.can_grant_view,
-        canWatch: this.permissions.can_watch,
-        canEdit: this.permissions.can_edit,
-        canMakeSessionOfficial: this.permissions.can_make_session_official,
-        isOwner: this.permissions.is_owner,
-      }, { emitEvent: false });
+      this.form.reset({ ...this.permissions }, { emitEvent: false });
     }
   }
 
@@ -64,16 +57,16 @@ export class PermissionsEditDialogComponent implements OnChanges {
   }
 
   onAccept(): void {
-    const permissions: Permissions = {
-      can_view: this.form.get('canView')?.value as Permissions['can_view'],
-      can_grant_view: this.form.get('canGrantView')?.value as Permissions['can_grant_view'],
-      can_watch: this.form.get('canWatch')?.value as Permissions['can_watch'],
-      can_edit: this.form.get('canEdit')?.value as Permissions['can_edit'],
-      can_make_session_official: this.form.get('canMakeSessionOfficial')?.value as Permissions['can_make_session_official'],
-      is_owner: this.form.get('isOwner')?.value as Permissions['is_owner'],
+    const groupPermissions: Partial<GroupPermissions> = {
+      canView: this.form.get('canView')?.value as GroupPermissions['canView'],
+      canGrantView: this.form.get('canGrantView')?.value as GroupPermissions['canGrantView'],
+      canWatch: this.form.get('canWatch')?.value as GroupPermissions['canWatch'],
+      canEdit: this.form.get('canEdit')?.value as GroupPermissions['canEdit'],
+      canMakeSessionOfficial: this.form.get('canMakeSessionOfficial')?.value as GroupPermissions['canMakeSessionOfficial'],
+      isOwner: this.form.get('isOwner')?.value as GroupPermissions['isOwner'],
     };
 
-    this.save.emit(permissions);
+    this.save.emit(groupPermissions);
     this.close.emit();
   }
 }

--- a/src/app/modules/item/helpers/item-permissions-constraints.spec.ts
+++ b/src/app/modules/item/helpers/item-permissions-constraints.spec.ts
@@ -1,0 +1,346 @@
+import { canGrantViewValues, canViewValues } from './item-permissions';
+import { validateCanGrantView, validateCanView } from './item-permissions-constraints';
+
+function flatMap<T>(arr: T[][]) {
+  return arr.reduce((acc, val) => acc.concat(val), []);
+}
+
+/**
+ * Generate an array of object generated from all combination of objects values
+ * The object should have arrays with the different values as attrbutes
+ * Ex:
+ * ```
+ * combination({
+ *  a: [1, 2],
+ *  b: [3, 4]
+ * })
+ * ```
+ * will return
+ * ```
+ * [
+ *   {a: 1, b: 3},
+ *   {a: 1, b: 4},
+ *   {a: 2, b: 3},
+ *   {a: 2, b: 4}
+ * ]
+ * ```
+ */
+function combinations<T>(object: { [e in keyof T]: readonly T[e][] }): T[] {
+  return Object.keys(object).reduce(
+    (res, key) => flatMap(res.map(t =>
+      object[key as keyof T].map(value => {
+        const element: T = { ...t };
+        element[key as keyof T] = value;
+        return element;
+      })
+    )), [{}] as T[]);
+}
+
+describe('"can_view" permissions constraints', () => {
+
+  fit('should be a able to set to "none" ', () => {
+    for (const giverPermissions of combinations({ canGrantView: canGrantViewValues })) {
+      expect(validateCanView({ canView: 'none' }, giverPermissions)).toEqual({});
+    }
+  });
+
+  fit('should be a able to set to "info" ', () => {
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'enter', 'content', 'content_with_descendants', 'solution', 'solution_with_grant' ] as const
+    })) {
+      expect(validateCanView({ canView: 'info' }, giverPermissions)).toEqual({});
+    }
+
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'none' ] as const
+    })) {
+      expect(validateCanView({ canView: 'info' }, giverPermissions).canView).toBeDefined();
+    }
+  });
+
+  fit('should be a able to set to "content" ', () => {
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'content', 'content_with_descendants', 'solution', 'solution_with_grant' ] as const
+    })) {
+      expect(validateCanView({ canView: 'content' }, giverPermissions)).toEqual({});
+    }
+
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'none', 'enter' ] as const
+    })) {
+      expect(validateCanView({ canView: 'content' }, giverPermissions).canView).toBeDefined();
+    }
+  });
+
+  fit('should be a able to set to "content_with_descendants" ', () => {
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'content_with_descendants', 'solution', 'solution_with_grant' ] as const
+    })) {
+      expect(validateCanView({ canView: 'content_with_descendants' }, giverPermissions)).toEqual({});
+    }
+
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'none', 'enter', 'content' ] as const
+    })) {
+      expect(validateCanView({ canView: 'content_with_descendants' }, giverPermissions).canView).toBeDefined();
+    }
+  });
+
+  fit('should be a able to set to "solution" ', () => {
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'solution', 'solution_with_grant' ] as const
+    })) {
+      expect(validateCanView({ canView: 'solution' }, giverPermissions)).toEqual({});
+    }
+
+    for (const giverPermissions of combinations({
+      canGrantView: [ 'none', 'enter', 'content', 'content_with_descendants' ] as const
+    })) {
+      expect(validateCanView({ canView: 'solution' }, giverPermissions).canView).toBeDefined();
+    }
+  });
+
+});
+
+describe('"can_grant_view" permissions constraints', () => {
+
+  fit('should be a able to set to "none" ', () => {
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'none' ] as const,
+        canView: canViewValues,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions)).toEqual({});
+    }
+  });
+
+  fit('should be a able to set to "enter" ', () => {
+
+    // giver can_grant_view == 'solution_with_grant' && receiver can_view >= 'info'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'enter' ] as const,
+        canView: [ 'info', 'content', 'content_with_descendants', 'solution' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'solution_with_grant' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions)).toEqual({});
+    }
+
+    // receiver can_view < 'info'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'enter' ] as const,
+        canView: [ 'none' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+
+    // giver can_grant_view !== 'solution_with_grant'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'enter' ] as const,
+        canView: canViewValues,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'none', 'enter', 'content', 'content_with_descendants', 'solution' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+  });
+
+  fit('should be a able to set to "content" ', () => {
+
+    // giver can_grant_view == 'solution_with_grant' && receiver can_view >= 'content'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'content' ] as const,
+        canView: [ 'content', 'content_with_descendants', 'solution' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'solution_with_grant' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions)).toEqual({});
+    }
+
+    // receiver can_view < 'content'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'content' ] as const,
+        canView: [ 'none', 'info' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+
+    // giver can_grant_view !== 'solution_with_grant'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'content' ] as const,
+        canView: canViewValues,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'none', 'enter', 'content', 'content_with_descendants', 'solution' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+  });
+
+  fit('should be a able to set to "content_with_descendants" ', () => {
+
+    // giver can_grant_view == 'solution_with_grant' && receiver can_view >= 'content_with_descendants'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'content_with_descendants' ] as const,
+        canView: [ 'content_with_descendants', 'solution' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'solution_with_grant' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions)).toEqual({});
+    }
+
+    // receiver can_view < 'content_with_descendants'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'content_with_descendants' ] as const,
+        canView: [ 'none', 'info', 'content' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+
+    // giver can_grant_view !== 'solution_with_grant'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'content_with_descendants' ] as const,
+        canView: canViewValues,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'none', 'enter', 'content', 'content_with_descendants', 'solution' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+  });
+
+  fit('should be a able to set to "solution" ', () => {
+
+    // giver can_grant_view == 'solution_with_grant' && receiver can_view >= 'solution'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'solution' ] as const,
+        canView: [ 'solution' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'solution_with_grant' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions)).toEqual({});
+    }
+
+    // receiver can_view < 'solution'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'solution' ] as const,
+        canView: [ 'none', 'info', 'content', 'content_with_descendants' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+
+    // giver can_grant_view !== 'solution_with_grant'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'solution' ] as const,
+        canView: canViewValues,
+      }),
+      giverPermissions: combinations({
+        canGrantView: [ 'none', 'enter', 'content', 'content_with_descendants', 'solution' ] as const,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+  });
+
+  fit('should be a able to set to "solution_with_grant" ', () => {
+
+    // giver is_owner == true && receiver can_view >= 'solution'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'solution_with_grant' ] as const,
+        canView: [ 'solution' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ true ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions)).toEqual({});
+    }
+
+    // receiver can_view < 'solution'
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'solution_with_grant' ] as const,
+        canView: [ 'none', 'info', 'content', 'content_with_descendants' ] as const,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ true, false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+
+    // giver is_owner !== true
+    for (const p of combinations({
+      receiverPermissions: combinations({
+        canGrantView: [ 'solution_with_grant' ] as const,
+        canView: canViewValues,
+      }),
+      giverPermissions: combinations({
+        canGrantView: canGrantViewValues,
+        isOwner: [ false ] as const,
+      }),
+    })) {
+      expect(validateCanGrantView(p.receiverPermissions, p.giverPermissions).canGrantView).toBeDefined();
+    }
+  });
+});

--- a/src/app/modules/item/helpers/item-permissions-constraints.ts
+++ b/src/app/modules/item/helpers/item-permissions-constraints.ts
@@ -10,6 +10,12 @@ import {
   generateCanEditValues
 } from '../components/permissions-edit-dialog/permissions-edit-dialog-texts';
 
+const youNeedToBeOwnerText = $localize`You need to be owner of this item`;
+const youNeedText = $localize`You need`;
+const thisUserNeedsText = $localize`This user needs`;
+const toBeText = $localize`to be`;
+const toBeAtLeastText = $localize`to be at least`;
+
 function atLeast<T extends readonly string[]>(values: T, val: T[number], ref: T[number]): boolean {
   return values.indexOf(val) >= values.indexOf(ref);
 }
@@ -18,19 +24,31 @@ function validateCanView(receiverPermissions: GroupPermissions, giverPermissions
 
   if (receiverPermissions.canView === 'info' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'enter')) {
-    return { canView: [ 'You need at least can_grant_view >= enter' ] };
+    return { canView: [
+      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canGrantView.enter}`
+    ] };
   }
   if (receiverPermissions.canView === 'content' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'content')) {
-    return { canView: [ 'You need at least can_grant_view >= content' ] };
+    return { canView: [
+      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canGrantView.content}`
+    ] };
   }
   if (receiverPermissions.canView === 'content_with_descendants' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'content_with_descendants')) {
-    return { canView: [ 'You need at least can_grant_view >= content_with_descendants' ] };
+    return { canView: [
+      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canGrantView.content_with_descendants}`
+    ] };
   }
   if (receiverPermissions.canView === 'solution' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'solution')) {
-    return { canView: [ 'You need at least can_grant_view >= solution' ] };
+    return { canView: [
+      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canGrantView.solution}`
+    ] };
   }
   return {};
 }
@@ -42,27 +60,37 @@ function validateCanGrantView(receiverPermissions: GroupPermissions, giverPermis
   const errors: string[] = [];
 
   if (receiverPermissions.canGrantView === 'solution_with_grant') {
-    if (!giverPermissions.isOwner) errors.push('You need to be owner of this item');
-    if (!atLeast(canViewValues, receiverPermissions.canView, 'solution')) errors.push('This user needs at least can_view >= solution');
+    if (!giverPermissions.isOwner) {
+      errors.push(youNeedToBeOwnerText);
+    }
+    if (!atLeast(canViewValues, receiverPermissions.canView, 'solution')) {
+      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canView.solution}`);
+    }
   } else {
 
     if (!(giverPermissions.canGrantView === 'solution_with_grant')) {
-      errors.push('You need can_grant_view = solution_with_grant');
+      errors.push(`${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeText} ${
+        permissionsInfoString.canGrantView.solution_with_grant}`);
     }
 
     if (receiverPermissions.canGrantView === 'enter' && !atLeast(canViewValues, receiverPermissions.canView, 'info')) {
-      errors.push('This user needs at least can_view >= info');
+      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canView.info}`);
     }
 
     if (receiverPermissions.canGrantView === 'content' && !atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-      errors.push('This user needs at least content');
+      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canView.content}`);
     }
     if (receiverPermissions.canGrantView === 'content_with_descendants' &&
         !atLeast(canViewValues, receiverPermissions.canView, 'content_with_descendants')) {
-      errors.push('This user needs at least content_with_descendants');
+      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canView.content_with_descendants}`);
     }
     if (receiverPermissions.canGrantView === 'solution' && !atLeast(canViewValues, receiverPermissions.canView, 'solution')) {
-      errors.push('This user needs at least solution');
+      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeText} ${
+        permissionsInfoString.canView.solution}`);
     }
   }
 
@@ -77,16 +105,18 @@ function validateCanWatch(receiverPermissions: GroupPermissions, giverPermission
 
   // For all canWatch except 'none'
   if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-    errors.push('This user needs at least canView >= content');
+    errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
+      permissionsInfoString.canView.content}`);
   }
 
   if (receiverPermissions.canWatch === 'answer_with_grant' && !giverPermissions.isOwner) {
-    errors.push('You need to be owner of this item');
+    errors.push(youNeedToBeOwnerText);
   } else {
 
     // if receiverPermissions.canWatch is 'result' or 'answer'
     if (!(giverPermissions.canWatch === 'answer_with_grant')) {
-      errors.push('You need at canWatch == answer_with_grant');
+      errors.push(`${youNeedText} ${permissionsInfoString.canWatch.string} ${toBeText} ${
+        permissionsInfoString.canWatch.answer_with_grant}`);
     }
   }
 
@@ -101,16 +131,18 @@ function validateCanEdit(receiverPermissions: GroupPermissions, giverPermissions
 
   // For all can_edit except 'none'
   if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-    errors.push('This user needs at least canView >= content');
+    errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
+      permissionsInfoString.canView.content}`);
   }
 
   if (receiverPermissions.canEdit === 'all_with_grant' && !giverPermissions.isOwner) {
-    errors.push('You need to be owner of this item');
+    errors.push(youNeedToBeOwnerText);
   } else {
 
     // if receiverPermissions.canEdit is 'children' or 'all_with_grant'
     if (!(giverPermissions.canEdit === 'all_with_grant')) {
-      errors.push('You need at canEdit == all_with_grant');
+      errors.push(`${youNeedText} ${permissionsInfoString.canEdit.string} ${toBeText} ${
+        permissionsInfoString.canEdit.all_with_grant}`);
     }
   }
 
@@ -126,14 +158,15 @@ function validateCanMakeSessionOfficial(
 
   if (receiverPermissions.canMakeSessionOfficial && !previousValue) {
     if (!giverPermissions.isOwner) {
-      errors.push('You need to be owner of this item');
+      errors.push(youNeedToBeOwnerText);
     }
     if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-      errors.push('This user needs can_view >= content');
+      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
+        permissionsInfoString.canView.content}`);
     }
   }
 
-  return { canMakeSessionOfficial: errors.length === 0 ? undefined : errors };
+  return errors.length === 0 ? {} : { canMakeSessionOfficial: errors };
 }
 
 function validateIsOwner(
@@ -143,11 +176,10 @@ function validateIsOwner(
 ): { isOwner?: string[] } {
 
   if (receiverPermissions.isOwner && !previousValue && !giverPermissions.isOwner) {
-    return { isOwner: [ 'You need to be owner of this item' ] };
+    return { isOwner: [ youNeedToBeOwnerText ] };
   }
   return {};
 }
-
 
 export function permissionsConstraintsValidator(
   receiverPermissions: GroupPermissions,

--- a/src/app/modules/item/helpers/item-permissions-constraints.ts
+++ b/src/app/modules/item/helpers/item-permissions-constraints.ts
@@ -1,0 +1,173 @@
+import { ValidationErrors, ValidatorFn, AbstractControl } from '@angular/forms';
+import { GroupPermissions } from 'src/app/shared/http-services/group-permissions.service';
+import { PermissionsInfo, canGrantViewValues, canViewValues } from './item-permissions';
+
+function atLeast<T extends readonly string[]>(values: T, val: T[number], ref: T[number]): boolean {
+  return values.indexOf(val) >= values.indexOf(ref);
+}
+
+function validateCanView(receiverPermissions: GroupPermissions, giverPermissions: PermissionsInfo): ValidationErrors {
+
+  if (receiverPermissions.canView === 'info' &&
+  !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'enter')) {
+    return { canView: [ 'You need at least can_grant_view >= enter' ] };
+  }
+  if (receiverPermissions.canView === 'content' &&
+  !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'content')) {
+    return { canView: [ 'You need at least can_grant_view >= content' ] };
+  }
+  if (receiverPermissions.canView === 'content_with_descendants' &&
+  !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'content_with_descendants')) {
+    return { canView: [ 'You need at least can_grant_view >= content_with_descendants' ] };
+  }
+  if (receiverPermissions.canView === 'solution' &&
+  !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'solution')) {
+    return { canView: [ 'You need at least can_grant_view >= solution' ] };
+  }
+  return {};
+}
+
+function validateCanGrantView(receiverPermissions: GroupPermissions, giverPermissions: PermissionsInfo): ValidationErrors {
+
+  if (receiverPermissions.canGrantView === 'none') return {};
+
+  const errors: string[] = [];
+
+  if (receiverPermissions.canGrantView === 'solution_with_grant') {
+    if (!giverPermissions.isOwner) errors.push('You need to be owner of this item');
+    if (!atLeast(canViewValues, receiverPermissions.canView, 'solution')) errors.push('This user needs at least can_view >= solution');
+  } else {
+
+    if (!(giverPermissions.canGrantView === 'solution_with_grant')) {
+      errors.push('You need can_grant_view = solution_with_grant');
+    }
+
+    if (receiverPermissions.canGrantView === 'enter' && !atLeast(canViewValues, receiverPermissions.canView, 'info')) {
+      errors.push('This user needs at least can_view >= info');
+    }
+
+    if (receiverPermissions.canGrantView === 'content' && !atLeast(canViewValues, receiverPermissions.canView, 'content')) {
+      errors.push('This user needs at least content');
+    }
+    if (receiverPermissions.canGrantView === 'content_with_descendants' &&
+        !atLeast(canViewValues, receiverPermissions.canView, 'content_with_descendants')) {
+      errors.push('This user needs at least content_with_descendants');
+    }
+    if (receiverPermissions.canGrantView === 'solution' && !atLeast(canViewValues, receiverPermissions.canView, 'solution')) {
+      errors.push('This user needs at least solution');
+    }
+  }
+
+  return { canGrantView: errors.length === 0 ? undefined : errors };
+}
+
+function validateCanWatch(receiverPermissions: GroupPermissions, giverPermissions: PermissionsInfo): ValidationErrors {
+
+  if (receiverPermissions.canWatch === 'none') return {};
+
+  const errors: string[] = [];
+
+  // For all canWatch except 'none'
+  if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
+    errors.push('This user needs at least canView >= content');
+  }
+
+  if (receiverPermissions.canWatch === 'answer_with_grant' && !giverPermissions.isOwner) {
+    errors.push('You need to be owner of this item');
+  } else {
+
+    // if receiverPermissions.canWatch is 'result' or 'answer'
+    if (!(giverPermissions.canWatch === 'answer_with_grant')) {
+      errors.push('You need at canWatch == answer_with_grant');
+    }
+  }
+
+  return { canWatch: errors.length === 0 ? undefined : errors };
+}
+
+function validateCanEdit(receiverPermissions: GroupPermissions, giverPermissions: PermissionsInfo): ValidationErrors {
+
+  if (receiverPermissions.canEdit === 'none') return {};
+
+  const errors: string[] = [];
+
+  // For all can_edit except 'none'
+  if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
+    errors.push('This user needs at least canView >= content');
+  }
+
+  if (receiverPermissions.canEdit === 'all_with_grant' && !giverPermissions.isOwner) {
+    errors.push('You need to be owner of this item');
+  } else {
+
+    // if receiverPermissions.canEdit is 'children' or 'all_with_grant'
+    if (!(giverPermissions.canEdit === 'all_with_grant')) {
+      errors.push('You need at canEdit == all_with_grant');
+    }
+  }
+
+  return { canEdit: errors.length === 0 ? undefined : errors };
+}
+
+function validateCanMakeSessionOfficial(
+  previousValue: boolean,
+  receiverPermissions: GroupPermissions,
+  giverPermissions: PermissionsInfo
+): ValidationErrors {
+  const errors: string[] = [];
+
+  if (receiverPermissions.canMakeSessionOfficial && !previousValue) {
+    if (!giverPermissions.isOwner) {
+      errors.push('You need to be owner of this item');
+    }
+    if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
+      errors.push('This user needs can_view >= content');
+    }
+  }
+
+  return { canMakeSessionOfficial: errors.length === 0 ? undefined : errors };
+}
+
+function validateIsOwner(
+  previousValue: boolean,
+  receiverPermissions: GroupPermissions,
+  giverPermissions: PermissionsInfo
+): ValidationErrors {
+
+  if (receiverPermissions.isOwner && !previousValue && !giverPermissions.isOwner) {
+    return { isOwner: [ 'You need to be owner of this item' ] };
+  }
+  return {};
+}
+
+
+export function permissionsConstraintsValidator(
+  receiverPermissions: GroupPermissions,
+  giverPermissions: PermissionsInfo
+): ValidatorFn {
+
+  return (group: AbstractControl): ValidationErrors|null => {
+
+    const value: GroupPermissions = {
+      canView: group.get('canView')?.value as GroupPermissions['canView'],
+      canGrantView: group.get('canGrantView')?.value as GroupPermissions['canGrantView'],
+      canWatch: group.get('canWatch')?.value as GroupPermissions['canWatch'],
+      canEdit: group.get('canEdit')?.value as GroupPermissions['canEdit'],
+      canMakeSessionOfficial: group.get('canMakeSessionOfficial')?.value as GroupPermissions['canMakeSessionOfficial'],
+      isOwner: group.get('isOwner')?.value as GroupPermissions['isOwner'],
+      canEnterFrom: new Date(),
+      canEnterUntil: new Date(),
+    };
+
+    const errors: ValidationErrors = {
+      ...validateCanView(value, giverPermissions),
+      ...validateCanGrantView(value, giverPermissions),
+      ...validateCanWatch(value, giverPermissions),
+      ...validateCanEdit(value, giverPermissions),
+      ...validateCanMakeSessionOfficial(receiverPermissions.canMakeSessionOfficial, value, giverPermissions),
+      ...validateIsOwner(receiverPermissions.canMakeSessionOfficial, value, giverPermissions),
+    };
+
+    return Object.keys(errors).length > 0 ? errors : null;
+  };
+}

--- a/src/app/modules/item/helpers/item-permissions-constraints.ts
+++ b/src/app/modules/item/helpers/item-permissions-constraints.ts
@@ -10,11 +10,7 @@ import {
   generateCanEditValues
 } from '../components/permissions-edit-dialog/permissions-edit-dialog-texts';
 
-const youNeedToBeOwnerText = $localize`You need to be <b>owner</b> of this item`;
-const youNeedText = $localize`You need`;
-const thisUserNeedsText = $localize`This user needs`;
-const toBeText = $localize`to be`;
-const toBeAtLeastText = $localize`to be at least`;
+const bolden = (text: string): string => `<b>${text}</b>`;
 
 function hasAtLeastPermission<T extends readonly string[]>(permissionsSortedByLoosest: T, permission: T[number]) {
   return (minimumPermission: T[number]): boolean =>
@@ -30,26 +26,25 @@ function validateCanView(
 
   if (receiverPermissions.canView === 'info' && !giverCanAtLeastGrantView('enter')) {
     return { canView: [
-      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canGrantView.enter}</b>`
+      `You need ${bolden(permissionsInfoString.canGrantView.string)} to be at least ${bolden(permissionsInfoString.canGrantView.enter)}`
     ] };
   }
   if (receiverPermissions.canView === 'content' && !giverCanAtLeastGrantView('content')) {
     return { canView: [
-      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canGrantView.content}</b>`
+      `You need ${bolden(permissionsInfoString.canGrantView.string)} to be at least ${
+        bolden(permissionsInfoString.canGrantView.content)}`
     ] };
   }
   if (receiverPermissions.canView === 'content_with_descendants' && !giverCanAtLeastGrantView('content_with_descendants')) {
     return { canView: [
-      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canGrantView.content_with_descendants}</b>`
+      `You need ${bolden(permissionsInfoString.canGrantView.string)} to be at least ${
+        bolden(permissionsInfoString.canGrantView.content_with_descendants)}`
     ] };
   }
   if (receiverPermissions.canView === 'solution' && !giverCanAtLeastGrantView('solution')) {
     return { canView: [
-      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canGrantView.solution}</b>`
+      `You need ${bolden(permissionsInfoString.canGrantView.string)} to be at least ${
+        bolden(permissionsInfoString.canGrantView.solution)}`
     ] };
   }
   return {};
@@ -69,35 +64,35 @@ function validateCanGrantView(
 
   if (receiverPermissions.canGrantView === 'solution_with_grant') {
     if (!giverPermissions.isOwner) {
-      errors.push(youNeedToBeOwnerText);
+      errors.push($localize`You need to be owner of this item`);
     }
     if (!receiverCanAtLeastView('solution')) {
-      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canView.solution}</b>`);
+      errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be at least ${
+        bolden(permissionsInfoString.canView.solution)}`);
     }
   } else {
 
     if (!(giverPermissions.canGrantView === 'solution_with_grant')) {
-      errors.push(`${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeText} <b>${
-        permissionsInfoString.canGrantView.solution_with_grant}</b>`);
+      errors.push(`You need ${bolden(permissionsInfoString.canGrantView.string)} to be ${
+        bolden(permissionsInfoString.canGrantView.solution_with_grant)}`);
     }
 
     if (receiverPermissions.canGrantView === 'enter' && !receiverCanAtLeastView('info')) {
-      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canView.info}</b>`);
+      errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be at least ${
+        bolden(permissionsInfoString.canView.info)}`);
     }
 
     if (receiverPermissions.canGrantView === 'content' && !receiverCanAtLeastView('content')) {
-      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canView.content}</b>`);
+      errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be at least ${
+        bolden(permissionsInfoString.canView.content)}`);
     }
     if (receiverPermissions.canGrantView === 'content_with_descendants' && !receiverCanAtLeastView('content_with_descendants')) {
-      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canView.content_with_descendants}</b>`);
+      errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be at least ${
+        bolden(permissionsInfoString.canView.content_with_descendants)}`);
     }
     if (receiverPermissions.canGrantView === 'solution' && !receiverCanAtLeastView('solution')) {
-      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeText} <b>${
-        permissionsInfoString.canView.solution}</b>`);
+      errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be ${
+        bolden(permissionsInfoString.canView.solution)}`);
     }
   }
 
@@ -115,18 +110,18 @@ function validateCanWatch(
 
   // For all canWatch except 'none'
   if (!hasAtLeastPermission(canViewValues, receiverPermissions.canView)('content')) {
-    errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
-      permissionsInfoString.canView.content}</b>`);
+    errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be at least ${
+      bolden(permissionsInfoString.canView.content)}`);
   }
 
   if (receiverPermissions.canWatch === 'answer_with_grant' && !giverPermissions.isOwner) {
-    errors.push(youNeedToBeOwnerText);
+    errors.push($localize`You need to be owner of this item`);
   } else {
 
     // if receiverPermissions.canWatch is 'result' or 'answer'
     if (!(giverPermissions.canWatch === 'answer_with_grant')) {
-      errors.push(`${youNeedText} <b>${permissionsInfoString.canWatch.string}</b> ${toBeText} <b>${
-        permissionsInfoString.canWatch.answer_with_grant}</b>`);
+      errors.push(`You need ${bolden(permissionsInfoString.canWatch.string)} to be ${
+        bolden(permissionsInfoString.canWatch.answer_with_grant)}`);
     }
   }
 
@@ -144,18 +139,18 @@ function validateCanEdit(
 
   // For all can_edit except 'none'
   if (!hasAtLeastPermission(canViewValues, receiverPermissions.canView)('content')) {
-    errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
-      permissionsInfoString.canView.content}</b>`);
+    errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be at least ${
+      bolden(permissionsInfoString.canView.content)}`);
   }
 
   if (receiverPermissions.canEdit === 'all_with_grant' && !giverPermissions.isOwner) {
-    errors.push(youNeedToBeOwnerText);
+    errors.push($localize`You need to be owner of this item`);
   } else {
 
     // if receiverPermissions.canEdit is 'children' or 'all_with_grant'
     if (!(giverPermissions.canEdit === 'all_with_grant')) {
-      errors.push(`${youNeedText} <b>${permissionsInfoString.canEdit.string}</b> ${toBeText} <b>${
-        permissionsInfoString.canEdit.all_with_grant}</b>`);
+      errors.push(`You need ${bolden(permissionsInfoString.canEdit.string)} to be ${
+        bolden(permissionsInfoString.canEdit.all_with_grant)}`);
     }
   }
 
@@ -171,11 +166,11 @@ function validateCanMakeSessionOfficial(
 
   if (receiverPermissions.canMakeSessionOfficial && !previousValue) {
     if (!giverPermissions.isOwner) {
-      errors.push(youNeedToBeOwnerText);
+      errors.push($localize`You need to be owner of this item`);
     }
     if (!hasAtLeastPermission(canViewValues, receiverPermissions.canView)('content')) {
-      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
-        permissionsInfoString.canView.content}</b>`);
+      errors.push(`This user needs ${bolden(permissionsInfoString.canView.string)} to be at least ${
+        bolden(permissionsInfoString.canView.content)}`);
     }
   }
 
@@ -189,7 +184,7 @@ function validateIsOwner(
 ): { isOwner?: string[] } {
 
   if (receiverPermissions.isOwner && !previousValue && !giverPermissions.isOwner) {
-    return { isOwner: [ youNeedToBeOwnerText ] };
+    return { isOwner: [ $localize`You need to be owner of this item` ] };
   }
   return {};
 }
@@ -251,5 +246,26 @@ export function generateValues(
       const errors = validateCanEdit({ ...receiverPermissions, canEdit: val.value }, giverPermissions);
       return errors.canEdit ? { ...val, disabled: true, tooltip: errors.canEdit } : val;
     })
+  };
+}
+
+export function canViewValidator(giverPermissions: PermissionsInfo) {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const receiverPermissions = {
+      canView: control.value as GroupPermissions['canView']
+    };
+    return validateCanView(receiverPermissions, giverPermissions);
+  };
+}
+
+export function canGrantViewValidator(giverPermissions: PermissionsInfo) {
+  return (control: AbstractControl): ValidationErrors | null => {
+
+    const receiverPermissions = {
+      canView: control.parent?.get('canView')?.value as GroupPermissions['canView'],
+      canGrantView: control.value as GroupPermissions['canGrantView'],
+    };
+
+    return validateCanGrantView(receiverPermissions, giverPermissions);
   };
 }

--- a/src/app/modules/item/helpers/item-permissions-constraints.ts
+++ b/src/app/modules/item/helpers/item-permissions-constraints.ts
@@ -10,7 +10,7 @@ import {
   generateCanEditValues
 } from '../components/permissions-edit-dialog/permissions-edit-dialog-texts';
 
-const youNeedToBeOwnerText = $localize`You need to be owner of this item`;
+const youNeedToBeOwnerText = $localize`You need to be <b>owner</b> of this item`;
 const youNeedText = $localize`You need`;
 const thisUserNeedsText = $localize`This user needs`;
 const toBeText = $localize`to be`;
@@ -25,29 +25,29 @@ function validateCanView(receiverPermissions: GroupPermissions, giverPermissions
   if (receiverPermissions.canView === 'info' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'enter')) {
     return { canView: [
-      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canGrantView.enter}`
+      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canGrantView.enter}</b>`
     ] };
   }
   if (receiverPermissions.canView === 'content' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'content')) {
     return { canView: [
-      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canGrantView.content}`
+      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canGrantView.content}</b>`
     ] };
   }
   if (receiverPermissions.canView === 'content_with_descendants' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'content_with_descendants')) {
     return { canView: [
-      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canGrantView.content_with_descendants}`
+      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canGrantView.content_with_descendants}</b>`
     ] };
   }
   if (receiverPermissions.canView === 'solution' &&
   !atLeast(canGrantViewValues, giverPermissions.canGrantView, 'solution')) {
     return { canView: [
-      `${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canGrantView.solution}`
+      `${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canGrantView.solution}</b>`
     ] };
   }
   return {};
@@ -64,33 +64,33 @@ function validateCanGrantView(receiverPermissions: GroupPermissions, giverPermis
       errors.push(youNeedToBeOwnerText);
     }
     if (!atLeast(canViewValues, receiverPermissions.canView, 'solution')) {
-      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canView.solution}`);
+      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canView.solution}</b>`);
     }
   } else {
 
     if (!(giverPermissions.canGrantView === 'solution_with_grant')) {
-      errors.push(`${youNeedText} ${permissionsInfoString.canGrantView.string} ${toBeText} ${
-        permissionsInfoString.canGrantView.solution_with_grant}`);
+      errors.push(`${youNeedText} <b>${permissionsInfoString.canGrantView.string}</b> ${toBeText} <b>${
+        permissionsInfoString.canGrantView.solution_with_grant}</b>`);
     }
 
     if (receiverPermissions.canGrantView === 'enter' && !atLeast(canViewValues, receiverPermissions.canView, 'info')) {
-      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canView.info}`);
+      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canView.info}</b>`);
     }
 
     if (receiverPermissions.canGrantView === 'content' && !atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canView.content}`);
+      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canView.content}</b>`);
     }
     if (receiverPermissions.canGrantView === 'content_with_descendants' &&
         !atLeast(canViewValues, receiverPermissions.canView, 'content_with_descendants')) {
-      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canView.content_with_descendants}`);
+      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canView.content_with_descendants}</b>`);
     }
     if (receiverPermissions.canGrantView === 'solution' && !atLeast(canViewValues, receiverPermissions.canView, 'solution')) {
-      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeText} ${
-        permissionsInfoString.canView.solution}`);
+      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeText} <b>${
+        permissionsInfoString.canView.solution}</b>`);
     }
   }
 
@@ -105,8 +105,8 @@ function validateCanWatch(receiverPermissions: GroupPermissions, giverPermission
 
   // For all canWatch except 'none'
   if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-    errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
-      permissionsInfoString.canView.content}`);
+    errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
+      permissionsInfoString.canView.content}</b>`);
   }
 
   if (receiverPermissions.canWatch === 'answer_with_grant' && !giverPermissions.isOwner) {
@@ -115,8 +115,8 @@ function validateCanWatch(receiverPermissions: GroupPermissions, giverPermission
 
     // if receiverPermissions.canWatch is 'result' or 'answer'
     if (!(giverPermissions.canWatch === 'answer_with_grant')) {
-      errors.push(`${youNeedText} ${permissionsInfoString.canWatch.string} ${toBeText} ${
-        permissionsInfoString.canWatch.answer_with_grant}`);
+      errors.push(`${youNeedText} <b>${permissionsInfoString.canWatch.string}</b> ${toBeText} <b>${
+        permissionsInfoString.canWatch.answer_with_grant}</b>`);
     }
   }
 
@@ -131,8 +131,8 @@ function validateCanEdit(receiverPermissions: GroupPermissions, giverPermissions
 
   // For all can_edit except 'none'
   if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-    errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
-      permissionsInfoString.canView.content}`);
+    errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
+      permissionsInfoString.canView.content}</b>`);
   }
 
   if (receiverPermissions.canEdit === 'all_with_grant' && !giverPermissions.isOwner) {
@@ -141,8 +141,8 @@ function validateCanEdit(receiverPermissions: GroupPermissions, giverPermissions
 
     // if receiverPermissions.canEdit is 'children' or 'all_with_grant'
     if (!(giverPermissions.canEdit === 'all_with_grant')) {
-      errors.push(`${youNeedText} ${permissionsInfoString.canEdit.string} ${toBeText} ${
-        permissionsInfoString.canEdit.all_with_grant}`);
+      errors.push(`${youNeedText} <b>${permissionsInfoString.canEdit.string}</b> ${toBeText} <b>${
+        permissionsInfoString.canEdit.all_with_grant}</b>`);
     }
   }
 
@@ -161,8 +161,8 @@ function validateCanMakeSessionOfficial(
       errors.push(youNeedToBeOwnerText);
     }
     if (!atLeast(canViewValues, receiverPermissions.canView, 'content')) {
-      errors.push(`${thisUserNeedsText} ${permissionsInfoString.canView.string} ${toBeAtLeastText} ${
-        permissionsInfoString.canView.content}`);
+      errors.push(`${thisUserNeedsText} <b>${permissionsInfoString.canView.string}</b> ${toBeAtLeastText} <b>${
+        permissionsInfoString.canView.content}</b>`);
     }
   }
 

--- a/src/app/modules/item/helpers/item-permissions.ts
+++ b/src/app/modules/item/helpers/item-permissions.ts
@@ -1,10 +1,15 @@
 import * as D from 'io-ts/Decoder';
 
+export const canViewValues = [ 'none', 'info', 'content', 'content_with_descendants', 'solution' ] as const;
+export const canWatchValues = [ 'none','result','answer','answer_with_grant' ] as const;
+export const canEditValues = [ 'none','children','all','all_with_grant' ] as const;
+export const canGrantViewValues = [ 'none','enter','content','content_with_descendants','solution','solution_with_grant' ] as const;
+
 export const permissionsDecoder = D.struct({
-  canView: D.literal('none','info','content','content_with_descendants','solution'),
-  canWatch: D.literal('none','result','answer','answer_with_grant'),
-  canEdit: D.literal('none','children','all','all_with_grant'),
-  canGrantView: D.literal('none','enter','content','content_with_descendants','solution','solution_with_grant'),
+  canView: D.literal(...canViewValues),
+  canWatch: D.literal(...canWatchValues),
+  canEdit: D.literal(...canEditValues),
+  canGrantView: D.literal(...canGrantViewValues),
   isOwner: D.boolean,
 });
 

--- a/src/app/modules/item/helpers/item-permissions.ts
+++ b/src/app/modules/item/helpers/item-permissions.ts
@@ -26,3 +26,37 @@ export function canCurrentUserViewItemContent(item: ItemPermissionsInfo): boolea
 export function canCurrentUserViewItem (item: ItemPermissionsInfo): boolean {
   return item.permissions.canView !== 'none';
 }
+
+export const permissionsInfoString = {
+  canView: {
+    string: $localize`Can view`,
+    none: $localize`Nothing`,
+    info: $localize`Info`,
+    content: $localize`Content`,
+    content_with_descendants: $localize`Content and descendants`,
+    solution: $localize`Solution`,
+  },
+  canGrantView: {
+    string: $localize`Can grant view`,
+    none: $localize`Nothing`,
+    enter: $localize`Info & enter`,
+    content: $localize`Content`,
+    content_with_descendants: $localize`Content and descendants`,
+    solution: $localize`Solution`,
+    solution_with_grant: $localize`Solution and grant`,
+  },
+  canWatch: {
+    string: $localize`Can watch`,
+    none: $localize`Nothing`,
+    result: $localize`Result`,
+    answer: $localize`Answer`,
+    answer_with_grant: $localize`Answer and grant`,
+  },
+  canEdit: {
+    string: $localize`Can edit`,
+    none: $localize`Nothing`,
+    children: $localize`Children`,
+    all: $localize`All`,
+    all_with_grant: $localize`All and grant`,
+  }
+};

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
@@ -100,6 +100,7 @@
       [title]="dialogTitle"
       [targetType]="currentFilter"
       [permissions]="dialogPermissions.permissions"
+      [giverPermissions]="itemData?.item?.permissions"
       (close)="onDialogClose()"
       (save)="onDialogSave($event)"
     ></alg-permissions-edit-dialog>

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
@@ -7,7 +7,7 @@ import { GetGroupChildrenService } from 'src/app/modules/group/http-services/get
 import { formatUser } from 'src/app/shared/helpers/user';
 import { GetGroupDescendantsService } from 'src/app/shared/http-services/get-group-descendants.service';
 import { GetGroupProgressService, TeamUserProgress } from 'src/app/shared/http-services/get-group-progress.service';
-import { GroupPermissionsService, Permissions } from 'src/app/shared/http-services/group-permissions.service';
+import { GroupPermissionsService, GroupPermissions } from 'src/app/shared/http-services/group-permissions.service';
 import { progressiveObservableFromList } from 'src/app/shared/operators/progressive-observable-from-list';
 import { mapToFetchState } from 'src/app/shared/operators/state';
 import { withPreviousFetchState } from 'src/app/shared/operators/with-previous-fetch-state';
@@ -51,19 +51,21 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
   currentFilter = this.defaultFilter;
 
   dialogPermissions: {
-    permissions: Permissions,
+    permissions: GroupPermissions,
     itemId: string,
     targetGroupId: string,
   } = {
     itemId: '',
     targetGroupId: '',
     permissions: {
-      can_view: 'none',
-      can_grant_view: 'none',
-      can_watch: 'none',
-      can_edit: 'none',
-      can_make_session_official: false,
-      is_owner: true,
+      canView: 'none',
+      canGrantView: 'none',
+      canWatch: 'none',
+      canEdit: 'none',
+      canMakeSessionOfficial: false,
+      isOwner: true,
+      canEnterFrom: new Date(),
+      canEnterUntil: new Date(),
     }
   };
 
@@ -260,14 +262,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
         this.dialogPermissions = {
           itemId: itemId,
           targetGroupId: targetGroupId,
-          permissions: {
-            can_view: permissions.granted.can_view,
-            can_grant_view: permissions.granted.can_grant_view,
-            can_watch: permissions.granted.can_watch,
-            can_edit: permissions.granted.can_edit,
-            is_owner: permissions.granted.is_owner,
-            can_make_session_official: permissions.granted.can_make_session_official,
-          }
+          permissions: permissions.granted
         };
         this.dialog = 'opened';
       });
@@ -277,7 +272,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
     this.dialog = 'closed';
   }
 
-  onDialogSave(permissions: Permissions): void {
+  onDialogSave(permissions: Partial<GroupPermissions>): void {
     if (!this.group) return;
 
     this.groupPermissionsService.updatePermissions(this.group.id, this.dialogPermissions.targetGroupId,

--- a/src/app/modules/shared-components/components/collapsible-section/collapsible-section.component.html
+++ b/src/app/modules/shared-components/components/collapsible-section/collapsible-section.component.html
@@ -4,7 +4,7 @@
       <i class="{{ icon }}"></i>
     </span>
     <span class="header-title">{{ title }}</span>
-    <ng-container *ngIf="contentTemplate && collapsed"
+    <ng-container *ngIf="contentTemplate && collapsed && collapsible"
       [ngTemplateOutlet]="contentTemplate"
       [ngTemplateOutletContext]="{ $implicit: true }"
     ></ng-container>
@@ -14,7 +14,7 @@
     </span>
   </div>
   <ng-container
-    *ngIf="contentTemplate && !collapsed"
+    *ngIf="contentTemplate && !(collapsed && collapsible)"
     [ngTemplateOutlet]="contentTemplate"
     [ngTemplateOutletContext]="{ $implicit: false }"
   ></ng-container>

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
@@ -19,7 +19,11 @@
         <i
           *ngIf="idx === selected"
           class="fa"
-          [ngClass]="{'fa-lock-open': type === 'checksWithLock', 'fa-check': type === 'simple'}"
+          [ngClass]="{
+            'fa-lock': validationErrors && type === 'checksWithLock',
+            'fa-lock-open': !validationErrors && type === 'checksWithLock',
+            'fa-check': type === 'simple'
+          }"
         ></i>
       </span>
       <span *ngIf="idx + 1 < values.length" class="progress-branch" [ngClass]="{active: idx < selected}"></span>
@@ -29,5 +33,11 @@
       <div class="progress-desc-comment">{{ item.comment }}</div>
     </div>
     <div *ngIf="item.disabled" class="gray-overlay"></div>
+  </div>
+  <div class="progress-select-item error" *ngIf="validationErrors">
+    <i class="icon" [ngClass]="'fa fa-exclamation-triangle'"></i>
+    <div class="errors">
+      <p *ngFor="let error of validationErrors">{{error}}</p>
+    </div>
   </div>
 </div>

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
@@ -26,7 +26,7 @@
           }"
         ></i>
       </span>
-      <span *ngIf="idx + 1 < values.length" class="progress-branch" [ngClass]="{active: idx < selected}"></span>
+      <span *ngIf="idx + 1 < values.length" class="progress-branch" [ngClass]="{active: idx < selected, disabled: values[idx + 1]?.disabled}"></span>
     </div>
     <div class="progress-desc">
       <div class="progress-desc-name" [ngClass]="{active: idx < selected + 1}" (click)="onSet(item.value)">{{ item.label }}</div>

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
@@ -36,12 +36,13 @@
       [pTooltip]="item.tooltip?.join('\n') || ''"
       tooltipPosition="top"
       tooltipStyleClass="permissions-dialog"
+      [escape]="false"
     ></div>
   </div>
   <div class="progress-select-item error" *ngIf="validationErrors">
     <i class="icon" [ngClass]="'fa fa-exclamation-triangle'"></i>
     <div class="errors">
-      <p *ngFor="let error of validationErrors">{{error}}</p>
+      <p *ngFor="let error of validationErrors" [innerHTML]="error"></p>
     </div>
   </div>
 </div>

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.html
@@ -32,7 +32,11 @@
       <div class="progress-desc-name" [ngClass]="{active: idx < selected + 1}" (click)="onSet(item.value)">{{ item.label }}</div>
       <div class="progress-desc-comment">{{ item.comment }}</div>
     </div>
-    <div *ngIf="item.disabled" class="gray-overlay"></div>
+    <div *ngIf="item.disabled" class="gray-overlay tool"
+      [pTooltip]="item.tooltip?.join('\n') || ''"
+      tooltipPosition="top"
+      tooltipStyleClass="permissions-dialog"
+    ></div>
   </div>
   <div class="progress-select-item error" *ngIf="validationErrors">
     <i class="icon" [ngClass]="'fa fa-exclamation-triangle'"></i>

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.scss
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.scss
@@ -67,6 +67,10 @@ $inactive-bk-color: #d8d8d8;
         &.active {
           background-color: $base-color;
         }
+
+        &.disabled {
+          opacity: 0.5;
+        }
       }
     }
 

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.scss
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.scss
@@ -99,6 +99,24 @@ $inactive-bk-color: #d8d8d8;
         margin-bottom: 1rem;
       }
     }
+
+    &.error {
+      color: #a94442;
+      padding-left: 1rem;
+      display: flex;
+      align-items: center;
+      font-size: medium;
+      height: auto;
+
+
+      .errors {
+        margin-left: 2rem;
+
+        p {
+          margin: 0;
+        }
+      }
+    }
   }
 
   .gray-overlay {

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.ts
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.ts
@@ -43,6 +43,8 @@ export class ProgressSelectComponent<T> implements OnChanges, OnInit, ControlVal
   @Input() defaultValue?: T;
   @Input() value?: T;
 
+  @Input() validationErrors?: string[];
+
   @Input() type: 'simple' | 'checksWithLock' = 'checksWithLock';
 
   @ContentChild('description') descriptionTemplate?: TemplateRef<any>;

--- a/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.ts
+++ b/src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component.ts
@@ -7,6 +7,7 @@ export interface ProgressSelectValue<T> {
   comment: string,
   value: T,
   disabled?: boolean,
+  tooltip?: string[],
 }
 
 /**

--- a/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html
+++ b/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html
@@ -23,4 +23,10 @@
       </div>
     </div>
   </div>
+  <div class="item error" *ngIf="validationErrors">
+    <i class="icon" [ngClass]="'fa fa-exclamation-triangle'"></i>
+    <div class="errors">
+      <p *ngFor="let error of validationErrors">{{error}}</p>
+    </div>
+  </div>
 </div>

--- a/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html
+++ b/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html
@@ -26,7 +26,7 @@
   <div class="item error" *ngIf="validationErrors">
     <i class="icon" [ngClass]="'fa fa-exclamation-triangle'"></i>
     <div class="errors">
-      <p *ngFor="let error of validationErrors">{{error}}</p>
+      <p *ngFor="let error of validationErrors" [innerHtml]="error"></p>
     </div>
   </div>
 </div>

--- a/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.scss
+++ b/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.scss
@@ -55,5 +55,23 @@ $inactive-bk-color: #d8d8d8;
         }
       }
     }
+
+    &.error {
+      color: #a94442;
+      padding-left: 1rem;
+      display: flex;
+      align-items: center;
+      font-size: medium;
+      height: auto;
+
+
+      .errors {
+        margin-left: 2rem;
+
+        p {
+          margin: 0;
+        }
+      }
+    }
   }
 }

--- a/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.ts
+++ b/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.ts
@@ -32,6 +32,8 @@ export class SwitchFieldComponent implements ControlValueAccessor {
   @Input() value = false;
   @Input() collapsed = false;
 
+  @Input() validationErrors?: string[];
+
   @ContentChild('description') descriptionTemplate?: TemplateRef<any>;
   @ContentChild('label') labelTemplate?: TemplateRef<any>;
 

--- a/src/assets/scss/components/tooltip.scss
+++ b/src/assets/scss/components/tooltip.scss
@@ -1,0 +1,6 @@
+.p-tooltip {
+
+  &.permissions-dialog {
+    max-width: none;
+  }
+}

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -64,21 +64,21 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="4996073393875425335" datatype="html">
         <source>via group</source><target state="translated">via le groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">98</context></context-group></trans-unit><trans-unit id="1679971178283595016" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="1679971178283595016" datatype="html">
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="new">Your current access rights do not allow you to list the content of this skill.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">150</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">34</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">34</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ 'Your current access rights do not allow you to list the content of this chapter.' }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">65</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">201</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">184</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
         <source>You are a member of the group</source><target state="new">You are a member of the group</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">206</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">189</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
         <source>Your current access rights do not allow you to start the activity.</source><target state="new">Your current access rights do not allow you to start the activity.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">256</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">30</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">30</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -93,7 +93,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">28</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="2192178401851161061" datatype="html">
         <source>Unable to load the list.</source><target state="translated">Erreur lors du chargement de la liste.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">41</context></context-group></trans-unit><trans-unit id="6599854887630038646" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="6599854887630038646" datatype="html">
         <source>Retry now</source><target state="translated">Réessayer</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/error/error.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="4219108310098283044" datatype="html">
@@ -126,16 +126,10 @@
       </trans-unit><trans-unit id="6673660887182833564" datatype="html">
         <source>Customize</source><target state="translated">Personnaliser</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="4861926948802653243" datatype="html">
-        <source> Yes </source><target state="translated"> Oui </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/progress-section/boolean-section/boolean-section.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="3603720768157919481" datatype="html">
-        <source> No </source><target state="translated"> Non </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/progress-section/boolean-section/boolean-section.component.html</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="4449471207584645508" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="4449471207584645508" datatype="html">
         <source>Permissions successfully updated.</source><target state="translated">Permissions mises à jour avec succès.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">286</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">281</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context>
@@ -156,7 +150,7 @@
       </trans-unit><trans-unit id="3542042671420335679" datatype="html">
         <source>No</source><target state="translated">Non</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">51</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">277</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">291</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">341</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">36</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="6595442071355967826" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">51</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">277</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">291</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">341</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">36</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="6595442071355967826" datatype="html">
         <source>You have left "<x id="PH" equiv-text="groupName"/>"</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="3538887675032003480" datatype="html">
         <source>You have delete "<x id="PH" equiv-text="groupName"/>"</source><target state="new">You have delete "<x id="PH" equiv-text="groupName"/>"</target>
 
@@ -600,7 +594,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="2159130950882492111" datatype="html">
         <source>Cancel</source><target state="translated">Annuler</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="7798083029915432586" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">92</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">130</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="7798083029915432586" datatype="html">
         <source>You are already a member of this group.</source><target state="translated">Vous êtes déjà membre de ce groupe.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">77</context></context-group></trans-unit><trans-unit id="5339756092671133656" datatype="html">
@@ -621,23 +615,17 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </source><target state="new"> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context>
-          <context context-type="linenumber">10,12</context>
-        </context-group>
-      </trans-unit><trans-unit id="5302971017875260731" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="5302971017875260731" datatype="html">
         <source>Only owner can delete items</source><target state="new">Only owner can delete items</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context>
-          <context context-type="linenumber">15</context>
-        </context-group>
-      </trans-unit><trans-unit id="970391649916938978" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="970391649916938978" datatype="html">
         <source>Error while loading the item info</source><target state="new">Error while loading the item info</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="1069107129309456759" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="1069107129309456759" datatype="html">
         <source>Delete this item</source><target state="new">Delete this item</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="6961901997149121725" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">21</context></context-group></trans-unit><trans-unit id="6961901997149121725" datatype="html">
         <source>Deleting it will also remove permanently all answers and results related with this content.</source><target state="new">Deleting it will also remove permanently all answers and results related with this content.</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="4937090815943334145" datatype="html">
@@ -646,7 +634,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="2807800733729323332" datatype="html">
         <source>Yes</source><target state="new">Yes</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">275</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">289</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">339</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="465834534537881731" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">275</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">289</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">339</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">61</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="465834534537881731" datatype="html">
         <source>Unable to remove the selected user(s)</source><target state="translated">Erreur lors de la suppression des utilisateurs sélectionés du groupe</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/user-removal-response-handling.ts</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="4648900870671159218" datatype="html">
@@ -862,7 +850,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.ts</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="194816385249516309" datatype="html">
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="6260891589219088351" datatype="html">
-     <source>The user</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="3465962430409924123" datatype="html">
+     <source>The user</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="3465962430409924123" datatype="html">
         <source>Personal Information</source><target state="new">Personal Information</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/current-user/current-user.component.html</context><context context-type="linenumber">21</context></context-group></trans-unit><trans-unit id="2454050363478003966" datatype="html">
@@ -944,79 +932,64 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="6272778843499478025" datatype="html">
         <source>The group</source><target state="translated">Le groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="6070393949096550098" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="6070393949096550098" datatype="html">
         <source>The team</source><target state="translated">L’équipe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="8856153672062826842" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="8856153672062826842" datatype="html">
         <source>Can view</source><target state="translated">Visibilité</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="2619974973973470112" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">26</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="2619974973973470112" datatype="html">
         <source>Can grant view</source><target state="translated">Droit de donner des droits de visibilité</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="5086832329438229437" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">48</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="5086832329438229437" datatype="html">
         <source> User(s) can give and revoke members access to some content </source><target state="new"> User(s) can give and revoke members access to some content </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="7308369809380680356" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="7308369809380680356" datatype="html">
         <source>Can watch members</source><target state="new">Can watch members</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="731959018199918793" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="731959018199918793" datatype="html">
         <source> User(s) can watch the members' activity on some content </source><target state="new"> User(s) can watch the members' activity on some content </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">68</context></context-group></trans-unit><trans-unit id="6674111336491636600" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">73</context></context-group></trans-unit><trans-unit id="6674111336491636600" datatype="html">
         <source>Can watch</source><target state="translated">Droit d'observation</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="1898683424750626599" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="1898683424750626599" datatype="html">
         <source>Can edit</source><target state="translated">Droit d'édition</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="4134892396030781951" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">56</context></context-group></trans-unit><trans-unit id="4134892396030781951" datatype="html">
         <source>Can attach official sessions</source><target state="translated">Droit d'attacher des sessions officielles</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="8035899978067879476" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="8035899978067879476" datatype="html">
         <source>Is owner</source><target state="translated">Propriétaire</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="2159130950882492111" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="2159130950882492111" datatype="html">
         <source>Cancel</source><target state="translated">Annuler</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">75</context></context-group></trans-unit><trans-unit id="1181910457994920507" datatype="html">
         <source>Proceed</source><target state="translated">Valider</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">90</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="9119511347263876873" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">98</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">136</context></context-group></trans-unit><trans-unit id="9119511347263876873" datatype="html">
         <source>Can list the members</source><target state="new">Can list the members</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context>
-          <context context-type="linenumber">25</context>
-        </context-group>
-      </trans-unit><trans-unit id="3737711445155929474" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="3737711445155929474" datatype="html">
         <source>Membership</source><target state="new">Membership</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context>
-          <context context-type="linenumber">29</context>
-        </context-group>
-      </trans-unit><trans-unit id="2692535648170033936" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="2692535648170033936" datatype="html">
         <source>Can manage (add, remove, invite, ...) members</source><target state="new">Can manage (add, remove, invite, ...) members</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context>
-          <context context-type="linenumber">30</context>
-        </context-group>
-      </trans-unit><trans-unit id="1920513678812261969" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="1920513678812261969" datatype="html">
         <source>Full</source><target state="new">Full</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context>
-          <context context-type="linenumber">34</context>
-        </context-group>
-      </trans-unit><trans-unit id="2357554189942911948" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="2357554189942911948" datatype="html">
         <source>Can manage members, managers, and change group settings</source><target state="new">Can manage members, managers, and change group settings</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context>
-          <context context-type="linenumber">35</context>
-        </context-group>
-      </trans-unit><trans-unit id="5697804787450123368" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="5697804787450123368" datatype="html">
         <source>New permissions successfully saved.</source><target state="new">New permissions successfully saved.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="1850357961340956981" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="1850357961340956981" datatype="html">
         <source>Failed to save permissions.</source><target state="new">Failed to save permissions.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="1195043541071899024" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="1195043541071899024" datatype="html">
         <source>Default access</source><target state="new">Default access</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/propagation-edit-menu/propagation-edit-menu.component.html</context>
@@ -1046,14 +1019,14 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="146991741218180729" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{targetTypeString}}"/> may attach official sessions to this item, that will be visible to everyone in the content tab of the item</source><target state="translated"><x id="INTERPOLATION" equiv-text="{{targetTypeString}}"/> peut attacher des sessions officielles à cet élément qui seront visibles dans son onglet contenu.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="3303008548461857588" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="3303008548461857588" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{targetTypeString}}"/> own this item, and get the maximum access in all categories above, and may also delete this item</source><target state="translated"><x id="INTERPOLATION" equiv-text="{{targetTypeString}}"/> est propriétaire de cet
  et a donc toutes les permissions ci-dessus maximales. Il peut également l'effacer.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="4705822664965381735" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="4705822664965381735" datatype="html">
         <source>Children</source><target state="translated">Enfants</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">122</context></context-group></trans-unit><trans-unit id="8052476462144624454" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="8052476462144624454" datatype="html">
         <source>Enable score weight</source><target state="new">Enable score weight</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context>
@@ -1136,103 +1109,103 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">20</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">51</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">90</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="5158149204451635281" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">50</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="5158149204451635281" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can't see the item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> ne peut pas voir cet élément</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">21</context></context-group></trans-unit><trans-unit id="314315645942131479" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="314315645942131479" datatype="html">
         <source>Info</source><target state="translated">Info</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="276512967364950264" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">34</context></context-group></trans-unit><trans-unit id="276512967364950264" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the item title and description, but not its content</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir cet élément</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="6205355627445317276" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="6205355627445317276" datatype="html">
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">30</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">61</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">35</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">43</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
         <source>Content and descendants</source><target state="translated">Contenu et descendants</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">35</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="4367139476225965577" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">36</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">44</context></context-group></trans-unit><trans-unit id="4367139476225965577" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the content of this items descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir le contenu de tous les descendants de cet élément (lorsque c'est possible pour ce groupe)</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="2577694282301310795" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group></trans-unit><trans-unit id="2577694282301310795" datatype="html">
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">71</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">37</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">45</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">46</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can't grant any access to this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> ne peut pas donner d'accès à cet élément</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">52</context></context-group></trans-unit><trans-unit id="1656969124420182024" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="1656969124420182024" datatype="html">
         <source>Info &amp; enter</source><target state="translated">Info &amp; Entrée</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">56</context></context-group></trans-unit><trans-unit id="3877952366729282439" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="3877952366729282439" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can grant 'Can view: info' and  'Can enter' access</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut donner le droit de visibilité 'info' et le droit d'entrée (si applicable)</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="4018984822711626214" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">65</context></context-group></trans-unit><trans-unit id="4018984822711626214" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also grant 'Can view: content' access</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également donner le droit de visibilité "contenu"</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="7801635454394159717" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="7801635454394159717" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also grant 'Can view: content and descendants' access</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également donner le droit de visibilité "contenu et descendants"</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="8322709316676964645" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">75</context></context-group></trans-unit><trans-unit id="8322709316676964645" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also grant 'Can view: solution' access</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également donner le droit de visibilité "solution"</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="8633307416259747737" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="8633307416259747737" datatype="html">
         <source>Solution and grant</source><target state="translated">Solution et transfert</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">77</context></context-group></trans-unit><trans-unit id="2055048329776603001" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">46</context></context-group></trans-unit><trans-unit id="2055048329776603001" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also grant 'Can grant view' access</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également donner le droit de donner les droit de visibilité</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">78</context></context-group></trans-unit><trans-unit id="6767431387675594216" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="6767431387675594216" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can't watch the activity of others on this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> ne peut observer les utilisateurs sur cet élément</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="2525230676386818985" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="2525230676386818985" datatype="html">
         <source>Result</source><target state="translated">Résultats</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="6744117517239451341" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="6744117517239451341" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can view information about submissions and scores of others on this item, but not their answers</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir les soumissions et scores des utilisateurs sur cet élément, mais pas leurs réponses</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">97</context></context-group></trans-unit><trans-unit id="4669216542007588508" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="4669216542007588508" datatype="html">
         <source>Answer</source><target state="translated">Réponse</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="179825020038700385" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">52</context></context-group></trans-unit><trans-unit id="179825020038700385" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also look at other people's answers on this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les réponses des autres utilisateurs sur cet élément</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="8665674003252205412" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">110</context></context-group></trans-unit><trans-unit id="8665674003252205412" datatype="html">
         <source>Answer and grant</source><target state="translated">Réponse et transfert</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="5037851248977334512" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="5037851248977334512" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also grant 'Can watch' access to others</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également donner le droit d'observation à d'autres</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="2746501966920310361" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">115</context></context-group></trans-unit><trans-unit id="2746501966920310361" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can't make any changes to this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> ne pas modifier cet élément</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">118</context></context-group></trans-unit><trans-unit id="4705822664965381735" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">129</context></context-group></trans-unit><trans-unit id="4705822664965381735" datatype="html">
         <source>Children</source><target state="translated">Enfants</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">122</context></context-group></trans-unit><trans-unit id="1401837687305228091" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can add children to this item and edit how permissions propagate to them</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut ajouter des enfants à cet élément et éditer comment les permissions se propagent vers eux</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">123</context></context-group></trans-unit><trans-unit id="1616102757855967475" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">134</context></context-group></trans-unit><trans-unit id="1616102757855967475" datatype="html">
         <source>All</source><target state="translated">Tout</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">127</context></context-group></trans-unit><trans-unit id="7027429249361248522" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="7027429249361248522" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also edit the content of the item itself, but may not delete it</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également éditer le contenu de cet élément, mais pas le supprimer</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="7644477740441451078" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">139</context></context-group></trans-unit><trans-unit id="7644477740441451078" datatype="html">
         <source>All and grant</source><target state="translated">Tout et transfert</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">132</context></context-group></trans-unit><trans-unit id="1586778869242032005" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/item-permissions.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="1586778869242032005" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also give 'Can edit' access to others</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également donner les droits d'édition à d'autres</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">133</context></context-group></trans-unit><trans-unit id="4378796785985219718" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">144</context></context-group></trans-unit><trans-unit id="4378796785985219718" datatype="html">
         <source>Class</source><target state="translated">Classe</target>
 
 
@@ -1366,7 +1339,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="6306138344256927663" datatype="html">
         <source>Read-only</source><target state="translated">Lecture seule</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="4530794177600687289" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="4530794177600687289" datatype="html">
         <source>Memberships</source><target state="translated">Membres</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">42</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/managed-group-list/managed-group-list.component.ts</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="8651754097639378857" datatype="html">
@@ -1395,20 +1368,14 @@
         </context-group>
       </trans-unit><trans-unit id="7838784407251919653" datatype="html">
         <source>Management level</source><target state="new">Management level</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context>
-          <context context-type="linenumber">29</context>
-        </context-group>
-      </trans-unit><trans-unit id="367178788667281065" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="367178788667281065" datatype="html">
         <source>The permissions that the user(s) has on this group</source><target state="new">The permissions that the user(s) has on this group</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="3077731577529874277" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="3077731577529874277" datatype="html">
         <source>Can grant access</source><target state="new">Can grant access</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context>
-          <context context-type="linenumber">44</context>
-        </context-group>
-      </trans-unit><trans-unit id="1153571395259772276" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="1153571395259772276" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> group(s) have been removed</source><target state="new"><x id="PH" equiv-text="result.countSuccess"/> group(s) have been removed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/components/member-list/group-removal-response-handling.ts</context>
@@ -1587,11 +1554,8 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-no-permission/group-no-permission.component.html</context><context context-type="linenumber">1</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-managers/group-managers.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="2245297782531854585" datatype="html">
         <source> Only an empty group can be deleted. </source><target state="new"> Only an empty group can be deleted. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context>
-          <context context-type="linenumber">9,10</context>
-        </context-group>
-      </trans-unit><trans-unit id="625198541404386219" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="625198541404386219" datatype="html">
         <source>Are you sure you want to delete the group "<x id="PH" equiv-text="this.group.name"/>"</source><target state="new">Are you sure you want to delete the group "<x id="PH" equiv-text="this.group.name"/>"</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.ts</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="3768927257183755959" datatype="html">
@@ -1703,7 +1667,37 @@
       </trans-unit><trans-unit id="6629094035123468873" datatype="html">
         <source>ACCESS</source><target state="translated">ACCÈS</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="6746605846893800788" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="2035437600846010522" datatype="html">
+        <source>You need to be &lt;b&gt;owner&lt;/b&gt; of this item</source><target state="translated">Vous devez être &lt;b&gt;propriétaire&lt;/b&gt; de cet activité</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit><trans-unit id="2445279236045755407" datatype="html">
+        <source>You need</source><target state="translated">Vous devez avoir</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
+          <context context-type="linenumber">14</context>
+        </context-group>
+      </trans-unit><trans-unit id="3742549360822749870" datatype="html">
+        <source>This user needs</source><target state="translated">Cet utilisateur doit avoir</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
+          <context context-type="linenumber">15</context>
+        </context-group>
+      </trans-unit><trans-unit id="2913790852956203897" datatype="html">
+        <source>to be</source><target state="translated">égal à</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit><trans-unit id="4601425161855798823" datatype="html">
+        <source>to be at least</source><target state="translated">au moins égal à</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit><trans-unit id="6746605846893800788" datatype="html">
         <source>Error while loading the group progress</source><target state="new">Error while loading the group progress</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/chapter-group-progress/chapter-group-progress.component.html</context>
@@ -1763,10 +1757,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-details/group-details.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="80384927579662477" datatype="html">
         <source>Error while loading the group info</source><target state="translated">Error lors du chargement du groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">14</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-details/group-details.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="3835604152936342866" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-details/group-details.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="3835604152936342866" datatype="html">
         <source>Delete this group</source><target state="new">Delete this group</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="8675432263399119284" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="8675432263399119284" datatype="html">
         <source>My groups</source><target state="translated">Mes groupes</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.ts</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="8471940861423120175" datatype="html">

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1667,35 +1667,27 @@
       </trans-unit><trans-unit id="6629094035123468873" datatype="html">
         <source>ACCESS</source><target state="translated">ACCÈS</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="2035437600846010522" datatype="html">
-        <source>You need to be &lt;b&gt;owner&lt;/b&gt; of this item</source><target state="translated">Vous devez être &lt;b&gt;propriétaire&lt;/b&gt; de cet activité</target>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="1346386960355422306" datatype="html">
+        <source>You need to be owner of this item</source><target state="translated">Vous devez être propriétaire de cet élément</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
-          <context context-type="linenumber">13</context>
+          <context context-type="linenumber">67</context>
         </context-group>
-      </trans-unit><trans-unit id="2445279236045755407" datatype="html">
-        <source>You need</source><target state="translated">Vous devez avoir</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
-          <context context-type="linenumber">14</context>
+          <context context-type="linenumber">118</context>
         </context-group>
-      </trans-unit><trans-unit id="3742549360822749870" datatype="html">
-        <source>This user needs</source><target state="translated">Cet utilisateur doit avoir</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
-          <context context-type="linenumber">15</context>
+          <context context-type="linenumber">147</context>
         </context-group>
-      </trans-unit><trans-unit id="2913790852956203897" datatype="html">
-        <source>to be</source><target state="translated">égal à</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
-          <context context-type="linenumber">16</context>
+          <context context-type="linenumber">169</context>
         </context-group>
-      </trans-unit><trans-unit id="4601425161855798823" datatype="html">
-        <source>to be at least</source><target state="translated">au moins égal à</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/helpers/item-permissions-constraints.ts</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">187</context>
         </context-group>
       </trans-unit><trans-unit id="6746605846893800788" datatype="html">
         <source>Error while loading the group progress</source><target state="new">Error while loading the group progress</target>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -28,6 +28,7 @@
 @import 'assets/scss/components/propagation-edit-menu';
 @import 'assets/scss/components/group-join-by-code';
 @import 'assets/scss/components/block-ui';
+@import 'assets/scss/components/tooltip';
 
 html {
   height: 100%;


### PR DESCRIPTION
(this PR still needs some work, I just need some insights)

Fixes #593 

~~The non valid options in the permissions edition dialog box are now grayed out according to the [constraints on receiver](https://france-ioi.github.io/algorea-devdoc/design/access-rights/items/#changing-and-propagating-permissions).~~

~~The only missing behavior is when a permission is changed that invalidates another, the invalid one is set to the closest valid one For example if someone has `can_view = content` and `can_watch = result`, if we set `can_view` to `info` the receiver cannot have `can_watch = result` because he needs `can_view ≥ content`, so the `can_watch` permissions should be also updated.~~

 ~~My solution would be to make the `ProgressSectionValue` and `BooleanSectionComponent` components implement  `ControlValueAccessor` to make the permission edition dialog a form. It will be easier to manipulate and changes can be handled directly from the `PermissionsEditDialogComponent`. The permissions would also be saved if changed (if the form is dirty)~~

~~The only issue is that without strongly typed forms a lot of problems can occur when getting the value from the form and when setting them programmatically.
I used a packaged that made forms strongly typed in another PR (#472) and I can really see how it could be used here to simplify everything form related~~

See [here](https://github.com/France-ioi/AlgoreaFrontend/pull/692#issuecomment-940177540) for the update