### PR TITLE
refactor rx messaging channel method to accept sync responses as well

### DIFF
--- a/src/app/modules/item/task-communication/task-proxy.ts
+++ b/src/app/modules/item/task-communication/task-proxy.ts
@@ -5,7 +5,7 @@
  * It depends on jschannel.
  */
 
-import { Observable, of, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { delay, map, retryWhen, switchMap, take } from 'rxjs/operators';
 import { rxBuild, RxMessagingChannel } from './rxjschannel';
 import * as D from 'io-ts/Decoder';
@@ -241,40 +241,17 @@ export class Task {
   }
 }
 
-export class TaskPlatform {
-  constructor(implementation: Partial<TaskPlatform>) {
-    Object.assign(this, implementation); // assigning implementation object to self will override methods
-  }
+export interface TaskPlatform {
   /*
    * Simple prototypes for Bebras platform API functions, to be overriden by your
    * "platform"'s specific functions (for each platform object).
    */
-  validate(_mode: string): Observable<void> {
-    return throwError(() => new Error('platform.validate is not defined'));
-  }
-  showView(_views: string): Observable<void> {
-    return throwError(() => new Error('platform.showView is not defined'));
-  }
-  askHint(_platformToken: string): Observable<void> {
-    return throwError(() => new Error('platform.validate is not defined'));
-  }
-  updateHeight(height: number): Observable<void> {
-    return this.updateDisplay({ height });
-  }
-  updateDisplay(_data: UpdateDisplayParams): Observable<void> {
-    return throwError(() => new Error('platform.updateDisplay is not defined!'));
-  }
-  openUrl(_url: OpenUrlParams): Observable<void> {
-    return throwError(() => new Error('platform.openUrl is not defined!'));
-  }
-  log(_data: TaskLog): Observable<void> {
-    return throwError(() => new Error('platform.log is not defined!'));
-  }
-  getTaskParams({ key, defaultValue }: TaskParamsKeyDefault = {}): Observable<TaskParamsValue> {
-    const res: Record<string, TaskParamsValue> = { minScore: -3, maxScore: 10, randomSeed: 0, noScore: 0, readOnly: false, options: {} };
-    if (!key) return of(res);
-    return key !== 'options' && key in res
-      ? of(res[key])
-      : of(defaultValue);
-  }
+  validate(mode: string): Observable<void>,
+  showView(views: string): void,
+  askHint(platformToken: string): Observable<void>,
+  updateHeight(height: number): void,
+  updateDisplay(data: UpdateDisplayParams): void,
+  openUrl(url: OpenUrlParams): void,
+  log(data: TaskLog): void,
+  getTaskParams(keyAndDefaultValue: TaskParamsKeyDefault): TaskParamsValue,
 }


### PR DESCRIPTION
Fixes #701

## Tests

Branch and prod apps should behave exactly the same.

- [x] `getTaskParams` − Cannot be tested using UI, I tested by hand using logs
- [x] `openUrl` − [branch](https://dev.algorea.org/branch/refactor/rxmessaging-bind-method/en/#/activities/by-id/837046206729127555;path=1352246428241737349,314613032161178344;attempId=0/details) / [prod](https://dev.algorea.org/en/#/activities/by-id/837046206729127555;path=1352246428241737349,314613032161178344;attempId=0/details) (scroll a bit, then click on "Activité en blockly" or "Activité en Python")
- [x] `showView` − [branch](https://dev.algorea.org/branch/refactor/rxmessaging-bind-method/en/#/activities/by-id/1511229473173712830;path=4702,1352246428241737349,1545709256713023530,1128536253570566326;parentAttempId=0/details) / [prod](https://dev.algorea.org/en/#/activities/by-id/1511229473173712830;path=4702,1352246428241737349,1545709256713023530,1128536253570566326;parentAttempId=0/details) (click on "Solution" tab)
- [x] `updateHeight` and `updateDisplay` − any task: [branch](https://dev.algorea.org/branch/refactor/rxmessaging-bind-method/en/#/activities/by-id/837046206729127555;path=4702,1352246428241737349,314613032161178344;parentAttempId=0/details) / [prod](https://dev.algorea.org/en/#/activities/by-id/837046206729127555;path=4702,1352246428241737349,314613032161178344;parentAttempId=0/details) (check that the height of the iframe is updated to match the height of the task)