### PR TITLE
lti: restrict navigaton to given content

### DIFF
--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -80,10 +80,10 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
    * In some cases (ie LTI), the user visits the app only to work on an exercise, chapter or task and then returns to the original platform.
    * For that purpose, we want to be able to restrict in-app navigation to a specific chapter.
    * This is done by hiding the left menu and allowing only neighbor navigation while disabling others.
-   * When this variable is undefined, no restriction is applied.
+   * When this variable is null, no restriction is applied.
    * When it is populated with an element id, the neighbor navigation will only be restricted to its descendants _not including self_.
    */
-  navigationNeighborsRestrictedToDescendantOfElementId: string | undefined = undefined;
+  navigationNeighborsRestrictedToDescendantOfElementId: string | null = null;
   navigationNeighbors$: Observable<FetchState<NavigationNeighbors|undefined>> = this.state$.pipe(
     mapStateData(navData => {
       if (!navData.selectedElementId) return undefined;

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -76,6 +76,13 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
     shareReplay(1),
   );
 
+  /**
+   * In some cases (ie LTI), the user visits the app only to work on an exercise, chapter or task and then returns to the original platform.
+   * For that purpose, we want to be able to restrict in-app navigation to a specific chapter.
+   * This is done by hiding the left menu and allowing only neighbor navigation while disabling others.
+   * When this variable is undefined, no restriction is applied.
+   * When it is populated with an element id, the neighbor navigation will only be restricted to its descendants _not including self_.
+   */
   navigationNeighborsRestrictedToDescendantOfElementId: string | undefined = undefined;
   navigationNeighbors$: Observable<FetchState<NavigationNeighbors|undefined>> = this.state$.pipe(
     mapStateData(navData => {

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -50,7 +50,7 @@ export class LTIComponent implements OnDestroy {
   );
 
   private subscriptions = [
-    this.contentId$.subscribe(contentId => this.activityNavTreeService.setNavigationRootElement(contentId)),
+    this.contentId$.subscribe(contentId => this.activityNavTreeService.navigationNeighborsRestrictedToDescendantOfElementId = contentId),
     this.navigationData$.pipe(readyData()).subscribe({
       next: ({ firstChild, path, attemptId }) => {
         const itemRoute = fullItemRoute('activity', firstChild.id, path, { parentAttemptId: attemptId });


### PR DESCRIPTION
## Description

Fixes #841 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

I tried to implement navigation restriction respecting dependency directions, it felt appropriate to place the logic in nav tree service since it's the one already holding the `navigationNeighbours$` observable.

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this chapter](https://dev.algorea.org/branch/feat/lti-restrict-navigation/en/#/lti/1625159049301502151)
  3. ~And I navigate to the parent using navigation arrows~ Then I cannot navigate to parent because the parent button is disabled
  4. And I navigate to any child at any depth
  5. Then I see the navigation works as usual
