### PR TITLE
push language to task

### DIFF
--- a/src/app/modules/item/http-services/get-item-by-id.service.ts
+++ b/src/app/modules/item/http-services/get-item-by-id.service.ts
@@ -15,6 +15,7 @@ export const itemDecoder = pipe(
     string: pipe(
       D.struct({
         title: D.nullable(D.string),
+        languageTag: D.string,
       }),
       D.intersect(
         D.partial({

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -67,7 +67,8 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   readonly taskConfig$: Observable<TaskConfig> = combineLatest([
     this.formerAnswer$,
     this.taskReadOnly$,
-  ]).pipe(map(([ formerAnswer, readOnly ]) => ({ readOnly, formerAnswer })));
+    this.itemData$.pipe(readyData()),
+  ]).pipe(map(([ formerAnswer, readOnly, data ]) => ({ readOnly, formerAnswer, locale: data.item.string.languageTag })));
 
   // Any value emitted in skipBeforeUnload$ resumes navigation WITHOUT cancelling the save request.
   private skipBeforeUnload$ = new Subject<void>();

--- a/src/app/modules/item/services/item-task-init.service.ts
+++ b/src/app/modules/item/services/item-task-init.service.ts
@@ -17,6 +17,7 @@ export interface ItemTaskConfig {
   attemptId: string,
   formerAnswer: Answer | null,
   readOnly: boolean,
+  locale?: string,
 }
 
 @Injectable()
@@ -33,7 +34,9 @@ export class ItemTaskInitService implements OnDestroy {
 
   readonly iframeSrc$ = this.taskToken$.pipe(
     withLatestFrom(this.config$),
-    map(([ taskToken, { url }]) => taskUrlWithParameters(this.checkUrl(url), taskToken, appConfig.itemPlatformId, taskChannelIdPrefix)),
+    map(([ taskToken, { url, locale }]) =>
+      taskUrlWithParameters(this.checkUrl(url), taskToken, appConfig.itemPlatformId, taskChannelIdPrefix, locale)
+    ),
     shareReplay(1), // avoid duplicate xhr calls
   );
 
@@ -73,11 +76,11 @@ export class ItemTaskInitService implements OnDestroy {
     if (!this.configFromIframe$.closed) this.configFromIframe$.complete();
   }
 
-  configure(route: FullItemRoute, url: string, attemptId: string, formerAnswer: Answer | null, readOnly = false): void {
+  configure(route: FullItemRoute, url: string, attemptId: string, formerAnswer: Answer | null, locale?: string, readOnly = false): void {
     if (this.configured) throw new Error('task init service can be configured once only');
     this.configured = true;
 
-    this.configFromItem$.next({ route, url, attemptId, formerAnswer, readOnly });
+    this.configFromItem$.next({ route, url, attemptId, formerAnswer, locale, readOnly });
     this.configFromItem$.complete();
   }
 

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -16,6 +16,7 @@ import { ItemTaskViewsService } from './item-task-views.service';
 export interface TaskConfig {
   readOnly: boolean,
   formerAnswer: Answer | null,
+  locale?: string,
 }
 
 @Injectable()
@@ -64,7 +65,7 @@ export class ItemTaskService {
   configure(route: FullItemRoute, url: string, attemptId: string, options: TaskConfig): void {
     this.readOnly = options.readOnly;
     this.attemptId = attemptId;
-    this.initService.configure(route, url, attemptId, options.formerAnswer, options.readOnly);
+    this.initService.configure(route, url, attemptId, options.formerAnswer, options.locale, options.readOnly);
   }
 
   initTask(iframe: HTMLIFrameElement): void {


### PR DESCRIPTION
## Description

Fixes #911 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

I noticed that if the visited item/activity does not have strings for a given language (say "fr") but we are _actually visiting_ the platform in "fr", the item.string.language_tag is "en" anyway.
As a consequence, if we base the task locale on the item strings, we might have inconsistencies ; should I make a change to use the locale from the locale service instead ?

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this activity with app in English](https://dev.algorea.org/branch/feat/task-locale/en/#/activities/by-id/766891051147204195;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0/details)
  3. Then the task is loaded in English

- [ ] Case 2:
  1. Given I am any user
  2. When I go to [this activity with app in French](https://dev.algorea.org/branch/feat/task-locale/fr/#/activities/by-id/766891051147204195;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0/details)
  3. Then the task is loaded in French
