### PR TITLE
lti: keep same task on refresh

### DIFF
--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -11,8 +11,9 @@ import { Title } from '@angular/platform-browser';
 import { appConfig } from '../shared/helpers/config';
 import {
   getRedirectToSubPathAtInit,
-  getUrlWithFromPath,
   removeSubPathRedirectionAtInit,
+  fromPathKey,
+  appendUrlWithQuery,
 } from '../shared/helpers/redirect-to-sub-path-at-init';
 
 @Component({
@@ -54,7 +55,8 @@ export class AppComponent implements OnInit, OnDestroy {
     const subPathToRedirectTo = getRedirectToSubPathAtInit();
     if (subPathToRedirectTo) {
       removeSubPathRedirectionAtInit();
-      void this.router.navigateByUrl(getUrlWithFromPath(subPathToRedirectTo, location.hash.slice(1)), { replaceUrl: true });
+      const url = appendUrlWithQuery(subPathToRedirectTo, fromPathKey, location.hash.slice(1));
+      void this.router.navigateByUrl(url, { replaceUrl: true });
     }
   }
 

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -9,7 +9,11 @@ import { LocaleService } from './services/localeService';
 import { LayoutService } from '../shared/services/layout.service';
 import { Title } from '@angular/platform-browser';
 import { appConfig } from '../shared/helpers/config';
-import { getRedirectToSubPathAtInit, removeSubPathRedirectionAtInit } from '../shared/helpers/redirect-to-sub-path-at-init';
+import {
+  getRedirectToSubPathAtInit,
+  getUrlWithFromPath,
+  removeSubPathRedirectionAtInit,
+} from '../shared/helpers/redirect-to-sub-path-at-init';
 
 @Component({
   selector: 'alg-root',
@@ -50,7 +54,7 @@ export class AppComponent implements OnInit, OnDestroy {
     const subPathToRedirectTo = getRedirectToSubPathAtInit();
     if (subPathToRedirectTo) {
       removeSubPathRedirectionAtInit();
-      void this.router.navigateByUrl(subPathToRedirectTo, { replaceUrl: true });
+      void this.router.navigateByUrl(getUrlWithFromPath(subPathToRedirectTo, location.hash.slice(1)), { replaceUrl: true });
     }
   }
 

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -9,12 +9,7 @@ import { LocaleService } from './services/localeService';
 import { LayoutService } from '../shared/services/layout.service';
 import { Title } from '@angular/platform-browser';
 import { appConfig } from '../shared/helpers/config';
-import {
-  getRedirectToSubPathAtInit,
-  removeSubPathRedirectionAtInit,
-  fromPathKey,
-  appendUrlWithQuery,
-} from '../shared/helpers/redirect-to-sub-path-at-init';
+import { urlToRedirectTo } from '../shared/helpers/redirect-to-sub-path-at-init';
 
 @Component({
   selector: 'alg-root',
@@ -52,11 +47,10 @@ export class AppComponent implements OnInit, OnDestroy {
       appConfig.languageSpecificTitles[this.localeService.currentLang.tag] : undefined;
     this.titleService.setTitle(title ?? appConfig.defaultTitle);
 
-    const subPathToRedirectTo = getRedirectToSubPathAtInit();
-    if (subPathToRedirectTo) {
-      removeSubPathRedirectionAtInit();
-      const url = appendUrlWithQuery(subPathToRedirectTo, fromPathKey, location.hash.slice(1));
-      void this.router.navigateByUrl(url, { replaceUrl: true });
+    const currentUrl = location.hash.slice(1); // omit leading "#"
+    const redirectTo = urlToRedirectTo(currentUrl);
+    if (redirectTo) {
+      void this.router.navigateByUrl(redirectTo, { replaceUrl: true });
     }
   }
 

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -9,9 +9,9 @@ import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
 import { isNotNull } from 'src/app/shared/helpers/null-undefined-predicates';
 import {
   allowFromPathKey,
+  appendUrlWithQuery,
   fromPathKey,
   getRedirectToSubPathAtInit,
-  getUrlWithAllowFromPath,
   setRedirectToSubPathAtInit,
 } from 'src/app/shared/helpers/redirect-to-sub-path-at-init';
 import { CheckLoginService } from 'src/app/shared/http-services/check-login.service';
@@ -114,7 +114,7 @@ export class LTIComponent implements OnDestroy {
 
         const redirectUrl = getRedirectToSubPathAtInit();
         if (!redirectUrl) throw new Error('redirect url should be set by now');
-        setRedirectToSubPathAtInit(getUrlWithAllowFromPath(redirectUrl));
+        setRedirectToSubPathAtInit(appendUrlWithQuery(redirectUrl, allowFromPathKey, '1'));
 
         if (fromPath) {
           void this.router.navigateByUrl(fromPath);

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -33,6 +33,7 @@ const noChildError = new Error(LTIError.NoChild);
 const loginError = new Error(LTIError.LoginError);
 
 const isRedirectionParam = 'is_redirection';
+// Only handle `?from_path` query when `?lti_use_from_path=1`, ignore it otherwise
 const useFromPathKey = 'lti_use_from_path';
 const loginIdParam = 'user_id';
 

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -8,7 +8,6 @@ import { GetItemPathService } from 'src/app/modules/item/http-services/get-item-
 import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
 import { isNotNull } from 'src/app/shared/helpers/null-undefined-predicates';
 import {
-  allowFromPathKey,
   appendUrlWithQuery,
   fromPathKey,
   getRedirectToSubPathAtInit,
@@ -34,6 +33,7 @@ const noChildError = new Error(LTIError.NoChild);
 const loginError = new Error(LTIError.LoginError);
 
 const isRedirectionParam = 'is_redirection';
+const useFromPathKey = 'lti_use_from_path';
 const loginIdParam = 'user_id';
 
 @Component({
@@ -50,7 +50,7 @@ export class LTIComponent implements OnDestroy {
   );
 
   private fromPath$ = this.activatedRoute.queryParamMap.pipe(
-    map(queryParams => (queryParams.get(allowFromPathKey) === '1' ? queryParams.get(fromPathKey) : null)),
+    map(queryParams => (queryParams.get(useFromPathKey) === '1' ? queryParams.get(fromPathKey) : null)),
   );
 
   private contentId$ = this.activatedRoute.paramMap.pipe(
@@ -114,7 +114,7 @@ export class LTIComponent implements OnDestroy {
 
         const redirectUrl = getRedirectToSubPathAtInit();
         if (!redirectUrl) throw new Error('redirect url should be set by now');
-        setRedirectToSubPathAtInit(appendUrlWithQuery(redirectUrl, allowFromPathKey, '1'));
+        setRedirectToSubPathAtInit(appendUrlWithQuery(redirectUrl, useFromPathKey, '1'));
 
         if (fromPath) {
           void this.router.navigateByUrl(fromPath);

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -46,7 +46,7 @@ export class LTIComponent implements OnDestroy {
   private loginId$ = this.activatedRoute.queryParamMap.pipe(map(queryParams => queryParams.get(loginIdParam)));
 
   private isRedirection$ = this.activatedRoute.queryParamMap.pipe(
-    map(queryParams => queryParams.has(isRedirectionParam)),
+    map(queryParams => queryParams.get(isRedirectionParam) === '1'),
   );
 
   private fromPath$ = this.activatedRoute.queryParamMap.pipe(
@@ -99,7 +99,7 @@ export class LTIComponent implements OnDestroy {
       this.contentId$,
       this.loginId$.pipe(filter(isNotNull)),
     ]).subscribe(([ contentId, loginId ]) => {
-      setRedirectToSubPathAtInit(`/lti/${contentId}?${loginIdParam}=${loginId}&${isRedirectionParam}=`);
+      setRedirectToSubPathAtInit(`/lti/${contentId}?${loginIdParam}=${loginId}&${isRedirectionParam}=1`);
       this.activityNavTreeService.navigationNeighborsRestrictedToDescendantOfElementId = contentId;
     }),
 

--- a/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
+++ b/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
@@ -1,7 +1,6 @@
 const storage = globalThis.sessionStorage;
 const redirectToSubPathKey = 'redirect_to_sub_path';
 export const fromPathKey = 'from_path';
-export const allowFromPathKey = 'allow_from_path';
 
 export function setRedirectToSubPathAtInit(subPath: string): void {
   storage.setItem(redirectToSubPathKey, subPath);

--- a/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
+++ b/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
@@ -1,5 +1,7 @@
 const storage = globalThis.sessionStorage;
 const redirectToSubPathKey = 'redirect_to_sub_path';
+export const fromPathKey = 'from_path';
+export const allowFromPathKey = 'allow_from_path';
 
 export function setRedirectToSubPathAtInit(subPath: string): void {
   storage.setItem(redirectToSubPathKey, subPath);
@@ -13,3 +15,14 @@ export function removeSubPathRedirectionAtInit(): void {
   storage.removeItem(redirectToSubPathKey);
 }
 
+export function getUrlWithFromPath(currentUrl: string, fromPath: string): string {
+  const url = new URL(currentUrl, location.origin);
+  url.searchParams.set(fromPathKey, fromPath);
+  return url.pathname + url.search;
+}
+
+export function getUrlWithAllowFromPath(currentUrl: string): string {
+  const url = new URL(currentUrl, location.origin);
+  url.searchParams.set(allowFromPathKey, '1');
+  return url.pathname + url.search;
+}

--- a/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
+++ b/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
@@ -19,3 +19,10 @@ export function appendUrlWithQuery(currentUrl: string, query: string, value: str
   url.searchParams.set(query, value);
   return url.pathname + url.search;
 }
+
+export function urlToRedirectTo(currentUrl: string): string | null {
+  const url = getRedirectToSubPathAtInit();
+  if (!url) return null;
+  removeSubPathRedirectionAtInit();
+  return appendUrlWithQuery(url, fromPathKey, currentUrl);
+}

--- a/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
+++ b/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
@@ -15,14 +15,8 @@ export function removeSubPathRedirectionAtInit(): void {
   storage.removeItem(redirectToSubPathKey);
 }
 
-export function getUrlWithFromPath(currentUrl: string, fromPath: string): string {
+export function appendUrlWithQuery(currentUrl: string, query: string, value: string): string {
   const url = new URL(currentUrl, location.origin);
-  url.searchParams.set(fromPathKey, fromPath);
-  return url.pathname + url.search;
-}
-
-export function getUrlWithAllowFromPath(currentUrl: string): string {
-  const url = new URL(currentUrl, location.origin);
-  url.searchParams.set(allowFromPathKey, '1');
+  url.searchParams.set(query, value);
   return url.pathname + url.search;
 }


### PR DESCRIPTION
## Description

Fixes #893 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

The LTI route must filter when to take the `?from_path` into account. Here's the flow:
1. Launch AlgoreaFrontend app, land on LTI route component. LTI component sets `redirect_to_sub_path` session storage item with current url + query param `is_redirection=1` to avoid infinite loops
2. Login is performed elsewhere and the page comes back to AlgoreaFrontend app on home page
3. From App component, redirect to sub path provided by session storage, add the query param `?from_path={current url}`, which in our case redirects to LTI route component
4. LTI route component **ignores `?from_path` at this point because we don't want to redirect to the home**, checks out that the user is logged, fetches item first child info, etc. **and appends to `redirect_to_sub_path` (session storage) the query param `?allow_from_path`
5. The user can now navigate as usual in LTI mode, if he refreshed, then …
6. The app component detects the `redirect_to_sub_path` (which contains now `?allow_from_path` for step 7) and redirects in our case to the LTI route with a populated `?from_path` query param
7. The LTI route component reads the query params, finds `allow_from_path` **and** `from_path`, retrieves all the required info as usual and then resets the `redirect_to_sub_path` as in step 4 in case the user re-refreshes. And since both `allow_from_path` and `from_path` are provided, instead of navigating to item first child, now it redirects to `from_path` value.

:tada:

Since the tests imply that the LTI login part works as expected, I also updated the `is_redirection` param to set it as `is_redirection=1` instead of `is_redirection=`

## Test cases

:warning: **All tests must be run using a local environment (localhost)**

- [ ] Case 1:
  1. Given I am an authorized moodle user
  2. When I go to [moodle "Test LTI 2"](http://moodletest.algorea.org/course/view.php?id=3)
  3. And I click on "[Test dev.algorea.org (new platform localhost)](http://moodletest.algorea.org/mod/lti/view.php?id=8)"
  4. Then I am redirected to Algorea platform (as before), which opens task "Les boucles bornées ou boucles à compteur" in LTI mode
  5. And I navigate to next sibling "Les boucles imbriquées" using header right arrow
  6. (Optional) And I throttle my network to slow down the page transitions
  7. And I refresh my page
  8. Then (after loads) I am redirected to the LTI page, which redirects to same page "Les boucles imbriquées" in LTI mode
  9. Steps 7+8 can be repeated indefinitely
