### PR TITLE
Fixes margin for validation text under tabs

### DIFF
--- a/src/app/modules/item/components/chapter-children/chapter-children.component.scss
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.scss
@@ -4,7 +4,8 @@
 .validation-text {
   color: var(--base-color);
   font-size: 1.6rem;
-  padding: 0 0 2rem 0;
+  margin: 0;
+  padding: 2rem 0;
   text-align: center;
 }
 .validation-text+* {


### PR DESCRIPTION
## Description

Fixes #950

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/broken-layout/en/#/activities/by-id/6707691810849260111;path=;parentAttempId=0/details)
  3. Then I see "This chapter has no content visible to you, so you can't validate it for now." without any breaks
