### PR TITLE
fix blank page when switching from item edit to normal mode

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -7,7 +7,7 @@ import { LayoutService } from '../../../../shared/services/layout.service';
 import { Router, RouterLinkActive } from '@angular/router';
 import { TaskTab } from '../item-display/item-display.component';
 import { Mode, ModeService } from 'src/app/shared/services/mode.service';
-import { combineLatest, fromEvent, merge, Observable, of, Subject } from 'rxjs';
+import { combineLatest, fromEvent, merge, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import {
   catchError,
   distinctUntilChanged,
@@ -49,7 +49,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent {
     map(state => state.isReady && state.data),
   );
 
-  private tabs = new Subject<TaskTab[]>();
+  private tabs = new ReplaySubject<TaskTab[]>(1);
   tabs$ = combineLatest([ this.tabs, this.itemData$.pipe(readyData()) ]).pipe(
     map(([ tabs, data ]) => {
       const canShowSolution = data.item.permissions.canView === 'solution' || !!data.currentResult?.validated;


### PR DESCRIPTION
## Description

Fixes #973 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this item](https://dev.algorea.org/branch/fix-blank-content/en/#/activities/by-id/6707691810849260111;path=;parentAttempId=0/details) in normal mode
  3. And I switch to edit mode
  4. And I switch back to normal mode
  5. Then I see the item is correctly displayed (page not blank)

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this item](https://dev.algorea.org/branch/fix-blank-content/en/#/activities/by-id/6707691810849260111;path=;parentAttempId=0/edit) in edit mode (directly)
  3. And I switch to normal mode
  4. Then I see the item is correctly displayed (page not blank)
