### PR TITLE
fix task no tab selected after viewport full frame change

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -162,6 +162,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
 
   setTaskTabs(tabs: TaskTab[]): void {
     this.tabs.next(tabs);
+    if (tabs.every(tab => tab.view !== this.taskView)) this.taskView = tabs[0]?.view;
   }
 
   setTaskTabActive(tab: TaskTab): void {


### PR DESCRIPTION
## Description

Fixes #965 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this task](https://dev.algorea.org/branch/fix/task-tab-change/en/#/activities/by-id/6010615591035594227;path=4702,1625159049301502151;attempId=0/details)
  3. And I collapse full frame
  4. And I click on "Solve" tab
  5. And I expand full frame
  6. Then I see the "Statement" tab is active
