### PR TITLE
keep task loaded when visiting progress tab

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -49,7 +49,8 @@
     </nav>
     <div class="bg-white">
       <alg-item-content
-        *ngIf="contentTab.isActive"
+        *ngIf="contentTab.isActive || taskTabs.length > 0"
+        [hidden]="!contentTab.isActive"
         [itemData]="itemData"
         [(taskView)]="taskView"
         (taskTabsChange)="setTaskTabs($event)"


### PR DESCRIPTION
## Description

Fixes #790 

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this item page](https://dev.algorea.org/branch/feat/keep-task-loaded/en/#/activities/by-id/9105453971757450756;path=4702,1625159049301502151;attempId=0/details)
  3. And I click on "Progress" tab
  4. And I click back on "Task" or "Editor" tab
  5. The task should not be reloaded **and** the correct view should be displayed

- [ ] Case 2:
  1. Given I am any user
  2. When I go to [this item progress page](https://dev.algorea.org/branch/feat/keep-task-loaded/en/#/activities/by-id/9105453971757450756;path=4702,1625159049301502151;attempId=0/details/progress/history)
  3. And I click on "Content" tab
  4. The task should be loaded as usual

- [ ] Case 3:
  1. Given I am any user
  2. When I go to [this item page](https://dev.algorea.org/branch/feat/keep-task-loaded/en/#/activities/by-id/9105453971757450756;path=4702,1625159049301502151;attempId=0/details)
  3. And I click on next/previous item, ie: "Activity with logs"
  4. The old task must be destroyed and the new task must loaded **as before**
