### PR TITLE
Implement task auto height

### DIFF
--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -25,7 +25,7 @@
       </ng-template>
     </ng-container>
   </div>
-  <div class="iframe-container" [style.height.px]="iframeHeight$ | async" *ngIf="!state.isError">
+  <div class="iframe-container" [style.height]="iframeHeight$ | async" *ngIf="!state.isError">
     <div class="saving-answer" *ngIf="savingAnswer">
       <p class="saving-answer-message">
         <span i18n>Saving answer...</span>
@@ -33,7 +33,7 @@
         <p-button type="button" (click)="skipSave.emit()" i18n-label label="Skip"></p-button>
       </p>
     </div>
-    <iframe *ngIf="iframeSrc$ | async as iframeSrc" [style.height.px]="iframeHeight$ | async" #iframe [src]="iframeSrc"></iframe>
+    <iframe *ngIf="iframeSrc$ | async as iframeSrc" [style.height]="iframeHeight$ | async" #iframe [src]="iframeSrc"></iframe>
     <div *ngIf="state.isFetching" class="loading">
       <alg-loading></alg-loading>
     </div>

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -25,7 +25,7 @@
       </ng-template>
     </ng-container>
   </div>
-  <div class="iframe-container" [style.height]="iframeHeight$ | async" *ngIf="!state.isError">
+  <div class="iframe-container" *ngIf="!state.isError">
     <div class="saving-answer" *ngIf="savingAnswer">
       <p class="saving-answer-message">
         <span i18n>Saving answer...</span>

--- a/src/app/modules/item/pages/item-display/item-display.component.scss
+++ b/src/app/modules/item/pages/item-display/item-display.component.scss
@@ -15,6 +15,9 @@
     position: relative;
     min-height: 12rem;
     background-color: white;
