### PR TITLE
Feat/load other user submissions

### DIFF
--- a/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.html
+++ b/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.html
@@ -1,0 +1,11 @@
+<div class="container" *ngIf="author$ | async as author">
+  <alg-loading *ngIf="author.isFetching && !author.data" size="small"></alg-loading>
+  <alg-error *ngIf="author.isError" i18n-message message="Error while fetching author info"></alg-error>
+
+  <div class="content" *ngIf="author.isReady && author.data as author" i18n>
+    Submitted by
+    <a [routerLink]="groupLink$ | async" class="alg-link links">{{ author | userCaption }}</a>
+    on {{ answer.createdAt | date:'short' }}.
+    <span *ngIf="answer.score || answer.score === 0" class="score">Score: {{ answer.score }} points.</span>
+  </div>
+</div>

--- a/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.scss
+++ b/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.scss
@@ -1,0 +1,22 @@
+@import 'src/colors';
+@import 'src/geometry';
+
+.container {
+  display: flex;
+  flex-wrap: nowrap;
+  flex-direction: column;
+  justify-content: center;
+  color: $base-color;
+  background-color: $section-color;
+  border-radius: $border-radius;
+}
+
+.content {
+  display: flex;
+  align-items: center;
+  padding: .5rem 1rem;
+}
+
+.links, .score {
+  margin: 0 .4rem;
+}

--- a/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.scss
+++ b/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.scss
@@ -6,7 +6,7 @@
   flex-wrap: nowrap;
   flex-direction: column;
   justify-content: center;
-  color: $base-color;
+  color: $base-text-color;
   background-color: $section-color;
   border-radius: $border-radius;
 }
@@ -19,4 +19,8 @@
 
 .links, .score {
   margin: 0 .4rem;
+  color: $base-color;
+  &:hover {
+    color: $base-color-hover;
+  }
 }

--- a/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.ts
+++ b/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { ReplaySubject } from 'rxjs';
+import { map, shareReplay, switchMap } from 'rxjs/operators';
+import { GetUserService } from 'src/app/modules/group/http-services/get-user.service';
+import { mapToFetchState, readyData } from 'src/app/shared/operators/state';
+import { groupRoute } from 'src/app/shared/routing/group-route';
+import { GroupRouter } from 'src/app/shared/routing/group-router';
+import { Answer } from '../../http-services/get-answer.service';
+
+@Component({
+  selector: 'alg-answer-author-indicator[answer]',
+  templateUrl: './answer-author-indicator.component.html',
+  styleUrls: [ './answer-author-indicator.component.scss' ],
+})
+export class AnswerAuthorIndicatorComponent implements OnChanges {
+
+  @Input() answer!: Answer;
+
+  private answer$ = new ReplaySubject<Answer>(1);
+  readonly author$ = this.answer$.pipe(
+    switchMap(answer => this.getUserService.getForId(answer.authorId)),
+    mapToFetchState(),
+    shareReplay(1),
+  );
+  readonly groupLink$ = this.author$.pipe(
+    readyData(),
+    map(user => this.groupRouter.urlArray(groupRoute({ id: user.groupId, isUser: true }, [])))
+  );
+
+  constructor(
+    private groupRouter: GroupRouter,
+    private getUserService: GetUserService,
+  ) { }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.answer) this.answer$.next(this.answer);
+  }
+}

--- a/src/app/modules/item/item.module.ts
+++ b/src/app/modules/item/item.module.ts
@@ -37,6 +37,7 @@ import { PropagationEditMenuComponent } from './components/propagation-edit-menu
 import { ItemDisplayComponent } from './pages/item-display/item-display.component';
 import { ItemRemoveButtonComponent } from './components/item-remove-button/item-remove-button.component';
 import { BeforeUnloadGuard } from 'src/app/shared/guards/before-unload-guard';
