### PR TITLE
Move left nav datasources to independant nav tree services

### DIFF
--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -1,55 +1,59 @@
-<p-tabView
-  styleClass="dark tab-left-nav"
-  (onChange)="onSelectionChangedByIdx($event)"
-  [(activeIndex)]="activeTabIndex"
-  *ngIf="currentUser$|async as currentUser"
->
+<ng-container *ngIf="activeTab$ | async as activeTab;">
 
-  <p-tabPanel>
-    <ng-template pTemplate="header" tabindex="5">
-      <span class="indicator dark"></span>
-      <i class="fa fa-hand-paper"></i>
-      <span class="p-tabview-title" i18n="|Tab name">Activities</span>
-    </ng-template>
-  </p-tabPanel>
+  <p-tabView
+    styleClass="dark tab-left-nav"
+    (onChange)="onSelectionChangedByIdx($event)"
+    [activeIndex]="activeTab.index"
+    *ngIf="currentUser$|async as currentUser"
+  >
 
-  <p-tabPanel>
-    <ng-template pTemplate="header" tabindex="6">
-      <span class="indicator dark"></span>
-      <i class="fa fa-graduation-cap"></i>
-      <span class="p-tabview-title" i18n="|Tab name">Skills</span>
-    </ng-template>
-  </p-tabPanel>
+    <p-tabPanel>
+      <ng-template pTemplate="header" tabindex="5">
+        <span class="indicator dark"></span>
+        <i class="fa fa-hand-paper"></i>
+        <span class="p-tabview-title" i18n="|Tab name">Activities</span>
+      </ng-template>
+    </p-tabPanel>
 
-  <p-tabPanel *ngIf="activeTabIndex === 2 || !currentUser.tempUser">
-    <ng-template pTemplate="header" tabindex="7">
-      <span class="indicator dark"></span>
-      <i class="fa fa-users"></i>
-      <span class="p-tabview-title" i18n="|Tab name">Groups</span>
-    </ng-template>
-  </p-tabPanel>
+    <p-tabPanel>
+      <ng-template pTemplate="header" tabindex="6">
+        <span class="indicator dark"></span>
+        <i class="fa fa-graduation-cap"></i>
+        <span class="p-tabview-title" i18n="|Tab name">Skills</span>
+      </ng-template>
+    </p-tabPanel>
 
-</p-tabView>
+    <p-tabPanel *ngIf="activeTab.index === 2 || !currentUser.tempUser">
+      <ng-template pTemplate="header" tabindex="7">
+        <span class="indicator dark"></span>
+        <i class="fa fa-users"></i>
+        <span class="p-tabview-title" i18n="|Tab name">Groups</span>
+      </ng-template>
+    </p-tabPanel>
 
-<ng-container *ngIf="$any($any(navTreeServices[activeTabIndex]!.state$) | async) as state">
+  </p-tabView>
 
-  <div class="spinner" *ngIf="state.isFetching">
-    <alg-loading size="medium"></alg-loading>
-  </div>
+  <ng-container *ngIf="$any($any(navTreeServices[activeTab.index]!.state$) | async) as state">
 
-  <alg-error
-    *ngIf="state.isError"
-    class="light"
-    i18n-message message="Unable to load the list."
-    [showRefreshButton]="true"
-    refreshButtonType="retry"
-    (refresh)="retryError()"
-  ></alg-error>
+    <div class="spinner" *ngIf="state.isFetching">
+      <alg-loading size="medium"></alg-loading>
+    </div>
 
-  <alg-left-nav-tree
-    *ngIf="state.isReady"
-    [data]="state.data"
-    [elementType]="$any(['activity', 'skill', 'group'][activeTabIndex])"
-  ></alg-left-nav-tree>
+    <alg-error
+      *ngIf="state.isError"
+      class="light"
+      i18n-message message="Unable to load the list."
+      [showRefreshButton]="true"
+      refreshButtonType="retry"
+      (refresh)="retryError(activeTab.index)"
+    ></alg-error>
+
+    <alg-left-nav-tree
+      *ngIf="state.isReady"
+      [data]="state.data"
+      [elementType]="$any(['activity', 'skill', 'group'][activeTab.index])"
+    ></alg-left-nav-tree>
+
+  </ng-container>
 
 </ng-container>

