### PR TITLE
Feature/not display via group for some groups

### DIFF
--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.html
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.html
@@ -52,7 +52,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.label }}
-              <span *ngIf="node.data.associatedGroupName">(via group "{{ node.data.associatedGroupName }}")</span>
+              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
+                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              </span>
             </span>
             <span
               class="node-state"
@@ -90,7 +92,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.label }}
-              <span *ngIf="node.data.associatedGroupName">(<span i18n>via group</span> "{{ node.data.associatedGroupName }}")</span>
+              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
+                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              </span>
             </span>
             <span class="node-state" *ngIf="node.data.locked">
               <i class="fa fa-lock"></i>
@@ -131,7 +135,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.data.title }}
-              <span *ngIf="node.data.associatedGroupName">(via group "{{ node.data.associatedGroupName }}")</span>
+              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
+                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              </span>
             </span>
             <span
               class="node-state"
@@ -233,7 +239,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.data.title }}
-              <span *ngIf="node.data.associatedGroupName">(via group "{{ node.data.associatedGroupName }}")</span>
+              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
+                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              </span>
             </span>
             <span
               class="node-state"

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -1,6 +1,7 @@
 import { arraysEqual } from 'src/app/shared/helpers/array';
 import { ensureDefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { ContentRoute } from 'src/app/shared/routing/content-route';
+import { RootItem } from '../../http-services/item-navigation.service';
 
 type Id = string;
 export enum GroupManagership { False = 'false', True = 'true', Descendant = 'descendant' }
@@ -16,6 +17,7 @@ export interface NavTreeElement {
   // specific uses
   locked?: boolean, // considering 'not set' as false
   associatedGroupName?: string,
+  associatedGroupType?: RootItem['type'],
   score?: { bestScore: number, currentScore: number, validated: boolean },
   groupRelation?: { isMember: boolean, managership: 'none'|'direct'|'ancestor'|'descendant' },
 }

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -46,6 +46,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
       map(groups => groups.map(g => ({
         ...this.mapChild(g.item, defaultAttemptId),
         associatedGroupName: g.name,
+        associatedGroupType: g.type,
       })))
     );
   }

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -18,7 +18,7 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">265</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.ts</context><context context-type="linenumber">134</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">118</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">265</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.ts</context><context context-type="linenumber">138</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">118</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
         <source>Language mismatch</source><target state="translated">Mauvaise langue?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/language-mismatch/language-mismatch.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="6895619751331935307" datatype="html">
@@ -65,24 +65,39 @@
       <trans-unit id="1939752001297092762" datatype="html">
         <source>There is no content to display</source><target state="translated">Il n'y a rien à afficher</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="4996073393875425335" datatype="html">
-        <source>via group</source><target state="translated">via le groupe</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">93</context></context-group></trans-unit><trans-unit id="1679971178283595016" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="viaGroup" datatype="html">
+        <source>via group</source><target state="new">via group</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
+          <context context-type="linenumber">56</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
+          <context context-type="linenumber">96</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
+          <context context-type="linenumber">139</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
+          <context context-type="linenumber">243</context>
+        </context-group>
+      </trans-unit><trans-unit id="1679971178283595016" datatype="html">
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="translated">Vos droits d'accès actuels ne vous autorisent pas à voir le contenu de cette compétence.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">139</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">145</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ node.data.groupRelation.managership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></source><target state="translated"><x id="INTERPOLATION" equiv-text="{{ Vos droits d'accès actuels ne vous autorisent pas à voir le contenu de ce chapitre. }}"/></target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">185</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">191</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
         <source>You are a member of the group</source><target state="translated">Vous êtes membre du groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">190</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">196</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
         <source>Your current access rights do not allow you to start the activity.</source><target state="translated">Vos droits d'accès actuels ne vous autorisent pas à commencer cette activité.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">241</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">249</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -460,7 +475,7 @@
         <source>An unknown error occurred. </source><target state="new">An unknown error occurred. </target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.ts</context><context context-type="linenumber">133</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.ts</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="translated">Erreur lors du chargement de la tâche</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="8679237608788920660" datatype="html">
@@ -927,7 +942,7 @@
       </trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="translated">Vos droits d'accès actuels ne vous permettent pas de lister le contenu de ce chapitre.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">60</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="3074566479590679594" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="3074566479590679594" datatype="html">
         <source> Starting the activity ... (if you are stuck on this message, please retry and contact us if the problem persists) </source><target state="translated"> Démarrage de l'activité ... (si vous restez bloqué sur ce message, veuillez réessayer et nous contacter si le problème persiste) </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">71</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">


### PR DESCRIPTION
## Description

Fixes #962

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/not-display-via-group-for-some-groups/en/#/activities/by-id/4702;path=;attempId=0/details)
  3. Then I see `Parcours officiels` without `(via group "AllUsers")`

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/not-display-via-group-for-some-groups/en/#/activities/by-id/4702;path=;attempId=0/details)
  3. Click on Skills tab
  4. Then I see `Trees` without `(via group "AllUsers")`
