### PR TITLE
let tasks score from 0 to 100

### DIFF
--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -60,7 +60,7 @@ export class ItemTaskService {
   private bindPlatform(task: Task): void {
     const platform: TaskPlatform = {
       validate: mode => this.validate(mode).pipe(mapTo(undefined)),
-      getTaskParams: () => ({ minScore: -3, maxScore: 10, randomSeed: 0, noScore: 0, readOnly: false, options: {} }),
+      getTaskParams: () => ({ minScore: 0, maxScore: 100, randomSeed: 0, noScore: 0, readOnly: false, options: {} }),
       updateHeight: height => platform.updateDisplay({ height }),
       updateDisplay: display => this.viewsService.updateDisplay(display),
       showView: view => this.viewsService.showView(view),


### PR DESCRIPTION
## Description

When solving tasks, we were getting a score of 10/100. Fix that.

## Test cases

- [x] Case 1:
  1. Given I am an anonymous user
  2. When I go to [the turtle task](https://dev.algorea.org/branch/task-score-over-100/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I solve it
  4. And go on "Progress" tab
  5. Then I see that I've just scored 100 points.
