### PR TITLE
allow task to disable progress tab through metadata

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -61,7 +61,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   );
   readonly taskTabs$ = this.tabs$.pipe(map(tabs => tabs.filter(tab => tab.view !== 'progress')));
   readonly showProgressTab$ = combineLatest([ this.userService.watchedGroup$, this.tabs$ ]).pipe(
-    map(([ watchedGroup, tabs ]) => !watchedGroup || tabs.some(tab => tab.view === 'progress')),
+    map(([ watchedGroup, tabs ]) => !!watchedGroup || tabs.some(tab => tab.view === 'progress')),
   );
   taskView?: TaskTab['view'];
 

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -57,7 +57,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
         : tabs.filter(tab => tab.view !== 'solution');
     }),
     map(tabs => tabs.filter(tab => !appConfig.featureFlags.hideTaskTabs.includes(tab.view))),
-    startWith(this.router.url.endsWith('/progress/history') ? [{ view: 'progress', name: 'Progress' }] : []),
+    startWith(this.isProgressPage() ? [{ view: 'progress', name: 'Progress' }] : []),
   );
   readonly taskTabs$ = this.tabs$.pipe(map(tabs => tabs.filter(tab => tab.view !== 'progress')));
   readonly showProgressTab$ = combineLatest([ this.userService.watchedGroup$, this.tabs$ ]).pipe(
@@ -119,7 +119,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
   private subscriptions = [
     this.itemDataSource.state$.subscribe(state => {
       // reset task tabs when item changes.
-      if (state.isFetching) this.tabs.next(this.router.url.endsWith('/progress/history') ? [{ view: 'progress', name: 'Progress' }] : []);
+      if (state.isFetching) this.tabs.next(this.isProgressPage() ? [{ view: 'progress', name: 'Progress' }] : []);
     }),
     fromEvent<BeforeUnloadEvent>(globalThis, 'beforeunload', { capture: true })
       .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent?.saveAnswerAndState() ?? of(undefined)), take(1))
@@ -174,6 +174,10 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   skipBeforeUnload(): void {
     this.skipBeforeUnload$.next();
+  }
+
+  private isProgressPage(): boolean {
+    return this.router.url.includes('/progress/history');
   }
 
 }

--- a/src/app/modules/item/task-communication/types.ts
+++ b/src/app/modules/item/task-communication/types.ts
@@ -70,6 +70,7 @@ export type TaskLog = D.TypeOf<typeof taskLogDecoder>;
 // Currently unused
 export const metadataDecoder = D.partial({
   autoHeight: D.boolean,
+  disablePlatformProgress: D.boolean,
 });
 export type TaskMetaData = D.TypeOf<typeof metadataDecoder>;
 export type TaskResources = unknown;

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -35,7 +35,6 @@ export interface Environment {
 
   featureFlags: {
     hideTaskTabs: string[],
-    hideActivityProgressTab: boolean,
   },
 }
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -23,7 +23,6 @@ export const environment: Environment = {
   theme: 'default',
   featureFlags: {
     hideTaskTabs: [],
-    hideActivityProgressTab: false,
   }
 };
 
@@ -31,9 +30,6 @@ type Preset = 'telecomParis';
 export const presets: Record<Preset, PartialDeep<Environment>> = {
   telecomParis: {
     theme: 'coursera-pt',
-    featureFlags: {
-      hideActivityProgressTab: true,
-    }
   },
 };
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -26,7 +26,6 @@ export const environment: Environment = {
   theme: 'default',
   featureFlags: {
     hideTaskTabs: [],
-    hideActivityProgressTab: false,
   },
 };
 
@@ -37,9 +36,6 @@ export const presets: Record<Preset, PartialDeep<Environment>> = {
     defaultTitle: 'Demo app',
     authType: 'cookies',
     theme: 'coursera-pt',
-    featureFlags: {
-      hideActivityProgressTab: true,
-    }
   },
 };
 


### PR DESCRIPTION
## Description

Fixes #919 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

### Task with multiple tabs and disabled progress tab

- [ ] Case 1: Watching a group
  1. Given I am the usual user
  2. When I go to [this group](https://dev.algorea.org/branch/feat/disable-progress-tab/en/#/groups/by-id/609422240375608067;path=/details)
  3. And I watch the group
  4. And I navigate to Activities / Parcours officiels / Motif Art / Task with hint (not Michel server)
  5. Then I see tabs a "Progress" tab
  3. And I unwatch the group
  5. Then the task is reloaded and I don't see any "Progress" tab

- [ ] Case 2: Landing on "content" tab
  1. Given I am the usual user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/disable-progress-tab/en/#/activities/by-id/6010615591035594227;path=4702,1625159049301502151;attempId=0/details)
  3. Then I don't see any "Progress" tab

- [ ] Case 3: Landing on "progress" tab
  1. Given I am an anonymous user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/disable-progress-tab/en/#/activities/by-id/6010615591035594227;path=4702,1625159049301502151;parentAttempId=0/details/progress/history)
  4. Then I see no tab is displayed while the task is loading
  5. Then I see tabs "Content" and "Progress"
  6. And I click on "content" tab and wait for the task to load
  7. Then I don't see any "Progress" tab

### Task with one tab and disabled progress tab

:warning: Can only be tested in localhost, you need to add the feature flag `hideTaskTabs: 'hints'` to your dev environment.

- [ ] Case 1: Task with only "task" tab and no progress tab
  1. Given I am the usual user
  2. When I go to [this group](http://localhost:4200/#/groups/by-id/609422240375608067;path=/details)
  3. And I watch the group
  4. And I navigate to Activities / Motif Art / Thomas tasks / Task with hidden progress
  5. Then I see tabs "Content" and "Progress"
  3. And I unwatch the group
  6. Then the task is reloaded and I see no tab once the task is loaded

- [ ] Case 2: Landing on "content" tab
  1. Given I am the usual user
  2. When I go to [this activity](http://localhost:4200/#/activities/by-id/1357671178979168705;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0/details)
  2. Then I see no tabs

- [ ] Case 3: landing on "progress" tab
  1. Given I am usual user
  2. When I go to [this activity](http://localhost:4200/#/activities/by-id/1357671178979168705;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0/details/progress/history)
  4. Then I see tabs "Content" and "Progress"
  5. And I click on "Content" tab and wait for the task to load
  6. Then I see no tab

### No regression tests

- [ ] Case 1: Transitioning from an activity progress to another
  1. Given I am the usual user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/disable-progress-tab/en/#/activities/by-id/6010615591035594227;path=4702,1625159049301502151;parentAttempId=0/details/progress/history)
  3. And I click expand left
  4. And I click on "Task ask hint"
  5. Then the progress page is correctly loaded

- [ ] Case 2: Task with enabled progress tab
  1. Given I am the usual user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/disable-progress-tab/en/#/activities/by-id/837046206729127555;path=4702,1352246428241737349,314613032161178344;attempId=0/details)
  3. Then I see tabs "Content" and "Progress" are displayed
  