+import { AnswerAuthorIndicatorComponent } from './components/answer-author-indicator/answer-author-indicator.component';
 
 @NgModule({
   declarations: [
@@ -67,6 +68,7 @@ import { BeforeUnloadGuard } from 'src/app/shared/guards/before-unload-guard';
     PropagationEditMenuComponent,
     ItemDisplayComponent,
     ItemRemoveButtonComponent,
+    AnswerAuthorIndicatorComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -15,7 +15,7 @@
         [url]="itemData.item.url"
         [attemptId]="attemptId"
         [view]="taskView"
-        [taskOptions]="taskOptions"
+        [taskConfig]="taskConfig"
         (viewChange)="taskViewChange.emit($event)"
         (tabsChange)="taskTabsChange.emit($event)"
         (scoreChange)="scoreChange.emit($event)"

--- a/src/app/modules/item/pages/item-content/item-content.component.ts
+++ b/src/app/modules/item/pages/item-content/item-content.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, Output, ViewChild } from '@angular/core';
 import { ItemData } from '../../services/item-datasource.service';
-import { ConfigureTaskOptions } from '../../services/item-task.service';
+import { TaskConfig } from '../../services/item-task.service';
 import { ItemDisplayComponent, TaskTab } from '../item-display/item-display.component';
 
 @Component({
@@ -13,7 +13,7 @@ export class ItemContentComponent implements OnChanges {
 
   @Input() itemData?: ItemData;
   @Input() taskView?: TaskTab['view'];
-  @Input() taskOptions: ConfigureTaskOptions = { readOnly: false, shouldLoadAnswer: true };
+  @Input() taskConfig: TaskConfig = { readOnly: false, formerAnswer: null };
 
   @Output() taskTabsChange = new EventEmitter<TaskTab[]>();
   @Output() taskViewChange = new EventEmitter<TaskTab['view']>();

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -48,16 +48,31 @@
       </a>
     </nav>
     <div class="bg-white">
-      <ng-container *ngIf="taskOptions$ | async as taskOptions">
-        <alg-item-content
-          *ngIf="contentTab.isActive || taskTabs.length > 0"
-          [hidden]="!contentTab.isActive"
-          [itemData]="itemData"
-          [taskOptions]="taskOptions"
-          [(taskView)]="taskView"
-          (taskTabsChange)="setTaskTabs($event)"
-          (scoreChange)="patchStateWithScore($event)"
-        ></alg-item-content>
+      <alg-error
+        *ngIf="unknownError"
+        i18n-message message="An unknown error occurred. If this problem persists, please contact us."
+      ></alg-error>
+
+      <ng-container *ngIf="contentTab.isActive || taskTabs.length > 0">
+        <alg-error *ngIf="answerFallbackLink$ | async as fallbackLink">
+          <ng-container *ngIf="(taskReadOnly$ | async); else fallback" i18n>Unable to load the answer</ng-container>
+          <ng-template #fallback>
+            <ng-container i18n>
+              Unable to load the answer, <a [routerLink]="fallbackLink" class="alg-link">load your most recent answer</a>
+            </ng-container>
+          </ng-template>
+        </alg-error>
+
+        <ng-container *ngIf="taskConfig$ | async as taskConfig">
+          <alg-item-content
+            [hidden]="!contentTab.isActive"
+            [itemData]="itemData"
+            [taskConfig]="taskConfig"
+            [(taskView)]="taskView"
+            (taskTabsChange)="setTaskTabs($event)"
+            (scoreChange)="patchStateWithScore($event)"
+          ></alg-item-content>
+        </ng-container>
       </ng-container>
       <alg-item-progress
         *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive"

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -77,7 +77,7 @@
       <alg-item-progress
         *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive"
         [itemData]="itemData"
-        [enableLoadSubmission]="(enableLoadSubmission$ | async) ?? false"
+        [isTaskReadOnly]="(taskReadOnly$ | async) ?? false"
         [savingAnswer]="savingAnswer"
         (skipSave)="skipBeforeUnload()"
       ></alg-item-progress>

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -64,7 +64,7 @@
         </alg-error>
 
         <ng-container *ngIf="taskConfig$ | async as taskConfig">
-          <div *ngIf="taskConfig.readOnly" class="indicator">
+          <div *ngIf="taskConfig.readOnly && contentTab.isActive" class="indicator">
             <alg-answer-author-indicator *ngIf="formerAnswer$ | async as answer" [answer]="answer"></alg-answer-author-indicator>
           </div>
           <alg-item-content

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -64,6 +64,9 @@
         </alg-error>
 
         <ng-container *ngIf="taskConfig$ | async as taskConfig">
+          <div *ngIf="taskConfig.readOnly" class="indicator">
+            <alg-answer-author-indicator *ngIf="formerAnswer$ | async as answer" [answer]="answer"></alg-answer-author-indicator>
+          </div>
           <alg-item-content
             [hidden]="!contentTab.isActive"
             [itemData]="itemData"

--- a/src/app/modules/item/pages/item-details/item-details.component.scss
+++ b/src/app/modules/item/pages/item-details/item-details.component.scss
@@ -1,0 +1,4 @@
+.indicator {
+  padding: 1rem;
+  margin-right: 2rem;
+}

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -2,16 +2,21 @@ import { Component, OnDestroy, ViewChild } from '@angular/core';
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { canCurrentUserViewItemContent } from '../../helpers/item-permissions';
 import { ItemDataSource } from '../../services/item-datasource.service';
-import { mapStateData } from 'src/app/shared/operators/state';
+import { mapStateData, readyData } from 'src/app/shared/operators/state';
 import { LayoutService } from '../../../../shared/services/layout.service';
 import { RouterLinkActive } from '@angular/router';
 import { TaskTab } from '../item-display/item-display.component';
 import { Mode, ModeService } from 'src/app/shared/services/mode.service';
-import { fromEvent, Observable, of, Subject } from 'rxjs';
-import { catchError, endWith, last, map, shareReplay, switchMap, take, takeUntil } from 'rxjs/operators';
-import { ConfigureTaskOptions } from '../../services/item-task.service';
+import { combineLatest, fromEvent, Observable, of, Subject } from 'rxjs';
+import { catchError, distinctUntilChanged, endWith, filter, last, map, shareReplay, switchMap, take, takeUntil } from 'rxjs/operators';
+import { TaskConfig } from '../../services/item-task.service';
 import { BeforeUnloadComponent } from 'src/app/shared/guards/before-unload-guard';
 import { ItemContentComponent } from '../item-content/item-content.component';
+import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
+import { urlArrayForItemRoute } from 'src/app/shared/routing/item-route';
+import { GetAnswerService } from '../../http-services/get-answer.service';
+
+const loadForbiddenAnswerError = new Error('load answer forbidden');
 
 @Component({
   selector: 'alg-item-details',
@@ -36,10 +41,30 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   readonly fullFrameContent$ = this.layoutService.fullFrameContent$;
   readonly watchedGroup$ = this.userService.watchedGroup$;
-  readonly taskOptions$: Observable<ConfigureTaskOptions> = this.modeService.mode$.pipe(map(mode => ({
-    readOnly: mode === Mode.Watching,
-    shouldLoadAnswer: mode === Mode.Normal,
-  })));
+
+  unknownError?: Error;
+
+  readonly formerAnswer$ = this.itemData$.pipe(
+    map(state => state.data?.route.answerId),
+    distinctUntilChanged(),
+    switchMap(answerId => (answerId ? this.getAnswerService.get(answerId) : of(null))),
+    shareReplay(1),
+  );
+
+  readonly formerAnswerError$ = this.formerAnswer$.pipe(
+    catchError(error => of(errorIsHTTPForbidden(error) ? loadForbiddenAnswerError : new Error(error))),
+    filter((error): error is Error => error instanceof Error),
+  );
+  readonly formerAnswerLoadForbidden$ = this.formerAnswerError$.pipe(filter(error => error === loadForbiddenAnswerError));
+  readonly answerFallbackLink$ = combineLatest([ this.itemData$.pipe(readyData()), this.formerAnswerLoadForbidden$ ]).pipe(
+    map(([{ route }]) => urlArrayForItemRoute({ ...route, attemptId: undefined, parentAttemptId: undefined, answerId: undefined })),
+  );
+
+  readonly taskReadOnly$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Watching));
+  readonly taskConfig$: Observable<TaskConfig> = combineLatest([
+    this.formerAnswer$,
+    this.taskReadOnly$,
+  ]).pipe(map(([ formerAnswer, readOnly ]) => ({ readOnly, formerAnswer })));
 
   readonly enableLoadSubmission$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Normal));
 
@@ -56,6 +81,9 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     fromEvent<BeforeUnloadEvent>(globalThis, 'beforeunload', { capture: true })
       .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent?.saveAnswerAndState() ?? of(undefined)), take(1))
       .subscribe(),
+    this.formerAnswerError$.subscribe(caught => {
+      if (caught !== loadForbiddenAnswerError) this.unknownError = caught;
+    }),
   ];
 
   constructor(
@@ -63,6 +91,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     private itemDataSource: ItemDataSource,
     private layoutService: LayoutService,
     private modeService: ModeService,
+    private getAnswerService: GetAnswerService,
   ) {}
 
   ngOnDestroy(): void {

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -66,8 +66,6 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     this.taskReadOnly$,
   ]).pipe(map(([ formerAnswer, readOnly ]) => ({ readOnly, formerAnswer })));
 
