### PR TITLE
'navigate to next task' when solving a task navigates to the parent if there is no next task

### DIFF
--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -31,7 +31,7 @@ export class ItemTaskService {
   readonly activeView$ = this.viewsService.activeView$;
 
   private navigateToNext$ = this.activityNavTreeService.navigationNeighbors$.pipe(
-    map(neighborsState => (neighborsState.isReady ? neighborsState.data?.next?.navigateTo : undefined)),
+    map(neighborsState => (neighborsState.isReady ? (neighborsState.data?.next ?? neighborsState.data?.parent)?.navigateTo : undefined)),
     shareReplay(1),
   );
 


### PR DESCRIPTION
## Description

Fixes #783 

## Notes

The behavior is still strange if there is no "next" and no "parent"... but we can currently ignore that case.

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [a task which is the last in its chapter](https://dev.algorea.org/branch/navigate-to-parent-on-last-task/en/#/activities/by-id/14357432750770873;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I solve it
  4. And I click on "navigate to next" on the message which is displayed
  4. Then I am sent to the chapter (its parent) page
