### PR TITLE
fix item blocking navigation

### DIFF
--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -198,6 +198,7 @@ export class ItemTaskAnswerService implements OnDestroy {
           startWith({ saving: true }),
         );
       }),
+      defaultIfEmpty({ saving: false }), // when a timeout is caught, the observable is empty
       shareReplay(1),
     );
   }


### PR DESCRIPTION
... by returning empty observable to before unload hook

## Description

Fixes #866 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix/item-blocking-nav/en/#/activities/by-id/126952315730161957;path=39530140456452546;attempId=0/details)
  3. And I navigate elsewhere (using top right nav, left nav, etc.)
  4. Then I see navigation is working.
