### PR TITLE
Item-navigation: use decoders

### DIFF
--- a/src/app/core/common/item-nav-menu-data.ts
+++ b/src/app/core/common/item-nav-menu-data.ts
@@ -1,6 +1,6 @@
 import { ItemDetails } from 'src/app/shared/models/content/item-info';
 import { FullItemRoute } from 'src/app/shared/routing/item-route';
-import { NavMenuItem } from '../http-services/item-navigation.service';
+import { NavMenuItem } from './nav-menu-item';
 
 type Id = string;
 

--- a/src/app/core/common/nav-menu-item.ts
+++ b/src/app/core/common/nav-menu-item.ts
@@ -1,0 +1,13 @@
+
+export interface NavMenuItem {
+  id: string,
+  title: string, // not null to implement NavTreeElement
+  hasChildren: boolean,
+  groupName?: string,
+  attemptId: string|null,
+  bestScore?: number,
+  currentScore?: number,
+  validated?: boolean,
+  children?: NavMenuItem[], // placeholder for children when fetched (may 'hasChildren' with 'children' not set)
+  locked: boolean,
+}

--- a/src/app/core/components/left-nav/left-nav-item-datasource.ts
+++ b/src/app/core/components/left-nav/left-nav-item-datasource.ts
@@ -3,21 +3,9 @@ import { map } from 'rxjs/operators';
 import { bestAttemptFromResults } from 'src/app/shared/helpers/attempts';
 import { isSkill, ItemTypeCategory } from 'src/app/shared/helpers/item-type';
 import { ItemInfo } from 'src/app/shared/models/content/item-info';
+import { NavMenuItem } from '../../common/nav-menu-item';
 import { ItemNavigationChild, ItemNavigationData, ItemNavigationService } from '../../http-services/item-navigation.service';
 import { LeftNavDataSource } from './left-nav-datasource';
