### PR TITLE
Feat/avoid losing task state

### DIFF
--- a/src/app/modules/item/item-routing.module.ts
+++ b/src/app/modules/item/item-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { BeforeUnloadGuard } from 'src/app/shared/guards/before-unload-guard';
 import { PendingChangesGuard } from 'src/app/shared/guards/pending-changes-guard';
 import { ItemByIdComponent } from './pages/item-by-id/item-by-id.component';
 import { ItemDetailsComponent } from './pages/item-details/item-details.component';
@@ -15,6 +16,7 @@ import { ItemEditComponent } from './pages/item-edit/item-edit.component';
         {
           path: 'details',
           component: ItemDetailsComponent,
+          canDeactivate: [ BeforeUnloadGuard ],
           // Children below do not use routing but there are defined here so that the router can validate the route exists
           children: [
             { path: '', pathMatch: 'full', },

--- a/src/app/modules/item/item.module.ts
+++ b/src/app/modules/item/item.module.ts
@@ -36,6 +36,7 @@ import { UserProgressDetailsComponent } from './components/user-progress-details
 import { PropagationEditMenuComponent } from './components/propagation-edit-menu/propagation-edit-menu.component';
 import { ItemDisplayComponent } from './pages/item-display/item-display.component';
 import { ItemRemoveButtonComponent } from './components/item-remove-button/item-remove-button.component';
+import { BeforeUnloadGuard } from 'src/app/shared/guards/before-unload-guard';
 
 @NgModule({
   declarations: [
@@ -83,6 +84,7 @@ import { ItemRemoveButtonComponent } from './components/item-remove-button/item-
   exports: [],
   providers: [
     PendingChangesGuard,
+    BeforeUnloadGuard,
   ]
 })
 export class ItemModule { }

--- a/src/app/modules/item/pages/item-content/item-content.component.ts
+++ b/src/app/modules/item/pages/item-content/item-content.component.ts
@@ -1,7 +1,7 @@
-import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
 import { ItemData } from '../../services/item-datasource.service';
 import { ConfigureTaskOptions } from '../../services/item-task.service';
-import { TaskTab } from '../item-display/item-display.component';
+import { ItemDisplayComponent, TaskTab } from '../item-display/item-display.component';
 
 @Component({
   selector: 'alg-item-content',
@@ -9,6 +9,7 @@ import { TaskTab } from '../item-display/item-display.component';
   styleUrls: [ './item-content.component.scss' ]
 })
 export class ItemContentComponent implements OnChanges {
+  @ViewChild(ItemDisplayComponent) itemDisplayComponent?: ItemDisplayComponent;
 
   @Input() itemData?: ItemData;
   @Input() taskView?: TaskTab['view'];

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -64,6 +64,7 @@
         [itemData]="itemData"
         [enableLoadSubmission]="(enableLoadSubmission$ | async) ?? false"
         [savingAnswer]="savingAnswer"
+        (skipSave)="skipBeforeUnload()"
       ></alg-item-progress>
     </div>
 

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -63,6 +63,7 @@
         *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive"
         [itemData]="itemData"
         [enableLoadSubmission]="(enableLoadSubmission$ | async) ?? false"
+        [savingAnswer]="savingAnswer"
       ></alg-item-progress>
     </div>
 

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -42,8 +42,11 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   })));
 
   readonly enableLoadSubmission$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Normal));
-  savingAnswer = false;
 
