### PR TITLE
Add eslint member-delimiter-style rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,11 @@ module.exports = {
       'error',
       { 'code': 140 },
     ],
+    '@typescript-eslint/member-delimiter-style': ['error', {
+      "multiline": { "delimiter": "comma", "requireLast": true },
+      "singleline": { "delimiter": "comma", "requireLast": false },
+      "multilineDetection": "last-member"
+    }],
     'no-console': ['error'],
     'arrow-parens': ['error', 'as-needed'],
     'arrow-body-style': ['error', 'as-needed'],

--- a/src/app/core/components/left-nav/left-nav-datasource.ts
+++ b/src/app/core/components/left-nav/left-nav-datasource.ts
@@ -17,8 +17,8 @@ interface DataSourceUpdate<T extends NavTreeElement> {
   elementUpdate?: (el:T) => T, // if set, function to update the element identified by elementId
 }
 interface DataSourceReplacement<T extends NavTreeElement> {
-  type: 'replace'
-  data: NavTreeData<T>
+  type: 'replace',
+  data: NavTreeData<T>,
 }
 interface DataSourceLoading { type: 'loading' }
 interface DataSourceError { type: 'error', error: any }

--- a/src/app/core/http-services/group-leave.service.ts
+++ b/src/app/core/http-services/group-leave.service.ts
@@ -6,7 +6,7 @@ import { appConfig } from 'src/app/shared/helpers/config';
 import { ActionResponse, successData } from 'src/app/shared/http-services/action-response';
 
 interface LeaveGroupResponseData {
-  changed: boolean
+  changed: boolean,
 }
 
 @Injectable({

--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -25,22 +25,22 @@ interface ActivityOrSkill {
   no_score: boolean,
   has_visible_children: boolean,
   permissions: {
-    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
+    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
   },
-  results: RawResult[]
+  results: RawResult[],
 }
 
 export interface RootActivity {
   // Some attributes are omitted as they are not used for the moment. Read the doc for the full list.
   group_id: string,
   name: string,
-  activity: ActivityOrSkill
+  activity: ActivityOrSkill,
 }
 
 interface RootSkill {
   group_id: string,
   name: string,
-  skill: ActivityOrSkill
+  skill: ActivityOrSkill,
 }
 
 interface RawResult {
@@ -58,7 +58,7 @@ interface RawNavData {
   string: ItemStrings,
   type: ItemType,
   permissions: {
-    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
+    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
   },
   children: {
     id: string,
@@ -68,10 +68,10 @@ interface RawNavData {
     no_score: boolean,
     has_visible_children: boolean,
     permissions: {
-      can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
+      can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
     },
     results: RawResult[],
-  }[]
+  }[],
 }
 
 interface Result {
@@ -98,7 +98,7 @@ export interface NavMenuItem {
 
 export interface NavMenuRootItem {
   parent?: NavMenuItem,
-  items: NavMenuItem[]
+  items: NavMenuItem[],
 }
 
 
@@ -124,7 +124,7 @@ function createNavMenuItem(raw: {
   no_score: boolean,
   best_score: number,
   permissions: {
-    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
+    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
   },
 }): NavMenuItem {
   const currentResult = raw.results ? bestAttemptFromResults(raw.results.map(rawResultToResult)) : undefined;

--- a/src/app/core/http-services/managed-groups.service.ts
+++ b/src/app/core/http-services/managed-groups.service.ts
@@ -13,7 +13,7 @@ export interface Group {
   type: GroupType,
   canManage: ManageType,
   canWatchMember: boolean,
-  canGrantGroupAccess: boolean
+  canGrantGroupAccess: boolean,
 }
 
 interface RawGroup {

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -2,12 +2,12 @@ import { ensureDefined } from 'src/app/shared/helpers/null-undefined-predicates'
 
 type Id = string;
 export interface NavTreeElement {
-  id: Id
-  title: string
-  hasChildren: boolean
-  children?: this[]
-  type?: string
-  locked: boolean
+  id: Id,
+  title: string,
+  hasChildren: boolean,
+  children?: this[],
+  type?: string,
+  locked: boolean,
 }
 
 /**

--- a/src/app/modules/group/components/group-invite-users/group-invite-users.component.ts
+++ b/src/app/modules/group/components/group-invite-users/group-invite-users.component.ts
@@ -9,7 +9,7 @@ interface Message
 {
   type: 'success' | 'info' | 'error',
   summary?: string,
-  detail: string
+  detail: string,
 }
 
 type GroupInviteState = 'empty'|'too_many'|'loading'|'ready';

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.ts
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.ts
@@ -6,12 +6,12 @@ import { ActivityLog, ActivityLogService } from '../../../../shared/http-service
 
 interface Column {
   field: string,
-  header: string
+  header: string,
 }
 
 interface Data {
   columns: Column[],
-  rowData: ActivityLog[]
+  rowData: ActivityLog[],
 }
 
 @Component({

--- a/src/app/modules/group/components/member-list/group-removal-response-handling.ts
+++ b/src/app/modules/group/components/member-list/group-removal-response-handling.ts
@@ -1,9 +1,9 @@
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
 
 export interface Result {
-  countRequests: number;
-  countSuccess: number;
-  errorText?: string;
+  countRequests: number,
+  countSuccess: number,
+  errorText?: string,
 }
 
 export function displayGroupRemovalResponseToast(feedbackService: ActionFeedbackService, result: Result): void {

--- a/src/app/modules/group/components/member-list/member-list.component.ts
+++ b/src/app/modules/group/components/member-list/member-list.component.ts
@@ -24,7 +24,7 @@ function getSelectedGroupChildCaptions(selection: GroupChild[]): string {
 interface Column {
   sortable?: boolean,
   field: string,
-  header: string
+  header: string,
 }
 
 const usersColumns: Column[] = [

--- a/src/app/modules/group/components/member-list/user-removal-response-handling.ts
+++ b/src/app/modules/group/components/member-list/user-removal-response-handling.ts
@@ -1,8 +1,8 @@
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
 
 export interface Result {
-  countRequests: number;
-  countSuccess: number;
+  countRequests: number,
+  countSuccess: number,
 }
 
 export function displayResponseToast(feedbackService: ActionFeedbackService, result: Result): void {

--- a/src/app/modules/group/components/pending-request/pending-request-response-handling.ts
+++ b/src/app/modules/group/components/pending-request/pending-request-response-handling.ts
@@ -2,8 +2,8 @@ import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.s
 import { Action } from '../../http-services/request-actions.service';
 
 export interface Result {
-  countRequests: number;
-  countSuccess: number;
+  countRequests: number,
+  countSuccess: number,
 }
 
 export function displayResponseToast(feedbackService: ActionFeedbackService, result: Result, action: Action): void {

--- a/src/app/modules/group/helpers/group-code.ts
+++ b/src/app/modules/group/helpers/group-code.ts
@@ -11,15 +11,15 @@ export const groupCodeDecoder = D.partial({
 type GroupCode = D.TypeOf<typeof groupCodeDecoder>;
 
 export interface CodeInfo {
-  codeExpiration?: Date;
-  hasCodeNotSet: boolean;
-  hasCodeUnused: boolean;
-  hasUnexpiringCode: boolean;
-  hasCodeInUse: boolean;
-  hasCodeExpired: boolean;
-  codeFirstUseDate?: Date;
-  durationSinceFirstCodeUse?: Duration;
-  durationBeforeCodeExpiration?: Duration;
+  codeExpiration?: Date,
+  hasCodeNotSet: boolean,
+  hasCodeUnused: boolean,
+  hasUnexpiringCode: boolean,
+  hasCodeInUse: boolean,
+  hasCodeExpired: boolean,
+  codeFirstUseDate?: Date,
+  durationSinceFirstCodeUse?: Duration,
+  durationBeforeCodeExpiration?: Duration,
 }
 
 export function codeInfo(g: GroupCode): CodeInfo {

--- a/src/app/modules/group/helpers/group-management.ts
+++ b/src/app/modules/group/helpers/group-management.ts
@@ -47,9 +47,9 @@ export function canCurrentUserManageGroup<T extends GroupManagership>(g: T): boo
 }
 
 export interface ManagementAdditions {
-  isCurrentUserManager: boolean;
-  canCurrentUserManageMembers: boolean;
-  canCurrentUserManageGroup: boolean;
+  isCurrentUserManager: boolean,
+  canCurrentUserManageMembers: boolean,
+  canCurrentUserManageGroup: boolean,
 }
 
 // Adds to the given group some new computed attributes (as value)

--- a/src/app/modules/group/http-services/code-actions.service.ts
+++ b/src/app/modules/group/http-services/code-actions.service.ts
@@ -6,7 +6,7 @@ import { map } from 'rxjs/operators';
 import { appConfig } from 'src/app/shared/helpers/config';
 
 export interface NewCodeSuccessResponse {
-  code: string
+  code: string,
 }
 
 @Injectable({

--- a/src/app/modules/group/http-services/get-group-breadcrumbs.service.ts
+++ b/src/app/modules/group/http-services/get-group-breadcrumbs.service.ts
@@ -16,7 +16,7 @@ const breadcrumbDecoder = D.struct({
 type Breadcrumb = D.TypeOf<typeof breadcrumbDecoder>;
 
 export interface GroupBreadcrumb extends Breadcrumb {
-  route: GroupRoute
+  route: GroupRoute,
 }
 
 @Injectable({

--- a/src/app/modules/group/http-services/get-group-members.service.ts
+++ b/src/app/modules/group/http-services/get-group-members.service.ts
@@ -6,8 +6,8 @@ import { map } from 'rxjs/operators';
 
 interface RawMember {
   id: string,
-  member_since: string|null;
-  action: 'invitation_accepted'|'join_request_accepted'|'joined_by_code'|'added_directly';
+  member_since: string|null,
+  action: 'invitation_accepted'|'join_request_accepted'|'joined_by_code'|'added_directly',
   user: null|{
     login: string,
     first_name: string|null,
@@ -19,8 +19,8 @@ interface RawMember {
 
 export interface Member {
   id: string,
-  memberSince: Date|null;
-  action: 'invitation_accepted'|'join_request_accepted'|'joined_by_code'|'added_directly';
+  memberSince: Date|null,
+  action: 'invitation_accepted'|'join_request_accepted'|'joined_by_code'|'added_directly',
   user: null|{
     login: string,
     firstName: string|null,

--- a/src/app/modules/group/http-services/group-creation.service.ts
+++ b/src/app/modules/group/http-services/group-creation.service.ts
@@ -6,7 +6,7 @@ import { appConfig } from 'src/app/shared/helpers/config';
 import { ActionResponse, assertSuccess, SimpleActionResponse, successData } from 'src/app/shared/http-services/action-response';
 
 interface NewGroupData {
-  id: string
+  id: string,
 }
 
 @Injectable({

--- a/src/app/modules/group/services/group-datasource.service.ts
+++ b/src/app/modules/group/services/group-datasource.service.ts
@@ -10,7 +10,7 @@ import { GetGroupByIdService, Group } from '../http-services/get-group-by-id.ser
 export interface GroupData {
   route: GroupRoute,
   group: Group,
-  navigation: GroupNavigationData;
+  navigation: GroupNavigationData,
   breadcrumbs: GroupBreadcrumb[],
 }
 

--- a/src/app/modules/item/components/item-children-edit/item-children-edit.component.ts
+++ b/src/app/modules/item/components/item-children-edit/item-children-edit.component.ts
@@ -25,10 +25,10 @@ interface InvisibleChildData extends BaseChildData {
   isVisible: false,
 }
 interface ChildData extends BaseChildData {
-  id?: string;
+  id?: string,
   isVisible: true,
-  title: string | null;
-  type: ItemType;
+  title: string | null,
+  type: ItemType,
   result?: {
     attemptId: string,
     validated: boolean,

--- a/src/app/modules/item/helpers/item-permissions.ts
+++ b/src/app/modules/item/helpers/item-permissions.ts
@@ -11,7 +11,7 @@ export const permissionsDecoder = D.struct({
 export type PermissionsInfo = D.TypeOf<typeof permissionsDecoder>;
 
 export interface ItemPermissionsInfo {
-  permissions: PermissionsInfo
+  permissions: PermissionsInfo,
 }
 
 export function canCurrentUserViewItemContent(item: ItemPermissionsInfo): boolean {

--- a/src/app/modules/item/http-services/create-item.service.ts
+++ b/src/app/modules/item/http-services/create-item.service.ts
@@ -7,13 +7,13 @@ import { map } from 'rxjs/operators';
 import { ActionResponse, successData } from '../../../shared/http-services/action-response';
 
 interface NewItemData {
-  id: string;
+  id: string,
 }
 
 export type NewItem = {
   title: string,
   type: ItemType,
-  languageTag: string
+  languageTag: string,
 } & ({ parent: string } | { asRootOfGroupId: string });
 
 @Injectable({

--- a/src/app/modules/item/http-services/get-breadcrumb.service.ts
+++ b/src/app/modules/item/http-services/get-breadcrumb.service.ts
@@ -21,8 +21,8 @@ interface RawBreadcrumbItem {
 
 export interface BreadcrumbItem {
   itemId: string,
-  title: string
-  route: FullItemRoute
+  title: string,
+  route: FullItemRoute,
   attemptCnt?: number,
 }
 

--- a/src/app/modules/item/http-services/update-item-string.service.ts
+++ b/src/app/modules/item/http-services/update-item-string.service.ts
@@ -9,7 +9,7 @@ export interface ItemStringChanges {
   description?: string | null,
   image_url?: string | null,
   subtitle?: string | null,
-  title?: string
+  title?: string,
 }
 
 @Injectable({

--- a/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts
+++ b/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts
@@ -11,7 +11,7 @@ import { ItemRouter } from '../../../../shared/routing/item-router';
 
 interface Column {
   field: string,
-  header: string
+  header: string,
 }
 
 interface RowData {

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
@@ -51,7 +51,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
   currentFilter = this.defaultFilter;
 
   dialogPermissions: {
-    permissions: Permissions
+    permissions: Permissions,
     itemId: string,
     targetGroupId: string,
   } = {
@@ -74,7 +74,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
       title: string,
       groupId: string,
       itemId: string,
-    };
+    },
   };
 
   dialog: 'loading'|'opened'|'closed' = 'closed';

--- a/src/app/modules/item/pages/item-by-id/item-route-validation.ts
+++ b/src/app/modules/item/pages/item-by-id/item-route-validation.ts
@@ -6,10 +6,10 @@ import { decodeItemRouterParameters, FullItemRoute, itemCategoryFromPrefix } fro
 type ItemId = string;
 
 interface ItemRouteError {
-  tag: 'error';
-  contentType: ItemTypeCategory;
-  id?: ItemId;
-  path?: ItemId[];
+  tag: 'error',
+  contentType: ItemTypeCategory,
+  id?: ItemId,
+  path?: ItemId[],
 }
 
 export function itemRouteFromParams(prefix: string, params: ParamMap): FullItemRoute|ItemRouteError {

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -10,12 +10,12 @@ import { UserSessionService, WatchedGroup } from '../../../../shared/services/us
 
 interface Column {
   field: string,
-  header: string
+  header: string,
 }
 
 interface Data {
   columns: Column[],
-  rowData: ActivityLog[]
+  rowData: ActivityLog[],
 }
 
 @Component({

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -19,7 +19,7 @@ export interface ItemData {
   breadcrumbs: BreadcrumbItem[],
   results?: Result[],
   currentResult?: Result,
-  itemNavigationData?: ItemNavigationData
+  itemNavigationData?: ItemNavigationData,
 }
 
 /**

--- a/src/app/modules/item/task-communication/rxjschannel.ts
+++ b/src/app/modules/item/task-communication/rxjschannel.ts
@@ -3,10 +3,10 @@ import { Observable } from 'rxjs';
 import { take } from 'rxjs/operators';
 
 export interface RxMessage {
-  method: string;
-  params?: unknown;
-  timeout?: number;
-  error?: (error: unknown, message: string) => void;
+  method: string,
+  params?: unknown,
+  timeout?: number,
+  error?: (error: unknown, message: string) => void,
 }
 
 /** Build a RxMessagingChannel, which is a jschannel with rxjs calls */

--- a/src/app/modules/item/task-communication/types.ts
+++ b/src/app/modules/item/task-communication/types.ts
@@ -44,7 +44,7 @@ export type TaskViews = D.TypeOf<typeof taskViewsDecoder>;
 export interface RawTaskGrade {
   score?: unknown,
   message?: unknown,
-  scoreToken?: unknown
+  scoreToken?: unknown,
 }
 export const taskGradeDecoder = D.partial({
   score: D.number,

--- a/src/app/modules/shared-components/components/grid/grid.component.ts
+++ b/src/app/modules/shared-components/components/grid/grid.component.ts
@@ -10,12 +10,12 @@ export function tableFactory(wrapper: GridComponent): Table|undefined {
 
 export interface GridColumn {
   field: string,
-  header: string
+  header: string,
 }
 
 export interface GridColumnGroup {
   columns: GridColumn[],
-  name?: string
+  name?: string,
 }
 
 @Component({

--- a/src/app/shared/guards/pending-changes-guard.ts
+++ b/src/app/shared/guards/pending-changes-guard.ts
@@ -7,7 +7,7 @@ export interface PendingChangesComponent {
   /**
    * Whether this component has pending changes
    */
-  isDirty(): boolean;
+  isDirty(): boolean,
 }
 
 @Injectable()

--- a/src/app/shared/helpers/attempts.ts
+++ b/src/app/shared/helpers/attempts.ts
@@ -18,10 +18,10 @@ export function bestAttemptFromResults<T extends Result>(results: T[]): T|null {
 }
 
 interface Item {
-  requiresExplicitEntry: boolean
+  requiresExplicitEntry: boolean,
   permissions: {
     canView: 'none'|'info'|'content'|'content_with_descendants'|'solution',
-  }
+  },
 }
 
 export function implicitResultStart(item: Item): boolean {

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -6,19 +6,19 @@ export interface LanguageConfig {
 }
 
 export interface Environment {
-  production: boolean;
+  production: boolean,
 
-  apiUrl: string; // full url (not including the trailing slash) of the backend
+  apiUrl: string, // full url (not including the trailing slash) of the backend
 
-  oauthServerUrl: string; // full url (not including the trailing slash) of the oauth server
-  oauthClientId: string;
+  oauthServerUrl: string, // full url (not including the trailing slash) of the oauth server
+  oauthClientId: string,
 
   // the id of the item to be loaded by default on home page (if no specific path is given) and in nav menu (if no other item is visited)
   // this item MUST be on one of all users' root and be implicitely startable
-  defaultActivityId: string;
+  defaultActivityId: string,
 
   // To add a default/fallback language, use a config with path = "/" and place it at the end.
-  languages: LanguageConfig[];
+  languages: LanguageConfig[],
 
   allowForcedToken: boolean, // for dev: allow devs to define 'forced_token' in storage so that this token is used in any case
   // The authType used with API is either 'tokens' or 'cookies'.

--- a/src/app/shared/helpers/sort-options.ts
+++ b/src/app/shared/helpers/sort-options.ts
@@ -2,8 +2,8 @@ import { HttpParams } from '@angular/common/http';
 import { SortEvent } from 'primeng/api';
 
 export interface SortOption {
-  field: string;
-  ascending: boolean;
+  field: string,
+  ascending: boolean,
 }
 export type SortOptions = readonly SortOption[];
 

--- a/src/app/shared/http-services/action-response.ts
+++ b/src/app/shared/http-services/action-response.ts
@@ -1,11 +1,11 @@
 
 // ActionResponse is the response format returned by the backend on action (PUT/POST/DELETE) services.
 export interface ActionResponse<T> {
-  message: string;
-  success: boolean;
-  data?: T;
-  errors?: object;
-  error_text?: string;
+  message: string,
+  success: boolean,
+  data?: T,
+  errors?: object,
+  error_text?: string,
 }
 
 // SimpleActionResponse is an action response with no "data"

--- a/src/app/shared/http-services/current-user.service.ts
+++ b/src/app/shared/http-services/current-user.service.ts
@@ -35,7 +35,7 @@ export const currentUserDecoder = pipe(
 export type UserProfile = D.TypeOf<typeof currentUserDecoder>;
 
 export interface UpdateUserBody {
-  default_language: string
+  default_language: string,
 }
 
 @Injectable({

--- a/src/app/shared/http-services/get-group-descendants.service.ts
+++ b/src/app/shared/http-services/get-group-descendants.service.ts
@@ -13,7 +13,7 @@ interface RawTeamDescendants {
     group_id: string,
     first_name: string|null,
     last_name: string|null,
-    grade: number|null;
+    grade: number|null,
   }[],
   parents: {
     id: string,
@@ -30,7 +30,7 @@ export interface TeamDescendants {
     groupId: string,
     firstName: string|null,
     lastName: string|null,
-    grade: number|null;
+    grade: number|null,
   }[],
   parents: {
     id: string,

--- a/src/app/shared/http-services/group-permissions.service.ts
+++ b/src/app/shared/http-services/group-permissions.service.ts
@@ -6,7 +6,7 @@ import { appConfig } from '../helpers/config';
 import { assertSuccess, SimpleActionResponse } from './action-response';
 
 export interface Permissions {
-  can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution'
+  can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
   can_grant_view: 'none'|'enter'|'content'|'content_with_descendants'|'solution'|'solution_with_grant',
   can_watch: 'none'|'result'|'answer'|'answer_with_grant',
   can_edit: 'none'|'children'|'all'|'all_with_grant',

--- a/src/app/shared/models/content/content-info.ts
+++ b/src/app/shared/models/content/content-info.ts
@@ -2,14 +2,14 @@ import { ContentBreadcrumb } from './content-breadcrumb';
 import { ContentRoute } from '../../routing/content-route';
 
 export interface ContentInfo {
-  type: string
+  type: string,
   breadcrumbs?: ContentBreadcrumb,
   title?: string, // page title
   route?: ContentRoute,
 }
 
 export interface RoutedContentInfo extends ContentInfo {
-  route: ContentRoute
+  route: ContentRoute,
 }
 
 /**

--- a/src/app/shared/routing/content-route.ts
+++ b/src/app/shared/routing/content-route.ts
@@ -7,9 +7,9 @@ const pathParamName = 'path';
 type Id = string;
 
 export interface ContentRoute {
-  contentType: string;
-  id: Id;
-  path: Id[];
+  contentType: string,
+  id: Id,
+  path: Id[],
 }
 
 export function pathFromRouterParameters(params: ParamMap): string|null {

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -6,15 +6,15 @@ import { UrlCommand } from '../helpers/url';
 import { ContentRoute, pathAsParameter, pathFromRouterParameters } from './content-route';
 
 export interface GroupRoute extends ContentRoute {
-  contentType: 'group';
-  isUser: boolean;
+  contentType: 'group',
+  isUser: boolean,
 }
 export type RawGroupRoute = Omit<GroupRoute, 'path'> & Partial<Pick<ContentRoute, 'path'>>;
 
 export interface GroupRouteError {
-  tag: 'error';
-  path?: string[];
-  id?: string;
+  tag: 'error',
+  path?: string[],
+  id?: string,
 }
 
 
@@ -62,7 +62,7 @@ function isGroupPage(page: string): page is GroupPage {
   return [ 'edit', 'details' ].includes(page);
 }
 
-export function decodeGroupRouterParameters(params: ParamMap): { id: string | null; path: string | null } {
+export function decodeGroupRouterParameters(params: ParamMap): { id: string | null, path: string | null } {
   return {
     id: params.get('id'),
     path: pathFromRouterParameters(params),

--- a/src/app/shared/routing/group-router.ts
+++ b/src/app/shared/routing/group-router.ts
@@ -16,7 +16,7 @@ export class GroupRouter {
    * Navigate to given group, on the path page.
    * If page is not given and we are currently on a group page, use the same page. Otherwise, default to 'details'.
    */
-  navigateTo(route: RawGroupRoute, options?: { page?: string; navExtras?: NavigationExtras }): void {
+  navigateTo(route: RawGroupRoute, options?: { page?: string, navExtras?: NavigationExtras }): void {
     void this.router.navigateByUrl(this.url(route, options?.page), options?.navExtras);
   }
 

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -27,9 +27,9 @@ type AttemptId = string;
 // When navigating, as many information as possible should be given to the item router so that the navigation is not slowed down.
 // So always prefer usage of FullItemRoute over ItemRoute over RawItemRoute.
 export interface ItemRoute extends ContentRoute {
-  contentType: ItemTypeCategory;
-  attemptId?: AttemptId;
-  parentAttemptId?: AttemptId;
+  contentType: ItemTypeCategory,
+  attemptId?: AttemptId,
+  parentAttemptId?: AttemptId,
 }
 type ItemRouteWithSelfAttempt = ItemRoute & { attemptId: AttemptId };
 type ItemRouteWithParentAttempt = ItemRoute & { parentAttemptId: AttemptId };
@@ -65,7 +65,7 @@ export function decodeItemRouterParameters(params: ParamMap): {
   id: string|null,
   path: string|null,
   attemptId: string|null,
-  parentAttemptId: string|null
+  parentAttemptId: string|null,
 } {
   return {
     id: params.get('id'),


### PR DESCRIPTION
Fixes #703

If using VSCode, this rule can be enforced automatically when saving by having the following in the settings
```
"editor.codeActionsOnSave": {
  "source.fixAll": true
},
```