### PR TITLE
Feat/hide solution tab

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -2,97 +2,99 @@
 
   <ng-container *ngIf="state.isReady && state.data as itemData">
 
-    <alg-item-header [itemData]="itemData" *ngIf="!(fullFrameContent$ | async)?.expanded"></alg-item-header>
+    <ng-container *ngIf="taskTabs$ | async as taskTabs">
+      <alg-item-header [itemData]="itemData" *ngIf="!(fullFrameContent$ | async)?.expanded"></alg-item-header>
 
-    <alg-access-code-view
-      *ngIf="showAccessCodeField$ | async"
-      i18n-sectionLabel sectionLabel="Access to activity"
-      i18n-buttonLabel buttonLabel="Access"
-      [itemData]="itemData"
-      (groupJoined)="reloadItem()"
-    ></alg-access-code-view>
-
-    <alg-item-permissions
-      *ngIf="watchedGroup$ | async as watchedGroup"
-      [itemData]="itemData"
-      [watchedGroup]="watchedGroup"
-    ></alg-item-permissions>
-
-    <nav class="nav-tab">
-      <a
-        class="nav-tab-item"
-        [routerLink]="'./'"
-        routerLinkActive #contentTab="routerLinkActive"
-        [routerLinkActiveOptions]="{exact: true}"
-        [class.active]="contentTab.isActive"
-        [hidden]="taskTabs.length > 1"
-        i18n
-      >
-        Content
-      </a>
-      <ng-container *ngIf="taskTabs.length > 1">
-        <a
-          *ngFor="let tab of taskTabs"
-          class="nav-tab-item cursor-pointer"
-          [routerLink]="'./'"
-          [class.active]="contentTab.isActive && tab.view === taskView"
-          (click)="setTaskTabActive(tab)"
-        >
-          {{ tab.name }}
-        </a>
-      </ng-container>
-      <a
-        *ngIf="!(watchedGroup$ | async) || itemData.item.permissions.canWatch !== 'none' || !contentTab.isActive"
-        class="nav-tab-item"
-        [routerLink]="'./progress'"
-        routerLinkActive #progressTab="routerLinkActive"
-        [class.active]="progressTab?.isActive"
-      >
-        <i class="fa fa-chart-line"></i>
-        &nbsp;
-        <span i18n>Progress</span>
-      </a>
-    </nav>
-    <div class="bg-white">
-      <alg-error
-        *ngIf="unknownError"
-        i18n-message message="An unknown error occurred. If this problem persists, please contact us."
-      ></alg-error>
-
-      <ng-container *ngIf="contentTab.isActive || taskTabs.length > 0">
-        <alg-error *ngIf="answerFallbackLink$ | async as fallbackLink">
-          <ng-container *ngIf="(taskReadOnly$ | async); else fallback" i18n>Unable to load the answer</ng-container>
-          <ng-template #fallback>
-            <ng-container i18n>
-              Unable to load the answer, <a [routerLink]="fallbackLink" class="alg-link">load your most recent answer</a>
-            </ng-container>
-          </ng-template>
-        </alg-error>
-
-        <ng-container *ngIf="taskConfig$ | async as taskConfig">
-          <div *ngIf="taskConfig.readOnly && contentTab.isActive" class="indicator">
-            <alg-answer-author-indicator *ngIf="formerAnswer$ | async as answer" [answer]="answer"></alg-answer-author-indicator>
-          </div>
-          <alg-item-content
-            [hidden]="!contentTab.isActive"
-            [itemData]="itemData"
-            [taskConfig]="taskConfig"
-            [savingAnswer]="(savingAnswer$ | async) ?? false"
-            [(taskView)]="taskView"
-            (taskTabsChange)="setTaskTabs($event)"
-            (scoreChange)="patchStateWithScore($event)"
-            (skipSave)="skipBeforeUnload()"
-          ></alg-item-content>
-        </ng-container>
-      </ng-container>
-      <alg-item-progress
-        *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive"
+      <alg-access-code-view
+        *ngIf="showAccessCodeField$ | async"
+        i18n-sectionLabel sectionLabel="Access to activity"
+        i18n-buttonLabel buttonLabel="Access"
         [itemData]="itemData"
