### PR TITLE
feat: load former submissions

### DIFF
--- a/src/app/modules/item/http-services/get-answer.service.ts
+++ b/src/app/modules/item/http-services/get-answer.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { appConfig } from 'src/app/shared/helpers/config';
+import * as D from 'io-ts/Decoder';
+import { decodeSnakeCase } from 'src/app/shared/operators/decode';
+import { dateDecoder } from 'src/app/shared/helpers/decoders';
+
+export const answerDecoder = D.struct({
+  answer: D.nullable(D.string),
+  attemptId: D.nullable(D.string),
+  authorId: D.string,
+  createdAt: dateDecoder,
+  gradedAt: D.nullable(dateDecoder),
+  id: D.string,
+  itemId: D.string,
+  score: D.nullable(D.number),
+  state: D.nullable(D.string),
+  type: D.literal('Submission', 'Saved', 'Current'),
+});
+
+export type Answer = D.TypeOf<typeof answerDecoder>;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GetAnswerService {
+
+  constructor(private http: HttpClient) {}
+
+  get(answerId: string): Observable<Answer | null> {
+    return this.http
+      .get<unknown>(`${appConfig.apiUrl}/answers/${answerId}`)
+      .pipe(decodeSnakeCase(answerDecoder));
+  }
+
+}

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -134,7 +134,7 @@ export class ItemByIdComponent implements OnDestroy {
     if (isItemRouteError(item)) {
       if (item.id) {
         this.state = fetchingState();
-        this.solveMissingPathAttempt(item.contentType, item.id, item.path);
+        this.solveMissingPathAttempt(item.contentType, item.id, item.path, item.answerId);
       } else this.state = errorState(new Error('No id in url'));
       return;
     }
@@ -148,16 +148,16 @@ export class ItemByIdComponent implements OnDestroy {
    * Called when either path or attempt is missing. Will fetch the path if missing, then will be fetch the attempt.
    * Will redirect when relevant data has been fetched.
    */
-  private solveMissingPathAttempt(contentType: ItemTypeCategory, id: string, path?: string[]): void {
+  private solveMissingPathAttempt(contentType: ItemTypeCategory, id: string, path?: string[], answerId?: string): void {
 
     const pathObservable = path ? of(path) : this.getItemPathService.getItemPath(id);
     pathObservable.pipe(
       switchMap(path => {
         // for empty path (root items), consider the item has a (fake) parent attempt id 0
-        if (path.length === 0) return of({ contentType: contentType, id: id, path: path, parentAttemptId: defaultAttemptId });
+        if (path.length === 0) return of({ contentType, id, path, parentAttemptId: defaultAttemptId, answerId });
         // else, will start all path but the current item
         return this.resultActionsService.startWithoutAttempt(path).pipe(
-          map(attemptId => ({ contentType: contentType, id: id, path: path, parentAttemptId: attemptId }))
+          map(attemptId => ({ contentType, id, path, parentAttemptId: attemptId, answerId }))
         );
       })
     ).subscribe({

--- a/src/app/modules/item/pages/item-by-id/item-route-validation.ts
+++ b/src/app/modules/item/pages/item-by-id/item-route-validation.ts
@@ -15,13 +15,15 @@ interface ItemRouteError {
 export function itemRouteFromParams(prefix: string, params: ParamMap): FullItemRoute|ItemRouteError {
   const cat = itemCategoryFromPrefix(prefix);
   if (cat === null) throw new Error('Unexpected item path prefix');
-  const { id, path, attemptId, parentAttemptId } = decodeItemRouterParameters(params);
+  const { id, path, attemptId, parentAttemptId, answerId } = decodeItemRouterParameters(params);
 
   if (!id) return { contentType: cat, tag: 'error', id: undefined }; // null or empty
   if (path === null) return { contentType: cat, tag: 'error', id: id };
   const pathList = path === '' ? [] : path.split(',');
-  if (attemptId) return { contentType: cat, id: id, path: pathList, attemptId: attemptId }; // not null nor empty
-  if (parentAttemptId) return { contentType: cat, id: id, path: pathList, parentAttemptId: parentAttemptId }; // not null nor empty
+  if (attemptId) return { contentType: cat, id: id, path: pathList, attemptId, answerId: answerId ?? undefined }; // not null nor empty
+  if (parentAttemptId) {
+    return { contentType: cat, id: id, path: pathList, parentAttemptId, answerId: answerId ?? undefined }; // not null nor empty
+  }
   return { contentType: cat, tag: 'error', id: id, path: pathList };
 }
 

--- a/src/app/modules/item/pages/item-by-id/item-route-validation.ts
+++ b/src/app/modules/item/pages/item-by-id/item-route-validation.ts
@@ -10,21 +10,21 @@ interface ItemRouteError {
   contentType: ItemTypeCategory,
   id?: ItemId,
   path?: ItemId[],
+  answerId?: string,
 }
 
 export function itemRouteFromParams(prefix: string, params: ParamMap): FullItemRoute|ItemRouteError {
   const cat = itemCategoryFromPrefix(prefix);
   if (cat === null) throw new Error('Unexpected item path prefix');
-  const { id, path, attemptId, parentAttemptId, answerId } = decodeItemRouterParameters(params);
+  const { id, path, attemptId, parentAttemptId, answerId: answerIdOrNull } = decodeItemRouterParameters(params);
+  const answerId = answerIdOrNull ?? undefined;
 
-  if (!id) return { contentType: cat, tag: 'error', id: undefined }; // null or empty
-  if (path === null) return { contentType: cat, tag: 'error', id: id };
+  if (!id) return { contentType: cat, tag: 'error', id: undefined, answerId }; // null or empty
+  if (path === null) return { contentType: cat, tag: 'error', id, answerId };
   const pathList = path === '' ? [] : path.split(',');
-  if (attemptId) return { contentType: cat, id: id, path: pathList, attemptId, answerId: answerId ?? undefined }; // not null nor empty
-  if (parentAttemptId) {
-    return { contentType: cat, id: id, path: pathList, parentAttemptId, answerId: answerId ?? undefined }; // not null nor empty
-  }
-  return { contentType: cat, tag: 'error', id: id, path: pathList };
+  if (attemptId) return { contentType: cat, id: id, path: pathList, attemptId, answerId }; // not null nor empty
+  if (parentAttemptId) return { contentType: cat, id: id, path: pathList, parentAttemptId, answerId }; // not null nor empty
+  return { contentType: cat, tag: 'error', id: id, path: pathList, answerId };
 }
 
 export function isItemRouteError(route: FullItemRoute|ItemRouteError): route is ItemRouteError {

--- a/src/app/modules/item/pages/item-content/item-content.component.ts
+++ b/src/app/modules/item/pages/item-content/item-content.component.ts
@@ -12,7 +12,7 @@ export class ItemContentComponent implements OnChanges {
 
   @Input() itemData?: ItemData;
   @Input() taskView?: TaskTab['view'];
-  @Input() taskOptions: ConfigureTaskOptions = { readOnly: false, shouldReloadAnswer: true };
+  @Input() taskOptions: ConfigureTaskOptions = { readOnly: false, shouldLoadAnswer: true };
 
   @Output() taskTabsChange = new EventEmitter<TaskTab[]>();
   @Output() taskViewChange = new EventEmitter<TaskTab['view']>();

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -61,7 +61,7 @@
       <alg-item-progress
         *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive"
         [itemData]="itemData"
-        [showSubmissionLoadLinks]="(showSubmissionLoadLinks$ | async) ?? false"
+        [enableLoadSubmission]="(enableLoadSubmission$ | async) ?? false"
       ></alg-item-progress>
     </div>
 

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -61,6 +61,7 @@
       <alg-item-progress
         *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive"
         [itemData]="itemData"
+        [showSubmissionLoadLinks]="(showSubmissionLoadLinks$ | async) ?? false"
       ></alg-item-progress>
     </div>
 

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -31,7 +31,7 @@ export class ItemDetailsComponent implements OnDestroy {
   readonly watchedGroup$ = this.userService.watchedGroup$;
   readonly taskOptions$: Observable<ConfigureTaskOptions> = this.modeService.mode$.pipe(map(mode => ({
     readOnly: mode === Mode.Watching,
-    shouldReloadAnswer: mode === Mode.Normal,
+    shouldLoadAnswer: mode === Mode.Normal,
   })));
 
   readonly enableLoadSubmission$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Normal));

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -34,7 +34,7 @@ export class ItemDetailsComponent implements OnDestroy {
     shouldReloadAnswer: mode === Mode.Normal,
   })));
 
-  readonly showSubmissionLoadLinks$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Normal));
+  readonly enableLoadSubmission$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Normal));
 
   private subscription = this.itemDataSource.state$.subscribe(state => {
     if (state.isFetching) this.taskTabs = []; // reset task tabs when item changes.

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -34,6 +34,8 @@ export class ItemDetailsComponent implements OnDestroy {
     shouldReloadAnswer: mode === Mode.Normal,
   })));
 
