### PR TITLE
populate task random seed with attempt id

### DIFF
--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -70,7 +70,9 @@ export class ItemTaskService {
   }
 
   private bindPlatform(task: Task): void {
-    if (!this.attemptId) throw new Error('attemptId must be defined');
+    if (!this.attemptId) throw new Error('attemptId must be defined. The "configure" method has probably not been called as expected');
+    // attempt id can be used as a seed as these are currently assigned incrementally by participant id
+    // If this changes, this needs to be adapted.
     const randomSeed = Number(this.attemptId);
     if (Number.isNaN(randomSeed)) throw new Error('random seed must be a number');
 

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -43,6 +43,7 @@ export class ItemTaskService {
   );
 
   private readOnly = false;
+  private attemptId?: string;
 
   constructor(
     private initService: ItemTaskInitService,
@@ -56,6 +57,7 @@ export class ItemTaskService {
 
   configure(route: FullItemRoute, url: string, attemptId: string, options: ConfigureTaskOptions): void {
     this.readOnly = options.readOnly;
+    this.attemptId = attemptId;
     this.initService.configure(route, url, attemptId, options.shouldReloadAnswer);
   }
 
@@ -68,12 +70,16 @@ export class ItemTaskService {
   }
 
   private bindPlatform(task: Task): void {
+    if (!this.attemptId) throw new Error('attemptId must be defined');
+    const randomSeed = Number(this.attemptId);
+    if (Number.isNaN(randomSeed)) throw new Error('random seed must be a number');
+
     const platform: TaskPlatform = {
       validate: mode => this.validate(mode).pipe(mapTo(undefined)),
       getTaskParams: () => ({
         minScore: 0,
         maxScore: 100,
-        randomSeed: 0,
+        randomSeed,
         noScore: 0,
         readOnly: this.readOnly,
         options: {},


### PR DESCRIPTION
## Description

Fixes #...

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases


- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/task-random-seed/en/#/activities/by-id/1655405614123744253;path=4702,1352246428241737349,1070539248445908636,35415640138424232;parentAttempId=0/details)
  3. The task should be displayed normally
- [ ] Case 2:
  1. Given I am an anonymous user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/task-random-seed/en/#/activities/by-id/1655405614123744253;path=4702,1352246428241737349,1070539248445908636,35415640138424232;parentAttempId=0/details)
  3. The task should be displayed normally