-        [isTaskReadOnly]="(taskReadOnly$ | async) ?? false"
-        [savingAnswer]="(savingAnswer$ | async) ?? false"
-        (skipSave)="skipBeforeUnload()"
-      ></alg-item-progress>
-    </div>
+        (groupJoined)="reloadItem()"
+      ></alg-access-code-view>
+
+      <alg-item-permissions
+        *ngIf="watchedGroup$ | async as watchedGroup"
+        [itemData]="itemData"
+        [watchedGroup]="watchedGroup"
+      ></alg-item-permissions>
+
+      <nav class="nav-tab">
+        <a
+          class="nav-tab-item"
+          [routerLink]="'./'"
+          routerLinkActive #contentTab="routerLinkActive"
+          [routerLinkActiveOptions]="{exact: true}"
+          [class.active]="contentTab.isActive"
+          [hidden]="taskTabs.length > 1"
+          i18n
+        >
+          Content
+        </a>
+        <ng-container *ngIf="taskTabs.length > 1">
+          <a
+            *ngFor="let tab of taskTabs"
+            class="nav-tab-item cursor-pointer"
+            [routerLink]="'./'"
+            [class.active]="contentTab.isActive && tab.view === taskView"
+            (click)="setTaskTabActive(tab)"
+          >
+            {{ tab.name }}
+          </a>
+        </ng-container>
+        <a
+          *ngIf="!(watchedGroup$ | async) || itemData.item.permissions.canWatch !== 'none' || !contentTab.isActive"
+          class="nav-tab-item"
+          [routerLink]="'./progress'"
+          routerLinkActive #progressTab="routerLinkActive"
+          [class.active]="progressTab?.isActive"
+        >
+          <i class="fa fa-chart-line"></i>
+          &nbsp;
+          <span i18n>Progress</span>
+        </a>
+      </nav>
+      <div class="bg-white">
+        <alg-error
+          *ngIf="unknownError"
+          i18n-message message="An unknown error occurred. If this problem persists, please contact us."
+        ></alg-error>
+
+        <ng-container *ngIf="contentTab.isActive || taskTabs.length > 0">
+          <alg-error *ngIf="answerFallbackLink$ | async as fallbackLink">
+            <ng-container *ngIf="(taskReadOnly$ | async); else fallback" i18n>Unable to load the answer</ng-container>
+            <ng-template #fallback>
+              <ng-container i18n>
+                Unable to load the answer, <a [routerLink]="fallbackLink" class="alg-link">load your most recent answer</a>
+              </ng-container>
+            </ng-template>
+          </alg-error>
+
+          <ng-container *ngIf="taskConfig$ | async as taskConfig">
+            <div *ngIf="taskConfig.readOnly && contentTab.isActive" class="indicator">
+              <alg-answer-author-indicator *ngIf="formerAnswer$ | async as answer" [answer]="answer"></alg-answer-author-indicator>
+            </div>
+            <alg-item-content
+              [hidden]="!contentTab.isActive"
+              [itemData]="itemData"
+              [taskConfig]="taskConfig"
+              [savingAnswer]="(savingAnswer$ | async) ?? false"
+              [(taskView)]="taskView"
+              (taskTabsChange)="setTaskTabs($event)"
+              (scoreChange)="patchStateWithScore($event)"
+              (skipSave)="skipBeforeUnload()"
+            ></alg-item-content>
+          </ng-container>
+        </ng-container>
+        <alg-item-progress
+          *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive"
+          [itemData]="itemData"
+          [isTaskReadOnly]="(taskReadOnly$ | async) ?? false"
+          [savingAnswer]="(savingAnswer$ | async) ?? false"
+          (skipSave)="skipBeforeUnload()"
+        ></alg-item-progress>
+      </div>
+    </ng-container>
 
   </ng-container>
 

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -8,7 +8,18 @@ import { RouterLinkActive } from '@angular/router';
 import { TaskTab } from '../item-display/item-display.component';
 import { Mode, ModeService } from 'src/app/shared/services/mode.service';
 import { combineLatest, fromEvent, merge, Observable, of, Subject } from 'rxjs';
-import { catchError, distinctUntilChanged, filter, map, mergeWith, shareReplay, switchMap, take, takeUntil } from 'rxjs/operators';
+import {
+  catchError,
+  distinctUntilChanged,
+  filter,
+  map,
+  mergeWith,
+  shareReplay,
+  startWith,
+  switchMap,
+  take,
+  takeUntil,
+} from 'rxjs/operators';
 import { TaskConfig } from '../../services/item-task.service';
 import { BeforeUnloadComponent } from 'src/app/shared/guards/before-unload-guard';
 import { ItemContentComponent } from '../item-content/item-content.component';
