### PR TITLE
rename task tabs

### DIFF
--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -155,12 +155,12 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
 
   private getTabNameByView(view: string): string {
     switch (view) {
-      case 'editor': return $localize`Editor`;
+      case 'editor': return $localize`Solve`;
       case 'forum': return $localize`Forum`;
       case 'hints': return $localize`Hints`;
       case 'solution': return $localize`Solution`;
       case 'submission': return $localize`Submission`;
-      case 'task': return $localize`Task`;
+      case 'task': return $localize`Statement`;
       default: return capitalize(view);
     }
   }

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -123,7 +123,7 @@
       </trans-unit><trans-unit id="6673660887182833564" datatype="html">
         <source>Customize</source><target state="translated">Personnaliser</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="4449471207584645508" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="4449471207584645508" datatype="html">
         <source>Permissions successfully updated.</source><target state="translated">Permissions mises à jour avec succès.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">278</context></context-group></trans-unit><trans-unit id="7463044993322326313" datatype="html">
@@ -428,22 +428,22 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="5928181193903168495" datatype="html">
         <source> Content </source><target state="translated"> Contenu </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">30</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
         <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="translated"> Erreur lors du chargement de la réponse, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>charger votre dernière réponse<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
         <source>Leave unsaved task</source><target state="translated">Quitter la tâche sans sauvegarder</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">109</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
         <source>You do not appear to be connected to the Internet, if you leave this task you may loose your progress. Are you sure you want to continue?</source><target state="translated">Vous ne semblez pas être connecté à Internet Si vous quittez cette tâche, vous pourriez perdre vos derniers changements. Êtes-vous sûr de vouloir continuer ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">109</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">111</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
         <source>Loose progress and leave the task</source><target state="translated">Perdre mes derniers changements et quitter la tâche</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">114</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">116</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
         <source>Retry</source><target state="translated">Réessayer</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">121</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="translated">Erreur lors du chargement de la tâche</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="1143295073021866312" datatype="html">
@@ -452,10 +452,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="3835920457327748126" datatype="html">
         <source>An unknown error occurred. If this problem persists, please contact us.</source><target state="translated">Une erreur inconnue s'est produire. Si ce problème persiste, contactez nous.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">60</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
         <source>Unable to load the answer</source><target state="translated">Erreur lors du chargement de la tâche</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">65</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="translated">Sauvegarde de la réponse ...</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
@@ -474,10 +474,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
         <source>An unknown error occurred while publishing your result</source><target state="translated">Une erreur s'est produite lors de la publication de votre score</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="3742657416068781599" datatype="html">
-        <source>Editor</source><target state="translated">Editeur</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">158</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
+        <source>Solve</source><target state="new">Solve</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
+          <context context-type="linenumber">158</context>
+        </context-group>
+      </trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="translated">Forum</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">159</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
@@ -486,7 +489,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">160</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="2418142705701622721" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="2418142705701622721" datatype="html">
         <source>Leave the group ?</source><target state="translated">Quitter le groupe ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context>
@@ -573,7 +576,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="4578192247039196794" datatype="html">
         <source>Task</source><target state="translated">Tâche</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">163</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6361086178368013800" datatype="html">
         <source>A new task which users can try to solve.</source><target state="translated">Une nouvelle tâche que les utilisateurs pourront tenter de résoudre.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/helpers/new-item-types.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="8317457230285174180" datatype="html">
@@ -633,7 +636,13 @@
       </trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">162</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">162</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
+        <source>Statement</source><target state="new">Statement</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
+          <context context-type="linenumber">163</context>
+        </context-group>
+      </trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -801,7 +810,10 @@
           <context context-type="linenumber">44</context>
         </context-group>
       </trans-unit><trans-unit id="265815261626670662" datatype="html">
