### PR TITLE
Feature/group access page add granted permissions

### DIFF
--- a/src/app/modules/group/components/group-permissions/group-permissions.component.html
+++ b/src/app/modules/group/components/group-permissions/group-permissions.component.html
@@ -4,7 +4,7 @@
       <div class="caption">Can View: {{ permissions.canView | groupPermissionCaption }}</div>
     </li>
     <li class="caption-item">
-      <div class="caption">Can Grand View: {{ permissions.canGrantView | groupPermissionCaption }}</div>
+      <div class="caption">Can Grant View: {{ permissions.canGrantView | groupPermissionCaption }}</div>
     </li>
     <li class="caption-item">
       <div class="caption">Can Enter From: {{ permissions.canEnterFrom | date:'d/MM/y' }}</div>

--- a/src/app/modules/group/components/group-permissions/group-permissions.component.html
+++ b/src/app/modules/group/components/group-permissions/group-permissions.component.html
@@ -1,0 +1,16 @@
+<ng-container *ngIf="permissions">
+  <ul class="captions">
+    <li class="caption-item">
+      <div class="caption">Can View: {{ permissions.canView | groupPermissionCaption }}</div>
+    </li>
+    <li class="caption-item">
+      <div class="caption">Can Grand View: {{ permissions.canGrantView | groupPermissionCaption }}</div>
+    </li>
+    <li class="caption-item">
+      <div class="caption">Can Enter From: {{ permissions.canEnterFrom | date:'d/MM/y' }}</div>
+    </li>
+    <li class="caption-item">
+      <div class="caption">Until: {{ permissions.canEnterUntil | date:'d/MM/y' }}</div>
+    </li>
+  </ul>
+</ng-container>

--- a/src/app/modules/group/components/group-permissions/group-permissions.component.scss
+++ b/src/app/modules/group/components/group-permissions/group-permissions.component.scss
@@ -18,4 +18,5 @@
 .caption {
   flex: 1;
   margin-right: 2rem;
+  text-align: right;
 }