+  // When navigating elsewhere but the current answer is unsaved, navigation is blocked until the save is performed.
+  // savingAnswer indicates the loading state while blocking navigation because of the save request.
+  savingAnswer = false;
+  // Any value emitted in skipBeforeUnload$ resumes navigation WITHOUT cancelling the save request.
   private skipBeforeUnload$ = new Subject<void>();
 
   private subscriptions = [

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -8,9 +8,10 @@ import { RouterLinkActive } from '@angular/router';
 import { TaskTab } from '../item-display/item-display.component';
 import { Mode, ModeService } from 'src/app/shared/services/mode.service';
 import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { catchError, map, mapTo } from 'rxjs/operators';
 import { ConfigureTaskOptions } from '../../services/item-task.service';
 import { BeforeUnloadComponent } from 'src/app/shared/guards/before-unload-guard';
+import { ItemContentComponent } from '../item-content/item-content.component';
 
 @Component({
   selector: 'alg-item-details',
@@ -19,6 +20,7 @@ import { BeforeUnloadComponent } from 'src/app/shared/guards/before-unload-guard
 })
 export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   @ViewChild('progressTab') progressTab?: RouterLinkActive;
+  @ViewChild(ItemContentComponent) itemContentComponent?: ItemContentComponent;
 
   itemData$ = this.itemDataSource.state$;
 
@@ -73,7 +75,8 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   }
 
   beforeUnload(): Observable<boolean> {
-    return of(false);
+    if (!this.itemContentComponent?.itemDisplayComponent) return of(false);
+    return this.itemContentComponent.itemDisplayComponent.saveAnswerAndState().pipe(mapTo(true), catchError(() => of(false)));
   }
 
 }

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -7,16 +7,17 @@ import { LayoutService } from '../../../../shared/services/layout.service';
 import { RouterLinkActive } from '@angular/router';
 import { TaskTab } from '../item-display/item-display.component';
 import { Mode, ModeService } from 'src/app/shared/services/mode.service';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ConfigureTaskOptions } from '../../services/item-task.service';
+import { BeforeUnloadComponent } from 'src/app/shared/guards/before-unload-guard';
 
 @Component({
   selector: 'alg-item-details',
   templateUrl: './item-details.component.html',
   styleUrls: [ './item-details.component.scss' ],
 })
