### PR TITLE
Feature/style the item error page like others

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.html
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.html
@@ -6,12 +6,6 @@
 <ng-container *ngIf="state.isError">
   <p class="alg-error-message" *ngIf="$any(state).error && ($any(state).error.status === 403 || $any(state).error.status === 404); else unknownError" i18n>
     This content does not exist or you are not allowed to view it.
-    <p-button
-      class="refresh-button"
-      icon="pi pi-refresh"
-      (click)="reloadContent()"
-      styleClass="p-button-sm"
-    ></p-button>
   </p>
   <ng-template #unknownError><p i18n>Error while loading the item.</p></ng-template>
   <p class="alg-error-message" [style.visibility]="(backToHome.isActive)?'hidden':'visible'">

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.html
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.html
@@ -4,11 +4,17 @@
 <alg-loading *ngIf="state.isFetching"></alg-loading>
 
 <ng-container *ngIf="state.isError">
-  <p *ngIf="$any(state).error && ($any(state).error.status === 403 || $any(state).error.status === 404); else unknownError" i18n>
+  <p class="alg-error-message" *ngIf="$any(state).error && ($any(state).error.status === 403 || $any(state).error.status === 404); else unknownError" i18n>
     This content does not exist or you are not allowed to view it.
+    <p-button
+      class="refresh-button"
+      icon="pi pi-refresh"
+      (click)="reloadContent()"
+      styleClass="p-button-sm"
+    ></p-button>
   </p>
   <ng-template #unknownError><p i18n>Error while loading the item.</p></ng-template>
-  <p [style.visibility]="(backToHome.isActive)?'hidden':'visible'">
+  <p class="alg-error-message" [style.visibility]="(backToHome.isActive)?'hidden':'visible'">
     <span i18n>Go back to the </span>
     <a
       routerLink="/"
@@ -19,5 +25,4 @@
       home page
     </a>
   </p>
-  <p><a [routerLink]="" (click)="reloadContent()" i18n>Retry loading it</a></p>
 </ng-container>

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.scss
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.scss
@@ -1,0 +1,3 @@
+.refresh-button {
+  margin-left: .5rem;
+}