-
-export interface NavMenuItem {
-  id: string,
-  title: string, // not null to implement NavTreeElement
-  hasChildren: boolean,
-  groupName?: string,
-  attemptId: string|null,
-  bestScore?: number,
-  currentScore?: number,
-  validated?: boolean,
-  children?: NavMenuItem[], // placeholder for children when fetched (may 'hasChildren' with 'children' not set)
-  locked: boolean,
-}
 
 export abstract class LeftNavItemDataSource<ItemT extends ItemInfo> extends LeftNavDataSource<ItemT,NavMenuItem> {
   constructor(

--- a/src/app/core/components/left-nav/left-nav-item-datasource.ts
+++ b/src/app/core/components/left-nav/left-nav-item-datasource.ts
@@ -3,8 +3,21 @@ import { map } from 'rxjs/operators';
 import { bestAttemptFromResults } from 'src/app/shared/helpers/attempts';
 import { isSkill, ItemTypeCategory } from 'src/app/shared/helpers/item-type';
 import { ItemInfo } from 'src/app/shared/models/content/item-info';
-import { ItemNavigationService, NavMenuItem } from '../../http-services/item-navigation.service';
+import { ItemNavigationChild, ItemNavigationData, ItemNavigationService } from '../../http-services/item-navigation.service';
 import { LeftNavDataSource } from './left-nav-datasource';
+
+export interface NavMenuItem {
+  id: string,
+  title: string, // not null to implement NavTreeElement
+  hasChildren: boolean,
+  groupName?: string,
+  attemptId: string|null,
+  bestScore?: number,
+  currentScore?: number,
+  validated?: boolean,
+  children?: NavMenuItem[], // placeholder for children when fetched (may 'hasChildren' with 'children' not set)
+  locked: boolean,
+}
 
 export abstract class LeftNavItemDataSource<ItemT extends ItemInfo> extends LeftNavDataSource<ItemT,NavMenuItem> {
   constructor(
@@ -15,14 +28,17 @@ export abstract class LeftNavItemDataSource<ItemT extends ItemInfo> extends Left
   }
 
   fetchRootTreeData(): Observable<NavMenuItem[]> {
-    return this.itemNavService.getRoot(this.category).pipe(
-      map(items => items.items)
+    return this.itemNavService.getRoots(this.category).pipe(
+      map(groups => groups.map(g => ({
+        ...mapChild(g.item),
+        groupName: g.name,
+      })))
     );
   }
 
   fetchNavDataFromChild(id: string, child: ItemT): Observable<{ parent: NavMenuItem, elements: NavMenuItem[] }> {
-    return this.itemNavService.getNavDataFromChildRoute(id, child.route, isSkill(this.category)).pipe(
-      map(items => ({ parent: items.parent, elements: items.items }))
+    return this.itemNavService.getItemNavigationFromChildRoute(id, child.route, isSkill(this.category)).pipe(
+      map(mapNavData)
     );
   }
 
@@ -69,4 +85,31 @@ export class LeftNavSkillDataSource extends LeftNavItemDataSource<ItemInfo> {
   constructor(itemNavService: ItemNavigationService) {
     super('skill', itemNavService);
   }
+}
+
+function mapChild(child: ItemNavigationChild): NavMenuItem {
+  const currentResult = bestAttemptFromResults(child.results);
+  return {
+    id: child.id,
+    title: child.string.title ?? '',
+    hasChildren: child.hasVisibleChildren && ![ 'none', 'info' ].includes(child.permissions.canView),
+    attemptId: currentResult?.attemptId ?? null,
+    bestScore: child.noScore ? undefined : child.bestScore,
+    currentScore: child.noScore ? undefined : currentResult?.scoreComputed,
+    validated: child.noScore ? undefined : currentResult?.validated,
+    locked: child.permissions.canView === 'info',
+  };
+}
+
+function mapNavData(data: ItemNavigationData): { parent: NavMenuItem, elements: NavMenuItem[] } {
+  return {
+    parent: {
+      id: data.id,
+      title: data.string.title ?? '',
+      hasChildren: data.children.length > 0,
+      attemptId: data.attemptId,
+      locked: data.permissions.canView === 'info'
+    },
+    elements: data.children.map(mapChild)
+  };
 }

--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -3,116 +3,14 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { bestAttemptFromResults } from 'src/app/shared/helpers/attempts';
-import { isRouteWithSelfAttempt, FullItemRoute } from 'src/app/shared/routing/item-route';
+import { isRouteWithSelfAttempt, FullItemRoute, ItemRoute } from 'src/app/shared/routing/item-route';
 import { appConfig } from 'src/app/shared/helpers/config';
-import { isASkill, isSkill, ItemType, ItemTypeCategory } from 'src/app/shared/helpers/item-type';
+import { isSkill, ItemTypeCategory, typeCategoryOfItem } from 'src/app/shared/helpers/item-type';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
 import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
 import { permissionsDecoder } from 'src/app/modules/item/helpers/item-permissions';
 import { dateDecoder } from 'src/app/shared/helpers/decoders';
-
-interface ItemStrings {
-  title: string|null,
-  language_tag: string,
-}
-
-interface RawResult {
-  attempt_id: string,
-  /* on 10/2020, the service defines latest_activity_at as nullable but this should be a mistake. The bug has been submitted. */
-  latest_activity_at: string,
-  started_at: string|null,
-  score_computed: number,
-  validated: boolean,
-}
-
-interface RawNavData {
-  id: string,
-  attempt_id: string,
-  string: ItemStrings,
-  type: ItemType,
-  permissions: {
-    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
-  },
-  children: {
-    id: string,
-    string: ItemStrings,
-    type: ItemType,
-    best_score: number,
-    no_score: boolean,
-    has_visible_children: boolean,
-    permissions: {
-      can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
-    },
-    results: RawResult[],
-  }[],
-}
-
-interface Result {
-  attemptId: string,
-  latestActivityAt: Date,
-  startedAt: Date|null,
-  score: number,
-  validated: boolean,
-}
-
-// exported nav menu structure
-export interface NavMenuItem {
-  id: string,
-  title: string, // not null to implement NavTreeElement
-  hasChildren: boolean,
-  groupName?: string,
-  attemptId: string|null,
-  bestScore?: number,
-  currentScore?: number,
-  validated?: boolean,
-  children?: NavMenuItem[], // placeholder for children when fetched (may 'hasChildren' with 'children' not set)
-  locked: boolean,
-}
-
-export interface NavMenuRootItem {
-  parent?: NavMenuItem,
-  items: NavMenuItem[],
-}
-
-
-export interface NavMenuRootItemWithParent extends NavMenuRootItem {
-  parent: NavMenuItem,
-}
-
-function rawResultToResult(r: RawResult): Result {
-  return {
-    attemptId: r.attempt_id,
-    latestActivityAt: new Date(r.latest_activity_at),
-    startedAt: r.started_at === null ? null : new Date(r.started_at),
-    score: r.score_computed,
-    validated: r.validated,
-  };
-}
-
-function createNavMenuItem(raw: {
-  id: string,
-  string: ItemStrings,
-  has_visible_children: boolean,
-  results?: RawResult[],
-  no_score: boolean,
-  best_score: number,
-  permissions: {
-    can_view: 'none'|'info'|'content'|'content_with_descendants'|'solution',
-  },
-}): NavMenuItem {
-  const currentResult = raw.results ? bestAttemptFromResults(raw.results.map(rawResultToResult)) : undefined;
-  return {
-    id: raw.id,
-    title: raw.string.title ?? '',
-    hasChildren: raw.has_visible_children && ![ 'none', 'info' ].includes(raw.permissions.can_view),
-    attemptId: currentResult?.attemptId ?? null,
-    bestScore: raw.no_score ? undefined : raw.best_score,
-    currentScore: raw.no_score ? undefined : currentResult?.score,
-    validated: raw.no_score ? undefined : currentResult?.validated,
-    locked: raw.permissions.can_view === 'info',
-  };
-}
 
 const itemNavigationChildDecoderBase = pipe(
   D.struct({
@@ -228,39 +126,6 @@ export class ItemNavigationService {
     );
   }
 
-  getNavData(itemId: string, attemptId: string, skillsOnly = false): Observable<NavMenuRootItemWithParent> {
-    return this.getNavDataGeneric(itemId, { attempt_id: attemptId }, skillsOnly);
-  }
-
-  getNavDataFromChildRoute(itemId: string, childRoute: FullItemRoute, skillsOnly = false): Observable<NavMenuRootItemWithParent> {
-    return this.getNavDataGeneric(
-      itemId,
-      isRouteWithSelfAttempt(childRoute) ? { child_attempt_id: childRoute.attemptId } : { attempt_id: childRoute.parentAttemptId },
-      skillsOnly
-    );
-  }
-
-  private getNavDataGeneric(itemId: string, parameters: {[param: string]: string}, skillsOnly: boolean):
-    Observable<NavMenuRootItemWithParent> {
-
-    return this.http
-      .get<RawNavData>(`${appConfig.apiUrl}/items/${itemId}/navigation`, {
-        params: parameters
-      })
-      .pipe(
-        map((data: RawNavData) => ({
-          parent: {
-            id: data.id,
-            title: data.string.title ?? '',
-            hasChildren: data.children !== null && data.children.length > 0,
-            attemptId: data.attempt_id,
-            locked: data.permissions.can_view === 'info',
-          },
-          items: data.children === null ? [] : data.children.filter(i => !skillsOnly || isASkill(i)).map(i => createNavMenuItem(i)),
-        }))
-      );
-  }
-
   getRootActivities(watchedGroupId?: string): Observable<RootActivities> {
     let httpParams = new HttpParams();
 
@@ -299,37 +164,35 @@ export class ItemNavigationService {
     // Root activity => no parent/left/right activity
     if (!parentId) return of({ parent: null, left: null, right: null });
 
-    return this.getNavDataFromChildRoute(parentId, itemRoute).pipe(map(navParent => {
-      const index = navParent.items.findIndex(item => item.id === itemRoute.id);
+    return this.getItemNavigationFromChildRoute(parentId, itemRoute).pipe(map(nav => {
+      const index = nav.children.findIndex(item => item.id === itemRoute.id);
       if (index === -1) throw new Error('Unexpected: item is missing from its parent children list');
 
-      const parentAttemptId = navParent.parent.attemptId;
-      if (parentAttemptId === null) throw new Error('Unexpected: parent of an item node has no attempt');
+      const leftItem = nav.children[index - 1];
+      const left = leftItem ? siblingRoute(leftItem, nav.attemptId, itemRoute) : null;
 
-      const leftItem = navParent.items[index - 1];
-      const left: FullItemRoute|null = leftItem ? {
-        id: leftItem.id,
-        contentType: itemRoute.contentType,
-        ...(leftItem.attemptId ? { attemptId: leftItem.attemptId } : { parentAttemptId }),
-        path: itemRoute.path,
-      } : null;
+      const rightItem = nav.children[index + 1];
+      const right = rightItem ? siblingRoute(rightItem, nav.attemptId, itemRoute) : null;
 
-      const rightItem = navParent.items[index + 1];
-      const right: FullItemRoute|null = rightItem ? {
-        id: rightItem.id,
-        contentType: itemRoute.contentType,
-        ...(rightItem.attemptId ? { attemptId: rightItem.attemptId } : { parentAttemptId }),
-        path: itemRoute.path,
-      } : null;
-
-      const parent: FullItemRoute = {
+      const parent = {
         id: parentId,
-        contentType: itemRoute.contentType,
+        contentType: typeCategoryOfItem(nav),
         path: itemRoute.path.slice(0, -1),
-        attemptId: parentAttemptId,
+        attemptId: nav.attemptId,
       };
 
       return { parent, left, right };
     }));
   }
+
+}
+
+function siblingRoute(child: ItemNavigationChild, parentAttemptId: string, itemRoute: ItemRoute): FullItemRoute {
+  const bestResult = bestAttemptFromResults(child.results);
+  return {
+    id: child.id,
+    contentType: typeCategoryOfItem(child),
+    ...(bestResult ? { attemptId: bestResult.attemptId } : { parentAttemptId }),
+    path: itemRoute.path,
+  };
 }

--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -73,30 +73,26 @@ const itemNavigationDataDecoder = D.struct({
 
 export type ItemNavigationData = D.TypeOf<typeof itemNavigationDataDecoder>;
 
-const rootActivitiesDecoder = D.array(
-  D.struct({
-    groupId: D.string,
-    name: D.string,
-    type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base', 'ContestParticipants'),
-    activity: itemNavigationChildDecoderBase
-  })
-);
+const rootActivityDecoder = D.struct({
+  groupId: D.string,
+  name: D.string,
+  type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base', 'ContestParticipants'),
+  activity: itemNavigationChildDecoderBase
+});
 
-export type RootActivities = D.TypeOf<typeof rootActivitiesDecoder>;
+export type RootActivity = D.TypeOf<typeof rootActivityDecoder>;
 
-const rootSkillsDecoder = D.array(
-  D.struct({
-    groupId: D.string,
-    name: D.string,
-    type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base', 'ContestParticipants'),
-    skill: itemNavigationChildDecoderBase
-  })
-);
+const rootSkillDecoder = D.struct({
+  groupId: D.string,
+  name: D.string,
+  type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base', 'ContestParticipants'),
+  skill: itemNavigationChildDecoderBase
+});
 
-export type RootSkills = D.TypeOf<typeof rootSkillsDecoder>;
+export type RootSkill = D.TypeOf<typeof rootSkillDecoder>;
 
-// common type to RootActivities and RootSkills if the activity/skill key is renamed 'item'
-export type RootItems = (Omit<RootActivities[number], 'activity'> & { item: RootActivities[number]['activity']})[];
+// common type to RootActivity and RootSkill if the activity/skill key is renamed 'item'
+export type RootItem = Omit<RootActivity, 'activity'> & { item: RootActivity['activity']};
 
 @Injectable({
   providedIn: 'root'
@@ -126,7 +122,7 @@ export class ItemNavigationService {
     );
   }
 
-  getRootActivities(watchedGroupId?: string): Observable<RootActivities> {
+  getRootActivities(watchedGroupId?: string): Observable<RootActivity[]> {
     let httpParams = new HttpParams();
 
     if (watchedGroupId) {
@@ -134,11 +130,11 @@ export class ItemNavigationService {
     }
 
     return this.http.get<unknown[]>(`${appConfig.apiUrl}/current-user/group-memberships/activities`, { params: httpParams }).pipe(
-      decodeSnakeCase(rootActivitiesDecoder),
+      decodeSnakeCase(D.array(rootActivityDecoder)),
     );
   }
 
-  getRootSkills(watchedGroupId?: string): Observable<RootSkills> {
+  getRootSkills(watchedGroupId?: string): Observable<RootSkill[]> {
     let httpParams = new HttpParams();
 
     if (watchedGroupId) {
@@ -146,11 +142,11 @@ export class ItemNavigationService {
     }
 
     return this.http.get<unknown[]>(`${appConfig.apiUrl}/current-user/group-memberships/skills`, { params: httpParams }).pipe(
-      decodeSnakeCase(rootSkillsDecoder),
+      decodeSnakeCase(D.array(rootSkillDecoder)),
     );
   }
 
-  getRoots(type: ItemTypeCategory): Observable<RootItems> {
+  getRoots(type: ItemTypeCategory): Observable<RootItem[]> {
     return isSkill(type) ?
       this.getRootSkills().pipe(map(groups => groups.map(g => ({ ...g, item: g.skill })))) :
       this.getRootActivities().pipe(map(groups => groups.map(g => ({ ...g, item: g.activity }))));

--- a/src/app/core/models/left-nav-loading/item-nav-tree-types.ts
+++ b/src/app/core/models/left-nav-loading/item-nav-tree-types.ts
@@ -1,4 +1,4 @@
-import { NavMenuItem } from '../../http-services/item-navigation.service';
+import { NavMenuItem } from '../../common/nav-menu-item';
 import { NavTreeElement } from './nav-tree-data';
 
 export function isANavMenuItem(e: NavTreeElement): e is NavMenuItem {

--- a/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
+++ b/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
@@ -14,7 +14,7 @@ export class SuggestionOfActivitiesComponent {
   readonly state$ = this.sessionService.watchedGroup$.pipe(
     filter(isNotUndefined),
     switchMap(watchedGroup =>
-      this.itemNavigationService.getRootActivities(watchedGroup.route.id).pipe(
+      this.itemNavigationService.getRootActivitiesLegacy(watchedGroup.route.id).pipe(
         map((rootActivity: RootActivity[]) =>
           rootActivity.sort(item => (item.group_id === watchedGroup.route.id ? -1 : 1)).slice(0, 4)
         ),

--- a/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
+++ b/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ItemNavigationService, RootActivity } from '../../../../core/http-services/item-navigation.service';
+import { ItemNavigationService } from '../../../../core/http-services/item-navigation.service';
 import { UserSessionService } from '../../../../shared/services/user-session.service';
 import { switchMap, filter, map } from 'rxjs/operators';
 import { isNotUndefined } from '../../../../shared/helpers/null-undefined-predicates';
@@ -14,9 +14,9 @@ export class SuggestionOfActivitiesComponent {
   readonly state$ = this.sessionService.watchedGroup$.pipe(
     filter(isNotUndefined),
     switchMap(watchedGroup =>
-      this.itemNavigationService.getRootActivitiesLegacy(watchedGroup.route.id).pipe(
-        map((rootActivity: RootActivity[]) =>
-          rootActivity.sort(item => (item.group_id === watchedGroup.route.id ? -1 : 1)).slice(0, 4)
+      this.itemNavigationService.getRootActivities(watchedGroup.route.id).pipe(
+        map(rootActivity =>
+          rootActivity.sort(item => (item.groupId === watchedGroup.route.id ? -1 : 1)).slice(0, 4)
         ),
       )
     ),


### PR DESCRIPTION
Use decoders for item-navigation services.
The behavior of the left menu should not have changed. Same for activity suggestion box (on [Pixal](https://dev.algorea.org/en/#/groups/by-id/672913018859223173;path=52767158366271444/details) page, click on observation button)

(out-of-scope/next step: clean usage of `NavMenuItem` vs `NavTreeElement`)