### PR TITLE
Let neighbor navigation use the nav tree service to get the info

### DIFF
--- a/src/app/modules/item/components/item-header/item-header.component.html
+++ b/src/app/modules/item/components/item-header/item-header.component.html
@@ -17,12 +17,17 @@
       <span *ngIf="itemData.item.string.subtitle">{{itemData.item.string.subtitle}}</span>
     </div>
     <alg-page-navigator
+      *ngIf="navigationNeighbors$ | async as navigationNeighbors"
       [allowEditing]="itemData.item.permissions.canEdit !== 'none'"
       [allowFullScreen]="false"
-      [navigationMode]="{parent: navigationNeighbors?.parent !== null, left: navigationNeighbors?.left !== null, right: navigationNeighbors?.right !== null}"
-      (parent)="onParentClicked()"
-      (left)="onLeftClicked()"
-      (right)="onRightClicked()"
+      [navigationMode]="{
+        parent: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.parent,
+        left: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.previous,
+        right: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.next
+      }"
+      (parent)="navigationNeighbors?.data?.parent?.navigateTo()"
+      (left)="navigationNeighbors?.data?.previous?.navigateTo()"
+      (right)="navigationNeighbors?.data?.next?.navigateTo()"
       (edit)="onEditButtonClicked()"
     ></alg-page-navigator>
   </div>

--- a/src/app/modules/item/components/item-header/item-header.component.ts
+++ b/src/app/modules/item/components/item-header/item-header.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { ItemNavigationService } from 'src/app/core/http-services/item-navigation.service';
-import { ItemRoute } from 'src/app/shared/routing/item-route';
-import { ItemRouter } from 'src/app/shared/routing/item-router';
+import { ActivityNavTreeService, SkillNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
+import { isASkill } from 'src/app/shared/helpers/item-type';
 import { ModeAction, ModeService } from 'src/app/shared/services/mode.service';
 import { ItemData } from '../../services/item-datasource.service';
 
@@ -13,41 +12,23 @@ import { ItemData } from '../../services/item-datasource.service';
 export class ItemHeaderComponent implements OnChanges {
   @Input() itemData?: ItemData;
 
-  navigationNeighbors: { parent: ItemRoute|null, left: ItemRoute|null, right: ItemRoute|null } = { parent: null, left: null, right: null };
+  private activityNavigationNeighbors$ = this.activitiyNavTreeService.navigationNeighbors$;
+  private skillNavigationNeighbors$ = this.skillNavTreeService.navigationNeighbors$;
+  navigationNeighbors$ = this.activityNavigationNeighbors$;
 
   constructor(
     private modeService: ModeService,
-    private itemNavigationService :ItemNavigationService,
-    private itemRouter: ItemRouter,
+    private activitiyNavTreeService: ActivityNavTreeService,
+    private skillNavTreeService: SkillNavTreeService,
   ) {}
 
   ngOnChanges(_changes: SimpleChanges): void {
     if (!this.itemData) return;
-
-    this.itemNavigationService.getNavigationNeighbors(this.itemData.route).subscribe(data => {
-      this.navigationNeighbors = data;
-    });
+    this.navigationNeighbors$ = isASkill(this.itemData.item) ? this.skillNavigationNeighbors$ : this.activityNavigationNeighbors$;
   }
 
   onEditButtonClicked(): void {
     this.modeService.modeActions$.next(ModeAction.StartEditing);
   }
 
-  onParentClicked(): void {
-    if (this.navigationNeighbors?.parent) {
-      this.itemRouter.navigateTo(this.navigationNeighbors.parent);
-    }
-  }
-
-  onLeftClicked(): void {
-    if (this.navigationNeighbors?.left) {
-      this.itemRouter.navigateTo(this.navigationNeighbors.left);
-    }
-  }
-
-  onRightClicked(): void {
-    if (this.navigationNeighbors?.right) {
-      this.itemRouter.navigateTo(this.navigationNeighbors.right);
-    }
-  }
 }


### PR DESCRIPTION
Let the neighbor navigation use the new nav tree service to get the info.


2 cases to be tested:
- parent-previous-next navigation on item pages (activities and skills): free play as testing
- "go to next task" in item task: **untested**. @ThomasJuster  could you test that properly?

Checked: there is no useless calls to the navigation services. 