### PR TITLE
fix group progress menu overlay

### DIFF
--- a/src/app/modules/item/components/user-progress-details/user-progress-details.component.html
+++ b/src/app/modules/item/components/user-progress-details/user-progress-details.component.html
@@ -1,8 +1,8 @@
 <p-overlayPanel #panel appendTo="body" styleClass="user-progress-overlay-panel" hideTransitionOptions="0s">
-  <ng-container *ngIf="openedOverlay$ | async as overlay">
-    <div class="user-progress-info" *ngIf="overlay?.progress as progress">
+  <ng-template pTemplate>
+    <div class="user-progress-info">
       <div class="content validated">
-        <ng-container *ngIf="progress.timeSpent > 0 || progress.score > 0; else notStarted">
+        <ng-container *ngIf="progress && (progress.timeSpent > 0 || progress.score > 0); else notStarted">
           <span>
             <i class="fa fa-clock"></i>
             <span class="menu-label" i18n>Time spent</span>
@@ -32,5 +32,5 @@
         </span>
       </div>
     </div>
-  </ng-container>
+  </ng-template>
 </p-overlayPanel>

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
@@ -29,8 +29,7 @@
 
     <alg-user-progress-details
       [canEditPermissions]="state.data?.can_access"
-      [progress]="progressOverlay?.progress"
-      [target]="progressOverlay?.target"
+      [progressData]="progressOverlay"
       (hide)="hideProgressDetail()"
       (editPermissions)="onAccessPermissions()"
     ></alg-user-progress-details>

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts
@@ -22,6 +22,7 @@ import { typeCategoryOfItem } from '../../../../shared/helpers/item-type';
 import { ItemRouter } from '../../../../shared/routing/item-router';
 import { GroupRouter } from '../../../../shared/routing/group-router';
 import { rawGroupRoute } from '../../../../shared/routing/group-route';
+import { ProgressData } from '../../components/user-progress-details/user-progress-details.component';
 
 interface Data {
   type: TypeFilter,
@@ -68,15 +69,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
       }
     };
 
-  progressOverlay?: {
-    progress: TeamUserProgress,
-    target: Element,
-    accessPermissions: {
-      title: string,
-      groupId: string,
-      itemId: string,
-    },
-  };
+  progressOverlay?: ProgressData;
 
   dialog: 'loading'|'opened'|'closed' = 'closed';
   dialogTitle = '';
@@ -144,6 +137,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
   }
 
   showProgressDetail(target: HTMLElement, userProgress: TeamUserProgress, row: Data['rows'][number], col: Data['items'][number]): void {
+    if (this.progressOverlay?.target === target) return;
     this.progressOverlay = {
       accessPermissions: {
         title: row.header,


### PR DESCRIPTION
## Description

Fixes #867 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am usual user
  2. Go to group ["DIU 2019"](https://dev.algorea.org/branch/fix/group-progress-menu/en/#/groups/by-id/609422240375608067;path=/details)
  2. And I observe group
  3. And I navigate to a SNT chapter, progress tab, chapter view: [link](https://dev.algorea.org/en/#/activities/by-id/314613032161178344;path=1352246428241737349;attempId=0/details/progress/chapter)
  4. And I click on the first cell with a score (top-left) 
  4. Then I see a menu
  5. And I click on the "sub-groups" subtab
  6. And I click on the first cell (top-left)... with no score
  7. ~No menu displayed~ Then the menu is displayed 
  8. And I click on the "users" subtab
  9.  And I click on the first cell with a score (top-left) (same as before-before)
  10. ~No menu is shown anymore~ Then the menu is displayed