-        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Given by<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/><x id="START_LINK" ctype="x-a" equiv-text="&lt;a                   class=&quot;alg-link&quot;                   [routerLink]=&quot;{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink&quot;                 >"/> <x id="INTERPOLATION" equiv-text="{{ grantedPermission.sourceGroup.name }}"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Donné par<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/><x id="START_LINK" ctype="x-a" equiv-text="&lt;a                   class=&quot;alg-link&quot;                   [routerLink]=&quot;{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink&quot;                 >"/><x id="INTERPOLATION" equiv-text="{{ grantedPermission.sourceGroup.name }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
+        <source><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Given by<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/><x id="START_LINK" ctype="x-a" equiv-text="&lt;a
+                  class=&quot;alg-link&quot;
+                  [routerLink]=&quot;{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink&quot;
+                >"/> <x id="INTERPOLATION" equiv-text="{{ grantedPermission.sourceGroup.name }}"/> <x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="translated"><x id="START_TAG_SPAN" ctype="x-span" equiv-text="&lt;span>"/>Donné par<x id="CLOSE_TAG_SPAN" ctype="x-span" equiv-text="&lt;/span>"/><x id="START_LINK" ctype="x-a" equiv-text="&lt;a                   class=&quot;alg-link&quot;                   [routerLink]=&quot;{ id: grantedPermission.sourceGroup.id, isUser: false } | groupLink&quot;                 >"/><x id="INTERPOLATION" equiv-text="{{ grantedPermission.sourceGroup.name }}"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context>
           <context context-type="linenumber">61,67</context>
@@ -817,7 +829,7 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <source>Access to activity</source>
-      <target state="translated">Accéder à l'activité</target><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
+      <target state="translated">Accéder à l'activité</target><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.ts</context><context context-type="linenumber">279</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
         <source>Access to activity</source><target state="translated">Accès à l'activité</target>
 
@@ -833,7 +845,7 @@
       </trans-unit><trans-unit id="5278627882107105833" datatype="html">
         <source>Access</source><target state="translated">Rejoindre</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
@@ -1223,31 +1235,55 @@
         <source>Error while loading the children item</source><target state="translated">Erreur lors du chargement du contenu du chapitre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="8309054658706496987" datatype="html">
-        <source> «<x id="INTERPOLATION" equiv-text="{{ watchedGroup.name }}"/>» <x id="INTERPOLATION_1" equiv-text="{{ ['content', 'content_with_descendants', 'solution'].includes(permissions.canView).toString() | i18nSelect : {           true: 'can',           other: 'can\'t'         } }}"/> access this <x id="INTERPOLATION_2" equiv-text="{{ itemData.item.type | i18nSelect : {           Skill: 'skill',           other: 'activity'         } }}"/> </source><target state="translated"> «<x id="INTERPOLATION" equiv-text="{{ watchedGroup.name }}"/>» {{ ['content', 'content_with_descendants', 'solution'].includes(permissions.canView).toString() | i18nSelect : {           true: 'peut',           other: 'ne peut pas'         } }} accéder à cette {{ itemData.item.type | i18nSelect : {           Skill: 'compétence',           other: 'activité'         } }} </target>
+        <source> «<x id="INTERPOLATION" equiv-text="{{ watchedGroup.name }}"/>» <x id="INTERPOLATION_1" equiv-text="{{ ['content', 'content_with_descendants', 'solution'].includes(permissions.canView).toString() | i18nSelect : {
+          true: 'can',
+          other: 'can\'t'
+        } }}"/> access this <x id="INTERPOLATION_2" equiv-text="{{ itemData.item.type | i18nSelect : {
+          Skill: 'skill',
+          other: 'activity'
+        } }}"/> </source><target state="translated"> «<x id="INTERPOLATION" equiv-text="{{ watchedGroup.name }}"/>» {{ ['content', 'content_with_descendants', 'solution'].includes(permissions.canView).toString() | i18nSelect : {           true: 'peut',           other: 'ne peut pas'         } }} accéder à cette {{ itemData.item.type | i18nSelect : {           Skill: 'compétence',           other: 'activité'         } }} </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context>
           <context context-type="linenumber">9,20</context>
         </context-group>
       </trans-unit><trans-unit id="1633175305056804241" datatype="html">