+    iframe {
+      display: block;
+    }
   }
 
   .loading {

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -11,10 +11,10 @@ import {
   SimpleChanges,
   ViewChild,
 } from '@angular/core';
-import { interval, merge, Observable } from 'rxjs';
-import { filter, map, pairwise, startWith, switchMap } from 'rxjs/operators';
+import { fromEvent, interval, merge, Observable, ReplaySubject } from 'rxjs';
+import { distinctUntilChanged, filter, map, pairwise, startWith, switchMap } from 'rxjs/operators';
 import { HOURS, SECONDS } from 'src/app/shared/helpers/duration';
-import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
+import { isNotNull, isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { TaskConfig, ItemTaskService } from '../../services/item-task.service';
 import { mapToFetchState } from 'src/app/shared/operators/state';
 import { capitalize } from 'src/app/shared/helpers/case_conversion';
@@ -27,7 +27,7 @@ import { PermissionsInfo } from '../../helpers/item-permissions';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
 
 const initialHeight = 0;
-const additionalHeightToPreventInnerScrollIssues = 40;
+const appMainSectionPaddingBottom = '6rem';
 const heightSyncInterval = 0.2*SECONDS;
 
 export interface TaskTab {
@@ -67,11 +67,24 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   );
 
 
+  private computeIframeOffsetTop$ = new ReplaySubject<void>(1);
+  private iframeOffsetTop$ = merge(fromEvent(globalThis, 'resize'), this.computeIframeOffsetTop$).pipe(
+    map(() => (this.iframe ? this.iframe.nativeElement.getBoundingClientRect().top + globalThis.scrollY : null)),
+    filter(isNotNull),
+    distinctUntilChanged(),
+  );
   // Start updating the iframe height to match the task's height
-  iframeHeight$ = merge(
-    this.taskService.task$.pipe(switchMap(task => interval(heightSyncInterval).pipe(switchMap(() => task.getHeight())))),
-    this.taskService.display$.pipe(map(({ height }) => height), filter(isNotUndefined)),
-  ).pipe(map(height => height + additionalHeightToPreventInnerScrollIssues), startWith(initialHeight));
+  iframeHeight$ = this.taskService.task$.pipe(
+    switchMap(task => task.getMetaData()),
+    switchMap(({ autoHeight }) => {
+      if (autoHeight) return this.iframeOffsetTop$.pipe(map(top => `calc(100vh - ${top}px - ${appMainSectionPaddingBottom})`));
+      return merge(
+        this.taskService.task$.pipe(switchMap(task => interval(heightSyncInterval).pipe(switchMap(() => task.getHeight())))),
+        this.taskService.display$.pipe(map(({ height }) => height), filter(isNotUndefined)),
+      ).pipe(startWith(initialHeight), map(height => `${height}px`));
+    }),
+    distinctUntilChanged(),
+  );
 
   private subscription = this.taskService.saveAnswerAndStateInterval$
     .pipe(startWith({ success: true }), pairwise())
@@ -101,6 +114,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
 
   ngAfterViewChecked(): void {
     if (!this.iframe || this.taskService.initialized) return;
+    this.computeIframeOffsetTop$.next();
     this.taskService.initTask(this.iframe.nativeElement);
   }
 
@@ -121,6 +135,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
 
   ngOnDestroy(): void {
     if (this.actionFeedbackService.hasFeedback) this.actionFeedbackService.clear();
+    this.computeIframeOffsetTop$.complete();
     this.subscription.unsubscribe();
   }
 

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -12,7 +12,7 @@ import {
   ViewChild,
 } from '@angular/core';
 import { fromEvent, interval, merge, Observable, ReplaySubject } from 'rxjs';
-import { distinctUntilChanged, filter, map, pairwise, startWith, switchMap } from 'rxjs/operators';
+import { delay, distinctUntilChanged, filter, map, pairwise, startWith, switchMap } from 'rxjs/operators';
 import { HOURS, SECONDS } from 'src/app/shared/helpers/duration';
 import { isNotNull, isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { TaskConfig, ItemTaskService } from '../../services/item-task.service';
@@ -25,6 +25,7 @@ import { FullItemRoute } from 'src/app/shared/routing/item-route';
 import { DomSanitizer } from '@angular/platform-browser';
 import { PermissionsInfo } from '../../helpers/item-permissions';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
+import { LayoutService } from 'src/app/shared/services/layout.service';
 
 const initialHeight = 0;
 const appMainSectionPaddingBottom = '6rem';
@@ -68,7 +69,11 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
 
 
   private computeIframeOffsetTop$ = new ReplaySubject<void>(1);
-  private iframeOffsetTop$ = merge(fromEvent(globalThis, 'resize'), this.computeIframeOffsetTop$).pipe(
+  private iframeOffsetTop$ = merge(
+    fromEvent(globalThis, 'resize'),
+    this.layoutService.fullFrameContent$.pipe(delay(1000)), // time for the animation be complete
+    this.computeIframeOffsetTop$,
+  ).pipe(
     map(() => (this.iframe ? this.iframe.nativeElement.getBoundingClientRect().top + globalThis.scrollY : null)),
     filter(isNotNull),
     distinctUntilChanged(),
@@ -105,6 +110,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
     private taskService: ItemTaskService,
     private sanitizer: DomSanitizer,
     private actionFeedbackService: ActionFeedbackService,
+    private layoutService: LayoutService,
   ) {}
 
   ngOnInit(): void {

--- a/src/app/modules/item/task-communication/task-proxy.ts
+++ b/src/app/modules/item/task-communication/task-proxy.ts
@@ -10,6 +10,7 @@ import { catchError, delay, map, retryWhen, switchMap, take } from 'rxjs/operato
 import { rxBuild, RxMessagingChannel } from './rxjschannel';
 import * as D from 'io-ts/Decoder';
 import {
+  metadataDecoder,
   OpenUrlParams,
   openUrlParamsDecoder,
   TaskGrade,
@@ -164,11 +165,10 @@ export class Task {
   }
 
   getMetaData(): Observable<TaskMetaData> {
-    // TODO: validator (currently unused)
     return this.chan.call({
       method: 'task.getMetaData',
-      timeout: 2000
-    });
+      timeout: 2000,
+    }).pipe(map(([ metadata ]) => decode(metadataDecoder)(metadata)));
   }
 
   getAnswer(): Observable<string> {

--- a/src/app/modules/item/task-communication/types.ts
+++ b/src/app/modules/item/task-communication/types.ts
@@ -68,7 +68,7 @@ export const taskLogDecoder = D.UnknownArray;
 export type TaskLog = D.TypeOf<typeof taskLogDecoder>;
 
 // Currently unused
-export const metadataDecoder = D.struct({
+export const metadataDecoder = D.partial({
   autoHeight: D.boolean,
 });
 export type TaskMetaData = D.TypeOf<typeof metadataDecoder>;

--- a/src/app/modules/item/task-communication/types.ts
+++ b/src/app/modules/item/task-communication/types.ts
@@ -68,7 +68,10 @@ export const taskLogDecoder = D.UnknownArray;
 export type TaskLog = D.TypeOf<typeof taskLogDecoder>;
 
 // Currently unused
-export type TaskMetaData = unknown;
+export const metadataDecoder = D.struct({
+  autoHeight: D.boolean,
+});
+export type TaskMetaData = D.TypeOf<typeof metadataDecoder>;
 export type TaskResources = unknown;
 
 export const openUrlParamsDecoder = D.union(


### PR DESCRIPTION
## Description

Fixes #862 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

There still look to be some place at the bottom, but that's a 5+ rem padding of app main section. If you want it to be less, maybe it could be another issue to assign to Aleksandr.
If I remove the app main section padding from the height calculus, the app can be scrolled a bit but it's only white space, which can be considered ok as well. You tell me.

## Test cases

- [ ] Case 1:
  1. Given I am an anonymous user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/task-auto-height/en/#/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. Then I see the task height is adapted to the viewport
  4. And I resize the browser
  5. Then I see the task height automatically matches the height of the viewport
  6. And I collapse the left menu
  7. Then I see the task height automatically matches the height of the viewport
  8. And I expand the left menu
  9. Then I see the task height automatically matches the height of the viewport

- [ ] Case 2: (no regression test)
  1. Given I am any user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/task-auto-height/en/#/activities/by-id/837046206729127555;path=4702,1352246428241737349,314613032161178344;parentAttempId=0/details)
  3. Then I see the task height is set by the task itself, scroll is at body level and not iframe-container level
  4. And I resize the browser
  5. Then (again) I see the task height is set by the task itself, scroll is at body level and not iframe-container level
  6. And I collapse the left menu
  7. Then (again) I see the task height is set by the task itself, scroll is at body level and not iframe-container level
  8. And I expand the left menu
  9. Then (again) I see the task height is set by the task itself, scroll is at body level and not iframe-container level