### PR TITLE
allow domain-specific configs

### DIFF
--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -35,6 +35,12 @@ export interface Environment {
 type Config = Environment; // config may be someday an extension of the environment
 
 const presetQueryParam = 'config_preset';
+/**
+ * Escape hatch to start the platform with the provided configuration preset. (presets are declared in each environment file)
+ * @example `http://dev.algorea.org/#/?config_preset=demo`
+ * @example `http://dev.algorea.org/#/activities/etc/?config_preset=demo`
+ * Should be used only by Algorea teams, for testing or demo purposes only.
+ */
 function getPresetNameFromQuery(): string | null {
   const url = globalThis.location.href;
   const search = url.includes('?') ? new URLSearchParams(url.slice(url.indexOf('?'))) : null;

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -1,4 +1,4 @@
-import { environment, presets, getPresetNameByDomain } from 'src/environments/environment';
+import { environment, presets, getPresetNameByOrigin } from 'src/environments/environment';
 
 export interface LanguageConfig {
   tag: string,
@@ -41,9 +41,10 @@ function getPresetNameFromQuery(): string | null {
   return search?.get(presetQueryParam) ?? null;
 }
 
-const presetName = getPresetNameByDomain(globalThis.location.hostname) ?? getPresetNameFromQuery();
+const origin = `${globalThis.location.protocol}//${globalThis.location.hostname}`;
+const presetName = getPresetNameByOrigin(origin) ?? getPresetNameFromQuery();
 
 export const appConfig: Config = {
   ...environment,
-  ...(presetName ? presets[presetName] : undefined),
+  ...(presetName ? presets[presetName as keyof typeof presets] : undefined),
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -20,3 +20,24 @@ export const environment: Environment = {
 
   itemPlatformId: 'algorea_backend',
 };
+
+export const presets: Record<string, Partial<Environment>> = {
+  example: {
+    defaultActivityId: '1625159049301502151', // Motif Art
+    defaultTitle: 'Example app',
+    authType: 'tokens',
+    itemPlatformId: 'Example',
+  },
+  demo: {
+    defaultActivityId: '1352246428241737349', // SNT
+    defaultTitle: 'Demo app'
+  },
+};
+
+export function getPresetNameByDomain(domain: string): string | null {
+  switch (domain) {
+    case 'example.algorea.org': return 'example';
+    default: return null;
+  }
+}
+

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -21,7 +21,8 @@ export const environment: Environment = {
   itemPlatformId: 'algorea_backend',
 };
 
-export const presets: Record<string, Partial<Environment>> = {
+type Preset = 'example' | 'demo';
+export const presets: Record<Preset, Partial<Environment>> = {
   example: {
     defaultActivityId: '1625159049301502151', // Motif Art
     defaultTitle: 'Example app',
@@ -34,9 +35,9 @@ export const presets: Record<string, Partial<Environment>> = {
   },
 };
 
-export function getPresetNameByDomain(domain: string): string | null {
-  switch (domain) {
-    case 'example.algorea.org': return 'example';
+export function getPresetNameByOrigin(origin: string): Preset | null {
+  switch (origin) {
+    case 'http://example.algorea.org': return 'example';
     default: return null;
   }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -24,7 +24,8 @@ export const environment: Environment = {
   itemPlatformId: 'algorea_backend',
 };
 
-export const presets: Record<string, Partial<Environment>> = {
+type Preset = 'demo';
+export const presets: Record<Preset, Partial<Environment>> = {
   demo: {
     defaultActivityId: '1352246428241737349', // SNT
     defaultTitle: 'Demo app',
@@ -32,9 +33,9 @@ export const presets: Record<string, Partial<Environment>> = {
   },
 };
 
-export function getPresetNameByDomain(domain: string): string | null {
-  switch (domain) {
-    case 'demo.localhost': return 'demo';
+export function getPresetNameByOrigin(origin: string): Preset | null {
+  switch (origin) {
+    case 'http://demo.localhost': return 'demo';
     default: return null;
   }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -24,6 +24,21 @@ export const environment: Environment = {
   itemPlatformId: 'algorea_backend',
 };
 
+export const presets: Record<string, Partial<Environment>> = {
+  demo: {
+    defaultActivityId: '1352246428241737349', // SNT
+    defaultTitle: 'Demo app',
+    authType: 'cookies',
+  },
+};
+
+export function getPresetNameByDomain(domain: string): string | null {
+  switch (domain) {
+    case 'demo.localhost': return 'demo';
+    default: return null;
+  }
+}
+
 /*
  * For easier debugging in development mode, you can import the following file
  * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.


### PR DESCRIPTION
## Description

Fixes #894 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1: No regression test
  1. Given I am the any user
  2. When I go to the [home page](https://dev.algorea.org/branch/feat/app-config/en/#/)
  3. Then I am redirected to "Parcours officiels" item
  4. Then I see the app title is "Algorea platform"
  5. And I open my devtools > session storage
  5. Then I see the platform works with an auth by cookie

- [ ] Case 2: "Example" app
  1. Given I am the any user
  2. When I go to the [home page](https://dev.algorea.org/branch/feat/app-config/en/#/?config_preset=example)
  3. Then I am redirected to "Motif art" item
  4. Then I see the app title is "Example app"
  5. And I open my devtools > session storage
  5. Then I see the platform works with an auth by token

- [ ] Case 3: "Demo" app
  1. Given I am the any user
  2. When I go to the [home page](https://dev.algorea.org/branch/feat/app-config/en/#/?config_preset=demo)
  3. Then I am redirected to "SNT" item
  4. Then I see the app title is "Demo app"
  5. And I open my devtools > session storage
  5. Then I see the platform works with an auth by cookie

- [ ] Case 4: By domain (to be tested on localhost)
  1. Given I added "demo.localhost" to my hosts and I serve the app via `ng serve --host demo.localhost`
  2. And I am the any user
  2. When I go to the [home page](http://demo.localhost/#/)
  3. Then I see the title is "Demo app"