### PR TITLE
Permissions edition refactoring with forms

### DIFF
--- a/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html
+++ b/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html
@@ -25,69 +25,61 @@
         This panel lets you select what you allow the selected user or group of users to do on the current group and its descendants.
       </p>
 
-      <alg-collapsible-section
-        [collapsible]="false"
-        [collapsed]="false"
-        i18n-title title="Management level"
-        icon="fa fa-users-cog"
-      >
-        <ng-template #content let-collapsed>
-          <alg-progress-select
-            [(value)]="managerValues.canManage"
-            [values]="managementLevelValues"
-            [collapsed]="collapsed"
-            type="simple"
-            (valueChange)="onValueChange()"
-          >
-            <ng-container #description>
-              <span description i18n>The permissions that the user(s) has on this group</span>
-            </ng-container>
-          </alg-progress-select>
-        </ng-template>
-      </alg-collapsible-section>
-
-      <alg-collapsible-section
-        [collapsible]="false"
-        [collapsed]="false"
-        i18n-title title="Can grant access"
-        icon="fa fa-key"
-      >
-        <ng-template #content let-collapsed>
-          <alg-switch-field
-            [(value)]="managerValues.canGrantGroupAccess"
-            [collapsed]="collapsed"
-            (valueChange)="onValueChange()"
-          >
-            <ng-template #label>
-              <span label i18n>
-                User(s) can give and revoke members access to some content
-              </span>
-            </ng-template>
-          </alg-switch-field>
-        </ng-template>
-      </alg-collapsible-section>
-
-      <alg-collapsible-section
-        [collapsible]="false"
-        [collapsed]="false"
-        i18n-title title="Can watch members"
-        icon="fa fa-binoculars"
-      >
-        <ng-template #content let-collapsed>
-          <alg-switch-field
-            [collapsed]="collapsed"
-            [(value)]="managerValues.canWatchMembers"
-            (valueChange)="onValueChange()"
-          >
-          <ng-template #label>
-            <span i18n>
-              User(s) can watch the members' activity on some content
-            </span>
+      <form [formGroup]="form">
+        <alg-collapsible-section
+          [collapsible]="false"
+          [collapsed]="false"
+          i18n-title title="Management level"
+          icon="fa fa-users-cog"
+        >
+          <ng-template #content let-collapsed>
+            <alg-progress-select
+              formControlName="canManage"
+              [values]="managementLevelValues"
+              [collapsed]="collapsed"
+              type="simple"
+            >
+              <ng-container #description>
+                <span description i18n>The permissions that the user(s) has on this group</span>
+              </ng-container>
+            </alg-progress-select>
           </ng-template>
-      </alg-switch-field>
-        </ng-template>
-      </alg-collapsible-section>
+        </alg-collapsible-section>
 
+        <alg-collapsible-section
+          [collapsible]="false"
+          [collapsed]="false"
+          i18n-title title="Can grant access"
+          icon="fa fa-key"
+        >
+          <ng-template #content let-collapsed>
+            <alg-switch-field [collapsed]="collapsed" formControlName="canGrantGroupAccess">
+              <ng-template #label>
+                <span label i18n>
+                  User(s) can give and revoke members access to some content
+                </span>
+              </ng-template>
+            </alg-switch-field>
+          </ng-template>
+        </alg-collapsible-section>
+
+        <alg-collapsible-section
+          [collapsible]="false"
+          [collapsed]="false"
+          i18n-title title="Can watch members"
+          icon="fa fa-binoculars"
+        >
+          <ng-template #content let-collapsed>
+            <alg-switch-field [collapsed]="collapsed" formControlName="canWatchMembers">
+              <ng-template #label>
+                <span i18n>
+                  User(s) can watch the members' activity on some content
+                </span>
+              </ng-template>
+            </alg-switch-field>
+          </ng-template>
+        </alg-collapsible-section>
+      </form>
     </div>
   </div>
 
@@ -99,17 +91,17 @@
 
       <ng-template #buttons>
         <alg-button
-            icon="fa fa-times"
-            i18n-label label="Cancel"
-            class="p-button-rounded p-button-danger"
-            (click)="onClose()"
+          icon="fa fa-times"
+          i18n-label label="Cancel"
+          class="p-button-rounded p-button-danger"
+          (click)="onClose()"
         ></alg-button>
         <alg-button