+  readonly showSubmissionLoadLinks$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Normal));
+
   private subscription = this.itemDataSource.state$.subscribe(state => {
     if (state.isFetching) this.taskTabs = []; // reset task tabs when item changes.
   });

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -1,6 +1,13 @@
 <div class="item-display" *ngIf="state$ | async as state">
   <div *ngIf="state.isError" class="errors">
-    <alg-error i18n-message message="Unable to load the task"></alg-error>
+    <alg-error *ngIf="answerFallbackLink$ | async as fallbackLink; else defaultErrorMessage" i18n>
+      Unable to load the answer, <a [routerLink]="fallbackLink">load your most recent answer</a>
+    </alg-error>
+
+    <ng-template #defaultErrorMessage>
+      <alg-error i18n-message message="Unable to load the task"></alg-error>
+    </ng-template>
+
     <ng-container *ngIf="['all', 'all_with_grant'].includes(canEdit)">
       <alg-error
         *ngIf="initError$ | async; else urlError"

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -20,7 +20,7 @@ import { capitalize } from 'src/app/shared/helpers/case_conversion';
 import { ItemTaskInitService } from '../../services/item-task-init.service';
 import { ItemTaskAnswerService } from '../../services/item-task-answer.service';
 import { ItemTaskViewsService } from '../../services/item-task-views.service';
