### PR TITLE
auto toggle full frame when initializing task

### DIFF
--- a/src/app/core/components/left-header/left-header.component.ts
+++ b/src/app/core/components/left-header/left-header.component.ts
@@ -19,11 +19,11 @@ export class LeftHeaderComponent {
   ) { }
 
   setFullFrameContent(): void {
-    this.layoutService.toggleFullFrameContent(true);
+    this.layoutService.toggleFullFrameContent(true, true);
   }
 
   unsetFullFrameContent(): void {
-    this.layoutService.toggleFullFrameContent(false);
+    this.layoutService.toggleFullFrameContent(false, true);
   }
 
   login(): void {

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -1,6 +1,6 @@
 import { AfterViewChecked, Component, ElementRef, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { interval, merge, Observable } from 'rxjs';
-import { filter, map, startWith, switchMap } from 'rxjs/operators';
+import { filter, map, startWith, switchMap, take, withLatestFrom } from 'rxjs/operators';
 import { SECONDS } from 'src/app/shared/helpers/duration';
 import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { ItemTaskService } from '../../services/item-task.service';
@@ -12,6 +12,7 @@ import { ItemTaskViewsService } from '../../services/item-task-views.service';
 import { FullItemRoute } from 'src/app/shared/routing/item-route';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PermissionsInfo } from '../../helpers/item-permissions';
+import { LayoutService } from 'src/app/shared/services/layout.service';
 
 const initialHeight = 0;
 const additionalHeightToPreventInnerScrollIssues = 40;
@@ -58,11 +59,17 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   constructor(
     private taskService: ItemTaskService,
     private sanitizer: DomSanitizer,
+    private layoutService: LayoutService,
   ) {}
 
   ngOnInit(): void {
     this.taskService.configure(this.route, this.url, this.attemptId);
     this.taskService.showView(this.view ?? 'task');
+    this.layoutService.fullFrameContent$.pipe(
+      take(1),
+      withLatestFrom(this.layoutService.canAutoToggle$),
+      filter(([ fullFrameContent, canAutoToggle ]) => canAutoToggle && !fullFrameContent),
+    ).subscribe(() => this.layoutService.toggleFullFrameContent(true, false));
   }
 
   ngAfterViewChecked(): void {

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, of, Subject, timer } from 'rxjs';
 import { delay, distinctUntilChanged, mapTo, shareReplay, startWith, switchMap } from 'rxjs/operators';
 import { HOURS } from '../helpers/duration';
 
-const delayUntilReactivateAutoToggle = 2*HOURS;
+const delayUntilReactivateAutoToggle = (): number => (globalThis as unknown as Record<string, number>).__DELAY ?? 2*HOURS;
 
 @Injectable({
   providedIn: 'root'
@@ -19,7 +19,7 @@ export class LayoutService {
   /** This observable last value (`withLatestFrom()`) determines whether a task is allowed to auto toggle full frame or not */
   readonly canAutoToggle$ = this.toggledManually$.pipe(
     switchMap(toggledManually => (toggledManually
-      ? timer(delayUntilReactivateAutoToggle).pipe(mapTo(true), startWith(false))
+      ? timer(delayUntilReactivateAutoToggle()).pipe(mapTo(true), startWith(false))
       : of(true)
     )),
     startWith(true),


### PR DESCRIPTION
## Description

Fixes #729 

## Notes

What should happen if the task initialisation fails after a timeout ? Should we wait for the task to be initialised **before** activating full frame ? Currently, full frame is activated.

**NB to the reviewer(s)**: Omit the second commit in the review, it is only test content and will be removed

## Test cases

(To be checked by reviewer)

- [x] Case 1:
  1. Given I am the usual user or anonymous (except for groups)
  2. When I go to [a chapter](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/activities/by-id/1352246428241737349;path=4702;parentAttempId=0/details), [a group](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/groups/by-id/672913018859223173;path=52767158366271444/details) or [a skill](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/skills/by-id/7999538872975560734;path=3000,3002;attempId=0/details)
  3. Full frame should not be activated
- [x] Case 2:
  1. Given I am the usual user OR anonymous
  2. When I go to an [item with task](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/activities/by-id/9105453971757450756;path=4702,1625159049301502151;attempId=0/details)
  3. It should activate full frame
- [x] Case 3:
  1. Given I am the usual user OR anonymous (:bulb: easier to test with usual user)
  2. When I go to [this item](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I complete the last version
  4. And I click on "Passer à la suite"
  5. It should leave full frame activated
- [x] Case 4:
  1. Given I am the usual user OR anonymous
  2. When I go to [this task](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/activities/by-id/9105453971757450756;path=4702,1625159049301502151;attempId=0/details)
  2. And I expand left menu manually
  3. And go to next or previous task
  4. I Full frame should **not** be activated
- [x] Case 4bis:
  1. Given I am the usual user OR anonymous
  2. When I go to [this task](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/activities/by-id/9105453971757450756;path=4702,1625159049301502151;attempId=0/details)
  3. Given I opened developer tools and inserted following JS: `window.__DELAY = 1000` (override 2 hours with 1s)
  4. And I expand left menu manually
  5. And I wait 1s
  6. And go to next or previous task
  7. I Full frame should be activated
- [x] Case 5:
  1. Given I am the usual user OR anonymous (:bulb: easier to test with usual user)
  2. When I go to [this item](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I expand left menu manually
  4. And I re-collapse left menu manually
  3. And I complete the last version
  4. And I click on "Passer à la suite"
  5. It should leave full frame activated
- [ ] Case 6:
  1. Given I am the usual user OR anonymous
  2. When I go to [this chapter](https://dev.algorea.org/branch/feat/task-auto-full-frame/en/#/activities/by-id/34689573454313988;path=4702,1352246428241737349,314613032161178344;attempId=0/details)
  3. And I expand left menu manually
  4. And I click on first child item
  5. It should leave full frame activated