### PR TITLE
implement LTI login

### DIFF
--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -9,6 +9,7 @@ import { LocaleService } from './services/localeService';
 import { LayoutService } from '../shared/services/layout.service';
 import { Title } from '@angular/platform-browser';
 import { appConfig } from '../shared/helpers/config';
+import { getRedirectToSubPathAtInit, removeSubPathRedirectionAtInit } from '../shared/helpers/redirect-to-sub-path-at-init';
 
 @Component({
   selector: 'alg-root',
@@ -45,6 +46,12 @@ export class AppComponent implements OnInit, OnDestroy {
     const title = appConfig.languageSpecificTitles && this.localeService.currentLang ?
       appConfig.languageSpecificTitles[this.localeService.currentLang.tag] : undefined;
     this.titleService.setTitle(title ?? appConfig.defaultTitle);
+
+    const subPathToRedirectTo = getRedirectToSubPathAtInit();
+    if (subPathToRedirectTo) {
+      removeSubPathRedirectionAtInit();
+      void this.router.navigateByUrl(subPathToRedirectTo, { replaceUrl: true });
+    }
   }
 
   ngOnInit(): void {

--- a/src/app/modules/lti/pages/lti/lti.component.html
+++ b/src/app/modules/lti/pages/lti/lti.component.html
@@ -12,4 +12,8 @@
     *ngIf="error === 'no_item_or_explicit_entry_with_no_result'"
     i18n-message message="This task is not correctly configured (item not found or explicit entry but no result)"
   ></alg-error>
+  <alg-error
+    *ngIf="error === 'login_error'"
+    i18n-message message="Login failed"
+  ></alg-error>
 </ng-container>

--- a/src/app/modules/lti/pages/lti/lti.component.html
+++ b/src/app/modules/lti/pages/lti/lti.component.html
@@ -12,8 +12,9 @@
     *ngIf="error === 'no_item_or_explicit_entry_with_no_result'"
     i18n-message message="This task is not correctly configured (item not found or explicit entry but no result)"
   ></alg-error>
-  <alg-error
-    *ngIf="error === 'login_error'"
-    i18n-message message="Login failed"
-  ></alg-error>
+  <alg-error *ngIf="error === 'login_error'" i18n>
+    Something wrong occurred during the login process, please <span class="alg-link" (click)="restartProcess()">retry</span>.
+    <br>
+    If the problem persists, please contact us.
+  </alg-error>
 </ng-container>

--- a/src/app/modules/lti/pages/lti/lti.component.html
+++ b/src/app/modules/lti/pages/lti/lti.component.html
@@ -13,7 +13,7 @@
     i18n-message message="This task is not correctly configured (item not found or explicit entry but no result)"
   ></alg-error>
   <alg-error *ngIf="error === 'login_error'" i18n>
-    Something wrong occurred during the login process, please <span class="alg-link" (click)="restartProcess()">retry</span>.
+    Something wrong occurred during the login process, please retry after closing this tab or window.
     <br>
     If the problem persists, please contact us.
   </alg-error>

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -7,7 +7,7 @@ import { GetItemChildrenService, ItemChild } from 'src/app/modules/item/http-ser
 import { GetItemPathService } from 'src/app/modules/item/http-services/get-item-path.service';
 import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
 import { isNotNull } from 'src/app/shared/helpers/null-undefined-predicates';
-import { removeSubPathRedirectionAtInit, setRedirectToSubPathAtInit } from 'src/app/shared/helpers/redirect-to-sub-path-at-init';
+import { setRedirectToSubPathAtInit } from 'src/app/shared/helpers/redirect-to-sub-path-at-init';
 import { CheckLoginService } from 'src/app/shared/http-services/check-login.service';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { mapToFetchState, readyData } from 'src/app/shared/operators/state';
@@ -122,16 +122,6 @@ export class LTIComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());
-  }
-
-  restartProcess(): void {
-    combineLatest([
-      this.contentId$,
-      this.loginId$.pipe(filter(isNotNull)),
-    ]).subscribe(([ contentId, loginId ]) => {
-      removeSubPathRedirectionAtInit();
-      window.location.href = `./#/lti/${contentId}?${loginIdParam}=${loginId}`;
-    });
   }
 
   private getNavigationData(itemId: string): Observable<{ firstChild: ItemChild, path: string[], attemptId: string }> {

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { combineLatest, EMPTY, forkJoin, Observable } from 'rxjs';
+import { combineLatest, EMPTY, forkJoin, Observable, of } from 'rxjs';
 import { catchError, filter, map, shareReplay, switchMap } from 'rxjs/operators';
 import { ActivityNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
 import { GetItemChildrenService, ItemChild } from 'src/app/modules/item/http-services/get-item-children.service';
@@ -36,13 +36,7 @@ const loginIdParam = 'user_id';
 })
 export class LTIComponent implements OnDestroy {
 
-  private loginId$ = this.activatedRoute.queryParamMap.pipe(
-    map(queryParams => {
-      const loginId = Number(queryParams.get(loginIdParam) ?? NaN);
-      if (Number.isNaN(loginId)) throw new Error('login id must be a number');
-      return loginId;
-    }),
-  );
+  private loginId$ = this.activatedRoute.queryParamMap.pipe(map(queryParams => queryParams.get(loginIdParam)));
 
   private isRedirection$ = this.activatedRoute.queryParamMap.pipe(
     map(queryParams => queryParams.has(isRedirectionParam)),
@@ -57,7 +51,7 @@ export class LTIComponent implements OnDestroy {
   );
 
   private isLoggedIn$ = this.loginId$.pipe(
-    switchMap(loginId => this.checkLoginService.check(loginId)),
+    switchMap(loginId => (loginId ? this.checkLoginService.check(loginId) : of(false))),
     shareReplay(1),
   );
 

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -1,24 +1,32 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { forkJoin, Observable } from 'rxjs';
-import { catchError, map, shareReplay, switchMap } from 'rxjs/operators';
+import { combineLatest, EMPTY, forkJoin, Observable } from 'rxjs';
+import { catchError, filter, map, shareReplay, switchMap, take } from 'rxjs/operators';
 import { ActivityNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
 import { GetItemChildrenService, ItemChild } from 'src/app/modules/item/http-services/get-item-children.service';
 import { GetItemPathService } from 'src/app/modules/item/http-services/get-item-path.service';
 import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
+import { isNotNull } from 'src/app/shared/helpers/null-undefined-predicates';
+import { setRedirectToSubPathAtInit } from 'src/app/shared/helpers/redirect-to-sub-path-at-init';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { mapToFetchState, readyData } from 'src/app/shared/operators/state';
 import { fullItemRoute } from 'src/app/shared/routing/item-route';
 import { ItemRouter } from 'src/app/shared/routing/item-router';
 import { LayoutService } from 'src/app/shared/services/layout.service';
+import { UserSessionService } from 'src/app/shared/services/user-session.service';
 
 enum LTIError {
   FetchError = 'fetch_error',
   NoItemOrExplicitEntryWithNoResult = 'no_item_or_explicit_entry_with_no_result',
   NoChild = 'no_child',
+  LoginError = 'login_error',
 }
 const noItemOrExplicitEntryWithNoResultError = new Error(LTIError.NoItemOrExplicitEntryWithNoResult);
 const noChildError = new Error(LTIError.NoChild);
+const loginError = new Error(LTIError.LoginError);
+
+const isRedirectionParam = 'is_redirection';
+const userIdParam = 'user_id';
 
 @Component({
   selector: 'alg-lti',
@@ -27,6 +35,14 @@ const noChildError = new Error(LTIError.NoChild);
 })
 export class LTIComponent implements OnDestroy {
 
+  private userId$ = this.activatedRoute.queryParamMap.pipe(
+    map(queryParams => queryParams.get(userIdParam)),
+  );
+
+  private isRedirection$ = this.activatedRoute.queryParamMap.pipe(
+    map(queryParams => queryParams.has(isRedirectionParam)),
+  );
+
   private contentId$ = this.activatedRoute.paramMap.pipe(
     map(params => {
       const contentId = params.get('contentId');
@@ -34,34 +50,60 @@ export class LTIComponent implements OnDestroy {
       return contentId;
     }),
   );
-  readonly navigationData$ = this.contentId$.pipe(
-    switchMap(contentId => this.getNavigationData(contentId).pipe(mapToFetchState())),
+
+  private isLoggedIn$ = combineLatest([ this.userSession.userProfile$, this.userId$ ]).pipe(
+    map(([ profile, userId ]) => !!userId && profile.groupId === userId),
+    take(1),
+  );
+
+  readonly navigationData$ = combineLatest([ this.isLoggedIn$, this.isRedirection$ ]).pipe(
+    switchMap(([ isLoggedIn, isRedirection ]) => {
+      if (!isLoggedIn) {
+        if (isRedirection) throw loginError;
+        return EMPTY;
+      }
+      return this.contentId$;
+    }),
+    switchMap(contentId => this.getNavigationData(contentId)),
+    mapToFetchState(),
     shareReplay(1),
   );
+
   readonly error$ = this.navigationData$.pipe(
     map((state): LTIError | undefined => {
       if (!state.isError) return undefined;
       switch (state.error) {
         case noChildError: return LTIError.NoChild;
         case noItemOrExplicitEntryWithNoResultError: return LTIError.NoItemOrExplicitEntryWithNoResult;
+        case loginError: return LTIError.LoginError;
         default: return LTIError.FetchError;
       }
     })
   );
 
   private subscriptions = [
-    this.contentId$.subscribe(contentId => this.activityNavTreeService.navigationNeighborsRestrictedToDescendantOfElementId = contentId),
-    this.navigationData$.pipe(readyData()).subscribe({
-      next: ({ firstChild, path, attemptId }) => {
-        const itemRoute = fullItemRoute('activity', firstChild.id, path, { parentAttemptId: attemptId });
-        this.itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
-      },
+    combineLatest([
+      this.contentId$,
+      this.userId$.pipe(filter(isNotNull)),
+    ]).subscribe(([ contentId, userId ]) => {
+      setRedirectToSubPathAtInit(`/lti/${contentId}?${userIdParam}=${userId}&${isRedirectionParam}=`);
+      this.activityNavTreeService.navigationNeighborsRestrictedToDescendantOfElementId = contentId;
+    }),
+
+    combineLatest([ this.isLoggedIn$, this.isRedirection$ ]).pipe(
+      filter(([ isLoggedIn, isRedirection ]) => !isLoggedIn && !isRedirection),
+    ).subscribe(() => this.userSession.login()), // will redirect outside the platform
+
+    this.navigationData$.pipe(readyData()).subscribe(({ firstChild, path, attemptId }) => {
+      const itemRoute = fullItemRoute('activity', firstChild.id, path, { parentAttemptId: attemptId });
+      this.itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
     }),
   ];
 
   constructor(
     private activatedRoute: ActivatedRoute,
     private itemRouter: ItemRouter,
+    private userSession: UserSessionService,
     private layoutService: LayoutService,
     private activityNavTreeService: ActivityNavTreeService,
     private getItemPathService: GetItemPathService,

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { combineLatest, EMPTY, forkJoin, Observable, of } from 'rxjs';
+import { combineLatest, EMPTY, forkJoin, Observable } from 'rxjs';
 import { catchError, filter, map, shareReplay, switchMap } from 'rxjs/operators';
 import { ActivityNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
 import { GetItemChildrenService, ItemChild } from 'src/app/modules/item/http-services/get-item-children.service';
@@ -51,7 +51,10 @@ export class LTIComponent implements OnDestroy {
   );
 
   private isLoggedIn$ = this.loginId$.pipe(
-    switchMap(loginId => (loginId ? this.checkLoginService.check(loginId) : of(false))),
+    switchMap(loginId => {
+      if (!loginId) throw loginError;
+      return this.checkLoginService.check(loginId);
+    }),
     shareReplay(1),
   );
 

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { combineLatest, EMPTY, forkJoin, Observable, of } from 'rxjs';
+import { combineLatest, EMPTY, forkJoin, Observable } from 'rxjs';
 import { catchError, filter, map, shareReplay, switchMap } from 'rxjs/operators';
 import { ActivityNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
 import { GetItemChildrenService, ItemChild } from 'src/app/modules/item/http-services/get-item-children.service';
@@ -56,11 +56,9 @@ export class LTIComponent implements OnDestroy {
     }),
   );
 
-  private isLoggedIn$ = combineLatest([ this.loginId$, this.userSession.userProfile$ ]).pipe(
-    switchMap(([ loginId, profile ]) => {
-      if (profile.tempUser) return of(false);
-      return this.checkLoginService.check(loginId);
-    }),
+  private isLoggedIn$ = this.loginId$.pipe(
+    switchMap(loginId => this.checkLoginService.check(loginId)),
+    shareReplay(1),
   );
 
   readonly navigationData$ = combineLatest([ this.isLoggedIn$, this.isRedirection$ ]).pipe(
@@ -105,7 +103,6 @@ export class LTIComponent implements OnDestroy {
       const itemRoute = fullItemRoute('activity', firstChild.id, path, { parentAttemptId: attemptId });
       this.itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
     }),
-
   ];
 
   constructor(

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -7,7 +7,7 @@ import { GetItemChildrenService, ItemChild } from 'src/app/modules/item/http-ser
 import { GetItemPathService } from 'src/app/modules/item/http-services/get-item-path.service';
 import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
 import { isNotNull } from 'src/app/shared/helpers/null-undefined-predicates';
-import { setRedirectToSubPathAtInit } from 'src/app/shared/helpers/redirect-to-sub-path-at-init';
+import { removeSubPathRedirectionAtInit, setRedirectToSubPathAtInit } from 'src/app/shared/helpers/redirect-to-sub-path-at-init';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { mapToFetchState, readyData } from 'src/app/shared/operators/state';
 import { fullItemRoute } from 'src/app/shared/routing/item-route';
@@ -98,6 +98,7 @@ export class LTIComponent implements OnDestroy {
       const itemRoute = fullItemRoute('activity', firstChild.id, path, { parentAttemptId: attemptId });
       this.itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
     }),
+
   ];
 
   constructor(
@@ -116,6 +117,16 @@ export class LTIComponent implements OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());
+  }
+
+  restartProcess(): void {
+    combineLatest([
+      this.contentId$,
+      this.userId$.pipe(filter(isNotNull)),
+    ]).subscribe(([ contentId, userId ]) => {
+      removeSubPathRedirectionAtInit();
+      window.location.href = `./#/lti/${contentId}?${userIdParam}=${userId}`;
+    });
   }
 
   private getNavigationData(itemId: string): Observable<{ firstChild: ItemChild, path: string[], attemptId: string }> {

--- a/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
+++ b/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
@@ -1,0 +1,15 @@
+const storage = globalThis.sessionStorage;
+const redirectToSubPathKey = 'redirect_to_sub_path';
+
+export function setRedirectToSubPathAtInit(subPath: string): void {
+  storage.setItem(redirectToSubPathKey, subPath);
+}
+
+export function getRedirectToSubPathAtInit(): string | null {
+  return storage.getItem(redirectToSubPathKey);
+}
+
+export function removeSubPathRedirectionAtInit(): void {
+  storage.removeItem(redirectToSubPathKey);
+}
+

--- a/src/app/shared/http-services/check-login.service.ts
+++ b/src/app/shared/http-services/check-login.service.ts
@@ -1,10 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { appConfig } from '../helpers/config';
 import * as D from 'io-ts/Decoder';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
-import { map } from 'rxjs/operators';
+import { delay, map } from 'rxjs/operators';
+
+const fakePassingId = 42;
 
 const dataDecoder = D.struct({
   loginIdMatched: D.boolean,
@@ -18,6 +20,8 @@ export class CheckLoginService {
   constructor(private http: HttpClient) {}
 
   check(loginId: number): Observable<boolean> {
+    if (loginId === fakePassingId) return of(true).pipe(delay(300));
+
     const params = new HttpParams({ fromObject: { login_id: loginId } });
 
     return this.http

--- a/src/app/shared/http-services/check-login.service.ts
+++ b/src/app/shared/http-services/check-login.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { appConfig } from '../helpers/config';
+import * as D from 'io-ts/Decoder';
+import { decodeSnakeCase } from 'src/app/shared/operators/decode';
+import { map } from 'rxjs/operators';
+
+const dataDecoder = D.struct({
+  loginIdMatched: D.boolean,
+});
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CheckLoginService {
+
+  constructor(private http: HttpClient) {}
+
+  check(loginId: number): Observable<boolean> {
+    const params = new HttpParams({ fromObject: { login_id: loginId } });
+
+    return this.http
+      .get<unknown>(`${appConfig.apiUrl}/current-user/check-login-id`, { params })
+      .pipe(
+        decodeSnakeCase(dataDecoder),
+        map(data => data.loginIdMatched),
+      );
+  }
+
+}

--- a/src/app/shared/http-services/check-login.service.ts
+++ b/src/app/shared/http-services/check-login.service.ts
@@ -1,12 +1,10 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { appConfig } from '../helpers/config';
 import * as D from 'io-ts/Decoder';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
-import { delay, map } from 'rxjs/operators';
-
-const fakePassingId = 42;
+import { map } from 'rxjs/operators';
 
 const dataDecoder = D.struct({
   loginIdMatched: D.boolean,
@@ -20,8 +18,6 @@ export class CheckLoginService {
   constructor(private http: HttpClient) {}
 
   check(loginId: number): Observable<boolean> {
-    if (loginId === fakePassingId) return of(true).pipe(delay(300));
-
     const params = new HttpParams({ fromObject: { login_id: loginId } });
 
     return this.http

--- a/src/app/shared/http-services/check-login.service.ts
+++ b/src/app/shared/http-services/check-login.service.ts
@@ -17,7 +17,7 @@ export class CheckLoginService {
 
   constructor(private http: HttpClient) {}
 
-  check(loginId: number): Observable<boolean> {
+  check(loginId: string): Observable<boolean> {
     const params = new HttpParams({ fromObject: { login_id: loginId } });
 
     return this.http

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -696,8 +696,8 @@
           <context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-      </trans-unit><trans-unit id="2205921893315386228" datatype="html">
-        <source> Something wrong occurred during the login process, please <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;alg-link&quot; (click)=&quot;restartProcess()&quot;>"/>retry<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> If the problem persists, please contact us. </source><target state="new"> Something wrong occurred during the login process, please <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;alg-link&quot; (click)=&quot;restartProcess()&quot;>"/>retry<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> If the problem persists, please contact us. </target>
+      </trans-unit><trans-unit id="4554929922442695846" datatype="html">
+        <source> Something wrong occurred during the login process, please retry after closing this tab or window. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> If the problem persists, please contact us. </source><target state="new"> Something wrong occurred during the login process, please retry after closing this tab or window. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> If the problem persists, please contact us. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context>
           <context context-type="linenumber">16,19</context>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -672,6 +672,12 @@
           <context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
+      </trans-unit><trans-unit id="8053477814844632887" datatype="html">
+        <source>Login failed</source><target state="new">Login failed</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
       </trans-unit><trans-unit id="5402924068010392760" datatype="html">
         <source>Join the group "<x id="PH" equiv-text="response.group.name"/>"</source><target state="translated">Rejoindre le groupe "<x id="PH" equiv-text="response.group.name"/>"</target>
 
@@ -1128,7 +1134,7 @@
         <source>Can manage members, managers, and change group settings</source><target state="new">Can manage members, managers, and change group settings</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.ts</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="1774407921639110803" datatype="html">
-        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ?
+        <source>Are you sure to remove from yourself the permission to edit group settings and edit managers ? 
         You may lose manager access and not be able to restore it.</source><target state="new">Are you sure to remove from yourself the permission to edit group settings and edit managers ?
         You may lose manager access and not be able to restore it.</target>
         <context-group purpose="location">
@@ -1256,7 +1262,7 @@
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">105</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -1270,7 +1276,7 @@
         <source>Solution</source><target state="translated">Solution</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">149</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -672,11 +672,11 @@
           <context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context>
           <context context-type="linenumber">13</context>
         </context-group>
-      </trans-unit><trans-unit id="8053477814844632887" datatype="html">
-        <source>Login failed</source><target state="new">Login failed</target>
+      </trans-unit><trans-unit id="2205921893315386228" datatype="html">
+        <source> Something wrong occurred during the login process, please <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;alg-link&quot; (click)=&quot;restartProcess()&quot;>"/>retry<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> If the problem persists, please contact us. </source><target state="new"> Something wrong occurred during the login process, please <x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span class=&quot;alg-link&quot; (click)=&quot;restartProcess()&quot;>"/>retry<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/>. <x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> If the problem persists, please contact us. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context>
-          <context context-type="linenumber">17</context>
+          <context context-type="linenumber">16,19</context>
         </context-group>
       </trans-unit><trans-unit id="5402924068010392760" datatype="html">
         <source>Join the group "<x id="PH" equiv-text="response.group.name"/>"</source><target state="translated">Rejoindre le groupe "<x id="PH" equiv-text="response.group.name"/>"</target>


### PR DESCRIPTION
## Description

Fixes #839 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Two main cases: when (1) login module user id matches current logged user or not (2).
Case (1) adds a step by calling backend service [check login id](https://france-ioi.github.io/algorea-devdoc/api/#operation/loginIDCheck).
For case (2) when user id does not match current user group id:
1. Store `redirect_to_sub_path: /lti/…` in session storage, this value is read and removed at app startup (ie when coming back after a login or refreshing). The LTI component will reset it to `/lti/…&is_redirection` right afterwards to stay in LTI mode even if the user refreshes the page
2. If `is_redirection` query param is set, we won't check again that the user id matches to avoid infinite loops. If the user id still mismatches the current user's group id, display an error.

## Test cases

:bulb: Be sure to clear the session storage "redirect_to_sub_path" between tests !
:warning: Tests work only for production app or localhost app because of the authorized login auth redirection urls. So you have to check out this branch to run the tests :confused: 

- [ ] Case 1: unlogged then already logged cases
  1. Given I am logged into moodle algorea as the lti demo user
  2. When I navigate to [this moodle item](http://moodletest.algorea.org/mod/lti/view.php?id=8)
  3. Then a pop-up is opened with url http://moodletest.algorea.org/mod/lti/launch.php?id=8 (useful to restart test or open a tab manually from here, clear the session storage if needed and throttle the network to see it in detail)
  4. Then there's a redirection to [algorea frontend](http://localhost:4200/en/#/lti/34689573454313988?user_id=100465069)
  5. Then there's a redirection to the login module re-redirecting to algorea frontend with proper login
  6. Then there's an internal app navigation to lti again, and finally we see the activity "Les boucles bornées ou à compteur"
  7. And clear `redirect_to_sub_path` in session storage and copy-paste [step 4 url](http://localhost:4200/en/#/lti/34689573454313988?user_id=100465069) (already logged in case)
  8. Then there's no redirection and the activity is launched

- [ ] Case 2: refresh to simulate invalid user id after login
  1. Given I am the lti demo user
  2. When I go to [home page](http://localhost:4200/#/)
  3. And I open devtools and add in session storage `redirect_to_sub_path: /lti/1625159049301502151?user_id=42&is_redirection=`
  4. And I refresh the page (still on the home page)
  5. Then I should see a login failed error

- [ ] Case 3: invalid user id in url -> force user to re-log in
  1. Given I am the any user
  2. When I go to [home page](http://localhost:4200/#/) (creates a temp user if none)
  3. And I go to [this chapter](http://localhost:4200/#/lti/1625159049301502151?user_id=43)
  4. Then I am redirected to the login module

- [ ] Case 4: no `user_id` (`loginId`) in url
  1. Given I am any user
  2. When I navigate to [this chapter in lti](http://localhost:4200/#/lti/1625159049301502151)
  3. Then I should see an error "Something wrong occurred in the login process …".