### PR TITLE
Hides parent button when false, adds animation

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.ts
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.ts
@@ -3,7 +3,7 @@ import { ModeAction, ModeService } from '../../../shared/services/mode.service';
 import { ContentInfo } from '../../../shared/models/content/content-info';
 import { Observable, of } from 'rxjs';
 import { CurrentContentService } from '../../../shared/services/current-content.service';
-import { delay, switchMap } from 'rxjs/operators';
+import { delay, switchMap, filter } from 'rxjs/operators';
 import { ActivityNavTreeService, SkillNavTreeService } from '../../services/navigation/item-nav-tree.service';
 import { isItemInfo } from '../../../shared/models/content/item-info';
 import { FullFrameContent } from 'src/app/shared/services/layout.service';
@@ -32,6 +32,7 @@ export class ContentTopBarComponent {
       return content.route.contentType === 'activity' ?
         this.activityNavTreeService.navigationNeighbors$ : this.skillNavTreeService.navigationNeighbors$;
     }),
+    filter(navigationNeighbors => !!navigationNeighbors?.isReady),
   );
 
   constructor(

--- a/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.html
+++ b/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.html
@@ -5,7 +5,9 @@
       type="button"
       icon="fa fa-arrow-up"
       class="neighbor-widget-button"
-      (click)="parent.emit()" [disabled]="!navigationMode.parent"
+      (click)="parent.emit()"
+      *ngIf="navigationMode.parent"
+      @buttonAnimation
     ></button>
     <button
       pButton
@@ -14,6 +16,7 @@
       class="neighbor-widget-button"
       (click)="left.emit()"
       [disabled]="!navigationMode.left"
+      [@borderAnimation]="navigationMode.parent ? 'roundOff' : 'roundOn'"
     ></button>
     <button
       pButton

--- a/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.html
+++ b/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.html
@@ -1,30 +1,31 @@
 <div class="neighbor-widget" *ngIf="navigationMode">
-  <span class="p-buttonset">
-    <button
-      pButton
-      type="button"
-      icon="fa fa-arrow-up"
-      class="neighbor-widget-button"
-      (click)="parent.emit()"
-      *ngIf="navigationMode.parent"
-      @buttonAnimation
-    ></button>
-    <button
-      pButton
-      type="button"
-      icon="fa fa-chevron-left"
-      class="neighbor-widget-button"
-      (click)="left.emit()"
-      [disabled]="!navigationMode.left"
-      [@borderAnimation]="navigationMode.parent ? 'roundOff' : 'roundOn'"
-    ></button>
-    <button
-      pButton
-      type="button"
-      icon="fa fa-chevron-right"
-      class="neighbor-widget-button"
-      (click)="right.emit()"
-      [disabled]="!navigationMode.right"
-    ></button>
-  </span>
+  <div class="neighbor-widget-wrapper">
+    <span class="p-buttonset">
+      <button
+        pButton
+        type="button"
+        icon="fa fa-arrow-up"
+        class="neighbor-widget-button up-button"
+        (click)="parent.emit()"
+        *ngIf="navigationMode.parent"
+        @buttonAnimation
+      ></button>
+      <button
+        pButton
+        type="button"
+        icon="fa fa-chevron-left"
+        class="neighbor-widget-button"
+        (click)="left.emit()"
+        [disabled]="!navigationMode.left"
+      ></button>
+      <button
+        pButton
+        type="button"
+        icon="fa fa-chevron-right"
+        class="neighbor-widget-button"
+        (click)="right.emit()"
+        [disabled]="!navigationMode.right"
+      ></button>
+    </span>
+  </div>
 </div>

--- a/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.scss
+++ b/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.scss
@@ -45,5 +45,5 @@
 }
 
 .up-button {
-  background-color: $dark-base-color;
+  background-color: var(--dark-base-color);
 }

--- a/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.scss
+++ b/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.scss
@@ -7,6 +7,11 @@
   height: 2.2rem;
 }
 
