### PR TITLE
Reorganisation of nav tree fetching

### DIFF
--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -1,4 +1,5 @@
 import { ensureDefined } from 'src/app/shared/helpers/null-undefined-predicates';
+import { ContentRoute, pathEquals } from 'src/app/shared/routing/content-route';
 
 type Id = string;
 export enum GroupManagership { False = 'false', True = 'true', Descendant = 'descendant' }
@@ -48,8 +49,9 @@ export class NavTreeData {
    * Return this with the element from `elements` (identified by its id) replaced by the given one
    * If the element is not found, return this unchanged.
    */
-  withUpdatedElement(id: Id, update: (el:NavTreeElement)=>NavTreeElement): NavTreeData {
-    const idx = this.elements.findIndex(i => i.id === id);
+  withUpdatedElement(route: ContentRoute, update: (el:NavTreeElement)=>NavTreeElement): NavTreeData {
+    if (!pathEquals(route.path, this.pathToElements)) return this; // the element in not in tree as their paths do not match
+    const idx = this.elements.findIndex(i => i.id === route.id);
     if (idx === -1) return this;
     const elements = [ ...this.elements ];
     elements[idx] = update(ensureDefined(elements[idx]));
@@ -69,18 +71,25 @@ export class NavTreeData {
    * Create a new sub-NavTreeData moving the child element and its siblings to `elements` and his parent as new parent.
    * If the element is not found, return this unchanged.
    */
-  subNavMenuData(childElementId: Id): NavTreeData {
-    const newParent = this.elements.find(i => i.children && i.children.some(c => c.id === childElementId));
-    if (!newParent || !newParent.children /* unexpected */) return this;
-    return new NavTreeData(newParent.children, this.pathToElements.concat([ newParent.id ]), childElementId, newParent);
+  subNavMenuData(route: ContentRoute): NavTreeData {
+    const newParent = this.elements.find(e => e.id === route.path[route.path.length-1]);
+    if (!newParent || !newParent.children /* unexpected */) throw new Error('Unexpected: subNavMenuData did not find parent');
+    return new NavTreeData(newParent.children, this.pathToElements.concat([ newParent.id ]), route.id, newParent);
   }
 
-  hasLevel1Element(id: Id): boolean {
-    return this.selectedElementId == id || this.elements.some(e => e.id === id);
+  hasElement(route: ContentRoute): boolean {
+    return this.hasLevel1Element(route) || this.hasLevel2Element(route);
   }
 
-  hasLevel2Element(id: Id): boolean {
-    return this.elements.some(e => e.children && e.children.some(c => c.id === id));
+  hasLevel1Element(route: ContentRoute): boolean {
+    return pathEquals(route.path, this.pathToElements) && this.elements.some(e => e.id === route.id);
+  }
+
+  hasLevel2Element(route: ContentRoute): boolean {
+    if (!pathEquals(route.path.slice(0,-1), this.pathToElements)) return false;
+    const parent = this.elements.find(e => e.id === route.path[route.path.length-1]);
+    if (!parent || !parent.children) return false;
+    return parent.children.some(c => c.id === route.id);
   }
 
   selectedElement(): NavTreeElement|undefined {

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -27,8 +27,8 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo, ItemNavigatio
     return pipe(
       map(content => {
         if (!content) return undefined;
-        if (content.details && ![ 'Chapter', 'Skill' ].includes(content.details?.type)) return undefined;
-        const attemptId = content.details?.attemptId;
+        if (!content.details || ![ 'Chapter', 'Skill' ].includes(content.details?.type)) return undefined;
+        const attemptId = content.route.attemptId ? content.route.attemptId : content.details?.attemptId;
         return attemptId ? { ...content.route, attemptId } : undefined;
       }),
       distinctUntilChanged((x, y) => x?.id === y?.id),

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -1,5 +1,5 @@
-import { combineLatest, EMPTY, Observable, of, OperatorFunction, Subject } from 'rxjs';
-import { delay, distinctUntilChanged, map, shareReplay, startWith, switchScan } from 'rxjs/operators';
+import { combineLatest, Observable, of, OperatorFunction, Subject } from 'rxjs';
+import { delay, distinctUntilChanged, map, mergeScan, shareReplay, startWith } from 'rxjs/operators';
 import { isDefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { repeatLatestWhen } from 'src/app/shared/helpers/repeatLatestWhen';
 import { fetchingState, FetchState, readyState } from 'src/app/shared/helpers/state';
@@ -12,49 +12,46 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo, Childre
 
   private reloadTrigger = new Subject<void>();
 
-  private contentInfo$ = this.currentContent.content$.pipe( // only keep those of interest for the current nav tree
+  private content$ = this.currentContent.content$.pipe( // only keep those of interest for the current nav tree
     // map those which are not of interest to `undefined`
     map(content => (this.isOfContentType(content) ? content : undefined)),
     distinctUntilChanged(), // remove multiple `undefined`
     startWith(undefined),
     repeatLatestWhen(this.reloadTrigger),
   );
+  private children$ = this.content$.pipe(this.childrenNavigation());
+  state$ = combineLatest([ this.content$, this.children$ ]).pipe(
+    mergeScan((prevState: FetchState<NavTreeData>, [ content, children ]) => {
 
-  state$ = combineLatest([ this.contentInfo$, this.contentInfo$.pipe(this.childrenNavigation()) ]).pipe(
-    switchScan((prevState: FetchState<NavTreeData>, [ contentInfo, children ]) => {
+      // CASE 1: the content is not of type of this menu
+      if (!content) {
+        // CASE 1A: the menu has already an element displayed -> just deselect what is selected if there was a selection
+        if (prevState.isReady) return of(readyState(prevState.data.withNoSelection()));
+        // CASE 1B: the menu has nothing displayed yet -> load item root
+        else return this.fetchDefaultNav();
 
-      if (prevState.isReady) {
-        const prevData = prevState.data;
+      } else {
+      // CASE 2: content is of type of this menu
+        const route = content.route;
 
-        // CASE: the current content is not to be displayed in the menu and the menu has already an element displayed
-        //       -> just deselect what is selected if there was a selection
-        if (!contentInfo) {
-          return prevData.selectedElementId === undefined ? EMPTY : of(readyState(prevData.withNoSelection()));
-        }
-
-        // CASE: the content is among the displayed items
-        //       -> updates its data, and either select it if at root or shift the tree "to the left" otherwise
-        const contentId = contentInfo.route.id;
-        const contentInMenuLev1 = prevData.hasLevel1Element(contentId);
-        const contentInMenuLev2 = prevData.hasLevel2Element(contentId);
-        if (contentInMenuLev1 || contentInMenuLev2) {
-          let data = contentInMenuLev1 ? prevData.withSelection(contentId) : prevData.subNavMenuData(contentId);
-          data = data.withUpdatedElement(contentId, el => this.addDetailsToTreeElement(el, contentInfo, children));
+        if (prevState.isReady && prevState.data.hasElement(route)) {
+          // CASE 2A : the content is among the displayed elements -> either select it if at root or shift the tree "to the left" otherwise
+          const prevData = prevState.data;
+          let data = prevData.hasLevel1Element(route) ? prevData.withSelection(route.id) : prevData.subNavMenuData(route);
+          data = data.withUpdatedElement(route, el => this.addDetailsToTreeElement(el, content, children));
           return of(readyState(data));
+
+          // CASE 2B: the content is not among the displayed elements -> fetch all nav
+        } else {
+          return this.fetchNewNav(content).pipe(
+            mapStateData(data => {
+              data = data.withUpdatedElement(route, el => this.addDetailsToTreeElement(el, content, children));
+              return data;
+            })
+          );
         }
-
-      } else /* prevState is not ready */ if (!contentInfo) {
-
-        // CASE: the content is not an item and the menu has not already item displayed -> load item root
-        return this.fetchDefaultNav();
       }
-
-      // OTHERWISE: the content is an item which is not currently displayed:
-      // CASE: The current content type matches the current tab
-      return this.fetchNewNav(contentInfo).pipe(
-        mapStateData(data => data.withUpdatedElement(contentInfo.route.id, el => this.addDetailsToTreeElement(el, contentInfo, children)))
-      );
-    }, fetchingState<NavTreeData>() /* the switchScan seed */),
+    }, fetchingState<NavTreeData>() /* the switchScan seed */, 1 /* concurrency = 1 so that we can always use the last state*/),
     delay(0),
     shareReplay(1),
   );

--- a/src/app/shared/routing/content-route.ts
+++ b/src/app/shared/routing/content-route.ts
@@ -21,3 +21,8 @@ export function pathAsParameter(value: string[]): UrlCommandParameters {
   params[pathParamName] = value;
   return params;
 }
+
+export function pathEquals(path1: Id[], path2: Id[]): boolean {
+  if (path1.length !== path2.length) return false;
+  return path1.every((id, idx) => id === path2[idx]);
+}


### PR DESCRIPTION
Reorganisation (improvements?) of code related to nav tree fetching.

* Should fix #726
* Should fix: because of the switchMap reception of additional info (attempt, ...) was cancelling the previous request and so some requests were possibly repeated because of that.
* Should make the core computation of nav tree (the content of the mergeScan) a bit cleaner