### PR TITLE
auto activate or deactivate full frame depending on item type

### DIFF
--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
@@ -38,7 +38,7 @@ export class LeftNavTreeComponent implements OnChanges {
     if (!this.data) throw new Error('Unexpected: missing data for left nav tree (navigateToParent)');
     if (!this.data.parent) throw new Error('Unexpected: missing parent when navigating to parent');
     const parent = this.data.parent;
-    parent.navigateTo(this.data.pathToElements.slice(0, -1));
+    parent.navigateTo(this.data.pathToElements.slice(0, -1), true);
   }
 
   selectNode(node: TreeNode<NavTreeElement>): void {
@@ -48,7 +48,7 @@ export class LeftNavTreeComponent implements OnChanges {
       if (!node.parent.data) throw new Error('Unexpected: missing data in parent for left nav tree (selectNode)');
       path = [ ...path, node.parent.data.id ];
     }
-    node.data?.navigateTo(path);
+    node.data?.navigateTo(path, true);
   }
 
   private typeForElement(e: NavTreeElement): string {

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -11,7 +11,7 @@ export interface NavTreeElement {
   title: string,
   hasChildren: boolean,
   children?: this[],
-  navigateTo: (path: Id[]) => void,
+  navigateTo: (path: Id[], preventFullFrame?: boolean) => void,
 
   // specific uses
   locked?: boolean, // considering 'not set' as false

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -62,7 +62,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     return {
       ...treeElement,
       title: details.title ?? '',
-      navigateTo: (): void => this.itemRouter.navigateTo(contentInfo.route),
+      navigateTo: (_path: string[], preventFullFrame = false): void => this.itemRouter.navigateTo(contentInfo.route, { preventFullFrame }),
       score: details.bestScore !== undefined && details.currentScore !== undefined && details.validated !== undefined ? {
         bestScore: details.bestScore,
         currentScore: details.bestScore,
@@ -77,8 +77,9 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
       id: child.id,
       title: child.string.title ?? '',
       hasChildren: child.hasVisibleChildren && ![ 'none', 'info' ].includes(child.permissions.canView),
-      navigateTo: (path): void => this.itemRouter.navigateTo(
-        fullItemRoute(typeCategoryOfItem(child), child.id, path, { attemptId: currentResult?.attemptId, parentAttemptId })
+      navigateTo: (path, preventFullFrame = false): void => this.itemRouter.navigateTo(
+        fullItemRoute(typeCategoryOfItem(child), child.id, path, { attemptId: currentResult?.attemptId, parentAttemptId }),
+        { preventFullFrame },
       ),
       locked: child.permissions.canView === 'info',
       score: !child.noScore && currentResult ? {
@@ -95,8 +96,9 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
         id: data.id,
         title: data.string.title ?? '',
         hasChildren: data.children.length > 0,
-        navigateTo: (path): void => this.itemRouter.navigateTo(
-          fullItemRoute(typeCategoryOfItem(data), data.id, path, { attemptId: data.attemptId })
+        navigateTo: (path, preventFullFrame = false): void => this.itemRouter.navigateTo(
+          fullItemRoute(typeCategoryOfItem(data), data.id, path, { attemptId: data.attemptId }),
+          { preventFullFrame },
         ),
         locked: data.permissions.canView === 'info'
       },

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -124,7 +124,7 @@ export class ItemByIdComponent implements OnDestroy {
         map(({ item }) => item.type),
       ).subscribe(itemType => {
         const canActivateFullFrame = itemType === 'Course' || itemType === 'Task';
-        const activateFullFrame = canActivateFullFrame && !(history.state as Record<string, unknown>).preventFullFrame;
+        const activateFullFrame = canActivateFullFrame && !(history.state as Record<string, boolean | undefined>).preventFullFrame;
         this.layoutService.toggleFullFrameContent(activateFullFrame);
       })
     );

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -20,7 +20,7 @@ import { UserSessionService } from 'src/app/shared/services/user-session.service
 import { isItemRouteError, itemRouteFromParams } from './item-route-validation';
 import { LayoutService } from 'src/app/shared/services/layout.service';
 import { readyData } from 'src/app/shared/operators/state';
-import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
+import { ensureDefined } from 'src/app/shared/helpers/null-undefined-predicates';
 
 const itemBreadcrumbCat = $localize`Items`;
 
@@ -124,9 +124,8 @@ export class ItemByIdComponent implements OnDestroy {
         distinctUntilChanged((a, b) => a.item.id === b.item.id),
         startWith(undefined),
         pairwise(),
-        filter(([ previous, current ]) => !previous || isTask(previous.item) || !current || isTask(current?.item)),
-        map(([ , current ]) => current?.item),
-        filter(isNotUndefined),
+        filter(([ previous, current ]) => (!!current && (!previous || isTask(previous.item) || isTask(current.item)))),
+        map(([ , current ]) => ensureDefined(current).item),
       ).subscribe(item => {
         const activateFullFrame = isTask(item) && !(history.state as Record<string, boolean | undefined>).preventFullFrame;
         this.layoutService.toggleFullFrameContent(activateFullFrame);

--- a/src/app/shared/helpers/item-type.ts
+++ b/src/app/shared/helpers/item-type.ts
@@ -22,4 +22,6 @@ export function isSkill(cat: ItemTypeCategory): cat is 'skill' {
   return cat === 'skill';
 }
 
-
+export function isTask(item: ItemWithType): boolean {
+  return item.type === 'Task' || item.type === 'Course';
+}

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -3,6 +3,12 @@ import { NavigationExtras, Router, UrlTree } from '@angular/router';
 import { ensureDefined } from '../helpers/null-undefined-predicates';
 import { itemCategoryFromPrefix, RawItemRoute, urlArrayForItemRoute } from './item-route';
 
+interface NavigateOptions {
+  page?: string|string[],
+  preventFullFrame?: boolean,
+  navExtras?: NavigationExtras,
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -16,8 +22,8 @@ export class ItemRouter {
    * Navigate to given item, on the path page.
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
-  navigateTo(item: RawItemRoute, options?: { page?: string|string[], navExtras?: NavigationExtras }): void {
-    void this.router.navigateByUrl(this.url(item, options?.page), options?.navExtras);
+  navigateTo(item: RawItemRoute, { page, navExtras, preventFullFrame = false }: NavigateOptions = {}): void {
+    void this.router.navigateByUrl(this.url(item, page), { ...navExtras, state: { ...navExtras?.state, preventFullFrame } });
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #729 
Closes #779 

## Notes

This PR _might_ evolve **slightly** when [this question](https://github.com/France-ioi/AlgoreaFrontend/issues/729#issuecomment-964154553) will be addressed.

Currently, I considered that courses ought to be treated just like tasks.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user (to test access to a group page :wink:)
  2. When I navigate to [this chapter](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/34689573454313988;path=4702,1352246428241737349,314613032161178344;attempId=0/details), [this skill](https://dev.algorea.org/branch/feat/task-full-frame/en/#/skills/by-id/3002;path=3000;parentAttempId=0/details) or [this group](https://dev.algorea.org/branch/feat/task-full-frame/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)
  3. Then the left nav remains expanded
- [ ] Case 2:
  1. Given I am any user
  2. When I navigate to [this task](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details) or [this course](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/837046206729127555;path=4702,1352246428241737349,314613032161178344;attempId=0/details)
  3. Then the left nav is collapsed
- [ ] Case 3:
  1. Given I am any user
  2. When I navigate to [this chapter](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/34689573454313988;path=4702,1352246428241737349,314613032161178344;attempId=0/details)
  3. And I click on first item in right content (not the left nav)
  4. Then the left nav must be collapsed
- [ ] Case 4:
  1. Given I am any user
  2. When I navigate to [this task](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I click on next item in header
  4. Then the next item must be displayed and the left nav **remains** collapsed
  5. And I click on previous item in header
  6. Then the previous item must be displayed and the left nav **remains** collapsed
  7. And I click on parent (which is a chapter) in item header
  8. Then the parent chapter must be displayed and the left must be expanded
- [ ] Case 5:
  1. Given I am any user
  2. When I navigate to [this task](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details) or [this chapter](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/34689573454313988;path=4702,1352246428241737349,314613032161178344;parentAttempId=0/details)
  3. And I expand left nav (if not expanded)
  4. And I click on "Les boucles imbriquées" **in the left nav**
  5. Then the left nav must **remain** expanded
- [ ] Case 5:
  1. Given I am any user
  2. When I navigate to [this task](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details) or [this chapter](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/34689573454313988;path=4702,1352246428241737349,314613032161178344;parentAttempId=0/details)
  3. And I expand left nav
  4. Then the left must be toggled as expected: it collapses if it was expanded and vice-versa.
- [ ] Case 6:
  1. Given I am any user
  2. I visit [this chapter](https://dev.algorea.org/branch/feat/task-full-frame/en/#/activities/by-id/34689573454313988;path=4702,1352246428241737349,314613032161178344;attempId=0/details)
  3. I manually collapse the menu
  4. I visit the parent (or non-task sibling) through the header
  5. Then the left menu stays as it was: collapsed

## No regression tests

- [ ] Case 1:
  1. Given I am any user
  2. And I navigate to [this skill](https://dev.algorea.org/branch/feat/task-full-frame/en/#/skills/by-id/3002;path=3000;attempId=0/details)
  3. And I click on a sub skill or parent skill in right content (not left nav)
  4. Then the left nav must remain expanded
- [ ] Case 2:
  1. Given I am any user
  2. And I navigate to [this skill](https://dev.algorea.org/branch/feat/task-full-frame/en/#/skills/by-id/3002;path=3000;attempId=0/details)
  3. And I navigate using header with parent/prev/next buttons
  4. Then the left nav must remain expanded
- [ ] Case 3:
  1. Given I am the usual user
  2. And I navigate to [this group](https://dev.algorea.org/branch/feat/task-full-frame/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)
  3. And I navigate using left nav or header buttons
  4. Then left nav must remain expanded