+.neighbor-widget-wrapper {
+  border-radius: 2.2rem;
+  overflow: hidden;
+}
+
 .neighbor-widget-button {
   background-color: var(--base-color);
   color: #fff;
@@ -16,6 +21,8 @@
   width: 2.6rem;
   height: 100%;
   cursor: pointer;
+  position: relative;
+  z-index: 2;
 
   &:hover:not(:disabled) {
     background-color: var(--base-dark-color-hover);
@@ -23,19 +30,20 @@
 
   &:disabled {
     cursor: not-allowed;
+    background: #a1c1ee;
+    opacity: 1;
   }
 
   &:first-child {
     padding-left: .2rem;
-    border-radius: 50% 0 0 50%;
-
-    &:not(:disabled) {
-      background-color: var(--dark-base-color);
-    }
+    z-index: 1;
   }
 
   &:last-child {
     padding-right: .2rem;
-    border-radius: 0 50% 50% 0;
   }
+}
+
+.up-button {
+  background-color: $dark-base-color;
 }

--- a/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.ts
+++ b/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.ts
@@ -1,9 +1,48 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { animate, state, style, transition, trigger } from '@angular/animations';
 
 @Component({
   selector: 'alg-neighbor-widget',
   templateUrl: './neighbor-widget.component.html',
   styleUrls: [ 'neighbor-widget.component.scss' ],
+  animations: [
+    trigger('buttonAnimation', [
+      transition(':leave', [
+        style({
+          marginRight: 0,
+          opacity: 1,
+        }),
+        animate('.2s .2s ease-in-out', style({
+          marginRight: '-.5rem',
+          opacity: 0,
+        })),
+      ]),
+      transition(':enter', [
+        style({
+          marginRight: '-.5rem',
+          opacity: 0,
+        }),
+        animate('.2s .2s ease-in-out', style({
+          marginRight: 0,
+          opacity: 1,
+        })),
+      ]),
+    ]),
+    trigger('borderAnimation', [
+      state('roundOn', style({
+        borderRadius: '50% 0 0 50%',
+      })),
+      state('roundOff', style({
+        borderRadius: '0',
+      })),
+      transition('roundOn => roundOff', [
+        animate('.2s .3s ease-in-out'),
+      ]),
+      transition('roundOff => roundOn', [
+        animate('.2s .1s ease-in-out'),
+      ]),
+    ])
+  ]
 })
 export class NeighborWidgetComponent {
   @Input() navigationMode?: {parent: boolean, left: boolean, right: boolean};

--- a/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.ts
+++ b/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.ts
@@ -10,21 +10,17 @@ import { animate, style, transition, trigger } from '@angular/animations';
       transition(':leave', [
         style({
           marginRight: 0,
-          opacity: 1,
         }),
         animate('.2s .2s ease-in-out', style({
           marginRight: '-2.6rem',
-          opacity: 0.6,
         })),
       ]),
       transition(':enter', [
         style({
           marginRight: '-2.6rem',
-          opacity: 0.6,
         }),
         animate('.2s .2s ease-in-out', style({
           marginRight: 0,
-          opacity: 1,
         })),
       ]),
     ]),

--- a/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.ts
+++ b/src/app/modules/shared-components/components/neighbor-widget/neighbor-widget.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { animate, state, style, transition, trigger } from '@angular/animations';
+import { animate, style, transition, trigger } from '@angular/animations';
 
 @Component({
   selector: 'alg-neighbor-widget',
@@ -13,14 +13,14 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
           opacity: 1,
         }),
         animate('.2s .2s ease-in-out', style({
-          marginRight: '-.5rem',
-          opacity: 0,
+          marginRight: '-2.6rem',
+          opacity: 0.6,
         })),
       ]),
       transition(':enter', [
         style({
-          marginRight: '-.5rem',
-          opacity: 0,
+          marginRight: '-2.6rem',
+          opacity: 0.6,
         }),
         animate('.2s .2s ease-in-out', style({
           marginRight: 0,
@@ -28,20 +28,6 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
         })),
       ]),
     ]),
-    trigger('borderAnimation', [
-      state('roundOn', style({
-        borderRadius: '50% 0 0 50%',
-      })),
-      state('roundOff', style({
-        borderRadius: '0',
-      })),
-      transition('roundOn => roundOff', [
-        animate('.2s .3s ease-in-out'),
-      ]),
-      transition('roundOff => roundOn', [
-        animate('.2s .1s ease-in-out'),
-      ]),
-    ])
   ]
 })
 export class NeighborWidgetComponent {

--- a/src/app/modules/shared-components/components/page-navigator/page-navigator.component.html
+++ b/src/app/modules/shared-components/components/page-navigator/page-navigator.component.html
@@ -15,7 +15,7 @@
   </span>
   <span class="navigator" *ngIf="navigationMode">
     <span class="p-buttonset">
-      <button pButton type="button" icon="fa fa-arrow-up" (click)="parent.emit()" [disabled]="!navigationMode.parent"></button>
+      <button pButton type="button" icon="fa fa-arrow-up" (click)="parent.emit()" *ngIf="navigationMode.parent"></button>
       <button pButton type="button" icon="fa fa-chevron-left" (click)="left.emit()" [disabled]="!navigationMode.left"></button>
       <button pButton type="button" icon="fa fa-chevron-right" (click)="right.emit()" [disabled]="!navigationMode.right"></button>
     </span>


### PR DESCRIPTION
## Description

Fixes #895

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Not sure about animation in page navigator as buttons disappears on loading time 

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/page-navigator-do-not-show-the-up-by-default/en/#/activities/by-id/4102;path=4702;parentAttempId=0/details)
  3. And I click on collapse left menu button
  4. Then I see parent/next/prev buttons
  5. Click on parent button
  6. Then I see button disappears with animation
  7. Click on browser back button
  8. Then I see button appears with animation

- [x] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/page-navigator-do-not-show-the-up-by-default/en/#/activities/by-id/4102;path=4702;parentAttempId=0/details)
  3. Then I see parent/next/prev buttons
  5. Click on parent button
  6. Then I see button disappears
  7. Click on browser back button
  8. Then I see button appears