### PR TITLE
Bug fixes of Permissions Form Refact PR

### DIFF
--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html
@@ -26,7 +26,7 @@
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
-              formControlName="can_view"
+              formControlName="canView"
               [values]="canViewValues"
             ></alg-progress-select>
           </ng-template>
@@ -44,7 +44,7 @@
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
-              formControlName="can_grant_view"
+              formControlName="canGrantView"
               [values]="canGrantViewValues"
             ></alg-progress-select>
           </ng-template>
@@ -54,7 +54,7 @@
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
-              formControlName="can_watch"
+              formControlName="canWatch"
               [values]="canWatchValues"
             ></alg-progress-select>
           </ng-template>
@@ -64,7 +64,7 @@
           <ng-template #content let-collapsed>
             <alg-progress-select
               [collapsed]="collapsed"
-              formControlName="can_edit"
+              formControlName="canEdit"
               [values]="canEditValues"
             ></alg-progress-select>
           </ng-template>
@@ -72,7 +72,7 @@
 
         <alg-collapsible-section i18n-title title="Can attach official sessions" icon="fa fa-paperclip">
           <ng-template #content let-collapsed>
-            <alg-switch-field [collapsed]="collapsed" formControlName="can_make_session_official">
+            <alg-switch-field [collapsed]="collapsed" formControlName="canMakeSessionOfficial">
               <ng-template #label>
                 <span i18n>{{targetTypeString}} may attach official sessions to this item, that will be visible to everyone in the content tab of the item</span>
               </ng-template>
@@ -82,7 +82,7 @@
 
         <alg-collapsible-section i18n-title title="Is owner" icon="fa fa-user-tie">
           <ng-template #content let-collapsed>
-            <alg-switch-field [collapsed]="collapsed" formControlName="is_owner">
+            <alg-switch-field [collapsed]="collapsed" formControlName="isOwner">
               <ng-template #label>
                 <span i18n>{{targetTypeString}} own this item, and get the maximum access in all categories above, and may also delete this item</span>
               </ng-template>

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -48,7 +48,14 @@ export class PermissionsEditDialogComponent implements OnChanges {
     }
 
     if (this.permissions) {
-      this.form.reset({ ...this.permissions }, { emitEvent: false });
+      this.form.reset({
+        canView: this.permissions.can_view,
+        canGrantView: this.permissions.can_grant_view,
+        canWatch: this.permissions.can_watch,
+        canEdit: this.permissions.can_edit,
+        canMakeSessionOfficial: this.permissions.can_make_session_official,
+        isOwner: this.permissions.is_owner,
+      }, { emitEvent: false });
     }
   }
 


### PR DESCRIPTION
This PR fixes bugs introduced in PR #727:
* `formControlName` were left in snake_case (but they were changed to camelCase in the form group definition)
* the `PermissionsInfo` and `Permissions` interfaces are almost the same but the attribute of `PermissionsInfo` are in camelCase and the one in the `Permissions` are in snake_case. So the refactoring `this.form.reset({ ...this.permissions })` was made but the attributes didn't match with the form controls.