### PR TITLE
Respond to `scrollTop` in `updateDisplay`

### DIFF
--- a/src/app/modules/item/services/item-task-init.service.ts
+++ b/src/app/modules/item/services/item-task-init.service.ts
@@ -23,6 +23,7 @@ export class ItemTaskInitService implements OnDestroy {
   private configFromIframe$ = new ReplaySubject<{ iframe: HTMLIFrameElement, bindPlatform(task: Task): void }>(1);
 
   readonly config$ = this.configFromItem$.asObservable();
+  readonly iframe$ = this.configFromIframe$.pipe(map(config => config.iframe));
   readonly taskToken$: Observable<TaskToken> = this.config$.pipe(
     switchMap(({ attemptId, route }) => this.taskTokenService.generate(route.id, attemptId)),
     shareReplay(1),

--- a/src/app/modules/item/services/item-task-views.service.ts
+++ b/src/app/modules/item/services/item-task-views.service.ts
@@ -32,6 +32,13 @@ export class ItemTaskViewsService implements OnDestroy {
 
   private subscriptions = [
     this.showViews$.subscribe({ error: err => this.errorSubject.next(err) }),
+    combineLatest([
+      this.initService.iframe$,
+      this.display$.pipe(map(display => display.scrollTop), filter(isNotUndefined)),
+    ]).subscribe(([ iframe, scrollTopInPx ]) => {
+      const iframeTopInPx = iframe.getBoundingClientRect().top + globalThis.scrollY;
+      globalThis.scrollTo({ behavior: 'smooth', top: iframeTopInPx + scrollTopInPx });
+    }),
   ];
 
   constructor(


### PR DESCRIPTION
## Description

Fixes #806 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I visit [this course](https://dev.algorea.org/branch/feat/task-scroll-top/en/#/activities/by-id/837046206729127555;path=4702,1352246428241737349,314613032161178344;parentAttempId=0/details)
  3. And I click on first button "Détails et solutions"
  4. Then it should scroll automatically to corresponding section (here: "Les boucles bornées ou boucles à compteur")
  5. And I rescroll top and click on second button "Détails et solutions"
  6. Then it should scroll automatically to corresponding section (here: "Les boucles imbriquées")
  7. … the operation can be rerun for any "Détails et solution" button of course
