### PR TITLE
fix editing while observing

### DIFF
--- a/src/app/modules/group/pages/group-edit/group-edit.component.ts
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { mapStateData, readyData } from 'src/app/shared/operators/state';
-import { Mode, ModeService } from 'src/app/shared/services/mode.service';
+import { ModeService } from 'src/app/shared/services/mode.service';
 import { of, Subscription } from 'rxjs';
 import { concatMap } from 'rxjs/operators';
 import { CreateItemService } from 'src/app/modules/item/http-services/create-item.service';
@@ -40,7 +40,7 @@ export class GroupEditComponent implements OnDestroy, PendingChangesComponent {
     private groupUpdateService: GroupUpdateService,
     private createItemService: CreateItemService,
   ) {
-    this.modeService.mode$.next(Mode.Editing);
+    this.modeService.startEditing();
 
     this.subscription = this.state$
       .pipe(readyData())
@@ -51,7 +51,7 @@ export class GroupEditComponent implements OnDestroy, PendingChangesComponent {
   }
 
   ngOnDestroy(): void {
-    this.modeService.mode$.next(Mode.Normal);
+    this.modeService.stopEditing();
     this.subscription?.unsubscribe();
   }
 

--- a/src/app/modules/item/pages/item-edit/item-edit.component.ts
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.ts
@@ -10,7 +10,7 @@ import { Item } from '../../http-services/get-item-by-id.service';
 import { ItemEditContentComponent } from '../item-edit-content/item-edit-content.component';
 import { PendingChangesComponent } from 'src/app/shared/guards/pending-changes-guard';
 import { CreateItemService, NewItem } from '../../http-services/create-item.service';
-import { Mode, ModeService } from 'src/app/shared/services/mode.service';
+import { ModeService } from 'src/app/shared/services/mode.service';
 import { readyData } from 'src/app/shared/operators/state';
 import { Duration } from '../../../../shared/helpers/duration';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
@@ -88,7 +88,7 @@ export class ItemEditComponent implements OnDestroy, PendingChangesComponent {
     private updateItemStringService: UpdateItemStringService,
     private actionFeedbackService: ActionFeedbackService,
   ) {
-    this.modeService.mode$.next(Mode.Editing);
+    this.modeService.startEditing();
     this.subscription = this.fetchState$
       .pipe(readyData(), map(data => ({
         ...data.item,
@@ -103,7 +103,7 @@ export class ItemEditComponent implements OnDestroy, PendingChangesComponent {
   }
 
   ngOnDestroy(): void {
-    this.modeService.mode$.next(Mode.Normal);
+    this.modeService.stopEditing();
     this.subscription?.unsubscribe();
   }
 

--- a/src/app/shared/services/mode.service.ts
+++ b/src/app/shared/services/mode.service.ts
@@ -37,6 +37,15 @@ export class ModeService implements OnDestroy {
     this.mode$.next(Mode.Normal);
   }
 
+  startEditing(): void {
+    this.session.stopGroupWatching();
+    this.mode$.next(Mode.Editing);
+  }
+
+  stopEditing(): void {
+    this.mode$.next(Mode.Normal);
+  }
+
   ngOnDestroy(): void {
     this.mode$.complete();
     this.modeActions$.complete();


### PR DESCRIPTION
Fixes #554 

Scenario:
- go to group 4LTDI1819/Pixal
- start observing
- click directly to visit "TestTask"
- in the progress tab, I see "Situation of Pixal"
- press the "start editing" icon
- press the "stop editing" icon
- in progress tab, I see "Your situation" (was "Situation of Pixal" on master)

Non-goals: the way to manage edit/observation modes is a bit strange and weird. The goal on this PR is just to fix the bug, not to improve the code. In the same way, probably there may be a better way to ensure that the observation mode is `off` than stopping it even if not already `on`, but that works and doing better would have require more code rewriting. 