### PR TITLE
Fixes user group invitation results parser

### DIFF
--- a/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.spec.ts
+++ b/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.spec.ts
@@ -143,12 +143,12 @@ describe('UserGroupInvitationsComponent', () => {
     expect(component.state).toEqual('processing');
 
     // step 2: success response received
-    serviceResponder$.next([{ changed: true }, { changed: false }]);
+    serviceResponder$.next([{ changed: true }, { changed: true }, { changed: false }]);
     serviceResponder$.complete();
 
     expect(component.state).toEqual('ready');
     expect(actionFeedbackService.partial).toHaveBeenCalledTimes(1);
-    expect(actionFeedbackService.partial).toHaveBeenCalledWith('1 request(s) have been accepted, 1 could not be executed');
+    expect(actionFeedbackService.partial).toHaveBeenCalledWith('2 request(s) have been accepted, 1 could not be executed');
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(2);
   });
 

--- a/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.spec.ts
+++ b/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.spec.ts
@@ -107,7 +107,6 @@ describe('UserGroupInvitationsComponent', () => {
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(1); // the initial one
 
     // step 2: success response received
-    // serviceResponder$.next([ new Map([ [ '12', 'success' ] ]) ]);
     serviceResponder$.next([{ changed: true }]);
     serviceResponder$.complete();
 
@@ -136,42 +135,32 @@ describe('UserGroupInvitationsComponent', () => {
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(2);
   });
 
-/*  it('should consider "unchanged" in response as success', () => {
-    component.onProcessRequests({ type: Action.Accept, data: [ MOCK_RESPONSE_2 ] });
-
-    serviceResponder$.next([ new Map([ [ '12', 'unchanged' ] ]) ]);
-    serviceResponder$.complete();
-
-    expect(actionFeedbackService.success).toHaveBeenCalledWith('1 request(s) have been accepted');
-  });*/
-
   it('should display an appropriate message on partial success', () => {
 
+    // step 1: select one and 'accept'
     component.onProcessRequests({ type: Action.Accept, data: MOCK_RESPONSE }); // select 10, 11 and 12
 
-    serviceResponder$.next([
-      { changed: true },
-      { changed: true },
-      // new Map([ [ '11', 'invalid' ] ]),
-      // new Map([ [ '12', 'success' ] ]),
-      // new Map([ [ '10', 'success' ] ]),
-    ]);
+    expect(component.state).toEqual('processing');
+
+    // step 2: success response received
+    serviceResponder$.next([{ changed: true }, { changed: false }]);
     serviceResponder$.complete();
 
     expect(component.state).toEqual('ready');
     expect(actionFeedbackService.partial).toHaveBeenCalledTimes(1);
-    expect(actionFeedbackService.partial).toHaveBeenCalledWith('2 request(s) have been accepted, 1 could not be executed');
+    expect(actionFeedbackService.partial).toHaveBeenCalledWith('1 request(s) have been accepted, 1 could not be executed');
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(2);
   });
 
-/*
   it('should display an appropriate error message when all accept requests failed', () => {
 
     component.onProcessRequests({ type: Action.Accept, data: MOCK_RESPONSE }); // select 10, 11 and 12
 
+    expect(component.state).toEqual('processing');
+
     serviceResponder$.next([
-      new Map([ [ '11', 'invalid' ] ]),
-      new Map([ [ '12', 'cycle' ] ]),
+      { changed: false },
+      { changed: false },
     ]);
     serviceResponder$.complete();
 
@@ -185,9 +174,11 @@ describe('UserGroupInvitationsComponent', () => {
 
     component.onProcessRequests({ type: Action.Reject, data: MOCK_RESPONSE }); // select 10, 11 and 12
 
+    expect(component.state).toEqual('processing');
+
     serviceResponder$.next([
-      new Map([ [ '11', 'invalid' ] ]),
-      new Map([ [ '12', 'cycle' ] ]),
+      { changed: false },
+      { changed: false },
     ]);
     serviceResponder$.complete();
 
@@ -196,7 +187,6 @@ describe('UserGroupInvitationsComponent', () => {
     expect(actionFeedbackService.error).toHaveBeenCalledWith('Unable to reject the selected request(s).');
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(2);
   });
-*/
 
   it('should display an appropriate error message when the service fails', () => {
 

--- a/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.spec.ts
+++ b/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.spec.ts
@@ -31,7 +31,7 @@ describe('UserGroupInvitationsComponent', () => {
   let requestActionsService: RequestActionsService;
   let getRequestsService: GetRequestsService;
   let actionFeedbackService: ActionFeedbackService;
-  let serviceResponder$: Subject<Map<string,any>[]>;
+  let serviceResponder$: Subject<{changed: boolean}[]>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -55,7 +55,7 @@ describe('UserGroupInvitationsComponent', () => {
   }));
 
   beforeEach(() => {
-    serviceResponder$ = new Subject<Map<string,any>[]>();
+    serviceResponder$ = new Subject<{changed: boolean}[]>();
     fixture = TestBed.createComponent(UserGroupInvitationsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -107,7 +107,8 @@ describe('UserGroupInvitationsComponent', () => {
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(1); // the initial one
 
     // step 2: success response received
-    serviceResponder$.next([ new Map([ [ '12', 'success' ] ]) ]);
+    // serviceResponder$.next([ new Map([ [ '12', 'success' ] ]) ]);
+    serviceResponder$.next([{ changed: true }]);
     serviceResponder$.complete();
 
     expect(component.state).toEqual('ready');
@@ -126,7 +127,7 @@ describe('UserGroupInvitationsComponent', () => {
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(1); // the initial one
 
     // step 2: success response received
-    serviceResponder$.next([ new Map([ [ '12', 'success' ] ]) ]);
+    serviceResponder$.next([{ changed: true }]);
     serviceResponder$.complete();
 
     expect(component.state).toEqual('ready');
@@ -135,23 +136,25 @@ describe('UserGroupInvitationsComponent', () => {
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(2);
   });
 
-  it('should consider "unchanged" in response as success', () => {
+/*  it('should consider "unchanged" in response as success', () => {
     component.onProcessRequests({ type: Action.Accept, data: [ MOCK_RESPONSE_2 ] });
 
     serviceResponder$.next([ new Map([ [ '12', 'unchanged' ] ]) ]);
     serviceResponder$.complete();
 
     expect(actionFeedbackService.success).toHaveBeenCalledWith('1 request(s) have been accepted');
-  });
+  });*/
 
   it('should display an appropriate message on partial success', () => {
 
     component.onProcessRequests({ type: Action.Accept, data: MOCK_RESPONSE }); // select 10, 11 and 12
 
     serviceResponder$.next([
-      new Map([ [ '11', 'invalid' ] ]),
-      new Map([ [ '12', 'success' ] ]),
-      new Map([ [ '10', 'success' ] ]),
+      { changed: true },
+      { changed: true },
+      // new Map([ [ '11', 'invalid' ] ]),
+      // new Map([ [ '12', 'success' ] ]),
+      // new Map([ [ '10', 'success' ] ]),
     ]);
     serviceResponder$.complete();
 
@@ -161,6 +164,7 @@ describe('UserGroupInvitationsComponent', () => {
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(2);
   });
 
+/*
   it('should display an appropriate error message when all accept requests failed', () => {
 
     component.onProcessRequests({ type: Action.Accept, data: MOCK_RESPONSE }); // select 10, 11 and 12
@@ -192,6 +196,7 @@ describe('UserGroupInvitationsComponent', () => {
     expect(actionFeedbackService.error).toHaveBeenCalledWith('Unable to reject the selected request(s).');
     expect(getRequestsService.getGroupInvitations).toHaveBeenCalledTimes(2);
   });
+*/
 
   it('should display an appropriate error message when the service fails', () => {
 

--- a/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.ts
+++ b/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.ts
@@ -8,7 +8,7 @@ import {
 } from 'src/app/modules/group/components/pending-request/pending-request-response-handling';
 import { fetchingState, readyState } from 'src/app/shared/helpers/state';
 import { GetRequestsService, PendingRequest } from '../../http-services/get-requests.service';
-import { Action, parseResults, RequestActionsService } from '../../http-services/request-actions.service';
+import { Action, parseGroupInvitationResults, RequestActionsService } from '../../http-services/request-actions.service';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
 
 @Component({
@@ -70,7 +70,7 @@ export class UserGroupInvitationsComponent implements OnDestroy, OnInit {
       .subscribe({
         next: result => {
           this.state = 'ready';
-          displayResponseToast(this.actionFeedbackService, parseResults(result), params.type);
+          displayResponseToast(this.actionFeedbackService, parseGroupInvitationResults(result), params.type);
           this.dataFetching.next({ sort: this.currentSort });
         },
         error: _err => {

--- a/src/app/modules/group/http-services/request-actions.service.ts
+++ b/src/app/modules/group/http-services/request-actions.service.ts
@@ -57,15 +57,14 @@ export class RequestActionsService {
     );
   }
 
-  processGroupInvitations(groupIds: string[], action: Action): Observable<Map<string, Status>[]> {
+  processGroupInvitations(groupIds: string[], action: Action): Observable<{ changed: boolean }[]> {
     const type = action === Action.Accept ? 'accept' : 'reject';
     return forkJoin(
       groupIds.map(groupId =>
         this.http
-          .post<ActionResponse<{[user: string]: Status}>>(`${appConfig.apiUrl}/current-user/group-invitations/${groupId}/${type}`, null)
+          .post<ActionResponse<{ changed: boolean }>>(`${appConfig.apiUrl}/current-user/group-invitations/${groupId}/${type}`, null)
           .pipe(
             map(successData),
-            map(data => new Map(Object.entries(data)))
           )
       )
     );
@@ -81,4 +80,11 @@ export function parseResults(data: Map<string, Status>[]): { countRequests: numb
       .reduce((acc, res) => acc + res, 0);
   });
   return res;
+}
+
+export function parseGroupInvitationResults(data: { changed: boolean }[]): { countRequests: number, countSuccess: number } {
+  return {
+    countRequests: data.length,
+    countSuccess: data.filter(state => state.changed).length,
+  };
 }


### PR DESCRIPTION
## Description

Fixes #926

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The response type expected on FE for groupInvitationAccept/Reject was wrong

https://france-ioi.github.io/algorea-devdoc/api/#operation/groupInvitationAccept

## Test cases

As the demo user: Make sure your are not in the "DIU 2019" group via [my groups](https://dev.algorea.org/branch/bugfix/error-while-accepting-an-invitation/en/#/groups/mine) page and leave it if you are

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/error-while-accepting-an-invitation/en/#/groups/by-id/609422240375608067;path=/details/members)
  3. Using the invitation form (bottom of the page), invite the demo user "usr_5p020x2thuyu"
  4. As demo user go to [my groups](https://dev.algorea.org/branch/bugfix/error-while-accepting-an-invitation/en/#/groups/mine)
  5. Open the "pending invitations" panel
  6. Accept the "DIU 2019" invitation
  7. Then I see success message

- [x] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/error-while-accepting-an-invitation/en/#/groups/by-id/609422240375608067;path=/details/members)
  3. Using the invitation form (bottom of the page), invite the demo user "usr_5p020x2thuyu"
  4. As demo user go to [my groups](https://dev.algorea.org/branch/bugfix/error-while-accepting-an-invitation/en/#/groups/mine)
  5. Open the "pending invitations" panel
  6. Reject the "DIU 2019" invitation
  7. Then I see success message
