### PR TITLE
Fix bug: only emit error only when the first connection is not made

### DIFF
--- a/src/app/modules/item/services/item-task-init.service.ts
+++ b/src/app/modules/item/services/item-task-init.service.ts
@@ -54,7 +54,7 @@ export class ItemTaskInitService implements OnDestroy {
 
   readonly initError$ = this.configFromIframe$.pipe(switchMap(({ iframe }) => fromEvent(iframe, 'load'))).pipe(
     switchMap(() => this.task$),
-    timeout(loadTaskTimeout), // after the iframe has loaded, if no connection to jschannel is made, consider the task broken
+    timeout({ first: loadTaskTimeout }), // after the iframe has loaded, if no connection to jschannel is made, consider the task broken
     catchError(timeoutError => of(timeoutError)),
     filter(error => error instanceof TimeoutError),
   ) as Observable<TimeoutError>;


### PR DESCRIPTION
**Urgent fix.** 
Fix bug: only emit error only when the first connection is not emitted. Was expecting regular emission.

Fixes #981 