-        <source>You cannot watch this <x id="INTERPOLATION" equiv-text="{{ itemData.item.type | i18nSelect : {             Skill: 'skill',             other: 'activity'           } }}"/> </source><target state="translated">Vous ne pouvez pas observer cette {{ itemData.item.type | i18nSelect : {             Skill: 'compétence',             other: 'activité'           } }} </target>
+        <source>You cannot watch this <x id="INTERPOLATION" equiv-text="{{ itemData.item.type | i18nSelect : {
+            Skill: 'skill',
+            other: 'activity'
+          } }}"/> </source><target state="translated">Vous ne pouvez pas observer cette {{ itemData.item.type | i18nSelect : {             Skill: 'compétence',             other: 'activité'           } }} </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context>
           <context context-type="linenumber">23,27</context>
         </context-group>
       </trans-unit><trans-unit id="7210234374199239920" datatype="html">
-        <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'user',               other: 'group'             } }}"/> cannot currently view this content. </source><target state="translated"> {{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'Cet utilisateur',               other: 'Ce groupe'             } }} ne peut pas actuellement voir ce contenu. </target>
+        <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {
+              true: 'user',
+              other: 'group'
+            } }}"/> cannot currently view this content. </source><target state="translated"> {{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'Cet utilisateur',               other: 'Ce groupe'             } }} ne peut pas actuellement voir ce contenu. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context>
           <context context-type="linenumber">32,37</context>
         </context-group>
       </trans-unit><trans-unit id="3905090940376140689" datatype="html">
-        <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'user',               other: 'group'             } }}"/> can list this <x id="INTERPOLATION_1" equiv-text="{{ itemData.item.type | i18nSelect : {               Skill: 'skill',               other: 'activity'             } }}"/> but cannot <x id="INTERPOLATION_2" equiv-text="{{ ['Skill', 'Chapter'].includes(itemData.item.type).toString() | i18nSelect : {               true: 'list its content.',               other: 'view its content.'             } }}"/> </source><target state="translated"> {{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'Cet utilisateur',               other: 'Ce groupe'             } }} peut voir cette {{ itemData.item.type | i18nSelect : {               Skill: 'compétence',               other: 'activité'             } }} mais ne peut pas {{ ['Skill', 'Chapter'].includes(itemData.item.type).toString() | i18nSelect : {               true: 'lister son contenu.',               other: 'voir son contenu.'             } }} </target>
+        <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {
+              true: 'user',
+              other: 'group'
+            } }}"/> can list this <x id="INTERPOLATION_1" equiv-text="{{ itemData.item.type | i18nSelect : {
+              Skill: 'skill',
+              other: 'activity'
+            } }}"/> but cannot <x id="INTERPOLATION_2" equiv-text="{{ ['Skill', 'Chapter'].includes(itemData.item.type).toString() | i18nSelect : {
+              true: 'list its content.',
+              other: 'view its content.'
+            } }}"/> </source><target state="translated"> {{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'Cet utilisateur',               other: 'Ce groupe'             } }} peut voir cette {{ itemData.item.type | i18nSelect : {               Skill: 'compétence',               other: 'activité'             } }} mais ne peut pas {{ ['Skill', 'Chapter'].includes(itemData.item.type).toString() | i18nSelect : {               true: 'lister son contenu.',               other: 'voir son contenu.'             } }} </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context>
           <context context-type="linenumber">39,54</context>
         </context-group>
       </trans-unit><trans-unit id="5268813630599686558" datatype="html">
-        <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'user',               other: 'group'             } }}"/> can view this activity. </source><target state="translated">{{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'Cet utilisateur',               other: 'Ce groupe'             } }} peut voir cette activité. </target>
+        <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {
+              true: 'user',
+              other: 'group'
+            } }}"/> can view this activity. </source><target state="translated">{{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'Cet utilisateur',               other: 'Ce groupe'             } }} peut voir cette activité. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context>
           <context context-type="linenumber">56,61</context>
@@ -1340,7 +1376,7 @@
       <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source>
 =======
       <target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir la solution de ces contenus et de leurs descendants (lorsque cela est possible pour ce groupe)</target><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
-&gt;&gt;&gt;&gt;&gt;&gt;&gt; 6e0ed607 (add translations)
+>>>>>>> 6e0ed607 (add translations)
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de ce contenu et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">


### PR DESCRIPTION
## Description

Fixes #933 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this activity](https://dev.algorea.org/branch/rename-task-tabs/en/#/activities/by-id/6010615591035594227;path=4702,1625159049301502151;attempId=0/details)
  4. Then I see the left tab is named "Statement" and the right tab containing the editor "Solve"