--- a/src/app/modules/group/components/group-permissions/group-permissions.component.scss
+++ b/src/app/modules/group/components/group-permissions/group-permissions.component.scss
@@ -1,0 +1,21 @@
+@import "src/colors.scss";
+@import "src/geometry.scss";
+
+.captions {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.caption-item {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  color: $secondary-color;
+  font-weight: bold;
+}
+
+.caption {
+  flex: 1;
+  margin-right: 2rem;
+}

--- a/src/app/modules/group/components/group-permissions/group-permissions.component.ts
+++ b/src/app/modules/group/components/group-permissions/group-permissions.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { GroupPermissions } from '../../http-services/granted-permissions.service';
+
+@Component({
+  selector: 'alg-group-permissions',
+  templateUrl: './group-permissions.component.html',
+  styleUrls: [ './group-permissions.component.scss' ],
+})
+export class GroupPermissionsComponent {
+  @Input() permissions?: GroupPermissions;
+}

--- a/src/app/modules/group/group.module.ts
+++ b/src/app/modules/group/group.module.ts
@@ -48,6 +48,7 @@ import { GroupAccessComponent } from './pages/group-access/group-access.componen
 import { GroupManagersComponent } from './pages/group-managers/group-managers.component';
 import { DialogModule } from 'primeng/dialog';
 import { ManagerPermissionDialogComponent } from './components/manager-permission-dialog/manager-permission-dialog.component';
+import { GroupPermissionsComponent } from './components/group-permissions/group-permissions.component';
 
 @NgModule({
   declarations: [
@@ -85,6 +86,7 @@ import { ManagerPermissionDialogComponent } from './components/manager-permissio
     SuggestionOfActivitiesComponent,
     GroupAccessComponent,
     ManagerPermissionDialogComponent,
+    GroupPermissionsComponent,
   ],
   imports: [
     CommonModule,

--- a/src/app/modules/group/http-services/granted-permissions.service.ts
+++ b/src/app/modules/group/http-services/granted-permissions.service.ts
@@ -5,7 +5,7 @@ import { decodeSnakeCase } from '../../../shared/operators/decode';
 import { dateDecoder } from '../../../shared/helpers/decoders';
 import { appConfig } from '../../../shared/helpers/config';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { permissionsDecoder } from '../../../shared/http-services/group-permissions.service';
+import { permissionsDecoder } from '../../../shared/helpers/group-permissions';
 import { pipe } from 'fp-ts/function';
 
 const groupPermissionsDecoder = pipe(

--- a/src/app/modules/group/http-services/granted-permissions.service.ts
+++ b/src/app/modules/group/http-services/granted-permissions.service.ts
@@ -5,17 +5,18 @@ import { decodeSnakeCase } from '../../../shared/operators/decode';
 import { dateDecoder } from '../../../shared/helpers/decoders';
 import { appConfig } from '../../../shared/helpers/config';
 import { HttpClient, HttpParams } from '@angular/common/http';
+import { permissionsDecoder } from '../../../shared/http-services/group-permissions.service';
+import { pipe } from 'fp-ts/function';
 
-const groupPermissionsDecoder = D.struct({
-  canEdit: D.literal('none', 'children', 'all', 'all_with_grant'),
-  canEnterFrom: dateDecoder,
-  canEnterUntil: dateDecoder,
-  canGrantView: D.literal('none', 'enter', 'content', 'content_with_descendants', 'solution', 'solution_with_grant'),
-  canMakeSessionOfficial: D.boolean,
-  canView: D.literal('none', 'info', 'content', 'content_with_descendants', 'solution'),
-  canWatch: D.literal('none', 'result', 'answer', 'answer_with_grant'),
-  isOwner: D.boolean,
-});
+const groupPermissionsDecoder = pipe(
+  permissionsDecoder,
+  D.intersect(
+    D.struct({
+      canEnterFrom: dateDecoder,
+      canEnterUntil: dateDecoder,
+    })
+  ),
+);
 
 const grantedPermissionsDecoder = D.struct({
   group: D.struct({

--- a/src/app/modules/group/http-services/granted-permissions.service.ts
+++ b/src/app/modules/group/http-services/granted-permissions.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import * as D from 'io-ts/Decoder';
+import { decodeSnakeCase } from '../../../shared/operators/decode';
+import { dateDecoder } from '../../../shared/helpers/decoders';
+import { appConfig } from '../../../shared/helpers/config';
+import { HttpClient, HttpParams } from '@angular/common/http';
+
+const groupPermissionsDecoder = D.struct({
+  canEdit: D.literal('none', 'children', 'all', 'all_with_grant'),
+  canEnterFrom: dateDecoder,
+  canEnterUntil: dateDecoder,
+  canGrantView: D.literal('none', 'enter', 'content', 'content_with_descendants', 'solution', 'solution_with_grant'),
+  canMakeSessionOfficial: D.boolean,
+  canView: D.literal('none', 'info', 'content', 'content_with_descendants', 'solution'),
+  canWatch: D.literal('none', 'result', 'answer', 'answer_with_grant'),
+  isOwner: D.boolean,
+});
+
+const grantedPermissionsDecoder = D.struct({
+  group: D.struct({
+    id: D.string,
+    name: D.string,
+  }),
+  item: D.struct({
+    id: D.string,
+    languageTag: D.string,
+    requiresExplicitEntry: D.boolean,
+    title: D.nullable(D.string),
+  }),
+  permissions: groupPermissionsDecoder,
+  sourceGroup: D.struct({
+    id: D.string,
+    name: D.string,
+  }),
+});
+
+export type GroupPermissions = D.TypeOf<typeof groupPermissionsDecoder>;
+export type GrantedPermissions = D.TypeOf<typeof grantedPermissionsDecoder>;
+
+@Injectable({
+  providedIn: 'root'
+})
+export class GrantedPermissionsService {
+  constructor(private http: HttpClient) {
+  }
+
+  get(id: string, descendants = 0): Observable<GrantedPermissions[]> {
+    const httpParams = new HttpParams().set('descendants', descendants);
+    return this.http.get<unknown>(`${appConfig.apiUrl}/groups/${ id }/granted_permissions`, {
+      params: httpParams,
+    }).pipe(
+      decodeSnakeCase(D.array(grantedPermissionsDecoder)),
+    );
+  }
+}

--- a/src/app/modules/group/pages/group-access/group-access.component.html
+++ b/src/app/modules/group/pages/group-access/group-access.component.html
@@ -55,14 +55,16 @@
             <strong>
               {{ grantedPermission.item.title }}.
             </strong>
-            <ng-container *ngIf="grantedPermission.sourceGroup.id !== group?.id && grantedPermission.group.id !== group?.id; else currentGroup">
-              <span i18n>Given by</span>
-              <a
-                class="alg-link"
-                [routerLink]="{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink"
-              >
-                {{ grantedPermission.sourceGroup.name }}
-              </a>
+            <ng-container
+              *ngIf="grantedPermission.sourceGroup.id !== group?.id && grantedPermission.group.id !== group?.id; else currentGroup"
+              i18n>
+                <span>Given by</span>
+                <a
+                  class="alg-link"
+                  [routerLink]="{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink"
+                >
+                  {{ grantedPermission.sourceGroup.name }}
+                </a>
             </ng-container>
             <ng-template #currentGroup>
               <span i18n>Given by this group</span>

--- a/src/app/modules/group/pages/group-access/group-access.component.html
+++ b/src/app/modules/group/pages/group-access/group-access.component.html
@@ -57,12 +57,12 @@
             </strong>
             <ng-container *ngIf="grantedPermission.sourceGroup.id !== group?.id && grantedPermission.group.id !== group?.id; else currentGroup">
               <span i18n>Given by</span>
-              <span
+              <a
                 class="alg-link"
-                (click)="onGroupClick(grantedPermission.sourceGroup.id)"
+                [routerLink]="{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink"
               >
                 {{ grantedPermission.sourceGroup.name }}
-              </span>
+              </a>
             </ng-container>
             <ng-template #currentGroup>
               <span i18n>Given by this group</span>

--- a/src/app/modules/group/pages/group-access/group-access.component.html
+++ b/src/app/modules/group/pages/group-access/group-access.component.html
@@ -55,15 +55,17 @@
             <strong>
               {{ grantedPermission.item.title }}.
             </strong>
-            <span i18n>Given by</span>
-            <span
-              class="alg-link"
-              (click)="onGroupClick(grantedPermission.sourceGroup.id)"
-              *ngIf="grantedPermission.sourceGroup.id !== group?.id && grantedPermission.group.id !== group?.id; else currentGroup">
+            <ng-container *ngIf="grantedPermission.sourceGroup.id !== group?.id && grantedPermission.group.id !== group?.id; else currentGroup">
+              <span i18n>Given by</span>
+              <span
+                class="alg-link"
+                (click)="onGroupClick(grantedPermission.sourceGroup.id)"
+              >
                 {{ grantedPermission.sourceGroup.name }}
-            </span>
+              </span>
+            </ng-container>
             <ng-template #currentGroup>
-              <span i18n> this group</span>
+              <span i18n>Given by this group</span>
             </ng-template>
           </div>
           <alg-group-permissions [permissions]="grantedPermission.permissions"></alg-group-permissions>

--- a/src/app/modules/group/pages/group-access/group-access.component.html
+++ b/src/app/modules/group/pages/group-access/group-access.component.html
@@ -59,7 +59,7 @@
             <span
               class="alg-link"
               (click)="onGroupClick(grantedPermission.sourceGroup.id)"
-              *ngIf="grantedPermission.sourceGroup.id !== group?.id; else currentGroup">
+              *ngIf="grantedPermission.sourceGroup.id !== group?.id && grantedPermission.group.id !== group?.id; else currentGroup">
                 {{ grantedPermission.sourceGroup.name }}
             </span>
             <ng-template #currentGroup>

--- a/src/app/modules/group/pages/group-access/group-access.component.html
+++ b/src/app/modules/group/pages/group-access/group-access.component.html
@@ -16,13 +16,62 @@
       <ng-container *ngIf="rootActivityState.isReady">
         <ng-container *ngIf="rootActivityState.data; else noActivity">
           <div class="item">
-            <i class="icon fa fa-folder"></i>
-            <strong i18n>Root activity: {{ rootActivityState.data.string.title }}</strong>
+            <div>
+              <i class="icon fa fa-folder"></i>
+              <strong i18n>Root activity: {{ rootActivityState.data.string.title }}</strong>
+            </div>
           </div>
         </ng-container>
 
         <ng-template #noActivity>
           <div i18n>This group has no activity.</div>
+        </ng-template>
+      </ng-container>
+    </ng-container>
+  </alg-section>
+
+  <alg-section
+    icon="fa fa-book"
+    i18n-label label="Specific permissions given to the group on content"
+  >
+    <ng-container *ngIf="permissionState$ | async as permissionState">
+      <div class="spinner" *ngIf="permissionState.isFetching">
+        <alg-loading size="medium"></alg-loading>
+      </div>
+
+      <alg-error
+        *ngIf="permissionState.isError"
+        i18n-message message="Error while loading permissions."
+        [showRefreshButton]="true"
+        refreshButtonType="refresh"
+        (refresh)="refreshPermissions()"
+      ></alg-error>
+
+      <ng-container *ngIf="permissionState.isReady">
+        <ng-container *ngIf="permissionState.data.length > 1; else noPermissions">
+          <div class="item" *ngFor="let grantedPermission of permissionState.data">
+          <div>
+            <i class="icon fa fa-folder"></i>
+            <strong>
+              {{ grantedPermission.item.title }}.
+            </strong>
+            <span i18n>Given by</span>
+            <span
+              class="alg-link"
+              (click)="onGroupClick(grantedPermission.sourceGroup.id)"
+              *ngIf="grantedPermission.sourceGroup.id !== group?.id; else currentGroup">
+                {{ grantedPermission.sourceGroup.name }}
+            </span>
+            <ng-template #currentGroup>
+              <span i18n> this group</span>
+            </ng-template>
+          </div>
+          <alg-group-permissions [permissions]="grantedPermission.permissions"></alg-group-permissions>
+        </div>
+        </ng-container>
+
+        <ng-template #noPermissions>
+          <div i18n>This group has no permissions.</div>
         </ng-template>
       </ng-container>
     </ng-container>

--- a/src/app/modules/group/pages/group-access/group-access.component.scss
+++ b/src/app/modules/group/pages/group-access/group-access.component.scss
@@ -2,7 +2,13 @@
 
 .item {
   display: flex;
-  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  border-bottom: 0.1rem solid rgba(74, 74, 74, 0.1);
+
+  &:last-child {
+    border-bottom: none;
+  }
 }
 
 .icon {

--- a/src/app/modules/group/pages/group-access/group-access.component.ts
+++ b/src/app/modules/group/pages/group-access/group-access.component.ts
@@ -4,6 +4,9 @@ import { GetItemByIdService } from '../../../item/http-services/get-item-by-id.s
 import { ReplaySubject, of, Subject } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { mapToFetchState } from '../../../../shared/operators/state';
+import { GrantedPermissionsService } from '../../http-services/granted-permissions.service';
+import { GroupRouter } from '../../../../shared/routing/group-router';
+import { rawGroupRoute } from '../../../../shared/routing/group-route';
 
 @Component({
   selector: 'alg-group-access',
@@ -13,11 +16,11 @@ import { mapToFetchState } from '../../../../shared/operators/state';
 export class GroupAccessComponent implements OnChanges, OnDestroy {
   @Input() group?: Group;
 
-  private readonly rootActivityId$ = new ReplaySubject<string | null>(1);
+  private readonly group$ = new ReplaySubject<Group>(1);
 
   private refresh$ = new Subject<void>();
-  rootActivityState$ = this.rootActivityId$.pipe(
-    switchMap(rootActivityId => {
+  rootActivityState$ = this.group$.pipe(
+    switchMap(({ rootActivityId }) => {
       if (!rootActivityId) {
         return of(null);
       }
@@ -26,17 +29,27 @@ export class GroupAccessComponent implements OnChanges, OnDestroy {
     mapToFetchState({ resetter: this.refresh$ }),
   );
 
-  constructor(private getItemByIdService: GetItemByIdService) {
+  private permissionsRefresh$ = new Subject<void>();
+  permissionState$ = this.group$.pipe(
+    switchMap(group => this.grantedPermissionsService.get(group.id)),
+    mapToFetchState({ resetter: this.permissionsRefresh$ }),
+  );
+
+  constructor(
+    private getItemByIdService: GetItemByIdService,
+    private grantedPermissionsService: GrantedPermissionsService,
+    private groupRouter: GroupRouter,
+  ) {
   }
 
   ngOnChanges(): void {
     if (this.group) {
-      this.rootActivityId$.next(this.group.rootActivityId);
+      this.group$.next(this.group);
     }
   }
 
   ngOnDestroy(): void {
-    this.rootActivityId$.complete();
+    this.group$.complete();
     this.refresh$.complete();
   }
 
@@ -44,4 +57,11 @@ export class GroupAccessComponent implements OnChanges, OnDestroy {
     this.refresh$.next();
   }
 
+  onGroupClick(groupId: string): void {
+    this.groupRouter.navigateTo(rawGroupRoute({ id: groupId, isUser: false }));
+  }
+
+  refreshPermissions(): void {
+    this.permissionsRefresh$.next();
+  }
 }

--- a/src/app/modules/group/pages/group-access/group-access.component.ts
+++ b/src/app/modules/group/pages/group-access/group-access.component.ts
@@ -5,8 +5,6 @@ import { ReplaySubject, of, Subject } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { mapToFetchState } from '../../../../shared/operators/state';
 import { GrantedPermissionsService } from '../../http-services/granted-permissions.service';
-import { GroupRouter } from '../../../../shared/routing/group-router';
-import { rawGroupRoute } from '../../../../shared/routing/group-route';
 
 @Component({
   selector: 'alg-group-access',
@@ -38,7 +36,6 @@ export class GroupAccessComponent implements OnChanges, OnDestroy {
   constructor(
     private getItemByIdService: GetItemByIdService,
     private grantedPermissionsService: GrantedPermissionsService,
-    private groupRouter: GroupRouter,
   ) {
   }
 
@@ -55,10 +52,6 @@ export class GroupAccessComponent implements OnChanges, OnDestroy {
 
   refresh(): void {
     this.refresh$.next();
-  }
-
-  onGroupClick(groupId: string): void {
-    this.groupRouter.navigateTo(rawGroupRoute({ id: groupId, isUser: false }));
   }
 
   refreshPermissions(): void {

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from
 import { FormBuilder } from '@angular/forms';
 import { ProgressSelectValue } from
   'src/app/modules/shared-components/components/collapsible-section/progress-select/progress-select.component';
-import { Permissions } from 'src/app/shared/http-services/group-permissions.service';
+import { Permissions } from 'src/app/shared/helpers/group-permissions';
 import { TypeFilter } from '../composition-filter/composition-filter.component';
 import { generateCanEditValues, generateCanGrantViewValues,
   generateCanViewValues, generateCanWatchValues } from './permissions-edit-dialog-texts';

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
@@ -7,7 +7,8 @@ import { GetGroupChildrenService } from 'src/app/modules/group/http-services/get
 import { formatUser } from 'src/app/shared/helpers/user';
 import { GetGroupDescendantsService } from 'src/app/shared/http-services/get-group-descendants.service';
 import { GetGroupProgressService, TeamUserProgress } from 'src/app/shared/http-services/get-group-progress.service';
-import { GroupPermissionsService, Permissions } from 'src/app/shared/http-services/group-permissions.service';
+import { GroupPermissionsService } from 'src/app/shared/http-services/group-permissions.service';
+import { Permissions } from 'src/app/shared/helpers/group-permissions';
 import { progressiveObservableFromList } from 'src/app/shared/operators/progressive-observable-from-list';
 import { mapToFetchState } from 'src/app/shared/operators/state';
 import { withPreviousFetchState } from 'src/app/shared/operators/with-previous-fetch-state';

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -61,6 +61,7 @@ import { ErrorComponent } from './components/error/error.component';
 import { LoadingComponent } from './components/loading/loading.component';
 import { CollapsibleSectionComponent } from './components/collapsible-section/collapsible-section.component';
 import { NeighborWidgetComponent } from './components/neighbor-widget/neighbor-widget.component';
+import { GroupPermissionCaptionPipe } from '../../shared/pipes/groupPermissionCaption';
 
 @NgModule({
   declarations: [
@@ -87,6 +88,7 @@ import { NeighborWidgetComponent } from './components/neighbor-widget/neighbor-w
     GroupLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,
+    GroupPermissionCaptionPipe,
     SubSectionComponent,
     AddContentComponent,
     FloatingSaveComponent,
@@ -155,6 +157,7 @@ import { NeighborWidgetComponent } from './components/neighbor-widget/neighbor-w
     GroupLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,
+    GroupPermissionCaptionPipe,
     SubSectionComponent,
     AddContentComponent,
     FloatingSaveComponent,

--- a/src/app/shared/helpers/group-permissions.ts
+++ b/src/app/shared/helpers/group-permissions.ts
@@ -1,0 +1,15 @@
+import { pipe } from 'fp-ts/function';
+import * as D from 'io-ts/Decoder';
+
+export const permissionsDecoder = pipe(
+  D.struct({
+    canView: D.literal('none','info','content','content_with_descendants','solution'),
+    canWatch: D.literal('none','result','answer','answer_with_grant'),
+    canEdit: D.literal('none','children','all','all_with_grant'),
+    canGrantView: D.literal('none','enter','content','content_with_descendants','solution','solution_with_grant'),
+    isOwner: D.boolean,
+    canMakeSessionOfficial: D.boolean,
+  }),
+);
+
+export type Permissions = D.TypeOf<typeof permissionsDecoder>;

--- a/src/app/shared/http-services/group-permissions.service.ts
+++ b/src/app/shared/http-services/group-permissions.service.ts
@@ -7,19 +7,7 @@ import { assertSuccess, SimpleActionResponse } from './action-response';
 import * as D from 'io-ts/Decoder';
 import { pipe } from 'fp-ts/function';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
-
-export const permissionsDecoder = pipe(
-  D.struct({
-    canView: D.literal('none','info','content','content_with_descendants','solution'),
-    canWatch: D.literal('none','result','answer','answer_with_grant'),
-    canEdit: D.literal('none','children','all','all_with_grant'),
-    canGrantView: D.literal('none','enter','content','content_with_descendants','solution','solution_with_grant'),
-    isOwner: D.boolean,
-    canMakeSessionOfficial: D.boolean,
-  })
-);
-
-export type Permissions = D.TypeOf<typeof permissionsDecoder>;
+import { permissionsDecoder, Permissions } from '../helpers/group-permissions';
 
 const groupPermissionsDecoder = pipe(
   D.struct({

--- a/src/app/shared/http-services/group-permissions.service.ts
+++ b/src/app/shared/http-services/group-permissions.service.ts
@@ -8,7 +8,7 @@ import * as D from 'io-ts/Decoder';
 import { pipe } from 'fp-ts/function';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
 
-const permissionsDecoder = pipe(
+export const permissionsDecoder = pipe(
   D.struct({
     canView: D.literal('none','info','content','content_with_descendants','solution'),
     canWatch: D.literal('none','result','answer','answer_with_grant'),

--- a/src/app/shared/pipes/groupPermissionCaption.ts
+++ b/src/app/shared/pipes/groupPermissionCaption.ts
@@ -1,0 +1,26 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+const PERMISSION_CAPTIONS = {
+  none: $localize`None`,
+  children: $localize`Children`,
+  all: $localize`All`,
+  all_with_grant: $localize`All with grant`,
+  enter: $localize`Enter`,
+  content: $localize`Content`,
+  content_with_descendants: $localize`Content with descendants`,
+  solution: $localize`Solution`,
+  solution_with_grant: $localize`Solution with grant`,
+  info: $localize`Info`,
+  result: $localize`Result`,
+  answer: $localize`Answer`,
+  answer_with_grant: $localize`Answer with grant`,
+};
+
+@Pipe({ name: 'groupPermissionCaption', pure: true })
+export class GroupPermissionCaptionPipe implements PipeTransform {
+  constructor() {}
+
+  transform(value: string): string {
+    return new Map<string, string>(Object.entries(PERMISSION_CAPTIONS)).get(value) || $localize`No caption`;
+  }
+}

--- a/src/app/shared/pipes/groupPermissionCaption.ts
+++ b/src/app/shared/pipes/groupPermissionCaption.ts
@@ -20,7 +20,7 @@ const PERMISSION_CAPTIONS = {
 export class GroupPermissionCaptionPipe implements PipeTransform {
   constructor() {}
 
-  transform(value: string): string {
-    return new Map<string, string>(Object.entries(PERMISSION_CAPTIONS)).get(value) || $localize`No caption`;
+  transform(value: keyof typeof PERMISSION_CAPTIONS): string {
+    return PERMISSION_CAPTIONS[value] ?? $localize`No caption`;
   }
 }

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -126,7 +126,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="4449471207584645508" datatype="html">
         <source>Permissions successfully updated.</source><target state="translated">Permissions mises à jour avec succès.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">283</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">284</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context>
@@ -339,7 +339,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="8373240794331669576" datatype="html">
         <source>The permissions cannot be retrieved. If the problem persists, please contact us.</source><target state="new">The permissions cannot be retrieved. If the problem persists, please contact us.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">269</context></context-group></trans-unit><trans-unit id="3768927257183755959" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">270</context></context-group></trans-unit><trans-unit id="3768927257183755959" datatype="html">
         <source>Save</source><target state="translated">Sauvegarder</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">99</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/floating-save/floating-save.component.html</context><context context-type="linenumber">1</context></context-group></trans-unit><trans-unit id="4675865183684903475" datatype="html">
@@ -769,22 +769,28 @@
           <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
           <context context-type="linenumber">44</context>
         </context-group>
-      </trans-unit><trans-unit id="5875164839897370180" datatype="html">
-        <source>Given by</source><target state="new">Given by</target>
-        
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="807906988305504107" datatype="html">
-        <source>Given by this group</source><target state="new">Given by this group</target>
+      </trans-unit><trans-unit id="265815261626670662" datatype="html">
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Given by<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/><x id="START_LINK" ctype="x-a" equiv-text="&lt;a
+                  class=&quot;alg-link&quot;
+                  [routerLink]=&quot;{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink&quot;
+                >"/> <x id="INTERPOLATION" equiv-text="{{ grantedPermission.sourceGroup.name }}"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="new"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Given by<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/><x id="START_LINK" ctype="x-a" equiv-text="&lt;a
+                  class=&quot;alg-link&quot;
+                  [routerLink]=&quot;{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink&quot;
+                >"/> <x id="INTERPOLATION" equiv-text="{{ grantedPermission.sourceGroup.name }}"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
-          <context context-type="linenumber">68</context>
+          <context context-type="linenumber">61,67</context>
         </context-group>
-      </trans-unit><trans-unit id="4471978812071001025" datatype="html">
+      </trans-unit><trans-unit id="807906988305504107" datatype="html">
+        <source>Given by this group</source><target state="new">Given by this group</target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="4471978812071001025" datatype="html">
         <source>This group has no permissions.</source><target state="new">This group has no permissions.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="4611536703147831594" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">78</context></context-group></trans-unit><trans-unit id="4611536703147831594" datatype="html">
         <source>You are not allowed to manage permissions of this group.</source><target state="new">You are not allowed to manage permissions of this group.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <source>Access to activity</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.ts</context><context context-type="linenumber">279</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
         <source>Access to activity</source><target state="translated">Accès à l'activité</target>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -771,26 +771,20 @@
         </context-group>
       </trans-unit><trans-unit id="5875164839897370180" datatype="html">
         <source>Given by</source><target state="new">Given by</target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="807906988305504107" datatype="html">
+        <source>Given by this group</source><target state="new">Given by this group</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
-          <context context-type="linenumber">58</context>
-        </context-group>
-      </trans-unit><trans-unit id="5564228719935129668" datatype="html">
-        <source> this group</source><target state="new"> this group</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">68</context>
         </context-group>
       </trans-unit><trans-unit id="4471978812071001025" datatype="html">
         <source>This group has no permissions.</source><target state="new">This group has no permissions.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
-          <context context-type="linenumber">74</context>
-        </context-group>
-      </trans-unit><trans-unit id="4611536703147831594" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="4611536703147831594" datatype="html">
         <source>You are not allowed to manage permissions of this group.</source><target state="new">You are not allowed to manage permissions of this group.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <source>Access to activity</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.ts</context><context context-type="linenumber">279</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
         <source>Access to activity</source><target state="translated">Accès à l'activité</target>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -149,15 +149,15 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">104</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.ts</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">51</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">109</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">281</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">295</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">345</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.ts</context><context context-type="linenumber">71</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">36</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/collapsible-section/switch-field/switch-field.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="7720833515469075698" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed</source><target state="new"><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="6863764519816340021" datatype="html">
         <source>Unable to remove the selected manager(s). <x id="PH" equiv-text="result.errorText || ''"/></source><target state="new">Unable to remove the selected manager(s). <x id="PH" equiv-text="result.errorText || ''"/></target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="2564386778587315692" datatype="html">
         <source><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed, <x id="PH_1" equiv-text="result.countRequests - result.countSuccess"/> could
        not be removed. <x id="PH_2" equiv-text="result.errorText || ''"/></source><target state="new"><x id="PH" equiv-text="result.countSuccess"/> manager(s) have been removed, <x id="PH_1" equiv-text="result.countRequests - result.countSuccess"/> could
        not be removed. <x id="PH_2" equiv-text="result.errorText || ''"/></target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-removal-response-handling.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6595442071355967826" datatype="html">
         <source>You have left "<x id="PH" equiv-text="groupName"/>"</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/joined-group-list/joined-group-list.component.ts</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="3538887675032003480" datatype="html">
         <source>You have delete "<x id="PH" equiv-text="groupName"/>"</source><target state="new">You have delete "<x id="PH" equiv-text="groupName"/>"</target>
@@ -426,7 +426,7 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">25</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
         <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="new"> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
 
@@ -438,14 +438,14 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
         <source>Unable to load the answer</source><target state="new">Unable to load the answer</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="new">Saving answer...</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
         <source>Skip</source><target state="new">Skip</target>
-        
-        
+
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="5172335096273253685" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet ?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet ?</target>
         
@@ -566,7 +566,43 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="9108820859798349403" datatype="html">
         <source>A new sub-skill.</source><target state="translated">Une nouvelle sous-compétence.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">29</context></context-group></trans-unit><trans-unit id="875621229969091247" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">29</context></context-group></trans-unit><trans-unit id="3305017324257919959" datatype="html">
+        <source>All with grant</source><target state="new">All with grant</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context>
+          <context context-type="linenumber">7</context>
+        </context-group>
+      </trans-unit><trans-unit id="7016790272435410171" datatype="html">
+        <source>Enter</source><target state="new">Enter</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context>
+          <context context-type="linenumber">8</context>
+        </context-group>
+      </trans-unit><trans-unit id="3700070166854933786" datatype="html">
+        <source>Content with descendants</source><target state="new">Content with descendants</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context>
+          <context context-type="linenumber">10</context>
+        </context-group>
+      </trans-unit><trans-unit id="7118211687824505601" datatype="html">
+        <source>Solution with grant</source><target state="new">Solution with grant</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context>
+          <context context-type="linenumber">12</context>
+        </context-group>
+      </trans-unit><trans-unit id="5525476874751783659" datatype="html">
+        <source>Answer with grant</source><target state="new">Answer with grant</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context>
+          <context context-type="linenumber">16</context>
+        </context-group>
+      </trans-unit><trans-unit id="6928692670367755308" datatype="html">
+        <source>No caption</source><target state="new">No caption</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
@@ -626,10 +662,10 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">103</context></context-group></trans-unit><trans-unit id="6202345244999431296" datatype="html">
         <source>Unable to load this task. Either you have a connexion issue or this task is not correctly configured. Please retry, if the problem persists, contact us.</source><target state="new">Unable to load this task. Either you have a connexion issue or this task is not correctly configured. Please retry, if the problem persists, contact us.</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="3494909424140166619" datatype="html">
         <source>This task is not correctly configured (chapter with task expected).</source><target state="new">This task is not correctly configured (chapter with task expected).</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="6099099963678196110" datatype="html">
         <source>This task is not correctly configured (item not found or explicit entry but no result)</source><target state="new">This task is not correctly configured (item not found or explicit entry but no result)</target>
         <context-group purpose="location">
@@ -718,13 +754,43 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="104198068484921859" datatype="html">
         <source>Root activity: <x id="INTERPOLATION" equiv-text="{{ rootActivityState.data.string.title }}"/></source><target state="new">Root activity: <x id="INTERPOLATION" equiv-text="{{ itemState.data.string.title }}"/></target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="936247180843553773" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">21</context></context-group></trans-unit><trans-unit id="936247180843553773" datatype="html">
         <source>This group has no activity.</source><target state="new">This group has no activity.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="4611536703147831594" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="1737222622761672885" datatype="html">
+        <source>Specific permissions given to the group on content</source><target state="new">Specific permissions given to the group on content</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
+          <context context-type="linenumber">35</context>
+        </context-group>
+      </trans-unit><trans-unit id="6444571656011193657" datatype="html">
+        <source>Error while loading permissions.</source><target state="new">Error while loading permissions.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
+          <context context-type="linenumber">44</context>
+        </context-group>
+      </trans-unit><trans-unit id="5875164839897370180" datatype="html">
+        <source>Given by</source><target state="new">Given by</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
+      </trans-unit><trans-unit id="5564228719935129668" datatype="html">
+        <source> this group</source><target state="new"> this group</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
+          <context context-type="linenumber">66</context>
+        </context-group>
+      </trans-unit><trans-unit id="4471978812071001025" datatype="html">
+        <source>This group has no permissions.</source><target state="new">This group has no permissions.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
+          <context context-type="linenumber">74</context>
+        </context-group>
+      </trans-unit><trans-unit id="4611536703147831594" datatype="html">
         <source>You are not allowed to manage permissions of this group.</source><target state="new">You are not allowed to manage permissions of this group.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">33</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <source>Access to activity</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.ts</context><context context-type="linenumber">279</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
         <source>Access to activity</source><target state="translated">Accès à l'activité</target>
@@ -1062,7 +1128,7 @@
         <source>Can manage members, managers, and change group settings</source><target state="new">Can manage members, managers, and change group settings</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="1774407921639110803" datatype="html">
-        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ? 
+        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ?
         You may lose manager access and not be able to restore it.</source><target state="new">Are you sure to remove from yourself the permission to edit group settings and edit managers ?
         You may lose manager access and not be able to restore it.</target>
         <context-group purpose="location">
@@ -1115,7 +1181,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="4705822664965381735" datatype="html">
         <source>Children</source><target state="translated">Enfants</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">123</context></context-group></trans-unit><trans-unit id="8052476462144624454" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">123</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="8052476462144624454" datatype="html">
         <source>Enable score weight</source><target state="new">Enable score weight</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="5991878472400123259" datatype="html">
@@ -1170,7 +1236,7 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="694771452558018718" datatype="html">
         <source> Submitted by <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;groupLink$ | async&quot; class=&quot;alg-link links&quot;>"/><x id="INTERPOLATION" equiv-text="{{ author | userCaption }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> on <x id="INTERPOLATION_1" equiv-text="{{ answer.createdAt | date:'short' }}"/>. <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span *ngIf=&quot;answer.score || answer.score === 0&quot; class=&quot;score&quot;>"/>Score: <x id="INTERPOLATION_2" equiv-text="{{ answer.score }}"/> points.<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></source><target state="new"> Submitted by <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;groupLink&quot; class=&quot;alg-link links&quot;>"/><x id="INTERPOLATION" equiv-text="{{ user | userCaption }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/> on <x id="INTERPOLATION_1" equiv-text="{{ answer.createdAt | date:'short' }}"/>. <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span *ngIf=&quot;answer.score || answer.score === 0&quot; class=&quot;score&quot;>"/>Score: <x id="INTERPOLATION_2" equiv-text="{{ answer.score }}"/> points.<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/></target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="7508893828342265603" datatype="html">
         <source>Nothing</source><target state="translated">Rien</target>
 
@@ -1183,14 +1249,14 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="314315645942131479" datatype="html">
         <source>Info</source><target state="translated">Info</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="276512967364950264" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">26</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="276512967364950264" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the item title and description, but not its content</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="6205355627445317276" datatype="html">
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -1204,7 +1270,7 @@
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">149</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
@@ -1237,13 +1303,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="2525230676386818985" datatype="html">
         <source>Result</source><target state="translated">Résultats</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="6744117517239451341" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">96</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6744117517239451341" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can view information about submissions and scores of others on this item, but not their answers</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir les soumissions et scores des utilisateurs sur cet élément, mais pas leurs réponses</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">98</context></context-group></trans-unit><trans-unit id="4669216542007588508" datatype="html">
         <source>Answer</source><target state="translated">Réponse</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="179825020038700385" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">102</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="179825020038700385" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also look at other people's answers on this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les réponses des autres utilisateurs sur cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">103</context></context-group></trans-unit><trans-unit id="8665674003252205412" datatype="html">
@@ -1264,7 +1330,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">124</context></context-group></trans-unit><trans-unit id="1616102757855967475" datatype="html">
         <source>All</source><target state="translated">Tout</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="7027429249361248522" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">128</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="7027429249361248522" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also edit the content of the item itself, but may not delete it</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également éditer le contenu de cet élément, mais pas le supprimer</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">129</context></context-group></trans-unit><trans-unit id="7644477740441451078" datatype="html">
@@ -1416,12 +1482,12 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/managed-group-list/managed-group-list.component.ts</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="6252070156626006029" datatype="html">
         <source>None</source><target state="translated">Rien</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/managed-group-list/managed-group-list.component.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="7610330755258977986" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/managed-group-list/managed-group-list.component.ts</context><context context-type="linenumber">60</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="7610330755258977986" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ group?.name }}"/>: manager access given to <x id="INTERPOLATION_1" equiv-text="{{ userCaption }}"/> </source><target state="new"> <x id="INTERPOLATION" equiv-text="{{ group?.name }}"/>: manager access given to <x id="INTERPOLATION_1" equiv-text="{{ userCaption }}"/> </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="9171311681863414398" datatype="html">
         <source> This panel lets you select what you allow the selected user or group of users to do on the current group and its descendants. </source><target state="new"> This panel lets you select what you allow the selected user or group of users to do on the current group and its descendants. </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="7838784407251919653" datatype="html">
         <source>Management level</source><target state="new">Management level</target>
         
@@ -1464,7 +1530,7 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="6365312852877051748" datatype="html">
         <source>Yes, remove me from the group managers</source><target state="new">Yes, remove me from the group managers</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="2665063333072587702" datatype="html">
         <source>Error while loading the group managers</source><target state="translated">Erreur lors du chargement des gestionnaires de groupe</target>
 


### PR DESCRIPTION
## Description

Fixes #828

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

I guess access page must be separated to sub components for avoid a lot someState$ variables inside.

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/group-access-page-add-granted-permissions/en/#/groups/by-id/120505918794412400;path=2012793249973596086/details/access)
  3. Then I see list of items and permissions for it.

- [ ] Case 2:
 1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/group-access-page-add-granted-permissions/en/#/groups/by-id/120505918794412400;path=2012793249973596086/details/access)
  3. And I click on `Given by [group]` should redirect to group page
