### PR TITLE
On task loading error: "show task" button

### DIFF
--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -23,17 +23,18 @@
           i18n-message message="An unknown error occurred. If this problem persists, please contact us."
         ></alg-error>
       </ng-template>
-
-      <div class="text-center">
-        <a class="alg-link error-message" (click)="showTaskAnyway = true" i18n>
-          Show task anyway (for debugging)
-        </a>
-      </div>
     </ng-container>
+
+    <div class="text-center">
+      <a class="alg-link error-message" (click)="showTaskAnyway = true" i18n>
+        Show task anyway (for debugging)
+      </a>
+    </div>
   </div>
   <div
-    class="iframe-container" *ngIf="!state.isError || ['all', 'all_with_grant'].includes(canEdit)"
+    class="iframe-container"
     [style.display]="state.isError && !showTaskAnyway ? 'none' : 'block'"
+    [algFullHeightContent]="true"
   >
     <div class="saving-answer" *ngIf="savingAnswer">
       <p class="saving-answer-message">
@@ -47,7 +48,7 @@
       [style.height]="iframeHeight$ | async"
       [src]="iframeSrc"
       #iframe
-      [algFullHeightContent]="state.isReady"
+      [algFullHeightContent]="state.isReady || showTaskAnyway"
       allowfullscreen
     ></iframe>
     <div *ngIf="state.isFetching" class="loading">

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -26,9 +26,10 @@
     </ng-container>
 
     <div class="text-center">
-      <a class="alg-link error-message" (click)="showTaskAnyway = true" i18n>
-        Show task anyway (for debugging)
-      </a>
+      <alg-button
+        i18n-label label="Show task anyway (for debugging)"
+        (click)="showTaskAnyway = true"
+      ></alg-button>
     </div>
   </div>
   <div

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -1,10 +1,10 @@
 <div class="item-display" *ngIf="state$ | async as state">
-  <div *ngIf="state.isError" class="errors">
+  <div *ngIf="state.isError && !showTaskAnyway" class="errors">
     <ng-template #defaultErrorMessage>
       <alg-error i18n-message message="Unable to load the task"></alg-error>
     </ng-template>
 
-    <ng-container *ngIf="['all', 'all_with_grant'].includes(canEdit)">
+    <ng-container *ngIf="['all', 'all_with_grant'].includes(canEdit); else defaultErrorMessage">
       <alg-error
         *ngIf="initError$ | async; else urlError"
         i18n-message message="It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us."
@@ -23,9 +23,18 @@
           i18n-message message="An unknown error occurred. If this problem persists, please contact us."
         ></alg-error>
       </ng-template>
+
+      <div class="text-center">
+        <a class="alg-link error-message" (click)="showTaskAnyway = true" i18n>
+          Show task anyway (for debugging)
+        </a>
+      </div>
     </ng-container>
   </div>
-  <div class="iframe-container" *ngIf="!state.isError">
+  <div
+    class="iframe-container" *ngIf="!state.isError || ['all', 'all_with_grant'].includes(canEdit)"
+    [style.display]="state.isError && !showTaskAnyway ? 'none' : 'block'"
+  >
     <div class="saving-answer" *ngIf="savingAnswer">
       <p class="saving-answer-message">
         <span i18n>Saving answer...</span>

--- a/src/app/modules/item/pages/item-display/item-display.component.scss
+++ b/src/app/modules/item/pages/item-display/item-display.component.scss
@@ -52,6 +52,12 @@
     justify-content: center;
   }
 
+  .error-message {
+    display: inline-block;
+    padding: 1rem;
+    font-size: 1.6rem;
+  }
+
   iframe {
     height: 0;
     width: 100%;

--- a/src/app/modules/item/pages/item-display/item-display.component.scss
+++ b/src/app/modules/item/pages/item-display/item-display.component.scss
@@ -52,12 +52,6 @@
     justify-content: center;
   }
 
-  .error-message {
-    display: inline-block;
-    padding: 1rem;
-    font-size: 1.6rem;
-  }
-
   iframe {
     height: 0;
     width: 100%;

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -74,6 +74,8 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
     distinctUntilChanged(),
   );
 
+  showTaskAnyway = false;
+
   @Output() viewChange = this.taskService.activeView$;
   @Output() tabsChange: Observable<TaskTab[]> = this.taskService.views$.pipe(
     map(views => views.map(view => ({ view, name: this.getTabNameByView(view) }))),

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -449,7 +449,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="1143295073021866312" datatype="html">
         <source>It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us.</source><target state="translated">Cela arrive habituellement lorsque l'"url" de la tâche est invalide. Si l'url est valide est que le problème persiste, veuillez nous contacter.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="3835920457327748126" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="4031874298525415345" datatype="html">
+        <source>Show task anyway (for debugging)</source><target state="new">Show task anyway (for debugging)</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
+          <context context-type="linenumber">30</context>
+        </context-group>
+      </trans-unit><trans-unit id="3835920457327748126" datatype="html">
         <source>An unknown error occurred. If this problem persists, please contact us.</source><target state="translated">Une erreur inconnue s'est produire. Si ce problème persiste, contactez nous.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">60</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
@@ -458,38 +464,35 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">65</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="translated">Sauvegarde de la réponse ...</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
         <source>Skip</source><target state="translated">Passer</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">33</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="5172335096273253685" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="5172335096273253685" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet ?</source><target state="translated">Vos derniers changements n'ont pas pu être sauvegardés. Êtes-vous connectés à Internet ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="translated">Changements sauvegardés!</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
         <source>You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.</source><target state="translated">Vous ne semblez plus être connecté, essayez de relancer l'exercice. Si le problème persiste, contactez-nous.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">108</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
         <source>An unknown error occurred while publishing your result</source><target state="translated">Une erreur s'est produite lors de la publication de votre score</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">109</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
         <source>Hint request failed</source><target state="new">Hint request failed</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
-          <context context-type="linenumber">112</context>
-        </context-group>
-      </trans-unit><trans-unit id="8993911766369461044" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">114</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
         <source>Solve</source><target state="new">Solve</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">160</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">162</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="translated">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">161</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">163</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="translated">Indices</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">162</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">164</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">44</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">81</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="2418142705701622721" datatype="html">
@@ -639,10 +642,10 @@
       </trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">164</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">166</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
         <source>Statement</source><target state="new">Statement</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">165</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">167</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -1371,7 +1374,7 @@
 
 
 &lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">163</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">165</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
 =======
       <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source>
 =======


### PR DESCRIPTION
## Description

Fixes #949 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

Since error messages are already blue, I used the usual link color (grey, not blue) because otherwise it was not obvious that a user action was available.

## Test cases

- [ ] Case 1:
  1. Given I am an anonymous user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/show-errored-task/en/#/activities/by-id/773396873861865944;path=4702,1625159049301502151;parentAttempId=0/details)
  3. And I wait for the task to fail
  4. Then I see the normal error message "Unable to load this task" and the message "Show task anyway"

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this activity](https://dev.algorea.org/branch/feat/show-errored-task/en/#/activities/by-id/773396873861865944;path=4702,1625159049301502151;parentAttempId=0/details)
  3. And I wait for the task to fail
  4. Then I see the two error messages: "It usually occurs when task url is invalid, if the task url is valid and the problem persists, please contact us" and "Show task anyway (for debugging)"
  5. And I click on "Show task anyway"
  6. Then I see the error message is hidden and the iframe is shown