### PR TITLE
disable full frame when switching to group page

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, ParamMap, UrlTree } from '@angular/router';
 import { of, Subscription } from 'rxjs';
-import { distinctUntilChanged, filter, map, pairwise, startWith, switchMap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, pairwise, startWith, switchMap, take } from 'rxjs/operators';
 import { defaultAttemptId } from 'src/app/shared/helpers/attempts';
 import { appDefaultItemRoute } from 'src/app/shared/routing/item-route';
 import { errorState, fetchingState, FetchState } from 'src/app/shared/helpers/state';
@@ -136,6 +136,9 @@ export class ItemByIdComponent implements OnDestroy {
   ngOnDestroy(): void {
     this.currentContent.clear();
     this.subscriptions.forEach(s => s.unsubscribe());
+    this.layoutService.fullFrameContent$
+      .pipe(take(1), filter(Boolean)) // if layout is in full frame and we quit an item page => disable full frame
+      .subscribe(() => this.layoutService.toggleFullFrameContent(false));
   }
 
   reloadContent(): void {


### PR DESCRIPTION
## Description

Fixes #814 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this item](https://dev.algorea.org/branch/fix/full-frame-on-group-page/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I uncollapse left nav and click on groups > [group of your choice]
  4. And I go back using history
  5. Then the left menu must collapse when visiting the item page
  6. And I go forward using history
  7. Then the left menu must expand
