### PR TITLE
Adapts member decoder for changed BE structure

### DIFF
--- a/src/app/modules/group/components/member-list/member-list.component.html
+++ b/src/app/modules/group/components/member-list/member-list.component.html
@@ -71,7 +71,9 @@
               </a>
             </ng-container>
             <ng-container *ngSwitchCase="'member_since'">
-              {{ rowData.memberSince | date:'short' }}
+              <ng-container *ngIf="rowData.memberSince">
+                {{ rowData.memberSince | date:'short' }}
+              </ng-container>
             </ng-container>
             <ng-container *ngSwitchDefault>
               {{ rowData[col.field] }}

--- a/src/app/modules/group/components/member-list/member-list.component.ts
+++ b/src/app/modules/group/components/member-list/member-list.component.ts
@@ -185,7 +185,7 @@ export class MemberListComponent implements OnChanges, OnDestroy {
             .pipe(
               map(members => ({
                 columns: usersColumns,
-                rowData: members.filter(member => !!member.user).map(member => ({
+                rowData: members.map(member => ({
                   ...member,
                   route: groupRoute({ id: member.id, isUser: true }, [ ...route.path, route.id ]),
                 })),

--- a/src/app/modules/group/http-services/get-group-members.service.ts
+++ b/src/app/modules/group/http-services/get-group-members.service.ts
@@ -21,12 +21,18 @@ export const userDecoder = pipe(
   ),
 );
 
-const memberDecoder = D.struct({
-  id: D.string,
-  memberSince: D.nullable(dateDecoder),
-  action: D.literal('', 'invitation_accepted', 'join_request_accepted', 'joined_by_code', 'added_directly'),
-  user: D.nullable(userDecoder),
-});
+const memberDecoder = pipe(
+  D.struct({
+    id: D.string,
+    user: userDecoder,
+  }),
+  D.intersect(
+    D.partial({
+      action: D.literal('invitation_accepted', 'join_request_accepted', 'joined_by_code', 'added_directly'),
+      memberSince: dateDecoder,
+    })
+  )
+);
 
 export type Member = D.TypeOf<typeof memberDecoder>;
 


### PR DESCRIPTION
## Description

Fixes #870

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/adapt-group-members-view-decoder/en/#/groups/by-id/609422240375608067;path=/details/members)
  3. Scroll down to table with users
  4. Then I see list of users
