### PR TITLE
Adds handling for empy task and course item  page

### DIFF
--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -8,18 +8,37 @@
 
       <alg-chapter-children [itemData]="itemData" *ngIf="itemData.item.type === 'Chapter'"></alg-chapter-children>
 
-      <alg-item-display
-        *ngIf="(itemData.item.type === 'Task' || itemData.item.type === 'Course') && itemData.item.url && attemptId"
-        [route]="itemData.route"
-        [canEdit]="itemData.item.permissions.canEdit"
-        [url]="itemData.item.url"
-        [attemptId]="attemptId"
-        [view]="taskView"
-        [taskOptions]="taskOptions"
-        (viewChange)="taskViewChange.emit($event)"
-        (tabsChange)="taskTabsChange.emit($event)"
-        (scoreChange)="scoreChange.emit($event)"
-      ></alg-item-display>
+      <ng-container *ngIf="(itemData.item.type === 'Task' || itemData.item.type === 'Course')">
+        <ng-container *ngIf="itemData.item.url; else noUrl">
+          <alg-item-display
+            *ngIf="attemptId; else noAttemptId"
+            [route]="itemData.route"
+            [canEdit]="itemData.item.permissions.canEdit"
+            [url]="itemData.item.url"
+            [attemptId]="attemptId"
+            [view]="taskView"
+            [taskOptions]="taskOptions"
+            (viewChange)="taskViewChange.emit($event)"
+            (tabsChange)="taskTabsChange.emit($event)"
+            (scoreChange)="scoreChange.emit($event)"
+          ></alg-item-display>
+
+          <ng-template #noAttemptId>
+            <p class="validation-text" i18n>
+              {{ itemData.item.requiresExplicitEntry ? 'This activity requires explicit entry (not implemented).' : 'Unable to start this activity, if the problem persists, please contact us.' }}
+            </p>
+          </ng-template>
+        </ng-container>
+
+        <ng-template #noUrl>
+          <p class="validation-text" i18n>
+            This activity has not been correctly configured.
+          </p>
+          <p class="validation-text" *ngIf="itemData.item.permissions.canEdit !== 'none'" i18n>
+            You need to set a url in editing mode.
+          </p>
+        </ng-template>
+      </ng-container>
 
       <alg-sub-skills [itemData]="itemData" *ngIf="itemData.item.type === 'Skill'"></alg-sub-skills>
       <alg-parent-skills [itemData]="itemData" *ngIf="itemData.item.type === 'Skill'"></alg-parent-skills>

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -64,6 +64,7 @@
         <span i18n>
           Starting the activity ... (if you are stuck on this message, please retry and contact us if the problem persists)
         </span>
+        <alg-loading size="medium"></alg-loading>
       </ng-template>
     </p>
   </ng-template>

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -24,8 +24,13 @@
           ></alg-item-display>
 
           <ng-template #noAttemptId>
-            <p class="validation-text" i18n>
-              {{ itemData.item.requiresExplicitEntry ? 'This activity requires explicit entry (not implemented).' : 'Unable to start this activity, if the problem persists, please contact us.' }}
+            <p class="validation-text">
+              <span *ngIf="itemData.item.requiresExplicitEntry; else noRequiresExplicitEntry" i18n>
+                This activity requires explicit entry (not implemented).
+              </span>
+              <ng-template #noRequiresExplicitEntry>
+                <span i18n>Unable to start this activity, if the problem persists, please contact us.</span>
+              </ng-template>
             </p>
           </ng-template>
         </ng-container>

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="itemData">
   <ng-container *ngIf="itemData.item.permissions.canView !== 'info'; else notAllowToWatch">
-    <ng-container *ngIf="itemData.currentResult">
+    <ng-container *ngIf="itemData.currentResult; else noCurrentResult">
 
       <alg-section icon="fa fa-book" i18n-label label="Description" *ngIf="itemData.item.string.description">
         <p>{{ itemData.item.string.description }} </p>
@@ -11,7 +11,7 @@
       <ng-container *ngIf="(itemData.item.type === 'Task' || itemData.item.type === 'Course')">
         <ng-container *ngIf="itemData.item.url; else noUrl">
           <alg-item-display