-            icon="fa fa-check"
-            i18n-label label="Proceed"
-            class="p-button-rounded"
-            (click)="onAccept()"
-            [disabled]="!valuesChanged"
+          icon="fa fa-check"
+          i18n-label label="Proceed"
+          class="p-button-rounded"
+          (click)="onAccept()"
+          [disabled]="!form.dirty"
         ></alg-button>
       </ng-template>
     </div>

--- a/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts
+++ b/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts
@@ -3,9 +3,10 @@ import { Group } from '../../http-services/get-group-by-id.service';
 import { Manager } from '../../http-services/get-group-managers.service';
 import { ProgressSelectValue } from
   '../../../shared-components/components/collapsible-section/progress-select/progress-select.component';
-import { UpdateGroupManagersService } from '../../http-services/update-group-managers.service';
+import { GroupManagerPermissionChanges, UpdateGroupManagersService } from '../../http-services/update-group-managers.service';
 import { formatUser } from '../../../../shared/helpers/user';
 import { ActionFeedbackService } from '../../../../shared/services/action-feedback.service';
+import { FormBuilder } from '@angular/forms';
 
 @Component({
   selector: 'alg-manager-permission-dialog',
@@ -19,7 +20,7 @@ export class ManagerPermissionDialogComponent implements OnChanges {
 
   @Output() close = new EventEmitter<{ updated: boolean }>();
 
-  managementLevelValues: ProgressSelectValue<string>[] = [
+  managementLevelValues: ProgressSelectValue<GroupManagerPermissionChanges['canManage']>[] = [
     {
       value: 'none',
       label: $localize`Read-only`,
@@ -37,28 +38,28 @@ export class ManagerPermissionDialogComponent implements OnChanges {
     },
   ];
 
-  managerValues = {
-    canManage: 'none',
-    canGrantGroupAccess: false,
-    canWatchMembers: false,
-  };
-
   userCaption?: string;
   isUpdating = false;
-  valuesChanged = false;
+
+  form = this.fb.group({
+    'canManage': [ 'none' ],
+    'canGrantGroupAccess': [ false ],
+    'canWatchMembers': [ false ],
+  });
 
   constructor(
     private updateGroupManagersService: UpdateGroupManagersService,
-    private actionFeedbackService: ActionFeedbackService
+    private actionFeedbackService: ActionFeedbackService,
+    private fb: FormBuilder,
   ) {}
 
   ngOnChanges(): void {
     if (this.manager) {
-      this.managerValues = {
+      this.form.reset({
         canManage: this.manager.canManage,
         canGrantGroupAccess: this.manager.canGrantGroupAccess,
         canWatchMembers: this.manager.canWatchMembers,
-      };
+      }, { emitEvent: false });
 
       this.userCaption = this.manager.login ? formatUser({
         login: this.manager.login,
@@ -70,7 +71,6 @@ export class ManagerPermissionDialogComponent implements OnChanges {
 
   onClose(): void {
     this.close.emit({ updated: false });
-    this.valuesChanged = false;
   }
 
   onAccept(): void {
@@ -78,22 +78,29 @@ export class ManagerPermissionDialogComponent implements OnChanges {
       throw new Error('Unexpected: Missed input component params');
     }
 
+    const formControls = {
+      canManage: this.form.get('canManage'),
+      canGrantGroupAccess: this.form.get('canGrantGroupAccess'),
+      canWatchMembers: this.form.get('canWatchMembers'),
+    };
+
+    const managerPermissions: GroupManagerPermissionChanges = {
+      canManage: formControls.canManage?.value as GroupManagerPermissionChanges['canManage'],
+      canGrantGroupAccess: formControls.canGrantGroupAccess?.value as GroupManagerPermissionChanges['canGrantGroupAccess'],
+      canWatchMembers: formControls.canWatchMembers?.value as GroupManagerPermissionChanges['canWatchMembers'],
+    };
+
     this.isUpdating = true;
-    this.updateGroupManagersService.update(this.group.id, this.manager.id, this.managerValues).subscribe({
+    this.updateGroupManagersService.update(this.group.id, this.manager.id, managerPermissions).subscribe({
       next: () => {
         this.isUpdating = false;
         this.actionFeedbackService.success($localize`New permissions successfully saved.`);
         this.close.emit({ updated: true });
-        this.valuesChanged = false;
       },
       error: () => {
         this.isUpdating = false;
         this.actionFeedbackService.error($localize`Failed to save permissions.`);
       }
     });
-  }
-
-  onValueChange(): void {
-    this.valuesChanged = true;
   }
 }

--- a/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts
+++ b/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts
@@ -42,9 +42,9 @@ export class ManagerPermissionDialogComponent implements OnChanges {
   isUpdating = false;
 
   form = this.fb.group({
-    'canManage': [ 'none' ],
-    'canGrantGroupAccess': [ false ],
-    'canWatchMembers': [ false ],
+    canManage: [ 'none' ],
+    canGrantGroupAccess: [ false ],
+    canWatchMembers: [ false ],
   });
 
   constructor(
@@ -78,16 +78,10 @@ export class ManagerPermissionDialogComponent implements OnChanges {
       throw new Error('Unexpected: Missed input component params');
     }
 
-    const formControls = {
-      canManage: this.form.get('canManage'),
-      canGrantGroupAccess: this.form.get('canGrantGroupAccess'),
-      canWatchMembers: this.form.get('canWatchMembers'),
-    };
-
     const managerPermissions: GroupManagerPermissionChanges = {
-      canManage: formControls.canManage?.value as GroupManagerPermissionChanges['canManage'],
-      canGrantGroupAccess: formControls.canGrantGroupAccess?.value as GroupManagerPermissionChanges['canGrantGroupAccess'],
-      canWatchMembers: formControls.canWatchMembers?.value as GroupManagerPermissionChanges['canWatchMembers'],
+      canManage: this.form.get('canManage')?.value as GroupManagerPermissionChanges['canManage'],
+      canGrantGroupAccess: this.form.get('canGrantGroupAccess')?.value as GroupManagerPermissionChanges['canGrantGroupAccess'],
+      canWatchMembers: this.form.get('canWatchMembers')?.value as GroupManagerPermissionChanges['canWatchMembers'],
     };
 
     this.isUpdating = true;

--- a/src/app/modules/group/http-services/update-group-managers.service.ts
+++ b/src/app/modules/group/http-services/update-group-managers.service.ts
@@ -4,6 +4,12 @@ import { Observable } from 'rxjs';
 import { appConfig } from 'src/app/shared/helpers/config';
 import { SimpleActionResponse } from '../../../shared/http-services/action-response';
 
+export interface GroupManagerPermissionChanges {
+  canManage?: 'none'|'memberships'|'memberships_and_group',
+  canGrantGroupAccess?: boolean,
+  canWatchMembers?: boolean,
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -14,7 +20,7 @@ export class UpdateGroupManagersService {
   update(
     groupId: string,
     managerId: string,
-    payload: { canManage: string, canGrantGroupAccess: boolean, canWatchMembers: boolean }
+    payload: GroupManagerPermissionChanges
   ): Observable<SimpleActionResponse> {
     return this.http.put<SimpleActionResponse>(`${appConfig.apiUrl}/groups/${groupId}/managers/${managerId}`, {
       can_manage: payload.canManage,

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
@@ -21,73 +21,75 @@
   <div class="dialog-container">
     <div class="dialog-content">
 
-      <alg-collapsible-section i18n-title title="Can view" icon="fa fa-eye">
-        <ng-template #content let-collapsed>
-          <alg-progress-select
-            [collapsed]="collapsed"
-            [(value)]="permissions.can_view"
-            [values]="canViewValues"
-          ></alg-progress-select>
-        </ng-template>
-      </alg-collapsible-section>
+      <form [formGroup]="form">
+        <alg-collapsible-section i18n-title title="Can view" icon="fa fa-eye">
+          <ng-template #content let-collapsed>
+            <alg-progress-select
+              [collapsed]="collapsed"
+              formControlName="can_view"
+              [values]="canViewValues"
+            ></alg-progress-select>
+          </ng-template>
+        </alg-collapsible-section>
 
-      <!--<alg-switch-field
-        i18n-title title="Can Enter"
-        icon="fa fa-door-open"
-        [(value)]="permissions.can_enter_from"
-      >
-        <ng-template #label i18n>{{targetTypeString}} may enter this item (a contest or time-limited chapter)</ng-template>
-      </alg-switch-field>-->
+        <!--<alg-switch-field
+          i18n-title title="Can Enter"
+          icon="fa fa-door-open"
+          [(value)]="permissions.can_enter_from"
+        >
+          <ng-template #label i18n>{{targetTypeString}} may enter this item (a contest or time-limited chapter)</ng-template>
+        </alg-switch-field>-->
 
-      <alg-collapsible-section i18n-title title="Can grant view" icon="fa fa-key">
-        <ng-template #content let-collapsed>
-          <alg-progress-select
-            [collapsed]="collapsed"
-            [(value)]="permissions.can_grant_view"
-            [values]="canGrantViewValues"
-          ></alg-progress-select>
-        </ng-template>
-      </alg-collapsible-section>
+        <alg-collapsible-section i18n-title title="Can grant view" icon="fa fa-key">
+          <ng-template #content let-collapsed>
+            <alg-progress-select
+              [collapsed]="collapsed"
+              formControlName="can_grant_view"
+              [values]="canGrantViewValues"
+            ></alg-progress-select>
+          </ng-template>
+        </alg-collapsible-section>
 
-      <alg-collapsible-section i18n-title title="Can watch" icon="fa fa-binoculars">
-        <ng-template #content let-collapsed>
-          <alg-progress-select
-            [collapsed]="collapsed"
-            [(value)]="permissions.can_watch"
-            [values]="canWatchValues"
-          ></alg-progress-select>
-        </ng-template>
-      </alg-collapsible-section>
+        <alg-collapsible-section i18n-title title="Can watch" icon="fa fa-binoculars">
+          <ng-template #content let-collapsed>
+            <alg-progress-select
+              [collapsed]="collapsed"
+              formControlName="can_watch"
+              [values]="canWatchValues"
+            ></alg-progress-select>
+          </ng-template>
+        </alg-collapsible-section>
 
-      <alg-collapsible-section i18n-title title="Can edit" icon="fa fa-pencil-alt">
-        <ng-template #content let-collapsed>
-          <alg-progress-select
-            [collapsed]="collapsed"
-            [(value)]="permissions.can_edit"
-            [values]="canEditValues"
-          ></alg-progress-select>
-        </ng-template>
-      </alg-collapsible-section>
+        <alg-collapsible-section i18n-title title="Can edit" icon="fa fa-pencil-alt">
+          <ng-template #content let-collapsed>
+            <alg-progress-select
+              [collapsed]="collapsed"
+              formControlName="can_edit"
+              [values]="canEditValues"
+            ></alg-progress-select>
+          </ng-template>
+        </alg-collapsible-section>
 
-      <alg-collapsible-section i18n-title title="Can attach official sessions" icon="fa fa-paperclip">
-        <ng-template #content let-collapsed>
-          <alg-switch-field [collapsed]="collapsed" [(value)]="permissions.can_make_session_official">
-            <ng-template #label>
-              <span i18n>{{targetTypeString}} may attach official sessions to this item, that will be visible to everyone in the content tab of the item</span>
-            </ng-template>
-          </alg-switch-field>
-        </ng-template>
-      </alg-collapsible-section>
+        <alg-collapsible-section i18n-title title="Can attach official sessions" icon="fa fa-paperclip">
+          <ng-template #content let-collapsed>
+            <alg-switch-field [collapsed]="collapsed" formControlName="can_make_session_official">
+              <ng-template #label>
+                <span i18n>{{targetTypeString}} may attach official sessions to this item, that will be visible to everyone in the content tab of the item</span>
+              </ng-template>
+            </alg-switch-field>
+          </ng-template>
+        </alg-collapsible-section>
 
-      <alg-collapsible-section i18n-title title="Is owner" icon="fa fa-user-tie">
-        <ng-template #content let-collapsed>
-          <alg-switch-field [collapsed]="collapsed" [(value)]="permissions.is_owner">
-            <ng-template #label>
-              <span i18n>{{targetTypeString}} own this item, and get the maximum access in all categories above, and may also delete this item</span>
-            </ng-template>
-          </alg-switch-field>
-        </ng-template>
-      </alg-collapsible-section>
+        <alg-collapsible-section i18n-title title="Is owner" icon="fa fa-user-tie">
+          <ng-template #content let-collapsed>
+            <alg-switch-field [collapsed]="collapsed" formControlName="is_owner">
+              <ng-template #label>
+                <span i18n>{{targetTypeString}} own this item, and get the maximum access in all categories above, and may also delete this item</span>
+              </ng-template>
+            </alg-switch-field>
+          </ng-template>
+        </alg-collapsible-section>
+      </form>
 
     </div>
   </div>
@@ -105,6 +107,7 @@
         i18n-label label="Proceed"
         class="p-button-rounded"
         (click)="onAccept()"
+        [disabled]="!form.dirty"
       ></alg-button>
     </div>
   </p-footer>

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -1,4 +1,5 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormBuilder } from '@angular/forms';
 import { ProgressSelectValue } from
   'src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component';
 import { Permissions } from 'src/app/shared/http-services/group-permissions.service';
@@ -15,7 +16,7 @@ export class PermissionsEditDialogComponent implements OnChanges {
 
   @Input() visible?: boolean;
   @Input() title?: string;
-  @Input() initialPermissions?: Permissions;
+  @Input() permissions?: Permissions;
   @Input() targetType: TypeFilter = 'Users';
   @Output() close = new EventEmitter<void>();
   @Output() save = new EventEmitter<Permissions>();
@@ -27,14 +28,16 @@ export class PermissionsEditDialogComponent implements OnChanges {
   canWatchValues: ProgressSelectValue<string>[] = [];
   canEditValues: ProgressSelectValue<string>[] = [];
 
-  permissions: Permissions = {
-    can_view: 'none',
-    can_grant_view: 'none',
-    can_watch: 'none',
-    can_edit: 'none',
-    can_make_session_official: false,
-    is_owner: true,
-  };
+  form = this.fb.group({
+    'can_view': [ 'none' ],
+    'can_grant_view': [ 'none' ],
+    'can_watch': [ 'none' ],
+    'can_edit': [ 'none' ],
+    'can_make_session_official': [ false ],
+    'is_owner': [ true ],
+  });
+
+  constructor(private fb: FormBuilder) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if ('targetType' in changes) {
@@ -44,8 +47,8 @@ export class PermissionsEditDialogComponent implements OnChanges {
       this.canEditValues = generateCanEditValues(this.targetType);
     }
 
-    if (this.initialPermissions) {
-      this.permissions = { ...this.initialPermissions };
+    if (this.permissions) {
+      this.form.reset({ ...this.permissions }, { emitEvent: false });
     }
   }
 
@@ -54,7 +57,25 @@ export class PermissionsEditDialogComponent implements OnChanges {
   }
 
   onAccept(): void {
-    this.save.emit(this.permissions);
+    const formControls = {
+      can_view: this.form.get('can_view'),
+      can_grant_view: this.form.get('can_grant_view'),
+      can_watch: this.form.get('can_watch'),
+      can_edit: this.form.get('can_edit'),
+      can_make_session_official: this.form.get('can_make_session_official'),
+      is_owner: this.form.get('is_owner'),
+    };
+
+    const permissions: Permissions = {
+      can_view: formControls.can_view?.value as Permissions['can_view'],
+      can_grant_view: formControls.can_grant_view?.value as Permissions['can_grant_view'],
+      can_watch: formControls.can_watch?.value as Permissions['can_watch'],
+      can_edit: formControls.can_edit?.value as Permissions['can_edit'],
+      can_make_session_official: formControls.can_make_session_official?.value as Permissions['can_make_session_official'],
+      is_owner: formControls.is_owner?.value as Permissions['is_owner'],
+    };
+
+    this.save.emit(permissions);
     this.close.emit();
   }
 }

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -29,12 +29,12 @@ export class PermissionsEditDialogComponent implements OnChanges {
   canEditValues: ProgressSelectValue<string>[] = [];
 
   form = this.fb.group({
-    'can_view': [ 'none' ],
-    'can_grant_view': [ 'none' ],
-    'can_watch': [ 'none' ],
-    'can_edit': [ 'none' ],
-    'can_make_session_official': [ false ],
-    'is_owner': [ true ],
+    canView: [ 'none' ],
+    canGrantView: [ 'none' ],
+    canWatch: [ 'none' ],
+    canEdit: [ 'none' ],
+    canMakeSessionOfficial: [ false ],
+    isOwner: [ true ],
   });
 
   constructor(private fb: FormBuilder) {}
@@ -57,22 +57,13 @@ export class PermissionsEditDialogComponent implements OnChanges {
   }
 
   onAccept(): void {
-    const formControls = {
-      can_view: this.form.get('can_view'),
-      can_grant_view: this.form.get('can_grant_view'),
-      can_watch: this.form.get('can_watch'),
-      can_edit: this.form.get('can_edit'),
-      can_make_session_official: this.form.get('can_make_session_official'),
-      is_owner: this.form.get('is_owner'),
-    };
-
     const permissions: Permissions = {
-      can_view: formControls.can_view?.value as Permissions['can_view'],
-      can_grant_view: formControls.can_grant_view?.value as Permissions['can_grant_view'],
-      can_watch: formControls.can_watch?.value as Permissions['can_watch'],
-      can_edit: formControls.can_edit?.value as Permissions['can_edit'],
-      can_make_session_official: formControls.can_make_session_official?.value as Permissions['can_make_session_official'],
-      is_owner: formControls.is_owner?.value as Permissions['is_owner'],
+      can_view: this.form.get('canView')?.value as Permissions['can_view'],
+      can_grant_view: this.form.get('canGrantView')?.value as Permissions['can_grant_view'],
+      can_watch: this.form.get('canWatch')?.value as Permissions['can_watch'],
+      can_edit: this.form.get('canEdit')?.value as Permissions['can_edit'],
+      can_make_session_official: this.form.get('canMakeSessionOfficial')?.value as Permissions['can_make_session_official'],
+      is_owner: this.form.get('isOwner')?.value as Permissions['is_owner'],
     };
 
     this.save.emit(permissions);

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
@@ -99,7 +99,7 @@
       [visible]="dialog === 'opened'"
       [title]="dialogTitle"
       [targetType]="currentFilter"
-      [initialPermissions]="dialogPermissions.permissions"
+      [permissions]="dialogPermissions.permissions"
       (close)="onDialogClose()"
       (save)="onDialogSave($event)"
     ></alg-permissions-edit-dialog>

--- a/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.ts
+++ b/src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.ts
@@ -1,7 +1,9 @@
-import { Component, ContentChild, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
+import { Component, ContentChild, EventEmitter, forwardRef, Input, Output, TemplateRef } from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 
 /**
- * This component is to be used in a `collapsible-section` component
+ * This component is to be used in a `collapsible-section` component.
+ * To use inside form, just set the `formControlName`
  * ```
  * <alg-collapsible-section ... >
  *      <ng-template #content let-collapsed>
@@ -16,9 +18,16 @@ import { Component, ContentChild, EventEmitter, Input, Output, TemplateRef } fro
 @Component({
   selector: 'alg-switch-field',
   templateUrl: './switch-field.component.html',
-  styleUrls: [ './switch-field.component.scss' ]
+  styleUrls: [ './switch-field.component.scss' ],
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SwitchFieldComponent),
+      multi: true,
+    }
+  ]
 })
-export class SwitchFieldComponent {
+export class SwitchFieldComponent implements ControlValueAccessor {
 
   @Input() value = false;
   @Input() collapsed = false;
@@ -28,10 +37,22 @@ export class SwitchFieldComponent {
 
   @Output() valueChange = new EventEmitter<boolean>();
 
-  constructor() { }
+  private onChange: (value: boolean) => void = () => {};
 
-  onSet(val: boolean): void {
-    this.value = val;
-    this.valueChange.emit(this.value);
+  writeValue(value: boolean): void {
+    this.value = value;
+  }
+
+  registerOnChange(fn: (value: boolean) => void): void {
+    this.onChange = fn;
+  }
+
+  registerOnTouched(_fn: (value: boolean) => void): void {
+  }
+
+  onSet(value: boolean): void {
+    this.writeValue(value);
+    this.valueChange.emit(value);
+    this.onChange(value);
   }
 }


### PR DESCRIPTION
Both `progress-select` and `switch-field` now implement the `ControlValueAccessor` so they can be used in forms as previously discussed [here](https://github.com/France-ioi/AlgoreaFrontend/pull/692#issuecomment-925890649).

The components using them (`manager-permission-dialog` and `permissions-edit-dialog`) have also been updated (they are now using forms) which simplified some of the code.

The next step will be to implement custom `Validators` to add permissions constraints (mainly for the `permissions-edit-dialog`) as specified in issue #593 and discussed in PR #692.
