### PR TITLE
Remove enum watching

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -147,10 +147,6 @@ export class ItemByIdComponent implements OnDestroy {
       .subscribe(() => this.layoutService.toggleFullFrameContent(false));
   }
 
-  reloadContent(): void {
-    this.fetchItemAtRoute(this.activatedRoute.snapshot.paramMap);
-  }
-
   private getItemRoute(params?: ParamMap): ReturnType<typeof itemRouteFromParams> {
     const snapshot = this.activatedRoute.snapshot;
     if (!snapshot.parent) throw new Error('Unexpected: activated route snapshot has no parent');

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -12,7 +12,7 @@ import { ItemDataSource, ItemData } from '../../services/item-datasource.service
 import { errorHasTag, errorIsHTTPForbidden, errorIsHTTPNotFound } from 'src/app/shared/helpers/errors';
 import { ItemRouter } from 'src/app/shared/routing/item-router';
 import { isTask, ItemTypeCategory } from 'src/app/shared/helpers/item-type';
-import { Mode, ModeAction, ModeService } from 'src/app/shared/services/mode.service';
+import { ModeAction, ModeService } from 'src/app/shared/services/mode.service';
 import { isItemInfo, itemInfo } from 'src/app/shared/models/content/item-info';
 import { repeatLatestWhen } from 'src/app/shared/helpers/repeatLatestWhen';
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
@@ -124,11 +124,6 @@ export class ItemByIdComponent implements OnDestroy {
         if (!isItemInfo(current)) throw new Error('Unexpected: in item-by-id but the current content is not an item');
         this.itemRouter.navigateTo(current.route, { page: action === ModeAction.StartEditing ? 'edit' : 'details' });
       }),
-
-      this.modeService.mode$.pipe(
-        filter(mode => [ Mode.Normal, Mode.Watching ].includes(mode)),
-        distinctUntilChanged(),
-      ).subscribe(() => this.reloadContent()),
 
       this.itemDataSource.state$.pipe(
         readyData(),

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -89,7 +89,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     map(([{ route }]) => urlArrayForItemRoute({ ...route, attemptId: undefined, parentAttemptId: undefined, answerId: undefined })),
   );
 
-  readonly taskReadOnly$ = this.watchedGroup$.pipe(map(watched => watched !== null));
+  readonly taskReadOnly$ = this.groupWatchingService.isWatching$;
   readonly taskConfig$: Observable<TaskConfig> = combineLatest([
     this.formerAnswer$,
     this.taskReadOnly$,

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -6,7 +6,6 @@ import { mapStateData, readyData } from 'src/app/shared/operators/state';
 import { LayoutService } from '../../../../shared/services/layout.service';
 import { Router, RouterLinkActive } from '@angular/router';
 import { TaskTab } from '../item-display/item-display.component';
-import { Mode, ModeService } from 'src/app/shared/services/mode.service';
 import { combineLatest, fromEvent, merge, Observable, of, Subject } from 'rxjs';
 import {
   catchError,
@@ -90,7 +89,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     map(([{ route }]) => urlArrayForItemRoute({ ...route, attemptId: undefined, parentAttemptId: undefined, answerId: undefined })),
   );
 
-  readonly taskReadOnly$ = this.modeService.mode$.pipe(map(mode => mode === Mode.Watching));
+  readonly taskReadOnly$ = this.watchedGroup$.pipe(map(watched => watched !== null));
   readonly taskConfig$: Observable<TaskConfig> = combineLatest([
     this.formerAnswer$,
     this.taskReadOnly$,
@@ -142,7 +141,6 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     private groupWatchingService: GroupWatchingService,
     private itemDataSource: ItemDataSource,
     private layoutService: LayoutService,
-    private modeService: ModeService,
     private getAnswerService: GetAnswerService,
     private router: Router,
   ) {}

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -51,7 +51,7 @@ export class ItemTaskAnswerService implements OnDestroy {
         return readOnly ? of(formerAnswer) : this.loadFormerAsNewCurrentAnswer(route.id, attemptId, formerAnswer);
       }
 
-      return this.getCurrentAnswer(route.id, attemptId);
+      return readOnly ? of(formerAnswer) : this.getCurrentAnswer(route.id, attemptId);
     }),
     shareReplay(1), // avoid duplicate xhr calls on multiple subscriptions.
   );

--- a/src/app/shared/services/mode.service.ts
+++ b/src/app/shared/services/mode.service.ts
@@ -5,7 +5,6 @@ import { UserSessionService } from './user-session.service';
 export enum Mode {
   Normal = 'normal',
   Editing = 'editing',
-  Watching = 'watching',
 }
 export enum ModeAction { StartEditing, StopEditing }
 


### PR DESCRIPTION
## Description

It was a double bug. With the refactoring of watching mode, I didn't not spot at the review the `Mode` enum still had a `Watching` value that is not used anymore. I removed it to automatically find files relying on it and fixed them. What was broken:
1. Task read-only indicator
2. Item task answer service falling back to "fetch current answer" even when mode is read-only
3. Dead code regarding item reload when switching from normal to watching mode

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this user page](https://dev.algorea.org/branch/remove-enum-watching/en/#/groups/users/752024252804317630)
  4. And I observe the user
  5. And I navigate to "Blockly basic task" in the left nav
  6. Then I see the task is loaded in read-only, no answer is loaded
  7. And I exit observe mode
  8. Then I see the content is reloaded (no regression)