-            *ngIf="attemptId; else noAttemptId"
+            *ngIf="attemptId; else noCurrentResult"
             [route]="itemData.route"
             [canEdit]="itemData.item.permissions.canEdit"
             [url]="itemData.item.url"
@@ -22,17 +22,6 @@
             (tabsChange)="taskTabsChange.emit($event)"
             (scoreChange)="scoreChange.emit($event)"
           ></alg-item-display>
-
-          <ng-template #noAttemptId>
-            <p class="validation-text">
-              <span *ngIf="itemData.item.requiresExplicitEntry; else noRequiresExplicitEntry" i18n>
-                This activity requires explicit entry (not implemented).
-              </span>
-              <ng-template #noRequiresExplicitEntry>
-                <span i18n>Unable to start this activity, if the problem persists, please contact us.</span>
-              </ng-template>
-            </p>
-          </ng-template>
         </ng-container>
 
         <ng-template #noUrl>
@@ -63,6 +52,19 @@
       <ng-container *ngIf="itemData.item.type === 'Skill'">
         <span i18n>Your current access rights do not allow you to list the content of this skill.</span>
       </ng-container>
+    </p>
+  </ng-template>
+
+  <ng-template #noCurrentResult>
+    <p class="validation-text">
+      <span *ngIf="itemData.item.requiresExplicitEntry; else noRequiresExplicitEntry" i18n>
+        This activity requires explicit entry (not implemented).
+      </span>
+      <ng-template #noRequiresExplicitEntry>
+        <span i18n>
+          Starting the activity ... (if you are stuck on this message, please retry and contact us if the problem persists)
+        </span>
+      </ng-template>
     </p>
   </ng-template>
 </ng-container>

--- a/src/app/modules/item/pages/item-content/item-content.component.scss
+++ b/src/app/modules/item/pages/item-content/item-content.component.scss
@@ -1,6 +1,9 @@
 @import 'src/colors.scss';
 
 .validation-text {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   margin: 0;
   padding: 1rem;
   color: $base-color;

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -65,7 +65,7 @@
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="new">Your current access rights do not allow you to list the content of this skill.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ 'Your current access rights do not allow you to list the content of this chapter.' }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">184</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
@@ -75,7 +75,7 @@
         <source>Your current access rights do not allow you to start the activity.</source><target state="new">Your current access rights do not allow you to start the activity.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -676,7 +676,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </source><target state="new"> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">5</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="5302971017875260731" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="5302971017875260731" datatype="html">
         <source>Only owner can delete items</source><target state="new">Only owner can delete items</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="970391649916938978" datatype="html">
@@ -744,22 +744,28 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="2875135670849639672" datatype="html">
+        <source> This activity requires explicit entry (not implemented). </source><target state="new"> This activity requires explicit entry (not implemented). </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
+          <context context-type="linenumber">27,28</context>
+        </context-group>
+      </trans-unit><trans-unit id="3938091459009039294" datatype="html">
+        <source>Unable to start this activity, if the problem persists, please contact us.</source><target state="new">Unable to start this activity, if the problem persists, please contact us.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit><trans-unit id="5441429049165852521" datatype="html">
         <source> This activity has not been correctly configured. </source><target state="new"> This activity has not been correctly configured. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
-          <context context-type="linenumber">33,34</context>
-        </context-group>
-      </trans-unit><trans-unit id="7327354999532189308" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
         <source> You need to set a url in editing mode. </source><target state="new"> You need to set a url in editing mode. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
-          <context context-type="linenumber">36,37</context>
-        </context-group>
-      </trans-unit><trans-unit id="7493155057912125679" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">41</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -65,7 +65,7 @@
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="new">Your current access rights do not allow you to list the content of this skill.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ 'Your current access rights do not allow you to list the content of this chapter.' }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">184</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
@@ -75,7 +75,7 @@
         <source>Your current access rights do not allow you to start the activity.</source><target state="new">Your current access rights do not allow you to start the activity.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -460,10 +460,10 @@
         </context-group>
       </trans-unit><trans-unit id="5172335096273253685" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet ?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet ?</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
         <source>Editor</source><target state="new">Editor</target>
 
