### PR TITLE
hide task loader in favor of app loader

### DIFF
--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -9,7 +9,7 @@
       <alg-chapter-children
         [itemData]="itemData"
         *ngIf="itemData.item.type === 'Chapter'"
-        algFullHeightContent
+        [algFullHeightContent]="true"
       ></alg-chapter-children>
 
       <ng-container *ngIf="(itemData.item.type === 'Task' || itemData.item.type === 'Course')">

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -38,7 +38,7 @@
       [style.height]="iframeHeight$ | async"
       [src]="iframeSrc"
       #iframe
-      algFullHeightContent
+      [algFullHeightContent]="state.isReady"
       allowfullscreen
     ></iframe>
     <div *ngIf="state.isFetching" class="loading">

--- a/src/app/shared/directives/full-height-content.directive.ts
+++ b/src/app/shared/directives/full-height-content.directive.ts
@@ -1,9 +1,11 @@
-import { AfterViewChecked, Directive, ElementRef, HostListener, Renderer2 } from '@angular/core';
+import { AfterViewChecked, Directive, ElementRef, HostListener, Input, Renderer2 } from '@angular/core';
 
 @Directive({
   selector: '[algFullHeightContent]',
 })
 export class FullHeightContentDirective implements AfterViewChecked {
+  @Input() algFullHeightContent = true;
+
   @HostListener('window:resize')
   resize(): void {
     this.setHeight();
@@ -18,7 +20,13 @@ export class FullHeightContentDirective implements AfterViewChecked {
   }
 
   setHeight(): void {
+    if (!this.algFullHeightContent) {
+      this.renderer.setStyle(this.el.nativeElement, 'min-height', '0');
+      this.renderer.setStyle(this.el.nativeElement, 'height', '0');
+      return;
+    }
     const top = this.el.nativeElement.getBoundingClientRect().top + globalThis.scrollY;
+    this.renderer.setStyle(this.el.nativeElement, 'height', null);
     this.renderer.setStyle(this.el.nativeElement, 'min-height', `calc(100vh - ${top}px)`);
   }
 }


### PR DESCRIPTION
## Description

Fixes #945 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this task](https://dev.algorea.org/branch/fix/hide-task-loading/en/#/activities/by-id/8148962848812891795;path=4702,458602124916982205,4769434107088212490,8123435593727593341,5072731755477071719,8600972556668887052;parentAttempId=0/details)
  4. Then I see the task loader is hidden in favor of the app loader until the task is ready