### PR TITLE
replace non-string values by empty string for get answer and state methods

### DIFF
--- a/src/app/modules/item/task-communication/task-proxy.ts
+++ b/src/app/modules/item/task-communication/task-proxy.ts
@@ -5,8 +5,8 @@
  * It depends on jschannel.
  */
 
-import { Observable } from 'rxjs';
-import { delay, map, retryWhen, switchMap, take } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import { catchError, delay, map, retryWhen, switchMap, take } from 'rxjs/operators';
 import { rxBuild, RxMessagingChannel } from './rxjschannel';
 import * as D from 'io-ts/Decoder';
 import {
@@ -175,7 +175,14 @@ export class Task {
     return this.chan.call({
       method: 'task.getAnswer',
       timeout: 2000
-    }).pipe(map(([ answer ]) => decode(D.string)(answer)));
+    }).pipe(
+      map(([ answer ]) => decode(D.string)(answer)),
+      catchError(error => {
+        // eslint-disable-next-line no-console
+        console.error(error);
+        return of('');
+      }),
+    );
   }
 
   reloadAnswer(answer: string): Observable<unknown> {
@@ -190,7 +197,14 @@ export class Task {
     return this.chan.call({
       method: 'task.getState',
       timeout: 2000
-    }).pipe(map(([ state ]) => decode(D.string)(state)));
+    }).pipe(
+      map(([ state ]) => decode(D.string)(state)),
+      catchError(error => {
+        // eslint-disable-next-line no-console
+        console.error(error);
+        return of('');
+      }),
+    );
   }
 
   reloadState(state: string): Observable<unknown> {

--- a/src/app/modules/item/task-communication/task-proxy.ts
+++ b/src/app/modules/item/task-communication/task-proxy.ts
@@ -177,11 +177,7 @@ export class Task {
       timeout: 2000
     }).pipe(
       map(([ answer ]) => decode(D.string)(answer)),
-      catchError(error => {
-        // eslint-disable-next-line no-console
-        console.error(error);
-        return of('');
-      }),
+      catchError(() => of('')),
     );
   }
 
@@ -199,11 +195,7 @@ export class Task {
       timeout: 2000
     }).pipe(
       map(([ state ]) => decode(D.string)(state)),
-      catchError(error => {
-        // eslint-disable-next-line no-console
-        console.error(error);
-        return of('');
-      }),
+      catchError(() => of('')),
     );
   }
 


### PR DESCRIPTION
## Description

Fixes #722 
Fixes #802

## Notes (out of scope, known isues, hints for reviewing code, ...)

The decoder already logs errors, and the task-proxy is visible in the first files of the stack trace, I considered it was enough

## Test cases

- [ ] Case 1:
  1. Given I am a new anonymous user (ie: using a private window)
  2. When I go to [this task](https://dev.algorea.org/branch/feat/handle-wrong-answer-state/en/#/activities/by-id/156925981597670916;path=4702,1352246428241737349,1070539248445908636,35415640138424232;parentAttempId=0/details)
  3. Then the task should load normally, video should not start since it's the first visit
  4. Then I see decoder errors logged in console
  5. When I reload the page
  6. Then the video should start automatically since we saved the state during first visit