--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -31,7 +31,7 @@
 
 </p-tabView>
 
-<ng-container *ngIf="$any($any(dataSources[activeTabIndex]!.state$) | async) as state">
+<ng-container *ngIf="$any($any(navTreeServices[activeTabIndex]!.state$) | async) as state">
 
   <div class="spinner" *ngIf="state.isFetching">
     <alg-loading size="medium"></alg-loading>

--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -33,7 +33,7 @@
 
   </p-tabView>
 
-  <ng-container *ngIf="$any($any(navTreeServices[activeTab.index]!.state$) | async) as state">
+  <ng-container *ngIf="navTreeServices[activeTab.index]!.state$ | async as state">
 
     <div class="spinner" *ngIf="state.isFetching">
       <alg-loading size="medium"></alg-loading>

--- a/src/app/core/components/left-nav/left-nav.component.ts
+++ b/src/app/core/components/left-nav/left-nav.component.ts
@@ -43,8 +43,7 @@ export class LeftNavComponent {
 
   @Output() themeChange = this.activeTab$.pipe(map(tab => (tab.index === 2 ? 'dark' : null)), delay(0));
 
-  readonly navTreeServices: [ActivityNavTreeService, SkillNavTreeService, GroupNavTreeService] =
-    [ this.activityNavTreeService, this.skillNavTreeService, this.groupNavTreeService ];
+  readonly navTreeServices = [ this.activityNavTreeService, this.skillNavTreeService, this.groupNavTreeService ];
   currentUser$ = this.sessionService.userProfile$.pipe(delay(0));
 
   constructor(

--- a/src/app/core/components/left-nav/left-nav.component.ts
+++ b/src/app/core/components/left-nav/left-nav.component.ts
@@ -45,28 +45,16 @@ export class LeftNavComponent implements OnInit, OnDestroy {
       pairwise(),
     ).subscribe(([ prevContent, content ]) => {
       // If the content changed (different id), clear the selection (clear all tabs as we don't really know on which tab was the selection)
-      if (prevContent?.type !== content?.type || prevContent?.route.id !== content?.route.id) {
-        this.navTreeServices.forEach(l => l.removeSelection());
-
-        if (content) {
-          this.selectId.emit(content.route.id);
-        }
+      if (content && (prevContent?.type !== content.type || prevContent?.route.id !== content.route.id)) {
+        this.selectId.emit(content.route.id);
       }
 
-      if (!content) { // no tab and no content to select
-        this.navTreeServices[this.activeTabIndex]?.focus(); // if the current tab has not been initialized yet, do it now
-
-      } else if (isGroupInfo(content)) {
+      if (!content) return;
+      if (isGroupInfo(content)) {
         this.changeTab(groupsTabIdx);
-        this.navTreeServices[groupsTabIdx].showContent(content);
-
-      } else if (isActivityInfo(content)) {
-        this.changeTab(activitiesTabIdx);
-        this.navTreeServices[activitiesTabIdx].showContent(content);
-
-      } else {
-        this.changeTab(skillsTabIdx);
-        this.navTreeServices[skillsTabIdx].showContent(content);
+      } else if (isItemInfo(content)) {
+        if (isActivityInfo(content)) this.changeTab(activitiesTabIdx);
+        else this.changeTab(skillsTabIdx);
       }
     });
   }
@@ -81,7 +69,6 @@ export class LeftNavComponent implements OnInit, OnDestroy {
 
   private changeTab(index: number): void {
     this.activeTabIndex = index;
-    this.navTreeServices[index]?.focus();
     this.themeChange.emit(this.activeTabIndex === 2 ? 'dark' : null);
   }
 

--- a/src/app/core/components/left-nav/left-nav.component.ts
+++ b/src/app/core/components/left-nav/left-nav.component.ts
@@ -1,5 +1,5 @@
 
-import { Component, Output, EventEmitter } from '@angular/core';
+import { Component, Output } from '@angular/core';
 import { merge, Subject } from 'rxjs';
 import { delay, distinct, distinctUntilChanged, filter, map, startWith } from 'rxjs/operators';
 import { isDefined } from 'src/app/shared/helpers/null-undefined-predicates';
@@ -21,11 +21,11 @@ const groupsTabIdx = 2;
   styleUrls: [ './left-nav.component.scss' ]
 })
 export class LeftNavComponent {
-  @Output() themeChange = new EventEmitter<string | null>(true /* async */);
   @Output() selectId = this.currentContent.content$.pipe(
     filter((content): content is RoutedContentInfo => !!content?.route),
     map(content => content.route.id),
     distinct(), // only emit 1x a change of id
+    delay(0),
   );
 
   private manualTabChange = new Subject<number>();
@@ -41,6 +41,8 @@ export class LeftNavComponent {
     map(idx => ({ index: idx })), // using object so that Angular ngIf does not ignore the "0" index
   );
 
+  @Output() themeChange = this.activeTab$.pipe(map(tab => (tab.index === 2 ? 'dark' : null)), delay(0));
+
   readonly navTreeServices: [ActivityNavTreeService, SkillNavTreeService, GroupNavTreeService] =
     [ this.activityNavTreeService, this.skillNavTreeService, this.groupNavTreeService ];
   currentUser$ = this.sessionService.userProfile$.pipe(delay(0));
@@ -54,12 +56,7 @@ export class LeftNavComponent {
   ) { }
 
   onSelectionChangedByIdx(e: { index: number }): void {
-    this.changeTab(e.index);
-  }
-
-  private changeTab(index: number): void {
-    this.manualTabChange.next(index);
-    this.themeChange.emit(index === 2 ? 'dark' : null);
+    this.manualTabChange.next(e.index);
   }
 
   retryError(tabIndex: number): void {

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { GroupInfo } from 'src/app/shared/models/content/group-info';
@@ -5,9 +6,12 @@ import { groupRoute } from 'src/app/shared/routing/group-route';
 import { GroupRouter } from 'src/app/shared/routing/group-router';
 import { GroupNavigationService, GroupNavigationChild, GroupNavigationData } from '../../http-services/group-navigation.service';
 import { NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
-import { LeftNavDataSource } from './left-nav-datasource';
+import { NavTreeService } from './nav-tree.service';
 
-export class LeftNavGroupDataSource extends LeftNavDataSource<GroupInfo> {
+@Injectable({
+  providedIn: 'root'
+})
+export class GroupNavTreeService extends NavTreeService<GroupInfo> {
 
   constructor(
     private groupNavigationService: GroupNavigationService,

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { GroupInfo } from 'src/app/shared/models/content/group-info';
+import { ContentInfo } from 'src/app/shared/models/content/content-info';
+import { GroupInfo, isGroupInfo } from 'src/app/shared/models/content/group-info';
 import { groupRoute } from 'src/app/shared/routing/group-route';
 import { GroupRouter } from 'src/app/shared/routing/group-router';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { GroupNavigationService, GroupNavigationChild, GroupNavigationData } from '../../http-services/group-navigation.service';
 import { NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
 import { NavTreeService } from './nav-tree.service';
@@ -14,10 +16,15 @@ import { NavTreeService } from './nav-tree.service';
 export class GroupNavTreeService extends NavTreeService<GroupInfo> {
 
   constructor(
+    currentContent: CurrentContentService,
     private groupNavigationService: GroupNavigationService,
     private groupRouter: GroupRouter,
   ) {
-    super();
+    super(currentContent);
+  }
+
+  isOfContentType(content: ContentInfo|null): content is GroupInfo {
+    return isGroupInfo(content);
   }
 
   addDetailsToTreeElement(contentInfo: GroupInfo, treeElement: NavTreeElement): NavTreeElement {

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -3,9 +3,11 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { bestAttemptFromResults, defaultAttemptId } from 'src/app/shared/helpers/attempts';
 import { isSkill, ItemTypeCategory, typeCategoryOfItem } from 'src/app/shared/helpers/item-type';
-import { ItemInfo } from 'src/app/shared/models/content/item-info';
+import { ContentInfo } from 'src/app/shared/models/content/content-info';
+import { isActivityInfo, isItemInfo, ItemInfo } from 'src/app/shared/models/content/item-info';
 import { fullItemRoute } from 'src/app/shared/routing/item-route';
 import { ItemRouter } from 'src/app/shared/routing/item-router';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { ItemNavigationChild, ItemNavigationData, ItemNavigationService } from '../../http-services/item-navigation.service';
 import { NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
 import { NavTreeService } from './nav-tree.service';
@@ -14,10 +16,11 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
 
   constructor(
     private category: ItemTypeCategory,
+    currentContent: CurrentContentService,
     private itemNavService: ItemNavigationService,
     private itemRouter: ItemRouter,
   ) {
-    super();
+    super(currentContent);
   }
 
   fetchRootTreeData(): Observable<NavTreeElement[]> {
@@ -99,8 +102,12 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
   providedIn: 'root'
 })
 export class ActivityNavTreeService extends ItemNavTreeService {
-  constructor(itemNavService: ItemNavigationService, itemRouter: ItemRouter) {
-    super('activity', itemNavService, itemRouter);
+  constructor(currentContent: CurrentContentService, itemNavService: ItemNavigationService, itemRouter: ItemRouter) {
+    super('activity', currentContent, itemNavService, itemRouter);
+  }
+
+  isOfContentType(content: ContentInfo|null): content is ItemInfo {
+    return isItemInfo(content) && isActivityInfo(content);
   }
 }
 
@@ -108,7 +115,11 @@ export class ActivityNavTreeService extends ItemNavTreeService {
   providedIn: 'root'
 })
 export class SkillNavTreeService extends ItemNavTreeService {
-  constructor(itemNavService: ItemNavigationService, itemRouter: ItemRouter) {
-    super('skill', itemNavService, itemRouter);
+  constructor(currentContent: CurrentContentService, itemNavService: ItemNavigationService, itemRouter: ItemRouter) {
+    super('skill', currentContent, itemNavService, itemRouter);
+  }
+
+  isOfContentType(content: ContentInfo|null): content is ItemInfo {
+    return isItemInfo(content) && !isActivityInfo(content);
   }
 }

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { bestAttemptFromResults, defaultAttemptId } from 'src/app/shared/helpers/attempts';
@@ -7,9 +8,10 @@ import { fullItemRoute } from 'src/app/shared/routing/item-route';
 import { ItemRouter } from 'src/app/shared/routing/item-router';
 import { ItemNavigationChild, ItemNavigationData, ItemNavigationService } from '../../http-services/item-navigation.service';
 import { NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
-import { LeftNavDataSource } from './left-nav-datasource';
+import { NavTreeService } from './nav-tree.service';
 
-export abstract class LeftNavItemDataSource extends LeftNavDataSource<ItemInfo> {
+abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
+
   constructor(
     private category: ItemTypeCategory,
     private itemNavService: ItemNavigationService,
@@ -93,13 +95,19 @@ export abstract class LeftNavItemDataSource extends LeftNavDataSource<ItemInfo> 
 
 }
 
-export class LeftNavActivityDataSource extends LeftNavItemDataSource {
+@Injectable({
+  providedIn: 'root'
+})
+export class ActivityNavTreeService extends ItemNavTreeService {
   constructor(itemNavService: ItemNavigationService, itemRouter: ItemRouter) {
     super('activity', itemNavService, itemRouter);
   }
 }
 
-export class LeftNavSkillDataSource extends LeftNavItemDataSource {
+@Injectable({
+  providedIn: 'root'
+})
+export class SkillNavTreeService extends ItemNavTreeService {
   constructor(itemNavService: ItemNavigationService, itemRouter: ItemRouter) {
     super('skill', itemNavService, itemRouter);
   }

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -7,7 +7,7 @@ import { RoutedContentInfo } from 'src/app/shared/models/content/content-info';
 import { mapStateData, mapToFetchState } from 'src/app/shared/operators/state';
 import { NavTreeData, NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
 
-export abstract class LeftNavDataSource<ContentT extends RoutedContentInfo> {
+export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
 
   private initialized = false;
   private contentChanges = new ReplaySubject<ContentT|undefined>(1);


### PR DESCRIPTION
Motivation: move toward all navigation info fetched through these nav tree services instead of item/groupData.

I recommended reviewing this commit by commit.

At the end it was not so complicated (so far) and even give a few nice improvements (in term of design/quality of code).

The expected behavior is the same as before for the menu (mainly test tab change). 
But a small "bug" has been fixed: when selecting an element and then quickly changing to another tab, the additional fetching requests were making the tab moving back to the previous tab (the one of the selected element).