### PR TITLE
make the api url work without domain

### DIFF
--- a/src/app/shared/http-services/auth.http-service.ts
+++ b/src/app/shared/http-services/auth.http-service.ts
@@ -20,7 +20,7 @@ const longAuthServicesTimeout = 10000;
 export class AuthHttpService {
 
   private http: HttpClient; // an http client specific to this class, skipping all http interceptors
-  private apiUrl = new URL(appConfig.apiUrl);
+  private apiUrl = new URL(appConfig.apiUrl, location.origin /* act as base when the url is relative, ignored otherwise */);
   private cookieParams = appConfig.authType === 'cookies' ? {
     use_cookie: '1',
     cookie_secure: this.apiUrl.protocol === 'https:' || this.apiUrl.hostname === 'localhost' ? '1' : '0',

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -23,9 +23,7 @@ export const environment: Environment = {
 
 type Preset = 'telecomParis';
 export const presets: Record<Preset, Partial<Environment>> = {
-  telecomParis: {
-    apiUrl: 'https://telecom-paris.france-ioi.org/api',
-  },
+  telecomParis: {},
 };
 
 export function getPresetNameByOrigin(origin: string): Preset | null {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ import { Environment } from 'src/app/shared/helpers/config';
 
 export const environment: Environment = {
   production: true,
-  apiUrl: 'https://dev.algorea.org/api',
+  apiUrl: '/api',
   oauthServerUrl: 'https://login.france-ioi.org',
   oauthClientId: '43',
 


### PR DESCRIPTION
## Description

Let the `apiUrl` config be ~a relative path~ specified without domain.
Will allow other domain to use the same config (without the need for special config)

(It wouldn't have done before anyway before because of a backend cookie issue, but the issue is now solved)

## Test cases

- [x] Case 0:
  1. Given a new user
  2. When I go to https://dev.algorea.org/branch/relative-api-url/
  3. The connection to the backend works as expected

- [x] Case 1:
  1. Given a new user
  2. When I go to https://telecom-paris.france-ioi.org/branch/relative-api-url/
  3. The connection to the backend works as expected
  
- [x] Case 2:
  1. On localhost (using full url)
  2. When I go to http://localhost:4200/
  3. The connection to the backend works as expected