### PR TITLE
fix chapter progress tab display

### DIFF
--- a/src/app/modules/item/item.module.ts
+++ b/src/app/modules/item/item.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { ReactiveComponentModule } from '@ngrx/component';
 import { ItemRoutingModule } from './item-routing.module';
 import { SharedComponentsModule } from '../shared-components/shared-components.module';
 import { ItemDetailsComponent } from './pages/item-details/item-details.component';
@@ -75,6 +76,7 @@ import { ItemPermissionsComponent } from './components/item-permissions/item-per
     ItemRoutingModule,
     SharedComponentsModule,
     ReactiveFormsModule,
+    ReactiveComponentModule,
     FormsModule,
     TooltipModule,
     DialogModule,

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -119,9 +119,9 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   private subscriptions = [
     this.itemDataSource.state$.subscribe(state => {
-      // reset task tabs when item changes. By default do not display it unless we currently are on progress page
+      // reset tabs when item changes. By default do not display it unless we currently are on progress page
       if (state.isFetching) this.tabs.next(this.isProgressPage() ? [{ view: 'progress', name: 'Progress' }] : []);
-      // update task tabs when item is fetched
+      // update tabs when item is fetched
       // Case 1: item is not a task: display the progress tab anyway
       // Case 2: item is a task: delegate tab display to item task service, start with no tabs
       if (state.isReady) this.tabs.next(isTask(state.data.item) && !this.isProgressPage() ? [] : [{ view: 'progress', name: 'Progress' }]);

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -15,7 +15,6 @@ import {
   map,
   mergeWith,
   shareReplay,
-  startWith,
   switchMap,
   take,
   takeUntil,
@@ -28,6 +27,7 @@ import { urlArrayForItemRoute } from 'src/app/shared/routing/item-route';
 import { GetAnswerService } from '../../http-services/get-answer.service';
 import { appConfig } from 'src/app/shared/helpers/config';
 import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
+import { isTask } from 'src/app/shared/helpers/item-type';
 
 const loadForbiddenAnswerError = new Error('load answer forbidden');
 
@@ -58,7 +58,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
         : tabs.filter(tab => tab.view !== 'solution');
     }),
     map(tabs => tabs.filter(tab => !appConfig.featureFlags.hideTaskTabs.includes(tab.view))),
-    startWith(this.isProgressPage() ? [{ view: 'progress', name: 'Progress' }] : []),
+    shareReplay(1),
   );
   readonly taskTabs$ = this.tabs$.pipe(map(tabs => tabs.filter(tab => tab.view !== 'progress')));
   readonly showProgressTab$ = combineLatest([ this.groupWatchingService.isWatching$, this.tabs$ ]).pipe(
@@ -121,6 +121,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     this.itemDataSource.state$.subscribe(state => {
       // reset task tabs when item changes.
       if (state.isFetching) this.tabs.next(this.isProgressPage() ? [{ view: 'progress', name: 'Progress' }] : []);
+      if (state.isReady) this.tabs.next(isTask(state.data.item) ? [] : [{ view: 'progress', name: 'Progress' }]);
     }),
     fromEvent<BeforeUnloadEvent>(globalThis, 'beforeunload', { capture: true })
       .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent?.saveAnswerAndState() ?? of(undefined)), take(1))

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -119,9 +119,12 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   private subscriptions = [
     this.itemDataSource.state$.subscribe(state => {
-      // reset task tabs when item changes.
+      // reset task tabs when item changes. By default do not display it unless we currently are on progress page
       if (state.isFetching) this.tabs.next(this.isProgressPage() ? [{ view: 'progress', name: 'Progress' }] : []);
-      if (state.isReady) this.tabs.next(isTask(state.data.item) ? [] : [{ view: 'progress', name: 'Progress' }]);
+      // update task tabs when item is fetched
+      // Case 1: item is not a task: display the progress tab anyway
+      // Case 2: item is a task: delegate tab display to item task service, start with no tabs
+      if (state.isReady) this.tabs.next(isTask(state.data.item) && !this.isProgressPage() ? [] : [{ view: 'progress', name: 'Progress' }]);
     }),
     fromEvent<BeforeUnloadEvent>(globalThis, 'beforeunload', { capture: true })
       .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent?.saveAnswerAndState() ?? of(undefined)), take(1))

--- a/src/app/modules/item/pages/item-progress/item-progress.component.html
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="isWatching$ | async as isWatching">
+<ng-container *ngrxLet="isWatching$ as isWatching">
   <alg-section
       icon="fa fa-list"
       *ngIf="itemData"


### PR DESCRIPTION
## Description

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1a:
  1. Given I am the usual user
  2. When I go to [this task](https://dev.algorea.org/branch/fix/chapter-progress-tab/en/#/activities/by-id/6010615591035594227;path=4702,1625159049301502151;attempId=0/details)
  4. Then I see no regression, the "progress" tab is still hidden

- [ ] Case 1b:
  1. Given I am the usual user
  2. When I go to [this task](https://dev.algorea.org/branch/fix/chapter-progress-tab/en/#/activities/by-id/6379723280369399253;path=4702,1625159049301502151,5207993233955027100;attempId=0/details)
  4. Then I see the "progress" tab is displayed

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this chapter](https://dev.algorea.org/branch/fix/chapter-progress-tab/en/#/activities/by-id/1625159049301502151;path=4702;attempId=0/details)
  3. Then I see the "Progress" tab is displayed

- [ ] Case 3a:
  1. Given I am the usual user
  2. When I go to [this activity](https://dev.algorea.org/branch/fix/chapter-progress-tab/en/#/activities/by-id/6010615591035594227;path=4702,1625159049301502151;attempId=0/details/progress/history) on "Progress" tab
  3. Then I see the "Progress" tab is displayed straight away

- [ ] Case 3b:
  1. Given I am the usual user
  2. When I go to [this activity](https://dev.algorea.org/branch/fix/chapter-progress-tab/en/#/activities/by-id/6379723280369399253;path=4702,1625159049301502151,5207993233955027100;attempId=0/details/progress/history) on "Progress" tab
  3. Then I see the "Progress" tab is displayed straight away