--- a/src/assets/scss/components/error-message.scss
+++ b/src/assets/scss/components/error-message.scss
@@ -1,8 +1,11 @@
+@import 'src/colors';
+
 .alg-error-message {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: medium;
+  font-size: 1.6rem;
+  color: $base-text-color;
   > * + * {
     margin-left: 0.25rem;
   }

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -108,7 +108,7 @@
       </trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
         <source>home page</source><target state="translated">accueil</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context>
@@ -126,21 +126,11 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="4449471207584645508" datatype="html">
         <source>Permissions successfully updated.</source><target state="translated">Permissions mises à jour avec succès.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">284</context></context-group></trans-unit><trans-unit id="8539005737773857870" datatype="html">
-        <source> This content does not exist or you are not allowed to view it. <x id="START_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;p-button
-      class=&quot;refresh-button&quot;
-      icon=&quot;pi pi-refresh&quot;
-      (click)=&quot;reloadContent()&quot;
-      styleClass=&quot;p-button-sm&quot;
-    >"/><x id="CLOSE_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;/p-button>"/></source><target state="new"> This content does not exist or you are not allowed to view it. <x id="START_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;p-button
-      class=&quot;refresh-button&quot;
-      icon=&quot;pi pi-refresh&quot;
-      (click)=&quot;reloadContent()&quot;
-      styleClass=&quot;p-button-sm&quot;
-    >"/><x id="CLOSE_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;/p-button>"/></target>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">284</context></context-group></trans-unit><trans-unit id="7463044993322326313" datatype="html">
+        <source> This content does not exist or you are not allowed to view it. </source><target state="new"> This content does not exist or you are not allowed to view it. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
-          <context context-type="linenumber">8,14</context>
+          <context context-type="linenumber">8,9</context>
         </context-group>
       </trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
@@ -873,8 +863,8 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -889,7 +879,7 @@
       </trans-unit><trans-unit id="9041444757418829014" datatype="html">
         <source>Error while loading the item.</source><target state="translated">Erreur lors du chargement du contenu.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
         <source>Add</source><target state="translated">Ajouter</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="5932939510039092507" datatype="html">

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -108,7 +108,7 @@
       </trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
         <source>home page</source><target state="translated">accueil</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context>
@@ -126,7 +126,23 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="4449471207584645508" datatype="html">
         <source>Permissions successfully updated.</source><target state="translated">Permissions mises à jour avec succès.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">284</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">284</context></context-group></trans-unit><trans-unit id="8539005737773857870" datatype="html">
+        <source> This content does not exist or you are not allowed to view it. <x id="START_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;p-button
+      class=&quot;refresh-button&quot;
+      icon=&quot;pi pi-refresh&quot;
+      (click)=&quot;reloadContent()&quot;
+      styleClass=&quot;p-button-sm&quot;
+    >"/><x id="CLOSE_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;/p-button>"/></source><target state="new"> This content does not exist or you are not allowed to view it. <x id="START_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;p-button
+      class=&quot;refresh-button&quot;
+      icon=&quot;pi pi-refresh&quot;
+      (click)=&quot;reloadContent()&quot;
+      styleClass=&quot;p-button-sm&quot;
+    >"/><x id="CLOSE_TAG_P_BUTTON" ctype="x-p_button" equiv-text="&lt;/p-button>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
+          <context context-type="linenumber">8,14</context>
+        </context-group>
+      </trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context>
@@ -842,29 +858,23 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
         <source> This activity has not been correctly configured. </source><target state="new"> This activity has not been correctly configured. </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
         <source> You need to set a url in editing mode. </source><target state="new"> You need to set a url in editing mode. </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">34</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="2875135670849639672" datatype="html">
         <source> This activity requires explicit entry (not implemented). </source><target state="new"> This activity requires explicit entry (not implemented). </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">63</context></context-group></trans-unit><trans-unit id="3074566479590679594" datatype="html">
         <source> Starting the activity ... (if you are stuck on this message, please retry and contact us if the problem persists) </source><target state="new"> Starting the activity ... (if you are stuck on this message, please retry and contact us if the problem persists) </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
-          <context context-type="linenumber">19,20</context>
-        </context-group>
-      </trans-unit><trans-unit id="7803285677819095346" datatype="html">
-        <source>Retry loading it</source><target state="translated">Recharger le contenu</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -876,16 +886,10 @@
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-      </trans-unit><trans-unit id="7463044993322326313" datatype="html">
-        <source> This content does not exist or you are not allowed to view it. </source><target state="translated"> Ce contenu n'existe et n'est pas visible pour vous. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
-          <context context-type="linenumber">8,9</context>
-        </context-group>
       </trans-unit><trans-unit id="9041444757418829014" datatype="html">
         <source>Error while loading the item.</source><target state="translated">Erreur lors du chargement du contenu.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
         <source>Add</source><target state="translated">Ajouter</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="5932939510039092507" datatype="html">
@@ -1146,7 +1150,7 @@
         <source>Can manage members, managers, and change group settings</source><target state="new">Can manage members, managers, and change group settings</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="1774407921639110803" datatype="html">
-        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ? 
+        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ?
         You may lose manager access and not be able to restore it.</source><target state="new">Are you sure to remove from yourself the permission to edit group settings and edit managers ?
         You may lose manager access and not be able to restore it.</target>
         <context-group purpose="location">
@@ -1288,7 +1292,7 @@
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">149</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">


### PR DESCRIPTION
## Description

Fixes #762

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/style-the-item-error-page-like-others/en/#/activities/by-id/22;path=;parentAttempId=0/details)
  3. Then I see improved style for error page