@@ -629,10 +629,10 @@
         </context-group>
       </trans-unit><trans-unit id="1125515177419706232" datatype="html">
         <source>Maformed url: "<x id="PH" equiv-text="url"/>"</source><target state="new">Maformed url: "<x id="PH" equiv-text="url"/>"</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="7800096150276874726" datatype="html">
         <source>Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</source><target state="new">Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">97</context></context-group></trans-unit><trans-unit id="4370087843628009533" datatype="html">
         <source>Invalid url, please provide a secure task url (https)</source><target state="new">Invalid url, please provide a secure task url (https)</target>
 
@@ -676,7 +676,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </source><target state="new"> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="5302971017875260731" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">5</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="5302971017875260731" datatype="html">
         <source>Only owner can delete items</source><target state="new">Only owner can delete items</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="970391649916938978" datatype="html">
@@ -744,10 +744,22 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
+        <source> This activity has not been correctly configured. </source><target state="new"> This activity has not been correctly configured. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
+          <context context-type="linenumber">33,34</context>
+        </context-group>
+      </trans-unit><trans-unit id="7327354999532189308" datatype="html">
+        <source> You need to set a url in editing mode. </source><target state="new"> You need to set a url in editing mode. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
+          <context context-type="linenumber">36,37</context>
+        </context-group>
+      </trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -65,7 +65,7 @@
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="new">Your current access rights do not allow you to list the content of this skill.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ 'Your current access rights do not allow you to list the content of this chapter.' }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">184</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
@@ -75,7 +75,7 @@
         <source>Your current access rights do not allow you to start the activity.</source><target state="new">Your current access rights do not allow you to start the activity.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -746,26 +746,23 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="2875135670849639672" datatype="html">
         <source> This activity requires explicit entry (not implemented). </source><target state="new"> This activity requires explicit entry (not implemented). </target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="3074566479590679594" datatype="html">
+        <source> Starting the activity ... (if you are stuck on this message, please retry and contact us if the problem persists) </source><target state="new"> Starting the activity ... (if you are stuck on this message, please retry and contact us if the problem persists) </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
-          <context context-type="linenumber">27,28</context>
-        </context-group>
-      </trans-unit><trans-unit id="3938091459009039294" datatype="html">
-        <source>Unable to start this activity, if the problem persists, please contact us.</source><target state="new">Unable to start this activity, if the problem persists, please contact us.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">63,64</context>
         </context-group>
       </trans-unit><trans-unit id="5441429049165852521" datatype="html">
         <source> This activity has not been correctly configured. </source><target state="new"> This activity has not been correctly configured. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
         <source> You need to set a url in editing mode. </source><target state="new"> You need to set a url in editing mode. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">41</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">30</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>


### PR DESCRIPTION
## Description

Fixes #766

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/do-not-let-item-page-empty/en/#/activities/by-id/2268458803184278714;path=;attempId=0/details)
  4. Then I see "This activity has not been correctly configured" and "You need to set a url in editing mode." messages
  

- [x] Case 2:
  1. Given am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/do-not-let-item-page-empty/en/#/activities/by-id/4161175831988689371;path=1352246428241737349,561969155071897034;parentAttempId=0/details)
  4. Then I see Chapter with "This activity requires explicit entry (not implemented)." message


- [x] Case 3:
  1. Given am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/do-not-let-item-page-empty/en/#/activities/by-id/7484937021725214233;path=1352246428241737349,561969155071897034;parentAttempId=0/details)
  4. Then I see Task with "This activity requires explicit entry (not implemented)." message
  
- [x] Case 4:
  1. Given am the user demouser
  2. When I go to [this page](https://dev.algorea.org/branch/feature/do-not-let-item-page-empty/en/#/activities/by-id/1501663083087440078;path=4702,1625159049301502151;parentAttempId=0/details)
  4. Then I see Task with "This activity has not been correctly configured." message