@@ -36,7 +47,16 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     map(state => state.isReady && state.data),
   );
 
-  taskTabs: TaskTab[] = [];
+  private taskTabs = new Subject<TaskTab[]>();
+  taskTabs$ = combineLatest([ this.taskTabs, this.itemData$.pipe(readyData()) ]).pipe(
+    map(([ tabs, data ]) => {
+      const canShowSolution = data.item.permissions.canView === 'solution' || !!data.currentResult?.validated;
+      return canShowSolution
+        ? tabs
+        : tabs.filter(tab => tab.view !== 'solution');
+    }),
+    startWith([]),
+  );
   taskView?: TaskTab['view'];
 
   readonly fullFrameContent$ = this.layoutService.fullFrameContent$;
@@ -91,7 +111,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   private subscriptions = [
     this.itemDataSource.state$.subscribe(state => {
-      if (state.isFetching) this.taskTabs = []; // reset task tabs when item changes.
+      if (state.isFetching) this.taskTabs.next([]); // reset task tabs when item changes.
     }),
     fromEvent<BeforeUnloadEvent>(globalThis, 'beforeunload', { capture: true })
       .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent?.saveAnswerAndState() ?? of(undefined)), take(1))
@@ -111,6 +131,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   ngOnDestroy(): void {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());
+    this.taskTabs.complete();
   }
 
   reloadItem(): void {
@@ -122,12 +143,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   }
 
   setTaskTabs(taskTabs: TaskTab[]): void {
-    this.itemData$.pipe(readyData(), take(1)).subscribe(data => {
-      const canShowSolution = data.item.permissions.canView === 'solution' || !!data.currentResult?.validated;
-      this.taskTabs = canShowSolution
-        ? taskTabs
-        : taskTabs.filter(tab => tab.view !== 'solution');
-    });
+    this.taskTabs.next(taskTabs);
   }
 
   setTaskTabActive(tab: TaskTab): void {

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -122,7 +122,11 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   }
 
   setTaskTabs(taskTabs: TaskTab[]): void {
-    this.taskTabs = taskTabs;
+    this.itemData$.pipe(readyData(), take(1)).subscribe(data => {
+      this.taskTabs = data.item.permissions.canView === 'solution'
+        ? taskTabs
+        : taskTabs.filter(tab => tab.view !== 'solution');
+    });
   }
 
   setTaskTabActive(tab: TaskTab): void {

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -123,7 +123,8 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   setTaskTabs(taskTabs: TaskTab[]): void {
     this.itemData$.pipe(readyData(), take(1)).subscribe(data => {
-      this.taskTabs = data.item.permissions.canView === 'solution'
+      const canShowSolution = data.item.permissions.canView === 'solution' || !!data.currentResult?.validated;
+      this.taskTabs = canShowSolution
         ? taskTabs
         : taskTabs.filter(tab => tab.view !== 'solution');
     });


### PR DESCRIPTION
## Description

Fixes #908 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

:bulb: Hide whitespace when reviewing :wink: 

## Test cases

- [ ] Case 1: Solution tab is displayed when can_view = solution
  1. Given I am the usual user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/hide-solution-tab/en/#/activities/by-id/1293400563985240032;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0/details)
  3. Then I see the solution tab is displayed (because can_view = 'solution')


- [ ] Case 2: Solution tab is displayed when can_view < solution but activity is validated
  1. Given I am usual user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/hide-solution-tab/en/#/activities/by-id/1376351457374039678;path=4702,1352246428241737349,369645559920184960,177279451139060234;parentAttempId=0/details)
  3. Then I see the solution tab is displayed


- [ ] Case 3: Solution tab is hidden when can_view < solution and the tab appears when validating activity
  1. Given I am an anonymous user
  2. When I go to [this task](https://dev.algorea.org/branch/feat/hide-solution-tab/en/#/activities/by-id/1376351457374039678;path=4702,1352246428241737349,369645559920184960,177279451139060234;parentAttempId=0/details)
  3. Then I see the solution tab is hidden (because can view = 'content')
  4. And I solve the exercise
  5. Then the solution tab appears