-export class ItemDetailsComponent implements OnDestroy {
+export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   @ViewChild('progressTab') progressTab?: RouterLinkActive;
 
   itemData$ = this.itemDataSource.state$;
@@ -69,6 +70,10 @@ export class ItemDetailsComponent implements OnDestroy {
 
   setTaskTabActive(tab: TaskTab): void {
     this.taskView = tab.view;
+  }
+
+  beforeUnload(): Observable<boolean> {
+    return of(false);
   }
 
 }

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -34,6 +34,7 @@
       <p class="saving-answer-message">
         <span i18n>Saving answer...</span>
         <alg-loading size="medium"></alg-loading>
+        <p-button type="button" (click)="skipSave()" i18n-label label="Skip"></p-button>
       </p>
     </div>
     <iframe *ngIf="iframeSrc$ | async as iframeSrc" [style.height.px]="iframeHeight$ | async" #iframe [src]="iframeSrc"></iframe>

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -30,6 +30,12 @@
     </ng-container>
   </div>
   <div class="iframe-container" [style.height.px]="iframeHeight$ | async" *ngIf="!state.isError">
+    <div class="saving-answer" *ngIf="savingAnswerAndState">
+      <p class="saving-answer-message">
+        <span i18n>Saving answer...</span>
+        <alg-loading size="medium"></alg-loading>
+      </p>
+    </div>
     <iframe *ngIf="iframeSrc$ | async as iframeSrc" [style.height.px]="iframeHeight$ | async" #iframe [src]="iframeSrc"></iframe>
     <div *ngIf="state.isFetching" class="loading">
       <alg-loading></alg-loading>

--- a/src/app/modules/item/pages/item-display/item-display.component.scss
+++ b/src/app/modules/item/pages/item-display/item-display.component.scss
@@ -30,6 +30,7 @@
   .saving-answer {
     background-color: rgba(74,74,74,.7);
     position: absolute;
+    z-index: 10;
     top: 0;
     left: 0;
     height: 100%;
@@ -42,7 +43,7 @@
     padding: 0.5rem 2rem;
     background: $base-bk-color;
     border-radius: $border-radius;
-    font-size: 2em;
+    font-size: 1.25em;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/app/modules/item/pages/item-display/item-display.component.scss
+++ b/src/app/modules/item/pages/item-display/item-display.component.scss
@@ -39,7 +39,7 @@
   .saving-answer-message {
     margin: 0;
     margin-top: 5rem;
-    padding: 0.5rem;
+    padding: 0.5rem 2rem;
     background: $base-bk-color;
     border-radius: $border-radius;
     font-size: 2em;

--- a/src/app/modules/item/pages/item-display/item-display.component.scss
+++ b/src/app/modules/item/pages/item-display/item-display.component.scss
@@ -1,4 +1,5 @@
 @import 'src/colors.scss';
+@import 'src/geometry.scss';
 
 :host {
   .item-display {
@@ -25,6 +26,26 @@
     font-size: 2em;
     opacity: 0.9;
     z-index: 10;
+  }
+  .saving-answer {
+    background-color: rgba(74,74,74,.7);
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    text-align: center;
+  }
+  .saving-answer-message {
+    margin: 0;
+    margin-top: 5rem;
+    padding: 0.5rem;
+    background: $base-bk-color;
+    border-radius: $border-radius;
+    font-size: 2em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 
   iframe {

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -73,6 +73,8 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
     this.taskService.display$.pipe(map(({ height }) => height), filter(isNotUndefined)),
   ).pipe(map(height => height + additionalHeightToPreventInnerScrollIssues), startWith(initialHeight));
 
+  savingAnswerAndState = false;
+
   private subscription?: Subscription;
 
   constructor(
@@ -128,7 +130,10 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   saveAnswerAndState(): Observable<void> {
     this.subscription?.unsubscribe();
     this.subscription = undefined;
-    return this.taskService.saveAnswerAndState();
+    const save$ = this.taskService.saveAnswerAndState();
+    this.savingAnswerAndState = true;
+    save$.subscribe(() => this.savingAnswerAndState = false);
+    return save$;
   }
 
   private getTabNameByView(view: string): string {

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -126,6 +126,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
 
   ngOnDestroy(): void {
     if (this.actionFeedbackService.hasFeedback) this.actionFeedbackService.clear();
+    this.subscription?.unsubscribe();
   }
 
   saveAnswerAndState(): Observable<{ saving: boolean }> {

--- a/src/app/modules/item/pages/item-progress/item-progress.component.html
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.html
@@ -46,7 +46,15 @@
         </div>
       </div>
 
-      <div>
+      <div class="container">
+        <div *ngIf="savingAnswer" class="save-answer-loader">
+          <p class="save-answer-loader-message">
+            <span i18n>Saving answer before loading submission...</span>
+            <alg-loading size="medium"></alg-loading>
+            <p-button type="button" (click)="skipSave.emit()" i18n-label label="Skip"></p-button>
+          </p>
+        </div>
+
         <alg-item-log-view
           *ngIf="!!historyTab?.isActive"
           [itemData]="itemData"

--- a/src/app/modules/item/pages/item-progress/item-progress.component.scss
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.scss
@@ -19,3 +19,28 @@
 .not-allow-caption {
   margin: 0;
 }
+
+.container {
+  position: relative;
+}
+.save-answer-loader {
+  background-color: rgba(74,74,74,.7);
+  position: absolute;
+  z-index: 10;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  text-align: center;
+}
+.save-answer-loader-message {
+  margin: 0;
+  margin-top: 5rem;
+  padding: 0.5rem 2rem;
+  background: $base-bk-color;
+  border-radius: $border-radius;
+  font-size: 1.25em;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/app/modules/item/pages/item-progress/item-progress.component.ts
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { ItemData } from '../../services/item-datasource.service';
 import { RouterLinkActive } from '@angular/router';
@@ -13,6 +13,9 @@ export class ItemProgressComponent implements OnChanges {
 
   @Input() itemData?: ItemData;
   @Input() enableLoadSubmission = false;
+  @Input() savingAnswer = false;
+
+  @Output() skipSave = new EventEmitter<void>();
 
   @ViewChild('historyTab') historyTab?: RouterLinkActive;
   @ViewChild('chapterGroupProgressTab') chapterGroupProgressTab?: RouterLinkActive;

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -24,7 +24,7 @@ import { GetAnswerService } from '../http-services/get-answer.service';
 import { GradeService } from '../http-services/grade.service';
 import { ItemTaskInitService } from './item-task-init.service';
 
-const answerAndStateSaveInterval = 1*SECONDS;
+const answerAndStateSaveInterval = (): number => ((window as unknown as Record<string, number>).__DELAY ?? 1)*SECONDS;
 const loadAnswerError = new Error('load answer forbidden');
 
 @Injectable()
@@ -81,7 +81,7 @@ export class ItemTaskAnswerService implements OnDestroy {
 
   private savedAnswerAndStateInterval$ = this.task$.pipe(
     delayWhen(() => combineLatest([ this.initializedTaskState$, this.initializedTaskAnswer$ ])),
-    repeatLatestWhen(interval(answerAndStateSaveInterval).pipe(takeUntil(this.destroyed$))),
+    repeatLatestWhen(interval(answerAndStateSaveInterval()).pipe(takeUntil(this.destroyed$))),
     switchMap(task => forkJoin({ answer: task.getAnswer(), state: task.getState() })),
     distinctUntilChanged((a, b) => a.answer === b.answer && a.state === b.state),
     skip(1), // avoid saving an answer right after fetching it

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -5,6 +5,7 @@ import {
   delayWhen,
   distinctUntilChanged,
   filter,
+  map,
   mapTo,
   shareReplay,
   skip,
@@ -100,9 +101,9 @@ export class ItemTaskAnswerService implements OnDestroy {
       switchMap(task => forkJoin({ answer: task.getAnswer(), state: task.getState() })),
       withLatestFrom(this.config$),
       switchMap(([ body, { route, attemptId }]) => this.currentAnswerService.update(route.id, attemptId, body).pipe(mapTo(body))),
-      shareReplay(1),
     ),
-  );
+    this.initialAnswer$.pipe(map(initial => (initial ? { answer: initial.answer, state: initial.state } : undefined))),
+  ).pipe(shareReplay(1));
   readonly saveAnswerAndStateInterval$ = this.savedAnswerAndStateInterval$.pipe(
     mapTo({ success: true }),
     catchError(() => of({ success: false })),

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -113,7 +113,6 @@ export class ItemTaskAnswerService implements OnDestroy {
   private subscriptions = [
     this.initializedTaskAnswer$.subscribe({ error: err => this.errorSubject.next(err) }),
     this.initializedTaskState$.subscribe({ error: err => this.errorSubject.next(err) }),
-    this.savedAnswerAndState$.subscribe({ error: err => this.errorSubject.next(err) }),
   ];
 
   constructor(

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -24,7 +24,7 @@ import { GetAnswerService } from '../http-services/get-answer.service';
 import { GradeService } from '../http-services/grade.service';
 import { ItemTaskInitService } from './item-task-init.service';
 
-const answerAndStateSaveInterval = 10*SECONDS;
+const answerAndStateSaveInterval = 1*SECONDS;
 const loadAnswerError = new Error('load answer forbidden');
 
 @Injectable()

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -125,7 +125,6 @@ export class ItemTaskAnswerService implements OnDestroy {
       if (savedOrError instanceof Error) this.saveError$.next(savedOrError);
       else this.saved$.next(savedOrError);
     }),
-    this.saved$.subscribe(saved => console.info('saved', saved)),
   ];
 
   constructor(

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -76,6 +76,10 @@ export class ItemTaskService {
     this.viewsService.showView(view);
   }
 
+  saveAnswerAndState(): Observable<void> {
+    return this.answerService.saveAnswerAndState();
+  }
+
   private bindPlatform(task: Task): void {
     if (!this.attemptId) throw new Error('attemptId must be defined. The "configure" method has probably not been called as expected');
     // attempt id can be used as a seed as these are currently assigned incrementally by participant id

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -76,7 +76,7 @@ export class ItemTaskService {
     this.viewsService.showView(view);
   }
 
-  saveAnswerAndState(): Observable<void> {
+  saveAnswerAndState(): Observable<{ saving: boolean }> {
     return this.answerService.saveAnswerAndState();
   }
 

--- a/src/app/shared/guards/before-unload-guard.ts
+++ b/src/app/shared/guards/before-unload-guard.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanDeactivate, RouterStateSnapshot } from '@angular/router';
+import { Observable } from 'rxjs';
+
+export interface BeforeUnloadComponent {
+  /**
+   * Whether this component has pending changes
+   */
+  beforeUnload(): Observable<boolean>,
+}
+
+@Injectable()
+export class BeforeUnloadGuard implements CanDeactivate<BeforeUnloadComponent> {
+
+  constructor() {}
+
+  canDeactivate(
+    component: BeforeUnloadComponent,
+    _currentRoute: ActivatedRouteSnapshot,
+    _currentState: RouterStateSnapshot,
+    _nextState: RouterStateSnapshot
+  ): Observable<boolean> {
+    return component.beforeUnload();
+  }
+
+}

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -65,7 +65,7 @@
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="new">Your current access rights do not allow you to list the content of this skill.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ 'Your current access rights do not allow you to list the content of this chapter.' }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">184</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
@@ -75,7 +75,7 @@
         <source>Your current access rights do not allow you to start the activity.</source><target state="new">Your current access rights do not allow you to start the activity.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">239</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -422,22 +422,38 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="3835920457327748126" datatype="html">
         <source>An unknown error occurred. If this problem persists, please contact us.</source><target state="new">An unknown error occurred. If this problem persists, please contact us.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="5172335096273253685" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
+        <source>Saving answer...</source><target state="new">Saving answer...</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit><trans-unit id="4563965495368336177" datatype="html">
+        <source>Skip</source><target state="new">Skip</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context>
+          <context context-type="linenumber">54</context>
+        </context-group>
+      </trans-unit><trans-unit id="5172335096273253685" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet ?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">97</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
         <source>Editor</source><target state="new">Editor</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">126</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">146</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="new">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">127</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">147</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">148</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">78</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="792911798404302156" datatype="html">
@@ -521,7 +537,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="4578192247039196794" datatype="html">
         <source>Task</source><target state="translated">Tâche</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">131</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">151</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
         <source>A new task which users can try to solve.</source><target state="translated">Une nouvelle tâche que les utilisateurs pourront tenter de résoudre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="8317457230285174180" datatype="html">
@@ -545,7 +561,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">29</context></context-group></trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">130</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -561,7 +577,13 @@
         <source> Chapter view </source><target state="new"> Chapter view </target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="7069121178850359614" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5711976490580430557" datatype="html">
+        <source>Saving answer before loading submission...</source><target state="new">Saving answer before loading submission...</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit><trans-unit id="7069121178850359614" datatype="html">
         <source>Situation of <x id="PH" equiv-text="watchedGroup.name"/></source><target state="new">Situation of <x id="PH" equiv-text="watchedGroup.name"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-progress/itemProgressLabel.ts</context>
@@ -576,13 +598,13 @@
       </trans-unit><trans-unit id="1125515177419706232" datatype="html">
         <source>Maformed url: "<x id="PH" equiv-text="url"/>"</source><target state="new">Maformed url: "<x id="PH" equiv-text="url"/>"</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="7800096150276874726" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">93</context></context-group></trans-unit><trans-unit id="7800096150276874726" datatype="html">
         <source>Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</source><target state="new">Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="4370087843628009533" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="4370087843628009533" datatype="html">
         <source>Invalid url, please provide a secure task url (https)</source><target state="new">Invalid url, please provide a secure task url (https)</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="5402924068010392760" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="5402924068010392760" datatype="html">
         <source>Join the group "<x id="PH" equiv-text="response.group.name"/>"</source><target state="translated">Rejoindre le groupe "<x id="PH" equiv-text="response.group.name"/>"</target>
 
       <source>The code does not correspond to the group attached to this page. Are you sure you want to join the group "
@@ -690,10 +712,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -1123,7 +1145,7 @@
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">129</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">149</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">


### PR DESCRIPTION
## Description

Fixes #710 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

Note: "any user" <=> the usual user or anonymous user visiting for the 1st time or anonymous user revisiting app.

### Internal navigation

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I navigate to sibling (via header arrows)
  4. Then the transition must be normal: no loader, no message, etc.

- [ ] Case 2:
  1. Given I am any user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I edit the task, ie: add a block
  4. And I wait for current answer to be saved (~1s should do, check out in dev tools network panel)
  5. And I navigate to sibling (via header arrows)
  6. Then the transition must be normal: no loader, no message, etc.

- [ ] Case 3:
  1. Given I am any user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I arbitrarily delay save interval to an hour using JS console :arrow_right: `window.taskSaveIntervalInSec = 60 * 60` (1 hour)
  4. And I navigate to sibling task (so that the delay change is taken into account)
  5. And I edit the task, ie: add a block
  6. And I throttle network to very slow connection using network panel
  7. And I navigate to sibling (via header arrows)
  8. Then navigation is blocked, displaying message "Saving answer..."
  9. And I click on "Skip" button
  10. Then navigation is resumed

- [ ] Case 4:
  1. Given I am usual user or a user with former submissions
  2. When I visit [this task progress](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details/progress/history)
  3. And I load former submission
  4. Then page is deactivated normally

- [ ] Case 5:
  1. Given I am usual user or a user with former submissions
  2. When I visit [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I navigate to progress tab
  4. And I load former submission
  5. Then page is deactivated normally

- [ ] Case 6:
  1. Given I am usual user or a user with former submissions
  2. When I visit [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I edit task, ie: add a block
  4. And I wait for the current answer to be saved (~1s, check network panel)
  5. And I navigate to progress tab
  6. And I load former submission
  7. Then page is deactivated normally

- [ ] Case 7:
  1. Given I am usual user or a user with former submissions
  2. When I visit [this task progress](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details/progress/history)
  3. And I arbitrarily delay save interval to an hour using JS console :arrow_right: `window.taskSaveIntervalInSec = 60 * 60` (1 hour)
  4. And I navigate to content tab
  5. And I edit task, ie: add a block
  6. And I navigate to progress tab
  7. And I throttle network (to see clearly what's happening)
  8. And I load former submission
  9. Then I get a message "Saving answer before loading submission" with a skip button
  10. And I click the "Skip" button
  11. Then navigation is resumed

### External navigation

- [ ] Case 1:
  1. Given I am the usual user OR anonymous user **visiting for the 1st time**
  2. When I go to [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I navigate to [another website (github)](https://github.com)
  4. Then the transition must be normal: no loader, no message, no network request

- [ ] Case 2:
  1. Given I am any user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I edit the task, ie: add a block
  4. And I wait for current answer to be saved (~1s should do, check out in dev tools network panel)
  5. And I navigate to another website, ie: [github](https://github.com)
  6. Then the transition must be normal: no loader, no message, no network request

- [ ] Case 3:
  1. Given I am any user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I arbitrarily delay save interval to an hour using JS console :arrow_right: `window.taskSaveIntervalInSec = 60 * 60` (1 hour)
  4. And I navigate to sibling task (so that the delay change is taken into account)
  5. And I edit the task, ie: add a block
  6. And I preserve logs in network panel
  7. And I navigate to another website, ie: [github](https://github.com)
  8. Then until the other website is loaded, I see a message "Saving answer..."
NOTE: For this case 3, you can also throttle you connection to a very bad one, it works the same and it allows to see clearly the page transitions

- [ ] Case 4:
  1. Given I am usual user or a user with former submissions
  2. When I visit [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I navigate to progress tab
  4. And I navigate to another website, ie: [github](https://github.com)
  5. Then page is unloaded normally

- [ ] Case 6:
  1. Given I am usual user or a user with former submissions
  2. When I visit [this task](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details)
  3. And I edit task, ie: add a block
  4. And I wait for the current answer to be saved (~1s, check network panel)
  5. And I navigate to progress tab
  6. And I navigate to another website, ie: [github](https://github.com)
  7. Then page is unloaded normally

- [ ] Case 7:
  1. Given I am usual user or a user with former submissions
  2. When I visit [this task progress](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details/progress/history)
  3. And I arbitrarily delay save interval to an hour using JS console :arrow_right: `window.taskSaveIntervalInSec = 60 * 60` (1 hour)
  4. And I navigate to content tab
  5. And I edit task, ie: add a block
  6. And I navigate to progress tab
  7. And I throttle network (to see clearly what's happening)
  8. And I navigate to another website, ie: [github](https://github.com)
  9. Then until the navigation occurs, I get a message "Saving answer before loading submission"

## Irregularities that might need discussion

### 1. Saving before navigating to external website + "Skip" button

In that case, the "Skip" button has no effect, but even with slow connections I think the ux is OK. This PR is already very complex to test, avoiding to add that "display skip button" condition is a fair compromise in my opinion.

### 2. Unexpected deactivation behavior for task loaded with a former submission
Steps to reproduce:
1. As usual user, navigate to [this task progress](https://dev.algorea.org/branch/feat/avoid-losing-task-state/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;attempId=0/details/progress/history)
2. Load first submission you see
3. Without changing anything, navigate elsewhere on the platform (ie: the sibling task)
4. A save occurs but we did nothing :shrug: 

This specific case will be handled in another PR addressing the issue #813 
