### PR TITLE
allow up to 2000-char url (change in the backend)

### DIFF
--- a/src/app/modules/item/pages/item-edit/item-edit.component.ts
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.ts
@@ -30,7 +30,7 @@ export class ItemEditComponent implements OnDestroy, PendingChangesComponent {
     title: [ '', [ Validators.required, Validators.minLength(3), Validators.maxLength(200) ] ],
     subtitle: [ '', Validators.maxLength(200) ],
     description: [ '' ],
-    url: [ '', Validators.maxLength(200) ],
+    url: [ '', Validators.maxLength(2000) ],
     text_id: [ '', Validators.maxLength(200) ],
     uses_api: [ false ],
     validation_type: [ '' ],


### PR DESCRIPTION
## Description

Quick fix to map a urgent change applied on the backend.
Some users had very long urls.

## Tests scenarios

- Go to https://dev.algorea.org/branch/url-2000-char-length/en/#/activities/by-id/126952315730161957 as the usual user
- edit it, you'll see it has a url longer than 200 char
- you can edit and save it without issues