-import { FullItemRoute } from 'src/app/shared/routing/item-route';
+import { FullItemRoute, urlArrayForItemRoute } from 'src/app/shared/routing/item-route';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PermissionsInfo } from '../../helpers/item-permissions';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
@@ -53,6 +53,9 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   state$ = this.taskService.task$.pipe(mapToFetchState());
   initError$ = this.taskService.initError$;
   urlError$ = this.taskService.urlError$;
+  answerFallbackLink$ = this.taskService.loadAnswerByIdError$.pipe(
+    map(() => urlArrayForItemRoute({ ...this.route, answerId: undefined })),
+  );
   unknownError$ = this.taskService.unknownError$;
   iframeSrc$ = this.taskService.iframeSrc$.pipe(map(url => this.sanitizer.bypassSecurityTrustResourceUrl(url)));
 

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -46,7 +46,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   @Input() canEdit: PermissionsInfo['canEdit'] = 'none';
   @Input() attemptId!: string;
   @Input() view?: TaskTab['view'];
-  @Input() taskOptions: ConfigureTaskOptions = { readOnly: false, shouldReloadAnswer: true };
+  @Input() taskOptions: ConfigureTaskOptions = { readOnly: false, shouldLoadAnswer: true };
 
   @ViewChild('iframe') iframe?: ElementRef<HTMLIFrameElement>;
 

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -41,7 +41,7 @@
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
-                <ng-container *ngIf="rowData.activityType === 'submission' && rowData.answerId">
+                <ng-container *ngIf="showSubmissionLoadLinks && rowData.activityType === 'submission' && rowData.answerId">
                   &nbsp;(<a class="alg-link" [routerLink]="rowData.item | rawItemLink:'details':rowData.answerId" i18n>Load</a>)
                 </ng-container>
               </ng-container>

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -41,6 +41,9 @@
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
+                <ng-container *ngIf="rowData.activityType === 'submission' && rowData.answerId">
+                  &nbsp;(<a class="alg-link" [routerLink]="rowData.item | rawItemLink:'details':rowData.answerId" i18n>Load</a>)
+                </ng-container>
               </ng-container>
               <ng-container *ngSwitchCase="'item.string.title'">
                 <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | rawItemLink">

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -41,7 +41,7 @@
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
-                <ng-container *ngIf="showSubmissionLoadLinks && rowData.activityType === 'submission' && rowData.answerId">
+                <ng-container *ngIf="enableLoadSubmission && rowData.activityType === 'submission' && rowData.answerId">
                   &nbsp;(<a class="alg-link" [routerLink]="rowData.item | rawItemLink:'details':rowData.answerId" i18n>Load</a>)
                 </ng-container>
               </ng-container>

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -26,7 +26,7 @@ interface Data {
 export class ItemLogViewComponent implements OnChanges, OnDestroy {
 
   @Input() itemData?: ItemData;
-  @Input() showSubmissionLoadLinks = false;
+  @Input() enableLoadSubmission = false;
 
   private readonly refresh$ = new Subject<void>();
   private readonly item$ = new ReplaySubject<Item>(1);

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -26,6 +26,7 @@ interface Data {
 export class ItemLogViewComponent implements OnChanges, OnDestroy {
 
   @Input() itemData?: ItemData;
+  @Input() showSubmissionLoadLinks = false;
 
   private readonly refresh$ = new Subject<void>();
   private readonly item$ = new ReplaySubject<Item>(1);

--- a/src/app/modules/item/pages/item-progress/item-progress.component.html
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.html
@@ -50,6 +50,7 @@
         <alg-item-log-view
           *ngIf="!!historyTab?.isActive"
           [itemData]="itemData"
+          [showSubmissionLoadLinks]="showSubmissionLoadLinks"
         ></alg-item-log-view>
 
         <div class="chapter-group-progress">

--- a/src/app/modules/item/pages/item-progress/item-progress.component.html
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.html
@@ -50,7 +50,7 @@
         <alg-item-log-view
           *ngIf="!!historyTab?.isActive"
           [itemData]="itemData"
-          [showSubmissionLoadLinks]="showSubmissionLoadLinks"
+          [enableLoadSubmission]="enableLoadSubmission"
         ></alg-item-log-view>
 
         <div class="chapter-group-progress">

--- a/src/app/modules/item/pages/item-progress/item-progress.component.ts
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.ts
@@ -12,7 +12,7 @@ import { ItemType } from '../../../../shared/helpers/item-type';
 export class ItemProgressComponent implements OnChanges {
 
   @Input() itemData?: ItemData;
-  @Input() showSubmissionLoadLinks = false;
+  @Input() enableLoadSubmission = false;
 
   @ViewChild('historyTab') historyTab?: RouterLinkActive;
   @ViewChild('chapterGroupProgressTab') chapterGroupProgressTab?: RouterLinkActive;

--- a/src/app/modules/item/pages/item-progress/item-progress.component.ts
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.ts
@@ -12,6 +12,7 @@ import { ItemType } from '../../../../shared/helpers/item-type';
 export class ItemProgressComponent implements OnChanges {
 
   @Input() itemData?: ItemData;
+  @Input() showSubmissionLoadLinks = false;
 
   @ViewChild('historyTab') historyTab?: RouterLinkActive;
   @ViewChild('chapterGroupProgressTab') chapterGroupProgressTab?: RouterLinkActive;

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -33,8 +33,8 @@ export class ItemTaskAnswerService implements OnDestroy {
   private taskToken$ = this.taskInitService.taskToken$.pipe(takeUntil(this.error$));
 
   private initialAnswer$: Observable<Answer | null> = this.config$.pipe(
-    switchMap(({ route, attemptId, shouldReloadAnswer }) => {
-      if (!shouldReloadAnswer) return of(null);
+    switchMap(({ route, attemptId, shouldLoadAnswer }) => {
+      if (!shouldLoadAnswer) return of(null);
       if (route.answerId) return this.getAnswerService.get(route.answerId);
       return this.currentAnswerService.get(route.id, attemptId).pipe(
         catchError(error => {

--- a/src/app/modules/item/services/item-task-init.service.ts
+++ b/src/app/modules/item/services/item-task-init.service.ts
@@ -14,7 +14,7 @@ export interface ItemTaskConfig {
   route: FullItemRoute,
   url: string,
   attemptId: string,
-  shouldReloadAnswer: boolean,
+  shouldLoadAnswer: boolean,
 }
 
 @Injectable()
@@ -70,11 +70,11 @@ export class ItemTaskInitService implements OnDestroy {
     if (!this.configFromIframe$.closed) this.configFromIframe$.complete();
   }
 
-  configure(route: FullItemRoute, url: string, attemptId: string, shouldReloadAnswer = true): void {
+  configure(route: FullItemRoute, url: string, attemptId: string, shouldLoadAnswer = true): void {
     if (this.configured) throw new Error('task init service can be configured once only');
     this.configured = true;
 
-    this.configFromItem$.next({ route, url, attemptId, shouldReloadAnswer });
+    this.configFromItem$.next({ route, url, attemptId, shouldLoadAnswer });
     this.configFromItem$.complete();
   }
 

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -22,8 +22,14 @@ export class ItemTaskService {
   readonly unknownError$ = merge(this.answerService.error$, this.viewsService.error$).pipe(shareReplay(1));
   readonly initError$ = this.initService.initError$.pipe(shareReplay(1));
   readonly urlError$ = this.initService.urlError$.pipe(shareReplay(1));
+  readonly loadAnswerByIdError$ = this.answerService.loadAnswerByIdError$.pipe(shareReplay(1));
 
-  private error$ = merge(this.initError$, this.urlError$, this.unknownError$).pipe(switchMap(error => throwError(() => error)));
+  private error$ = merge(
+    this.initError$,
+    this.urlError$,
+    this.loadAnswerByIdError$,
+    this.unknownError$,
+  ).pipe(switchMap(error => throwError(() => error)));
 
   readonly task$ = merge(this.initService.task$, this.error$);
   readonly iframeSrc$ = this.initService.iframeSrc$;

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -14,7 +14,7 @@ import { ItemTaskViewsService } from './item-task-views.service';
 
 export interface ConfigureTaskOptions {
   readOnly: boolean,
-  shouldReloadAnswer: boolean,
+  shouldLoadAnswer: boolean,
 }
 
 @Injectable()
@@ -56,7 +56,7 @@ export class ItemTaskService {
 
   configure(route: FullItemRoute, url: string, attemptId: string, options: ConfigureTaskOptions): void {
     this.readOnly = options.readOnly;
-    this.initService.configure(route, url, attemptId, options.shouldReloadAnswer);
+    this.initService.configure(route, url, attemptId, options.shouldLoadAnswer);
   }
 
   initTask(iframe: HTMLIFrameElement): void {

--- a/src/app/modules/shared-components/components/error/error.component.html
+++ b/src/app/modules/shared-components/components/error/error.component.html
@@ -1,7 +1,10 @@
 <div class="wrapper">
   <div class="message-container">
     <i *ngIf="icon" class="icon" [ngClass]="icon"></i>
-    <span class="message">{{ message }}</span>
+    <span class="message">
+      {{ message }}
+      <ng-content *ngIf="!message"></ng-content>
+    </span>
     <p-button
       *ngIf="showRefreshButton && refreshButtonType === 'refresh'"
       class="refresh-button"

--- a/src/app/shared/http-services/activity-log.service.ts
+++ b/src/app/shared/http-services/activity-log.service.ts
@@ -26,6 +26,7 @@ const activityLogDecoder = pipe(
   }),
   D.intersect(
     D.partial({
+      answerId: D.string,
       score: D.number,
       user: pipe(
         D.struct({

--- a/src/app/shared/pipes/rawItemLink.ts
+++ b/src/app/shared/pipes/rawItemLink.ts
@@ -10,6 +10,6 @@ import { rawItemRoute, urlArrayForItemRoute } from '../routing/item-route';
 @Pipe({ name: 'rawItemLink', pure: true })
 export class RawItemLinkPipe implements PipeTransform {
   transform({ id, type }: {id: string, type: ItemType}, page?: string|string[], answerId?: string): UrlCommand {
-    return urlArrayForItemRoute(rawItemRoute(typeCategoryOfItem({ type }), id), page, answerId);
+    return urlArrayForItemRoute(rawItemRoute(typeCategoryOfItem({ type }), id, answerId), page);
   }
 }

--- a/src/app/shared/pipes/rawItemLink.ts
+++ b/src/app/shared/pipes/rawItemLink.ts
@@ -9,7 +9,7 @@ import { rawItemRoute, urlArrayForItemRoute } from '../routing/item-route';
  */
 @Pipe({ name: 'rawItemLink', pure: true })
 export class RawItemLinkPipe implements PipeTransform {
-  transform({ id, type }: {id: string, type: ItemType}, page?: string|string[]): UrlCommand {
-    return urlArrayForItemRoute(rawItemRoute(typeCategoryOfItem({ type }), id), page);
+  transform({ id, type }: {id: string, type: ItemType}, page?: string|string[], answerId?: string): UrlCommand {
+    return urlArrayForItemRoute(rawItemRoute(typeCategoryOfItem({ type }), id), page, answerId);
   }
 }

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -43,8 +43,8 @@ export function isRouteWithSelfAttempt(item: FullItemRoute): item is ItemRouteWi
   return item.attemptId !== undefined;
 }
 
-export function rawItemRoute(contentType: ItemTypeCategory, id: ItemId): RawItemRoute {
-  return { contentType, id };
+export function rawItemRoute(contentType: ItemTypeCategory, id: ItemId, answerId?: AnswerId): RawItemRoute {
+  return { contentType, id, answerId };
 }
 export function itemRoute(contentType: ItemTypeCategory, id: ItemId, path: string[]): ItemRoute {
   return { ...rawItemRoute(contentType, id), path };
@@ -100,11 +100,11 @@ export function itemCategoryFromPrefix(prefix: string): ItemTypeCategory|null {
 /**
  * Return a url array (`commands` array) to the given item, on the given page.
  */
-export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] = 'details', answerId = route.answerId): UrlCommand {
+export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] = 'details'): UrlCommand {
   const params = route.path ? pathAsParameter(route.path) : {};
   if (route.attemptId) params[attemptParamName] = route.attemptId;
   else if (route.parentAttemptId) params[parentAttemptParamName] = route.parentAttemptId;
-  if (answerId) params[answerParamName] = answerId;
+  if (route.answerId) params[answerParamName] = route.answerId;
 
   const prefix = route.contentType === 'activity' ? activityPrefix : skillPrefix;
   const pagePath = isString(page) ? [ page ] : page;

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -100,12 +100,10 @@ export function itemCategoryFromPrefix(prefix: string): ItemTypeCategory|null {
 /**
  * Return a url array (`commands` array) to the given item, on the given page.
  */
-export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] = 'details', answerId?: AnswerId): UrlCommand {
+export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] = 'details', answerId = route.answerId): UrlCommand {
   const params = route.path ? pathAsParameter(route.path) : {};
   if (route.attemptId) params[attemptParamName] = route.attemptId;
   else if (route.parentAttemptId) params[parentAttemptParamName] = route.parentAttemptId;
-
-  answerId = answerId ?? route.answerId;
   if (answerId) params[answerParamName] = answerId;
 
   const prefix = route.contentType === 'activity' ? activityPrefix : skillPrefix;

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -11,10 +11,12 @@ const activityPrefix = 'activities';
 const skillPrefix = 'skills';
 const parentAttemptParamName = 'parentAttempId';
 const attemptParamName = 'attempId';
+const answerParamName = 'answerId';
 
 // alias for better readibility
 type ItemId = string;
 type AttemptId = string;
+type AnswerId = string;
 
 /* **********************************************************************************************************
  * Item Route: Object storing information required to navigate to an item without need for fetching a path
@@ -30,6 +32,7 @@ export interface ItemRoute extends ContentRoute {
   contentType: ItemTypeCategory,
   attemptId?: AttemptId,
   parentAttemptId?: AttemptId,
+  answerId?: AnswerId,
 }
 type ItemRouteWithSelfAttempt = ItemRoute & { attemptId: AttemptId };
 type ItemRouteWithParentAttempt = ItemRoute & { parentAttemptId: AttemptId };
@@ -71,12 +74,14 @@ export function decodeItemRouterParameters(params: ParamMap): {
   path: string|null,
   attemptId: string|null,
   parentAttemptId: string|null,
+  answerId: string|null,
 } {
   return {
     id: params.get('id'),
     path: pathFromRouterParameters(params),
     attemptId: params.get(attemptParamName),
-    parentAttemptId: params.get(parentAttemptParamName)
+    parentAttemptId: params.get(parentAttemptParamName),
+    answerId: params.get(answerParamName),
   };
 }
 
@@ -95,10 +100,13 @@ export function itemCategoryFromPrefix(prefix: string): ItemTypeCategory|null {
 /**
  * Return a url array (`commands` array) to the given item, on the given page.
  */
-export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] = 'details'): UrlCommand {
+export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] = 'details', answerId?: AnswerId): UrlCommand {
   const params = route.path ? pathAsParameter(route.path) : {};
   if (route.attemptId) params[attemptParamName] = route.attemptId;
   else if (route.parentAttemptId) params[parentAttemptParamName] = route.parentAttemptId;
+
+  answerId = answerId ?? route.answerId;
+  if (answerId) params[answerParamName] = answerId;
 
   const prefix = route.contentType === 'activity' ? activityPrefix : skillPrefix;
   const pagePath = isString(page) ? [ page ] : page;

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -96,7 +96,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit><trans-unit id="6599854887630038646" datatype="html">
         <source>Retry now</source><target state="translated">Réessayer</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/error/error.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="4219108310098283044" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/error/error.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="4219108310098283044" datatype="html">
         <source>Observation Mode</source><target state="new">Observation Mode</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/observation-bar/observation-bar.component.html</context>
@@ -410,34 +410,37 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="5928181193903168495" datatype="html">
         <source> Content </source><target state="translated"> Contenu </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">25</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
-        <source>Unable to load the task</source><target state="new">Unable to load the task</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">3</context></context-group></trans-unit><trans-unit id="1143295073021866312" datatype="html">
-        <source>It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us.</source><target state="new">It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us.</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="3835920457327748126" datatype="html">
-        <source>An unknown error occurred. If this problem persists, please contact us.</source><target state="new">An unknown error occurred. If this problem persists, please contact us.</target>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">25</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
+        <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="new"> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">4</context>
         </context-group>
-      </trans-unit><trans-unit id="5172335096273253685" datatype="html">
+      </trans-unit><trans-unit id="6885936620581271929" datatype="html">
+        <source>Unable to load the task</source><target state="new">Unable to load the task</target>
+
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="1143295073021866312" datatype="html">
+        <source>It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us.</source><target state="new">It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us.</target>
+
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="3835920457327748126" datatype="html">
+        <source>An unknown error occurred. If this problem persists, please contact us.</source><target state="new">An unknown error occurred. If this problem persists, please contact us.</target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="5172335096273253685" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet ?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
         <source>Editor</source><target state="new">Editor</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">123</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">127</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="new">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">124</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">125</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">129</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">78</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="792911798404302156" datatype="html">
@@ -521,7 +524,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="4578192247039196794" datatype="html">
         <source>Task</source><target state="translated">Tâche</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">132</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
         <source>A new task which users can try to solve.</source><target state="translated">Une nouvelle tâche que les utilisateurs pourront tenter de résoudre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="8317457230285174180" datatype="html">
@@ -545,7 +548,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">29</context></context-group></trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">127</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">131</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -1123,7 +1126,7 @@
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">126</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">130</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -68,7 +68,7 @@
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="new">Your current access rights do not allow you to list the content of this skill.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ 'Your current access rights do not allow you to list the content of this chapter.' }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">184</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
@@ -78,7 +78,7 @@
         <source>Your current access rights do not allow you to start the activity.</source><target state="new">Your current access rights do not allow you to start the activity.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">34</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -334,7 +334,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">269</context></context-group></trans-unit><trans-unit id="3768927257183755959" datatype="html">
         <source>Save</source><target state="translated">Sauvegarder</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/floating-save/floating-save.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="4675865183684903475" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">98</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/floating-save/floating-save.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="4675865183684903475" datatype="html">
         <source>Cancel Changes</source><target state="translated">Annuler les changements</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared-components/components/floating-save/floating-save.component.html</context>
@@ -349,7 +349,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/associated-activity/associated-activity.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="9048329397389521608" datatype="html">
         <source>The action cannot be executed. If the problem persists, contact us.</source><target state="translated">Cette action ne peut être exécutée. Contactez-nous si le problème persiste.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="1921521890321612796" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="1921521890321612796" datatype="html">
         <source>Add a content</source><target state="translated">Ajouter du contenu</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/add-item/add-item.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="1620208179561029065" datatype="html">
@@ -424,26 +424,20 @@
         </context-group>
       </trans-unit><trans-unit id="5172335096273253685" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet ?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet ?</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
-          <context context-type="linenumber">73</context>
-        </context-group>
-      </trans-unit><trans-unit id="4373686826857756108" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
-          <context context-type="linenumber">78</context>
-        </context-group>
-      </trans-unit><trans-unit id="3742657416068781599" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
         <source>Editor</source><target state="new">Editor</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">123</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="new">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">124</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">125</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">78</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="792911798404302156" datatype="html">
@@ -527,7 +521,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="4578192247039196794" datatype="html">
         <source>Task</source><target state="translated">Tâche</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">110</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
         <source>A new task which users can try to solve.</source><target state="translated">Une nouvelle tâche que les utilisateurs pourront tenter de résoudre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="8317457230285174180" datatype="html">
@@ -551,7 +545,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">29</context></context-group></trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">109</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">127</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -581,20 +575,14 @@
         </context-group>
       </trans-unit><trans-unit id="1125515177419706232" datatype="html">
         <source>Maformed url: "<x id="PH" equiv-text="url"/>"</source><target state="new">Maformed url: "<x id="PH" equiv-text="url"/>"</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context>
-          <context context-type="linenumber">91</context>
-        </context-group>
-      </trans-unit><trans-unit id="7800096150276874726" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="7800096150276874726" datatype="html">
         <source>Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</source><target state="new">Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context>
-          <context context-type="linenumber">94</context>
-        </context-group>
-      </trans-unit><trans-unit id="4370087843628009533" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="4370087843628009533" datatype="html">
         <source>Invalid url, please provide a secure task url (https)</source><target state="new">Invalid url, please provide a secure task url (https)</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="5402924068010392760" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="5402924068010392760" datatype="html">
         <source>Join the group "<x id="PH" equiv-text="response.group.name"/>"</source><target state="translated">Rejoindre le groupe "<x id="PH" equiv-text="response.group.name"/>"</target>
 
       <source>The code does not correspond to the group attached to this page. Are you sure you want to join the group "
@@ -612,7 +600,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="2159130950882492111" datatype="html">
         <source>Cancel</source><target state="translated">Annuler</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">95</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="7798083029915432586" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">92</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="7798083029915432586" datatype="html">
         <source>You are already a member of this group.</source><target state="translated">Vous êtes déjà membre de ce groupe.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">83</context></context-group></trans-unit><trans-unit id="5339756092671133656" datatype="html">
@@ -631,7 +619,7 @@
 
         <source>Error</source><target state="translated">Erreur</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </source><target state="new"> <x id="INTERPOLATION" equiv-text="{{ item.type === 'Chapter' ? 'Only empty chapters can be deleted.' : 'Only empty skills can be deleted.' }}"/> </target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="5302971017875260731" datatype="html">
@@ -658,7 +646,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/user-removal-response-handling.ts</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="4648900870671159218" datatype="html">
         <source>Success</source><target state="translated">Réussite</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="8000159602075761978" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="8000159602075761978" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> user(s) have been removed</source><target state="translated"><x id="PH" equiv-text="result.countSuccess"/> utilisateur(s) ont été retirés du groupe</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/user-removal-response-handling.ts</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="3487804242455918485" datatype="html">
@@ -705,7 +693,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">30</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -959,13 +947,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5086832329438229437" datatype="html">
         <source> User(s) can give and revoke members access to some content </source><target state="new"> User(s) can give and revoke members access to some content </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="7308369809380680356" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="7308369809380680356" datatype="html">
         <source>Can watch members</source><target state="new">Can watch members</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">69</context></context-group></trans-unit><trans-unit id="731959018199918793" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="731959018199918793" datatype="html">
         <source> User(s) can watch the members' activity on some content </source><target state="new"> User(s) can watch the members' activity on some content </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="6674111336491636600" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">73</context></context-group></trans-unit><trans-unit id="6674111336491636600" datatype="html">
         <source>Can watch</source><target state="translated">Droit d'observation</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="1898683424750626599" datatype="html">
@@ -1121,7 +1109,7 @@
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">81</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -1135,7 +1123,7 @@
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">108</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">126</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
@@ -1362,13 +1350,13 @@
       </trans-unit><trans-unit id="7838784407251919653" datatype="html">
         <source>Management level</source><target state="new">Management level</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="367178788667281065" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="367178788667281065" datatype="html">
         <source>The permissions that the user(s) has on this group</source><target state="new">The permissions that the user(s) has on this group</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="3077731577529874277" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="3077731577529874277" datatype="html">
         <source>Can grant access</source><target state="new">Can grant access</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">52</context></context-group></trans-unit><trans-unit id="1153571395259772276" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="1153571395259772276" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> group(s) have been removed</source><target state="new"><x id="PH" equiv-text="result.countSuccess"/> group(s) have been removed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/components/member-list/group-removal-response-handling.ts</context>
@@ -1604,10 +1592,16 @@
       </trans-unit><trans-unit id="4250630118662986728" datatype="html">
         <source> Advanced parameters </source><target> Paramètres avancés </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="1734171097636944073" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="9131913350495870905" datatype="html">
+        <source>Load</source><target state="new">Load</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context>
+          <context context-type="linenumber">45</context>
+        </context-group>
+      </trans-unit><trans-unit id="1734171097636944073" datatype="html">
         <source>There is no progress to report for this item.</source><target state="new">There is no progress to report for this item.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="6358863421707082858" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">69</context></context-group></trans-unit><trans-unit id="6358863421707082858" datatype="html">
         <source> You are not allowed to watch the progress of other users on this content. </source><target state="new"> You are not allowed to watch the progress of other users on this content. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context>
@@ -1638,13 +1632,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
         <source>Action</source><target state="translated">Opération</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">75</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
         <source>User</source><target state="new">User</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
         <source>Time</source><target state="translated">Date/Heure</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="1848556306631120071" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="1848556306631120071" datatype="html">
         <source>Time spent</source><target state="translated">Temps écoulé</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">8</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">74</context></context-group></trans-unit><trans-unit id="2827276519893025325" datatype="html">
@@ -1777,7 +1771,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-request/pending-request-response-handling.ts</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="5919144248317636057" datatype="html">
         <source>Partial success</source><target state="translated">Succès partiel</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="6484380298436821462" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="6484380298436821462" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> user(s) have been removed, <x id="PH_1" equiv-text="result.countRequests - result.countSuccess"/> could not be removed</source><target state="translated"><x id="PH" equiv-text="result.countSuccess"/> utilisateur(s) ont été retirés, <x id="PH_1" equiv-text="result.countRequests - result.countSuccess"/> n'ont pas pu être retiré du groupe</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/user-removal-response-handling.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="5056103486561628561" datatype="html">


### PR DESCRIPTION
## Description

Fixes #782

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

I opted to pass `answerId` as an url parameters (along with `path` and `(parent) attemptId`). This way, access to old answers is stateless.

This PR is draft because I forgot about one thing we discussed but did not write in the issue:
Considering the current answer might be overridden by former one when loading the task with, should I _in this PR_ add a mechanism to save current answer at some point, and if yes: when ?

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this chapter page](https://dev.algorea.org/branch/feat/load-former-submissions/en/#/activities/by-id/1352246428241737349;path=4702;attempId=0/details/progress/history)
  3. And I click on first submission load link
  4. Then I should be redirected to the proper task with the given answer reloaded

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this group page](https://dev.algorea.org/branch/feat/load-former-submissions/en/#/groups/by-id/4761034848060385407;path=/details)
  3. And I observe the group
  4. And I click on first item in dropdown
  5. And I navigate to progress
  6. Then I should not see load links
  7. And I exit observation mode
  8. Then it should reload list and I should see submission load links
