### PR TITLE
save task state & answer at regular interval

### DIFF
--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -60,7 +60,7 @@ export class ItemTaskAnswerService implements OnDestroy {
   readonly saveAnswerAndStateInterval$ = this.task$.pipe(
     delayWhen(() => combineLatest([ this.initializedTaskState$, this.initializedTaskAnswer$ ])),
     switchMap(task => forkJoin({ answer: task.getAnswer(), state: task.getState() })),
-    switchMap(({ answer, state }) => this.saveAnswerAndStateInterval(answer, state)),
+    switchMap(saved => this.saveAnswerAndStateInterval(saved.answer, saved.state)),
     shareReplay(1),
   );
 
@@ -121,7 +121,7 @@ export class ItemTaskAnswerService implements OnDestroy {
       switchMap(task => forkJoin({ answer: task.getAnswer(), state: task.getState() })),
       startWith({ answer: savedAnswer, state: savedState }), // start with saved answer & state to keep only changed answer & state
       distinctUntilChanged((a, b) => a.answer === b.answer && a.state === b.state),
-      skip(1), // skip currently saved answer & state ...
+      skip(1), // skip currently saved answer & state tuple ...
       take(1), // ... and take next unsaved one
       withLatestFrom(this.config$),
       switchMap(([{ answer, state }, { route, attemptId }]) =>

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -13,6 +13,7 @@ import {
   switchMapTo,
   take,
   takeUntil,
+  tap,
   withLatestFrom,
 } from 'rxjs/operators';
 import { SECONDS } from 'src/app/shared/helpers/duration';
@@ -151,10 +152,8 @@ export class ItemTaskAnswerService implements OnDestroy {
       withLatestFrom(this.config$),
       switchMap(([{ answer, state }, { route, attemptId }]) =>
         this.currentAnswerService.update(route.id, attemptId, { answer, state }).pipe(
-          map(() => {
-            Object.assign(saved, { answer, state });
-            return { success: true };
-          }),
+          tap(() => Object.assign(saved, { answer, state })),
+          map(() => ({ success: true })),
           catchError(() => of({ success: false })),
         )
       ),


### PR DESCRIPTION
## Description

Fixes #776

## Notes

...

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I navigate to [this task](https://dev.algorea.org/branch/feat/save-task-interval/en/#/activities/by-id/4080996542681828;path=4702,1352246428241737349,314613032161178344,310572474623192846;attempId=0/details)
  3. And I open developers tools on network tab
  4. And I throttle the network connection to slow it down (:bulb: to make the request exceed 5s, I created a profile with `download: 3kbit/s` and `latency: 1000ms`)
  5.  And I type code in the editor
  6. Then I must see requests every 5 seconds _after_ previous request ended, and requests lasting more than 5 seconds should not be cancelled
  :warning: Request non-cancellation cannot be tested on branch app because there is a timeout cancelling xhr requests after 3s. It can be tested locally: change `DEFAULT_TIMEOUT` value to >5s (ie: 10s) in app module providers OR lower the value of answer and state interval in item-task-answer service
