### PR TITLE
Feat/submission save current answer

### DIFF
--- a/src/app/modules/item/http-services/answer.service.ts
+++ b/src/app/modules/item/http-services/answer.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { appConfig } from 'src/app/shared/helpers/config';
+import { assertSuccess, SimpleActionResponse } from 'src/app/shared/http-services/action-response';
+
+export interface SaveAnswerPayload {
+  answer: string,
+  state: string,
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AnswerService {
+
+  constructor(private http: HttpClient) {}
+
+  save(itemId: string, attemptId: string, payload: SaveAnswerPayload): Observable<void> {
+    return this.http
+      .post<SimpleActionResponse>(`${appConfig.apiUrl}/items/${itemId}/attempts/${attemptId}/answers`, payload)
+      .pipe(map(assertSuccess));
+  }
+
+}

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -58,7 +58,8 @@ export class ItemByIdComponent implements OnDestroy {
 
     // on route change or user change: refetch item if needed
     this.activatedRoute.paramMap.pipe(
-      repeatLatestWhen(this.userSessionService.userChanged$)
+      repeatLatestWhen(this.userSessionService.userChanged$),
+      filter(() => !(history.state as Record<string, boolean>).preventRefetch),
     ).subscribe(params => this.fetchItemAtRoute(params)),
 
     this.subscriptions.push(
@@ -161,6 +162,15 @@ export class ItemByIdComponent implements OnDestroy {
     this.currentContent.replace(itemInfo({ route: item, breadcrumbs: { category: itemBreadcrumbCat, path: [], currentPageIdx: -1 } }));
     // trigger the fetch of the item (which will itself re-update the current content)
     this.itemDataSource.fetchItem(item);
+    if (item.answerId) {
+      this.itemRouter.navigateTo(
+        { ...item, answerId: undefined },
+        {
+          preventFullFrame: (history.state as Record<string, boolean>).preventFullFrame,
+          navExtras: { replaceUrl: true, state: { preventRefetch: true } },
+        },
+      );
+    }
   }
 
   /**

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -56,6 +56,9 @@ export class ItemByIdComponent implements OnDestroy {
     // on route change or user change: refetch item if needed
     this.activatedRoute.paramMap.pipe(
       repeatLatestWhen(this.userSessionService.userChanged$),
+      // When loading a task with a former answerId, we need to remove the answerId from the url to avoid reloading
+      // a former answer if the user refreshes the page
+      // However, replacing the url should not retrigger an item fetch either, thus the use of history.state.preventRefetch
       filter(() => !(history.state as Record<string, boolean>).preventRefetch),
     ).subscribe(params => this.fetchItemAtRoute(params)),
 

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -56,7 +56,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   initError$ = this.taskService.initError$;
   urlError$ = this.taskService.urlError$;
   answerFallbackLink$ = this.taskService.loadAnswerByIdError$.pipe(
-    map(() => urlArrayForItemRoute({ ...this.route, answerId: undefined })),
+    map(() => urlArrayForItemRoute({ ...this.route, attemptId: undefined, parentAttemptId: undefined, answerId: undefined })),
   );
   unknownError$ = this.taskService.unknownError$;
   iframeSrc$ = this.taskService.iframeSrc$.pipe(map(url => this.sanitizer.bypassSecurityTrustResourceUrl(url)));

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -41,7 +41,7 @@
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
-                <ng-container *ngIf="enableLoadSubmission && rowData.activityType === 'submission' && rowData.answerId">
+                <ng-container *ngIf="enableLoadSubmission && [ 'submission', 'saved_answer' ].includes(rowData.activityType) && rowData.answerId">
                   &nbsp;(<a class="alg-link" [routerLink]="rowData.item | rawItemLink:'details':rowData.answerId" i18n>Load</a>)
                 </ng-container>
               </ng-container>

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -64,7 +64,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy {
     return this.activityLogService.getActivityLog(item.id, watchingGroup?.route.id).pipe(
       map((data: ActivityLog[]) => ({
         columns: this.getLogColumns(item.type, watchingGroup),
-        rowData: data
+        rowData: data.filter(activity => activity.activityType !== 'current_answer'),
       }))
     );
   }

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -2,6 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { combineLatest, EMPTY, forkJoin, interval, merge, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import {
   catchError,
+  defaultIfEmpty,
   delayWhen,
   distinctUntilChanged,
   filter,
@@ -17,8 +18,10 @@ import {
 } from 'rxjs/operators';
 import { SECONDS } from 'src/app/shared/helpers/duration';
 import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
+import { isNotNull } from 'src/app/shared/helpers/null-undefined-predicates';
 import { repeatLatestWhen } from 'src/app/shared/helpers/repeatLatestWhen';
 import { AnswerTokenService } from '../http-services/answer-token.service';
+import { AnswerService } from '../http-services/answer.service';
 import { Answer, CurrentAnswerService } from '../http-services/current-answer.service';
 import { GetAnswerService } from '../http-services/get-answer.service';
 import { GradeService } from '../http-services/grade.service';
@@ -48,14 +51,7 @@ export class ItemTaskAnswerService implements OnDestroy {
   private initialAnswer$: Observable<Answer | null> = this.config$.pipe(
     switchMap(({ route, attemptId, shouldLoadAnswer }) => {
       if (!shouldLoadAnswer) return of(null);
-      if (route.answerId) {
-        return this.getAnswerService.get(route.answerId).pipe(
-          catchError(error => {
-            if (errorIsHTTPForbidden(error)) throw loadAnswerError;
-            throw error;
-          }),
-        );
-      }
+      if (route.answerId) return this.loadFormerAnswer(route.id, attemptId, route.answerId);
 
       return this.currentAnswerService.get(route.id, attemptId).pipe(
         catchError(error => {
@@ -130,6 +126,7 @@ export class ItemTaskAnswerService implements OnDestroy {
   constructor(
     private taskInitService: ItemTaskInitService,
     private currentAnswerService: CurrentAnswerService,
+    private answerService: AnswerService,
     private answerTokenService: AnswerTokenService,
     private gradeService: GradeService,
     private getAnswerService: GetAnswerService,
@@ -206,6 +203,33 @@ export class ItemTaskAnswerService implements OnDestroy {
         );
       }),
       shareReplay(1),
+    );
+  }
+
+  private loadFormerAnswer(itemId: string, attemptId: string, answerId: string): Observable<Answer | null> {
+    const saveCurrent$ = this.currentAnswerService.get(itemId, attemptId).pipe(
+      catchError(error => {
+        // currently, the backend returns a 403 status when no current answer exist for user+item+attempt
+        if (errorIsHTTPForbidden(error)) return of(null);
+        throw error;
+      }),
+      filter(isNotNull),
+      switchMap(current => this.answerService.save(itemId, attemptId, { answer: current.answer ?? '', state: current.state ?? '' })),
+      defaultIfEmpty(undefined),
+    );
+
+    const former$ = this.getAnswerService.get(answerId).pipe(
+      catchError(error => {
+        if (errorIsHTTPForbidden(error)) throw loadAnswerError;
+        throw error;
+      }),
+    );
+    return combineLatest([ former$, saveCurrent$ ]).pipe(
+      switchMap(([ former ]) => {
+        if (!former) return of(null);
+        const body = { answer: former.answer ?? '', state: former.state ?? '' };
+        return this.currentAnswerService.update(itemId, attemptId, body).pipe(mapTo(former));
+      }),
     );
   }
 }

--- a/src/app/shared/http-services/activity-log.service.ts
+++ b/src/app/shared/http-services/activity-log.service.ts
@@ -9,7 +9,7 @@ import { dateDecoder } from '../helpers/decoders';
 
 const activityLogDecoder = pipe(
   D.struct({
-    activityType: D.literal('result_started', 'submission', 'result_validated'),
+    activityType: D.literal('result_started', 'submission', 'result_validated', 'saved_answer', 'current_answer'),
     at: dateDecoder,
     item: D.struct({
       id: D.string,


### PR DESCRIPTION
## Description

Fixes #813 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

After some discussions, the issue has changed a bit:
- Saving the current-answer-to-override with former answer happens at task load rather than at "Load" link click
- Because of that, acceptance criteria indicating "no save" cannot be implemented. Concerned use cases:
  - `When opening a task for the first time, if I load a previous submission without having changed anything, there is no save.`
  - `After having loaded a former submission, if I load another submission without having changed anything, there is no save.`
- [This other PR](https://github.com/France-ioi/AlgoreaFrontend/pull/818) implicitly covers 2 use cases:
  - `If I load a former submission, the (latest, not just the latest saved current-answer) change is automatically saved`
  - `If I do a change and immediately load a former submission (while the auto-save of the current state has not been done yet), the (latest!) change is automatically saved`
- As for the last acceptance criteria `Make sure the saved answers are listed in the progress list and can be loaded as well`, it relies on [this backend PR](https://github.com/France-ioi/AlgoreaBackend/pull/808)

&nbsp;

To sum up, none of the acceptance criteria are handled by this PR, what this PR covers is:
- When loading the former answer, remove in url the path parameter `answerId` to avoid reloading the former answer when refreshing the page
- When initializing the task with a former answer id,
  - fetch current answer then save it as "Saved"
  - fetch former answer then save it as "Current" (only once former current is saved as "Saved")
- Handle "Saved" and "Current" answers in activity log service, allow to load "Saved" answers

## Test cases

- [ ] Case 1: `answerId` removal from url
  1. Given I am the usual user
  2. When I go to [this task activity/progress](https://dev.algorea.org/branch/feat/submission-save-current-answer/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details/progress/history)
  3. And I load any former submission
  4. Then I see the page is loaded with an `answerId` as path parameter
  5. And I wait a bit
  6. Then I see the `answerId` path parameter has been removed

- [ ] Case 2: initializing task with former answer id
  1. Given I am a brand new user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/submission-save-current-answer/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I solve first level
  4. And I add some blocks on second level
  5. And I click on "Progress tab"
  6. (optional) And I open developer tools on network panel (throttle network to clearly see it in action)
  7. And I load the (only) former answer
  8. Then I should be redirected to the task
  9. Then 2nd level should now be empty because task should have saved former current answer (containing 2nd level changes) and load former answer as new current answer
  10. And I navigate back to progress
  11. Then I should see two answers, one "Saved" and one "Submission"
  12. And I load the saved one
  13. Then I should have the same blocks I added before loading former answer (at step 4)

## No regression tests

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this task with bad answer id in url](https://dev.algorea.org/branch/feat/submission-save-current-answer/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0;answerId=1000/details)
  3. Then I should see "Unable to load task, [link] load your most recent answer [/link]`
  4. And I click on link
  5. Then the task should be reloaded with current answer