-  readonly enableLoadSubmission$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Normal));
-
   // When navigating elsewhere but the current answer is unsaved, navigation is blocked until the save is performed.
   // savingAnswer indicates the loading state while blocking navigation because of the save request.
   savingAnswer = false;

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -1,9 +1,5 @@
 <div class="item-display" *ngIf="state$ | async as state">
   <div *ngIf="state.isError" class="errors">
-    <alg-error *ngIf="answerFallbackLink$ | async as fallbackLink; else defaultErrorMessage" i18n>
-      Unable to load the answer, <a [routerLink]="fallbackLink">load your most recent answer</a>
-    </alg-error>
-
     <ng-template #defaultErrorMessage>
       <alg-error i18n-message message="Unable to load the task"></alg-error>
     </ng-template>

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -10,7 +10,7 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { interval, merge, Observable, Subject } from 'rxjs';
+import { EMPTY, interval, merge, Observable, Subject } from 'rxjs';
 import { endWith, filter, map, pairwise, shareReplay, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { HOURS, SECONDS } from 'src/app/shared/helpers/duration';
 import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
@@ -126,6 +126,8 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
 
   saveAnswerAndState(): Observable<{ saving: boolean }> {
     this.subscription.unsubscribe();
+    if (this.taskConfig.readOnly) return EMPTY;
+
     const save$ = this.taskService.saveAnswerAndState().pipe(
       takeUntil(this.skipSave$),
       endWith({ saving: false }),

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -14,13 +14,13 @@ import { interval, merge, Observable, Subject } from 'rxjs';
 import { endWith, filter, map, pairwise, shareReplay, startWith, switchMap, takeUntil } from 'rxjs/operators';
 import { HOURS, SECONDS } from 'src/app/shared/helpers/duration';
 import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
-import { ConfigureTaskOptions, ItemTaskService } from '../../services/item-task.service';
+import { TaskConfig, ItemTaskService } from '../../services/item-task.service';
 import { mapToFetchState } from 'src/app/shared/operators/state';
 import { capitalize } from 'src/app/shared/helpers/case_conversion';
 import { ItemTaskInitService } from '../../services/item-task-init.service';
 import { ItemTaskAnswerService } from '../../services/item-task-answer.service';
 import { ItemTaskViewsService } from '../../services/item-task-views.service';
-import { FullItemRoute, urlArrayForItemRoute } from 'src/app/shared/routing/item-route';
+import { FullItemRoute } from 'src/app/shared/routing/item-route';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PermissionsInfo } from '../../helpers/item-permissions';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
@@ -46,7 +46,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   @Input() canEdit: PermissionsInfo['canEdit'] = 'none';
   @Input() attemptId!: string;
   @Input() view?: TaskTab['view'];
-  @Input() taskOptions: ConfigureTaskOptions = { readOnly: false, shouldLoadAnswer: true };
+  @Input() taskConfig: TaskConfig = { readOnly: false, formerAnswer: null };
 
   @Output() scoreChange = this.taskService.scoreChange$;
 
@@ -55,9 +55,6 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   state$ = this.taskService.task$.pipe(mapToFetchState());
   initError$ = this.taskService.initError$;
   urlError$ = this.taskService.urlError$;
-  answerFallbackLink$ = this.taskService.loadAnswerByIdError$.pipe(
-    map(() => urlArrayForItemRoute({ ...this.route, attemptId: undefined, parentAttemptId: undefined, answerId: undefined })),
-  );
   unknownError$ = this.taskService.unknownError$;
   iframeSrc$ = this.taskService.iframeSrc$.pipe(map(url => this.sanitizer.bypassSecurityTrustResourceUrl(url)));
 
@@ -98,7 +95,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   ) {}
 
   ngOnInit(): void {
-    this.taskService.configure(this.route, this.url, this.attemptId, this.taskOptions);
+    this.taskService.configure(this.route, this.url, this.attemptId, this.taskConfig);
     this.taskService.showView(this.view ?? 'task');
   }
 

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -41,7 +41,7 @@
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
-                <ng-container *ngIf="enableLoadSubmission && [ 'submission', 'saved_answer' ].includes(rowData.activityType) && rowData.answerId">
+                <ng-container *ngIf="rowData.displayLoadButton">
                   &nbsp;(<a class="alg-link" [routerLink]="rowData.item | rawItemLink:'details':rowData.answerId" i18n>Load</a>)
                 </ng-container>
               </ng-container>

--- a/src/app/modules/item/pages/item-progress/item-progress.component.html
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.html
@@ -58,7 +58,7 @@
         <alg-item-log-view
           *ngIf="!!historyTab?.isActive"
           [itemData]="itemData"
-          [enableLoadSubmission]="enableLoadSubmission"
+          [isTaskReadOnly]="isTaskReadOnly"
         ></alg-item-log-view>
 
         <div class="chapter-group-progress">

--- a/src/app/modules/item/pages/item-progress/item-progress.component.ts
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.ts
@@ -12,7 +12,7 @@ import { ItemType } from '../../../../shared/helpers/item-type';
 export class ItemProgressComponent implements OnChanges {
 
   @Input() itemData?: ItemData;
-  @Input() enableLoadSubmission = false;
+  @Input() isTaskReadOnly = false;
   @Input() savingAnswer = false;
 
   @Output() skipSave = new EventEmitter<void>();

--- a/src/app/modules/item/services/item-task-init.service.ts
+++ b/src/app/modules/item/services/item-task-init.service.ts
@@ -4,6 +4,7 @@ import { catchError, delayWhen, filter, map, mapTo, shareReplay, switchMap, time
 import { appConfig } from 'src/app/shared/helpers/config';
 import { SECONDS } from 'src/app/shared/helpers/duration';
 import { FullItemRoute } from 'src/app/shared/routing/item-route';
+import { Answer } from '../http-services/get-answer.service';
 import { TaskTokenService, TaskToken } from '../http-services/task-token.service';
 import { Task, taskProxyFromIframe, taskUrlWithParameters } from '../task-communication/task-proxy';
 
@@ -14,7 +15,7 @@ export interface ItemTaskConfig {
   route: FullItemRoute,
   url: string,
   attemptId: string,
-  shouldLoadAnswer: boolean,
+  formerAnswer: Answer | null,
   readOnly: boolean,
 }
 
@@ -72,11 +73,11 @@ export class ItemTaskInitService implements OnDestroy {
     if (!this.configFromIframe$.closed) this.configFromIframe$.complete();
   }
 
-  configure(route: FullItemRoute, url: string, attemptId: string, shouldLoadAnswer = true, readOnly = false): void {
+  configure(route: FullItemRoute, url: string, attemptId: string, formerAnswer: Answer | null, readOnly = false): void {
     if (this.configured) throw new Error('task init service can be configured once only');
     this.configured = true;
 
-    this.configFromItem$.next({ route, url, attemptId, shouldLoadAnswer, readOnly });
+    this.configFromItem$.next({ route, url, attemptId, formerAnswer, readOnly });
     this.configFromItem$.complete();
   }
 

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -87,7 +87,7 @@ export class ItemTaskService {
     if (Number.isNaN(randomSeed)) throw new Error('random seed must be a number');
 
     const platform: TaskPlatform = {
-      validate: mode => this.validate(mode).pipe(mapTo(undefined)),
+      validate: mode => (this.readOnly ? this.validateReadOnly(mode) : this.validate(mode)).pipe(mapTo(undefined)),
       getTaskParams: () => ({
         minScore: 0,
         maxScore: 100,
@@ -122,6 +122,16 @@ export class ItemTaskService {
       case 'next': return this.answerService.submitAnswer().pipe(switchMap(() => this.navigateToNextItem()));
       case 'top': return this.answerService.submitAnswer().pipe(switchMap(() => this.scrollTop()));
       default: return this.answerService.submitAnswer();
+    }
+  }
+
+  private validateReadOnly(mode: string): Observable<unknown> {
+    switch (mode) {
+      case 'cancel': return EMPTY;
+      case 'nextImmediate': return this.navigateToNextItem();
+      case 'next': return this.navigateToNextItem();
+      case 'top': return this.scrollTop();
+      default: return EMPTY;
     }
   }
 

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -1,20 +1,21 @@
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
-import { animationFrames, merge, Observable, throwError } from 'rxjs';
+import { animationFrames, EMPTY, merge, Observable, throwError } from 'rxjs';
 import { map, mapTo, shareReplay, switchMap, take, tap } from 'rxjs/operators';
 import { LocaleService } from 'src/app/core/services/localeService';
 import { ActivityNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
 import { openNewTab, replaceWindowUrl } from 'src/app/shared/helpers/url';
 import { FullItemRoute, itemRoute } from 'src/app/shared/routing/item-route';
 import { ItemRouter } from 'src/app/shared/routing/item-router';
+import { Answer } from '../http-services/get-answer.service';
 import { Task, TaskPlatform } from '../task-communication/task-proxy';
 import { ItemTaskAnswerService } from './item-task-answer.service';
 import { ItemTaskInitService } from './item-task-init.service';
 import { ItemTaskViewsService } from './item-task-views.service';
 
-export interface ConfigureTaskOptions {
+export interface TaskConfig {
   readOnly: boolean,
-  shouldLoadAnswer: boolean,
+  formerAnswer: Answer | null,
 }
 
 @Injectable()
@@ -22,12 +23,10 @@ export class ItemTaskService {
   readonly unknownError$ = merge(this.answerService.error$, this.viewsService.error$).pipe(shareReplay(1));
   readonly initError$ = this.initService.initError$.pipe(shareReplay(1));
   readonly urlError$ = this.initService.urlError$.pipe(shareReplay(1));
-  readonly loadAnswerByIdError$ = this.answerService.loadAnswerByIdError$.pipe(shareReplay(1));
 
   private error$ = merge(
     this.initError$,
     this.urlError$,
-    this.loadAnswerByIdError$,
     this.unknownError$,
   ).pipe(switchMap(error => throwError(() => error)));
 
@@ -62,10 +61,10 @@ export class ItemTaskService {
     private localeService: LocaleService,
   ) {}
 
-  configure(route: FullItemRoute, url: string, attemptId: string, options: ConfigureTaskOptions): void {
+  configure(route: FullItemRoute, url: string, attemptId: string, options: TaskConfig): void {
     this.readOnly = options.readOnly;
     this.attemptId = attemptId;
-    this.initService.configure(route, url, attemptId, options.shouldLoadAnswer, options.readOnly);
+    this.initService.configure(route, url, attemptId, options.formerAnswer, options.readOnly);
   }
 
   initTask(iframe: HTMLIFrameElement): void {

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -22,19 +22,13 @@ export class ItemRouter {
    * Navigate to given item, on the path page.
    * If page is not given and we are currently on an item page, use the same page. Otherwise, default to 'details'.
    */
-  navigateTo(item: RawItemRoute, { page, navExtras, preventFullFrame = false }: NavigateOptions = {}): void {
+  navigateTo(item: RawItemRoute, {
+    page,
+    navExtras,
+    preventFullFrame = (history.state as Record<string, boolean>).preventFullFrame ?? false,
+  }: NavigateOptions = {}): void {
     void this.router.navigateByUrl(this.url(item, page), { ...navExtras, state: { ...navExtras?.state, preventFullFrame } });
   }
-
-  /**
-   * Navigate to the current page without path and attempt if we are on an item page.
-   * If we are not on an item page, do nothing.
-   */
-  navigateToRawItemOfCurrentPage(): void {
-    const currentPage = this.currentItemPagePath();
-    if (currentPage) void this.router.navigate(currentPage);
-  }
-
 
   /**
    * Return a url to the given item, on the given page.

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -147,27 +147,18 @@
       </trans-unit><trans-unit id="3542042671420335679" datatype="html">
         <source>No</source><target state="translated">Non</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">103</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">51</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">277</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">291</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">341</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">36</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="7720833515469075698" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">104</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.ts</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">51</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">109</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">281</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">295</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">345</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">71</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">36</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="7720833515469075698" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed</source><target state="new"><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-      </trans-unit><trans-unit id="6863764519816340021" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="6863764519816340021" datatype="html">
         <source>Unable to remove the selected manager(s). <x id="PH" equiv-text="result.errorText || ''"/></source><target state="new">Unable to remove the selected manager(s). <x id="PH" equiv-text="result.errorText || ''"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context>
-          <context context-type="linenumber">13</context>
-        </context-group>
-      </trans-unit><trans-unit id="2564386778587315692" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="2564386778587315692" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed, <x id="PH_1" equiv-text="result.countRequests - result.countSuccess"/> could
        not be removed. <x id="PH_2" equiv-text="result.errorText || ''"/></source><target state="new"><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed, <x id="PH_1" equiv-text="result.countRequests - result.countSuccess"/> could
        not be removed. <x id="PH_2" equiv-text="result.errorText || ''"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context>
-          <context context-type="linenumber">16,17</context>
-        </context-group>
-      </trans-unit><trans-unit id="6595442071355967826" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6595442071355967826" datatype="html">
         <source>You have left "<x id="PH" equiv-text="groupName"/>"</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="3538887675032003480" datatype="html">
         <source>You have delete "<x id="PH" equiv-text="groupName"/>"</source><target state="new">You have delete "<x id="PH" equiv-text="groupName"/>"</target>
 
@@ -351,7 +342,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">269</context></context-group></trans-unit><trans-unit id="3768927257183755959" datatype="html">
         <source>Save</source><target state="translated">Sauvegarder</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">98</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/floating-save/floating-save.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="4675865183684903475" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">99</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/floating-save/floating-save.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="4675865183684903475" datatype="html">
         <source>Cancel Changes</source><target state="translated">Annuler les changements</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared-components/components/floating-save/floating-save.component.html</context>
@@ -369,7 +360,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="1921521890321612796" datatype="html">
         <source>Add a content</source><target state="translated">Ajouter du contenu</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/add-item/add-item.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="1620208179561029065" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/add-item/add-item.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="3024902573076444503" datatype="html">
+        <source>Error while fetching author info</source><target state="new">Error while fetching author info</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit><trans-unit id="1620208179561029065" datatype="html">
         <source>Enter a title to create a new child</source><target state="translated">Entrez un titre afin de créer un nouveau contenu</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="6378470992307056425" datatype="html">
@@ -428,52 +425,46 @@
         <source> Content </source><target state="translated"> Contenu </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">25</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
-        <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="new"> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit><trans-unit id="6885936620581271929" datatype="html">
+        <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="new"> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="1143295073021866312" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="1143295073021866312" datatype="html">
         <source>It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us.</source><target state="new">It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="3835920457327748126" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="3835920457327748126" datatype="html">
         <source>An unknown error occurred. If this problem persists, please contact us.</source><target state="new">An unknown error occurred. If this problem persists, please contact us.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
+        <source>Unable to load the answer</source><target state="new">Unable to load the answer</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+      </trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="new">Saving answer...</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
-          <context context-type="linenumber">35</context>
-        </context-group>
-      </trans-unit><trans-unit id="4563965495368336177" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
         <source>Skip</source><target state="new">Skip</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context>
-          <context context-type="linenumber">54</context>
-        </context-group>
-      </trans-unit><trans-unit id="5172335096273253685" datatype="html">
+        
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="5172335096273253685" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet ?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
         <source>Editor</source><target state="new">Editor</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">147</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">146</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="new">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">148</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">147</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">149</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">148</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">78</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="792911798404302156" datatype="html">
@@ -557,7 +548,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="4578192247039196794" datatype="html">
         <source>Task</source><target state="translated">Tâche</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">152</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">151</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
         <source>A new task which users can try to solve.</source><target state="translated">Une nouvelle tâche que les utilisateurs pourront tenter de résoudre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="8317457230285174180" datatype="html">
@@ -581,7 +572,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">29</context></context-group></trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">151</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -630,13 +621,13 @@
       </trans-unit><trans-unit id="1125515177419706232" datatype="html">
         <source>Maformed url: "<x id="PH" equiv-text="url"/>"</source><target state="new">Maformed url: "<x id="PH" equiv-text="url"/>"</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="7800096150276874726" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="7800096150276874726" datatype="html">
         <source>Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</source><target state="new">Invalid url "<x id="PH" equiv-text="url"/>": please provide an http link</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">97</context></context-group></trans-unit><trans-unit id="4370087843628009533" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">98</context></context-group></trans-unit><trans-unit id="4370087843628009533" datatype="html">
         <source>Invalid url, please provide a secure task url (https)</source><target state="new">Invalid url, please provide a secure task url (https)</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="5402924068010392760" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">103</context></context-group></trans-unit><trans-unit id="5402924068010392760" datatype="html">
         <source>Join the group "<x id="PH" equiv-text="response.group.name"/>"</source><target state="translated">Rejoindre le groupe "<x id="PH" equiv-text="response.group.name"/>"</target>
 
       <source>The code does not correspond to the group attached to this page. Are you sure you want to join the group "
@@ -654,7 +645,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="2159130950882492111" datatype="html">
         <source>Cancel</source><target state="translated">Annuler</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">92</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="7798083029915432586" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="7798083029915432586" datatype="html">
         <source>You are already a member of this group.</source><target state="translated">Vous êtes déjà membre de ce groupe.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">83</context></context-group></trans-unit><trans-unit id="5339756092671133656" datatype="html">
@@ -852,13 +843,7 @@
          <context context-type="sourcefile">src/app/modules/group/components/user-group-invitations/user-group-invitations.component.ts</context>
          <context context-type="linenumber">24</context>
        </context-group>
-     </trans-unit><trans-unit id="988985965672863170" datatype="html">
-        <source>Failed to delete manager</source><target state="new">Failed to delete manager</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/http-services/remove-group-manager.service.ts</context>
-          <context context-type="linenumber">24</context>
-        </context-group>
-      </trans-unit><trans-unit id="544102334421307622" datatype="html">
+     </trans-unit><trans-unit id="544102334421307622" datatype="html">
         <source>The group(s) must be empty</source><target state="new">The group(s) must be empty</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/http-services/remove-group.service.ts</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="8953033926734869941" datatype="html">
@@ -1007,13 +992,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5086832329438229437" datatype="html">
         <source> User(s) can give and revoke members access to some content </source><target state="new"> User(s) can give and revoke members access to some content </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="7308369809380680356" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="7308369809380680356" datatype="html">
         <source>Can watch members</source><target state="new">Can watch members</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="731959018199918793" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="731959018199918793" datatype="html">
         <source> User(s) can watch the members' activity on some content </source><target state="new"> User(s) can watch the members' activity on some content </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">73</context></context-group></trans-unit><trans-unit id="6674111336491636600" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">74</context></context-group></trans-unit><trans-unit id="6674111336491636600" datatype="html">
         <source>Can watch</source><target state="translated">Droit d'observation</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="1898683424750626599" datatype="html">
@@ -1044,7 +1029,7 @@
         <source>Can manage members, managers, and change group settings</source><target state="new">Can manage members, managers, and change group settings</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="1774407921639110803" datatype="html">
-        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ?
+        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ? 
         You may lose manager access and not be able to restore it.</source><target state="new">Are you sure to remove from yourself the permission to edit group settings and edit managers ?
         You may lose manager access and not be able to restore it.</target>
         <context-group purpose="location">
@@ -1150,7 +1135,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="4085853929655384104" datatype="html">
         <source> This chapter has no content visible to you, so you can't validate it for now. </source><target state="translated"> Ce chapitre n'a pas contenu visible, vous ne pouvez pas le valider. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="7508893828342265603" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="694771452558018718" datatype="html">
+        <source> Submitted by <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;groupLink$ | async&quot; class=&quot;alg-link links&quot;>"/><x id="INTERPOLATION" equiv-text="{{ author | userCaption }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> on <x id="INTERPOLATION_1" equiv-text="{{ answer.createdAt | date:'short' }}"/>. <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span *ngIf=&quot;answer.score || answer.score === 0&quot; class=&quot;score&quot;>"/>Score: <x id="INTERPOLATION_2" equiv-text="{{ answer.score }}"/> points.<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source><target state="new"> Submitted by <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;groupLink&quot; class=&quot;alg-link links&quot;>"/><x id="INTERPOLATION" equiv-text="{{ user | userCaption }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> on <x id="INTERPOLATION_1" equiv-text="{{ answer.createdAt | date:'short' }}"/>. <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span *ngIf=&quot;answer.score || answer.score === 0&quot; class=&quot;score&quot;>"/>Score: <x id="INTERPOLATION_2" equiv-text="{{ answer.score }}"/> points.<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="7508893828342265603" datatype="html">
         <source>Nothing</source><target state="translated">Rien</target>
 
 
@@ -1169,7 +1157,7 @@
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">81</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -1183,7 +1171,7 @@
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">149</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
@@ -1397,26 +1385,20 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/managed-group-list/managed-group-list.component.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="7610330755258977986" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ group?.name }}"/>: manager access given to <x id="INTERPOLATION_1" equiv-text="{{ userCaption }}"/> </source><target state="new"> <x id="INTERPOLATION" equiv-text="{{ group?.name }}"/>: manager access given to <x id="INTERPOLATION_1" equiv-text="{{ userCaption }}"/> </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context>
-          <context context-type="linenumber">13,15</context>
-        </context-group>
-      </trans-unit><trans-unit id="9171311681863414398" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="9171311681863414398" datatype="html">
         <source> This panel lets you select what you allow the selected user or group of users to do on the current group and its descendants. </source><target state="new"> This panel lets you select what you allow the selected user or group of users to do on the current group and its descendants. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context>
-          <context context-type="linenumber">25,26</context>
-        </context-group>
-      </trans-unit><trans-unit id="7838784407251919653" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="7838784407251919653" datatype="html">
         <source>Management level</source><target state="new">Management level</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="367178788667281065" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="367178788667281065" datatype="html">
         <source>The permissions that the user(s) has on this group</source><target state="new">The permissions that the user(s) has on this group</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="3077731577529874277" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="3077731577529874277" datatype="html">
         <source>Can grant access</source><target state="new">Can grant access</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="1153571395259772276" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="1153571395259772276" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> group(s) have been removed</source><target state="new"><x id="PH" equiv-text="result.countSuccess"/> group(s) have been removed</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/components/member-list/group-removal-response-handling.ts</context>
@@ -1449,11 +1431,8 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="6365312852877051748" datatype="html">
         <source>Yes, remove me from the group managers</source><target state="new">Yes, remove me from the group managers</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context>
-          <context context-type="linenumber">100</context>
-        </context-group>
-      </trans-unit><trans-unit id="2665063333072587702" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="2665063333072587702" datatype="html">
         <source>Error while loading the group managers</source><target state="translated">Erreur lors du chargement des gestionnaires de groupe</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="2978634377936697829" datatype="html">
@@ -1692,13 +1671,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
         <source>Action</source><target state="translated">Opération</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
         <source>User</source><target state="new">User</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">110</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
         <source>Time</source><target state="translated">Date/Heure</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="1848556306631120071" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">115</context></context-group></trans-unit><trans-unit id="1848556306631120071" datatype="html">
         <source>Time spent</source><target state="translated">Temps écoulé</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">8</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">74</context></context-group></trans-unit><trans-unit id="2827276519893025325" datatype="html">


### PR DESCRIPTION
## Description

Fixes #816

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

I think the PR is easier to review commit by commit to understand which changes impact which part.

Also, the indicator generated a UI issue I didn't handle on purpose, thinking Aleksandr could do it (to reproduce, follow Indicator first test case below):
![image](https://user-images.githubusercontent.com/16257159/144225794-e5dc0667-2ff9-4d8c-919c-f5bef757200d.png)


## Test cases

### Load answer in read-only (= watch mode) test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this task with a bad answer id](https://dev.algorea.org/branch/feat/load-other-user-submissions/en/#/activities/by-id/6379723280369399253;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0;answerId=1/details)
  3. Then I should see "Unable to load the answer"

- [ ] Case 2: 
  1. Given I am the usual user
  2. When I go to [this group](https://dev.algorea.org/branch/feat/load-other-user-submissions/en/#/groups/by-id/6710944276987033666;path=5121055722873780306/details)
  3. And I observe the group
  3. And I open JS console and paste `window.taskSaveIntervalInSec = 60 * 60` (see later the before unload test) 
  4. And I click on first suggested activity "Blockly Basic Task"
  5. And I click on "Progress" tab
  6. Then:
      - I see demo user's answers _including_ current with a "load" button
      - I see my own answers _**not** including_ current with a "load" button
  7. And I load any answer (mine or another user's one)
  8. Then I am redirected to task (which is reloaded)
  9. And I go to first level
  10. And I open network panel and execute the program
  11. Then no save should occur
  12. And I move the root block
  13. And I exit the task (tip: navigate back to group by clicking in observation bar to get ready for next test)
  13. Then I should not have the deactivate/before unload hook

- [ ] Case 3: 
  1. Given I am the demo user (this user can only watch results of "Blockly Basic Task")
  2. When I go to [this group](https://dev.algorea.org/branch/feat/load-other-user-submissions/en/#/groups/by-id/6710944276987033666;path=5121055722873780306/details)
  3. And I observe the group
  4. And I click on first suggested activity "Blockly Basic Task"
  5. And I click on "Progress" tab
  6. Then I should see the activity history _without_ the load buttons, not even for self answers.

Note: There are no test cases when user has no watch permission (`< 'result'`) because in that case the user does not even have access to the progress tab in observation mode, I tested it when demo user had `can watch: 'none'`. You can edit permissions yourself to test it, but [currently permissions are broken](https://github.com/France-ioi/AlgoreaFrontend/pull/833)

### Indicator tests

- [ ] Case 1: 
  1. Given I am the usual user
  2. When I go to [this group](https://dev.algorea.org/branch/feat/load-other-user-submissions/en/#/groups/by-id/6710944276987033666;path=5121055722873780306/details)
  3. And I observe the group
  4. And I click on first suggested activity "Blockly Basic Task"
  5. And I click on "Progress" tab
  6. And I click on "Load" of first current answer
  7. Then task should be reloaded, and I should see an indicator with "Submitted by … on…" with no score info.
  8. And I click back on "Progress tab"
  9. Then I should see the message is still displayed
  10. And I click on first submission
  11. Then task should be reloaded, and I should see same indicator **with** score info this time

- [ ] Case 2:
  1. Given I am usual user
  2. When I go to [this task directly with an answer id](https://dev.algorea.org/branch/feat/load-other-user-submissions/en/#/activities/by-id/6379723280369399253;answerId=7944018955728558114/details)
  3. Then I should not see the indicator since we are not in observation mode