### PR TITLE
Feature/path suggestion overlay

### DIFF
--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -37,7 +37,7 @@
           let-columns="columns"
           let-index="rowIndex"
       >
-        <tr (mouseenter)="onMouseEnter($event, rowData.item.id, index)" (mouseleave)="onMouseLeave()">
+        <tr>
           <td *ngFor="let col of columns">
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
@@ -48,6 +48,8 @@
                   class="alg-link"
                   [ngClass]="{'disabled': !rowData.item}"
                   [routerLink]="rowData.item | rawItemLink"
+                  (mouseenter)="onMouseEnter($event, rowData.item.id, index)"
+                  (mouseleave)="onMouseLeave()"
                   #contentRef
                 >
                   {{ rowData.item.string.title }}

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -78,8 +78,8 @@
 </ng-container>
 
 <p-overlayPanel
+    styleClass="alg-path-suggestion-overlay"
     #op
-    [style]="{ minWidth: '30rem', maxWidth: '50rem' }"
 >
   <ng-container *ngIf="op.overlayVisible">
     <alg-path-suggestion [itemId]="(showOverlay$ | async)?.itemId"></alg-path-suggestion>

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -37,7 +37,7 @@
           let-columns="columns"
           let-index="rowIndex"
       >
-        <tr (mouseenter)="onMouseenter($event, rowData.item.id, index)" (mouseleave)="onMouseleave()">
+        <tr (mouseenter)="onMouseEnter($event, rowData.item.id, index)" (mouseleave)="onMouseLeave()">
           <td *ngFor="let col of columns">
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -38,7 +38,7 @@
           let-index="rowIndex"
       >
         <tr>
-          <td *ngFor="let col of columns">
+          <td *ngFor="let col of columns" (mouseleave)="onMouseLeave($event, col.field)">
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
@@ -49,7 +49,6 @@
                   [ngClass]="{'disabled': !rowData.item}"
                   [routerLink]="rowData.item | rawItemLink"
                   (mouseenter)="onMouseEnter($event, rowData.item.id, index)"
-                  (mouseleave)="onMouseLeave()"
                   #contentRef
                 >
                   {{ rowData.item.string.title }}
@@ -84,6 +83,6 @@
     #op
 >
   <ng-container *ngIf="op.overlayVisible">
-    <alg-path-suggestion [itemId]="(showOverlay$ | async)?.itemId"></alg-path-suggestion>
+    <alg-path-suggestion [itemId]="(showOverlay$ | async)?.itemId" (mouseleave)="closeOverlay()"></alg-path-suggestion>
   </ng-container>
 </p-overlayPanel>

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -35,15 +35,21 @@
           pTemplate="body"
           let-rowData
           let-columns="columns"
+          let-index="rowIndex"
       >
-        <tr>
+        <tr (mouseenter)="onMouseenter($event, rowData.item.id, index)" (mouseleave)="onMouseleave()">
           <td *ngFor="let col of columns">
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
                 {{ rowData.activityType | logActionDisplay : rowData.score }}
               </ng-container>
               <ng-container *ngSwitchCase="'item.string.title'">
-                <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | rawItemLink">
+                <a
+                  class="alg-link"
+                  [ngClass]="{'disabled': !rowData.item}"
+                  [routerLink]="rowData.item | rawItemLink"
+                  #contentRef
+                >
                   {{ rowData.item.string.title }}
                 </a>
               </ng-container>
@@ -70,3 +76,12 @@
     </p-table>
   </ng-container>
 </ng-container>
+
+<p-overlayPanel
+    #op
+    [style]="{ minWidth: '30rem', maxWidth: '50rem' }"
+>
+  <ng-container *ngIf="op.overlayVisible">
+    <alg-path-suggestion [itemId]="(showOverlay$ | async)?.itemId"></alg-path-suggestion>
+  </ng-container>
+</p-overlayPanel>

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.ts
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.ts
@@ -47,7 +47,7 @@ export class GroupLogViewComponent implements OnChanges, OnInit, OnDestroy {
     mapToFetchState({ resetter: this.refresh$ }),
   );
   private readonly showOverlaySubject$ = new BehaviorSubject<{ event: Event, itemId: string, target: HTMLElement }|undefined>(undefined);
-  showOverlay$ = this.showOverlaySubject$.asObservable().pipe(debounceTime(750), shareReplay());
+  showOverlay$ = this.showOverlaySubject$.asObservable().pipe(debounceTime(750), shareReplay(1));
 
   constructor(
     private activityLogService: ActivityLogService,

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.ts
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.ts
@@ -115,7 +115,7 @@ export class GroupLogViewComponent implements OnChanges, OnInit, OnDestroy {
     }));
   }
 
-  onMouseenter(event: Event, itemId: string, index: number): void {
+  onMouseEnter(event: Event, itemId: string, index: number): void {
     const targetRef = this.contentRef?.get(index);
     if (!targetRef) {
       throw new Error('Unexpected: Target is not found');
@@ -123,7 +123,7 @@ export class GroupLogViewComponent implements OnChanges, OnInit, OnDestroy {
     this.showOverlaySubject$.next({ event, itemId, target: targetRef.nativeElement });
   }
 
-  onMouseleave(): void {
+  onMouseLeave(): void {
     this.showOverlaySubject$.next(undefined);
   }
 

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.ts
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.ts
@@ -123,8 +123,34 @@ export class GroupLogViewComponent implements OnChanges, OnInit, OnDestroy {
     this.showOverlaySubject$.next({ event, itemId, target: targetRef.nativeElement });
   }
 
-  onMouseLeave(): void {
+  onMouseLeave(event: MouseEvent, field: string): void {
+    if (field !== 'item.string.title') {
+      return;
+    }
+
+    const target = event.target;
+    const relatedTarget = event.relatedTarget;
+    let closeOverlay = true;
+
+    if (target instanceof HTMLElement && relatedTarget instanceof HTMLElement) {
+      let currentElement = relatedTarget;
+      while (currentElement.parentElement) {
+        if (currentElement.classList.contains('alg-path-suggestion-overlay')) {
+          closeOverlay = false;
+          break;
+        }
+        currentElement = currentElement.parentElement;
+      }
+    }
+
+    if (closeOverlay) {
+      this.closeOverlay();
+    }
+  }
+
+  closeOverlay(): void {
     this.showOverlaySubject$.next(undefined);
+    this.op?.hide();
   }
 
 }

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.ts
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.ts
@@ -46,7 +46,7 @@ export class GroupLogViewComponent implements OnChanges, OnInit, OnDestroy {
     switchMap((groupId: string) => this.getData$(groupId)),
     mapToFetchState({ resetter: this.refresh$ }),
   );
-  showOverlaySubject$ = new BehaviorSubject<{ event: Event, itemId: string, target: HTMLElement }|undefined>(undefined);
+  private readonly showOverlaySubject$ = new BehaviorSubject<{ event: Event, itemId: string, target: HTMLElement }|undefined>(undefined);
   showOverlay$ = this.showOverlaySubject$.asObservable().pipe(debounceTime(750), shareReplay());
 
   constructor(

--- a/src/app/modules/item/http-services/get-breadcrumbs-from-roots.service.ts
+++ b/src/app/modules/item/http-services/get-breadcrumbs-from-roots.service.ts
@@ -1,0 +1,28 @@
+import { Observable } from 'rxjs';
+import { appConfig } from '../../../shared/helpers/config';
+import { decodeSnakeCase } from '../../../shared/operators/decode';
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import * as D from 'io-ts/Decoder';
+
+const breadcrumbsFromRootDecoder = D.struct({
+  id: D.string,
+  languageTag: D.string,
+  title: D.string,
+});
+
+export type BreadcrumbsFromRoot = D.TypeOf<typeof breadcrumbsFromRootDecoder>;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GetBreadcrumbsFromRootsService {
+  constructor(private http: HttpClient) {
+  }
+
+  get(id: string): Observable<BreadcrumbsFromRoot[][]> {
+    return this.http.get<unknown>(`${appConfig.apiUrl}/items/${id}/breadcrumbs-from-roots`).pipe(
+      decodeSnakeCase(D.array(D.array(breadcrumbsFromRootDecoder))),
+    );
+  }
+}

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
@@ -1,0 +1,31 @@
+<ng-container *ngIf="state$ | async as state">
+  <div class="spinner-container" *ngIf="state.isFetching">
+    <alg-loading size="small"></alg-loading>
+  </div>
+  <alg-error
+      *ngIf="state.isError"
+      class="dark"
+      icon="fa fa-exclamation-triangle"
+      i18n-message message="Error while loading path suggestion"
+      [showRefreshButton]="true"
+      (refresh)="refresh()"
+  ></alg-error>
+  <ng-container *ngIf="state.isReady">
+    <div *ngIf="state.data.length > 0; else noData">
+      <ng-container *ngFor="let group of state.data">
+        <ul class="breadcrumbs">
+          <ng-container *ngFor="let item of group | slice : 0 :group.length - 1">
+            <li class="breadcrumbs-item">
+              <a class="alg-link" routerLinkActive="base-color" [routerLink]="['/activities', 'by-id', item.id ]">
+                {{ item.title }}
+              </a>
+            </li>
+          </ng-container>
+        </ul>
+      </ng-container>
+    </div>
+    <ng-template #noData>
+      <span i18n>You have no path to this content.</span>
+    </ng-template>
+  </ng-container>
+</ng-container>

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
@@ -6,26 +6,36 @@
       *ngIf="state.isError"
       class="dark"
       icon="fa fa-exclamation-triangle"
-      i18n-message message="Error while loading path suggestion"
-      [showRefreshButton]="true"
+      [showRefreshButton]="$any(state.error).status !== 403"
       (refresh)="refresh()"
-  ></alg-error>
+  >
+    <ng-container *ngIf="$any(state.error).status === 403; else otherError;">
+      <span i18n>You are not allowed to view path suggestion.</span>
+    </ng-container>
+    <ng-template #otherError>
+      <span i18n>Error while loading path suggestion</span>
+    </ng-template>
+  </alg-error>
   <ng-container *ngIf="state.isReady">
-    <div *ngIf="state.data.length > 0; else noData">
-      <ng-container *ngFor="let group of state.data">
-        <ul class="breadcrumbs">
-          <ng-container *ngFor="let item of group | slice : 0 :group.length - 1">
-            <li class="breadcrumbs-item">
+    <ng-container *ngIf="state.data; else noPath">
+      <ng-container *ngIf="state.data.length > 0; else emptyPath">
+        <div class="breadcrumbs-container" *ngFor="let group of state.data">
+          <span class="breadcrumbs-prefix" i18n>via</span>
+          <ul class="breadcrumbs">
+            <li class="breadcrumbs-item" *ngFor="let item of group">
               <a class="alg-link" routerLinkActive="base-color" [routerLink]="['/activities', 'by-id', item.id ]">
                 {{ item.title }}
               </a>
             </li>
-          </ng-container>
-        </ul>
+          </ul>
+        </div>
       </ng-container>
-    </div>
-    <ng-template #noData>
+    </ng-container>
+    <ng-template #noPath>
       <span i18n>You have no path to this content.</span>
+    </ng-template>
+    <ng-template #emptyPath>
+      <span i18n>This content is one of your root activity/skill</span>
     </ng-template>
   </ng-container>
 </ng-container>

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
@@ -23,7 +23,7 @@
           <span class="breadcrumbs-prefix" i18n>via</span>
           <ul class="breadcrumbs">
             <li class="breadcrumbs-item" *ngFor="let item of breadcrumbs; let i = index">
-              <a class="alg-link" (click)="navigateToItem(item.id, breadcrumbs, i)">
+              <a class="alg-link" [routerLink]="item.url">
                 {{ item.title }}
               </a>
             </li>

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
@@ -4,7 +4,7 @@
   </div>
   <alg-error
       *ngIf="state.isError"
-      class="dark"
+      class="dark small"
       icon="fa fa-exclamation-triangle"
       [showRefreshButton]="$any(state.error).status !== 403"
       (refresh)="refresh()"
@@ -32,10 +32,14 @@
       </ng-container>
     </ng-container>
     <ng-template #noPath>
-      <span i18n>You have no path to this content.</span>
+      <alg-error class="dark small">
+        <span i18n>You have no path to this content.</span>
+      </alg-error>
     </ng-template>
     <ng-template #emptyPath>
-      <span i18n>This content is one of your root activity/skill</span>
+      <alg-error class="dark small">
+        <span i18n>This content is one of your root activity/skill</span>
+      </alg-error>
     </ng-template>
   </ng-container>
 </ng-container>

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html
@@ -19,11 +19,11 @@
   <ng-container *ngIf="state.isReady">
     <ng-container *ngIf="state.data; else noPath">
       <ng-container *ngIf="state.data.length > 0; else emptyPath">
-        <div class="breadcrumbs-container" *ngFor="let group of state.data">
+        <div class="breadcrumbs-container" *ngFor="let breadcrumbs of state.data">
           <span class="breadcrumbs-prefix" i18n>via</span>
           <ul class="breadcrumbs">
-            <li class="breadcrumbs-item" *ngFor="let item of group">
-              <a class="alg-link" routerLinkActive="base-color" [routerLink]="['/activities', 'by-id', item.id ]">
+            <li class="breadcrumbs-item" *ngFor="let item of breadcrumbs; let i = index">
+              <a class="alg-link" (click)="navigateToItem(item.id, breadcrumbs, i)">
                 {{ item.title }}
               </a>
             </li>

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: start;
   align-items: center;
+  padding: 0.571rem 1rem;
 }
 
 .breadcrumbs-prefix {

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
@@ -1,0 +1,19 @@
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+
+.breadcrumbs-item {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  &:not(:first-child):before {
+    content: '/';
+    display: inline;
+    margin: 0 .3rem;
+  }
+}

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
@@ -1,9 +1,20 @@
+.breadcrumbs-container {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+}
+
+.breadcrumbs-prefix {
+  color: var(--base-text-color);
+}
+
 .breadcrumbs {
   display: flex;
   align-items: center;
-  margin: 0;
+  margin: 0 0 0 .5rem;
   padding: 0;
   list-style-type: none;
+  overflow: hidden;
 }
 
 .breadcrumbs-item {

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
@@ -1,8 +1,13 @@
 import { Component, Input, OnChanges, OnDestroy } from '@angular/core';
-import { GetBreadcrumbsFromRootsService } from '../../../item/http-services/get-breadcrumbs-from-roots.service';
+import {
+  BreadcrumbsFromRoot,
+  GetBreadcrumbsFromRootsService
+} from '../../../item/http-services/get-breadcrumbs-from-roots.service';
 import { ReplaySubject, Subject, switchMap } from 'rxjs';
 import { mapToFetchState } from '../../../../shared/operators/state';
 import { map } from 'rxjs/operators';
+import { itemRoute } from '../../../../shared/routing/item-route';
+import { ItemRouter } from '../../../../shared/routing/item-router';
 
 @Component({
   selector: 'alg-path-suggestion',
@@ -36,7 +41,7 @@ export class PathSuggestionComponent implements OnDestroy, OnChanges {
     mapToFetchState({ resetter: this.refresh$ }),
   );
 
-  constructor(private getBreadcrumbsFromRootsService: GetBreadcrumbsFromRootsService) {
+  constructor(private getBreadcrumbsFromRootsService: GetBreadcrumbsFromRootsService, private itemRouter: ItemRouter) {
   }
 
   ngOnChanges(): void {
@@ -52,5 +57,10 @@ export class PathSuggestionComponent implements OnDestroy, OnChanges {
 
   refresh(): void {
     this.refresh$.next();
+  }
+
+  navigateToItem(id: string, breadcrumbs: BreadcrumbsFromRoot[], index: number): void {
+    const path = breadcrumbs.slice(0, index).map(item => item.id);
+    this.itemRouter.navigateTo(itemRoute('activity', id, path));
   }
 }

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
@@ -22,21 +22,9 @@ export class PathSuggestionComponent implements OnDestroy, OnChanges {
 
   state$ = this.itemId$.pipe(
     switchMap(itemId => this.getBreadcrumbsFromRootsService.get(itemId).pipe(
-      map(group => {
-        if (group.length === 0) {
-          return undefined;
-        }
-
-        const allBreadcrumbs = group
-          .map(items => items.slice(0, items.length - 1))
-          .reduce((state, items) => [ ...state, ...items ], []);
-
-        if (allBreadcrumbs.length === 0) {
-          return [];
-        }
-
-        return group.map(items => items.slice(0, items.length - 1)).filter(items => items.length > 0);
-      }),
+      map(group =>
+        (group.length > 0 ? group.map(items => items.slice(0, items.length - 1)).filter(items => items.length > 0) : undefined)
+      ),
     )),
     mapToFetchState({ resetter: this.refresh$ }),
   );

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, OnDestroy } from '@angular/core';
 import { GetBreadcrumbsFromRootsService } from '../../../item/http-services/get-breadcrumbs-from-roots.service';
 import { ReplaySubject, Subject, switchMap } from 'rxjs';
 import { mapToFetchState } from '../../../../shared/operators/state';
+import { map } from 'rxjs/operators';
 
 @Component({
   selector: 'alg-path-suggestion',
@@ -15,7 +16,23 @@ export class PathSuggestionComponent implements OnDestroy, OnChanges {
   private readonly refresh$ = new Subject<void>();
 
   state$ = this.itemId$.pipe(
-    switchMap(itemId => this.getBreadcrumbsFromRootsService.get(itemId)),
+    switchMap(itemId => this.getBreadcrumbsFromRootsService.get(itemId).pipe(
+      map(group => {
+        if (group.length === 0) {
+          return undefined;
+        }
+
+        const allBreadcrumbs = group
+          .map(items => items.slice(0, items.length - 1))
+          .reduce((state, items) => [ ...state, ...items ], []);
+
+        if (allBreadcrumbs.length === 0) {
+          return [];
+        }
+
+        return group.map(items => items.slice(0, items.length - 1)).filter(items => items.length > 0);
+      }),
+    )),
     mapToFetchState({ resetter: this.refresh$ }),
   );
 

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.ts
@@ -1,0 +1,39 @@
+import { Component, Input, OnChanges, OnDestroy } from '@angular/core';
+import { GetBreadcrumbsFromRootsService } from '../../../item/http-services/get-breadcrumbs-from-roots.service';
+import { ReplaySubject, Subject, switchMap } from 'rxjs';
+import { mapToFetchState } from '../../../../shared/operators/state';
+
+@Component({
+  selector: 'alg-path-suggestion',
+  templateUrl: './path-suggestion.component.html',
+  styleUrls: [ './path-suggestion.component.scss' ],
+})
+export class PathSuggestionComponent implements OnDestroy, OnChanges {
+  @Input() itemId?: string;
+
+  private readonly itemId$ = new ReplaySubject<string>(1);
+  private readonly refresh$ = new Subject<void>();
+
+  state$ = this.itemId$.pipe(
+    switchMap(itemId => this.getBreadcrumbsFromRootsService.get(itemId)),
+    mapToFetchState({ resetter: this.refresh$ }),
+  );
+
+  constructor(private getBreadcrumbsFromRootsService: GetBreadcrumbsFromRootsService) {
+  }
+
+  ngOnChanges(): void {
+    if (this.itemId) {
+      this.itemId$.next(this.itemId);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.itemId$.complete();
+    this.refresh$.complete();
+  }
+
+  refresh(): void {
+    this.refresh$.next();
+  }
+}

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -65,6 +65,7 @@ import { NeighborWidgetComponent } from './components/neighbor-widget/neighbor-w
 import { GroupPermissionCaptionPipe } from '../../shared/pipes/groupPermissionCaption';
 import { FullHeightContentDirective } from '../../shared/directives/full-height-content.directive';
 import { SectionHeaderComponent } from './components/section-header/section-header.component';
+import { PathSuggestionComponent } from './components/path-suggestion/path-suggestion.component';
 
 @NgModule({
   declarations: [
@@ -107,6 +108,7 @@ import { SectionHeaderComponent } from './components/section-header/section-head
     NeighborWidgetComponent,
     FullHeightContentDirective,
     SectionHeaderComponent,
+    PathSuggestionComponent,
   ],
   imports: [
     CommonModule,
@@ -179,6 +181,7 @@ import { SectionHeaderComponent } from './components/section-header/section-head
     NeighborWidgetComponent,
     FullHeightContentDirective,
     SectionHeaderComponent,
+    PathSuggestionComponent,
   ],
   providers: [],
 })

--- a/src/assets/scss/components/path-suggestion-overlay.scss
+++ b/src/assets/scss/components/path-suggestion-overlay.scss
@@ -2,6 +2,10 @@
   min-width: 30rem;
   max-width: 50rem;
 
+  .p-overlaypanel-content {
+    padding: 0;
+  }
+
   @media screen and (max-width: 1100px) {
     max-width: 40rem;
   }

--- a/src/assets/scss/components/path-suggestion-overlay.scss
+++ b/src/assets/scss/components/path-suggestion-overlay.scss
@@ -1,0 +1,8 @@
+.alg-path-suggestion-overlay {
+  min-width: 30rem;
+  max-width: 50rem;
+
+  @media screen and (max-width: 1100px) {
+    max-width: 40rem;
+  }
+}

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -145,8 +145,17 @@
       </trans-unit><trans-unit id="6673660887182833564" datatype="html">
         <source>Customize</source><target state="translated">Personnaliser</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="7463044993322326313" datatype="html">
-        <source> This content does not exist or you are not allowed to view it. </source><target state="new"> This content does not exist or you are not allowed to view it. </target>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="797234192640170277" datatype="html">
+        <source>You are not allowed to view path suggestion.</source><target state="new">You are not allowed to view path suggestion.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context>
+          <context context-type="linenumber">13</context>
+        </context-group>
+      </trans-unit><trans-unit id="4449471207584645508" datatype="html">
+        <source>Permissions successfully updated.</source><target state="translated">Permissions mises à jour avec succès.</target>
+
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">279</context></context-group></trans-unit><trans-unit id="7463044993322326313" datatype="html">
+        <source> This content does not exist or you are not allowed to view it. </source><target state="translated"> Ce contenu n'existe pas ou vous n'êtes pas autorisé à le voir. </target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
@@ -1343,11 +1352,23 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/parent-skills/parent-skills.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="7599176768250828782" datatype="html">
         <source>Error while loading path suggestion</source><target state="new">Error while loading path suggestion</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="7136816175934806999" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="7182192298964223312" datatype="html">
+        <source>via</source><target state="new">via</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+      </trans-unit><trans-unit id="7136816175934806999" datatype="html">
         <source>You have no path to this content.</source><target state="new">You have no path to this content.</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="4475993768283951722" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="4039557800195759728" datatype="html">
+        <source>This content is one of your root activity/skill</source><target state="new">This content is one of your root activity/skill</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context>
+          <context context-type="linenumber">38</context>
+        </context-group>
+      </trans-unit><trans-unit id="4475993768283951722" datatype="html">
         <source>Sub-skills</source><target state="translated">Sous-compétences</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="3303008548461857588" datatype="html">
@@ -1846,7 +1867,7 @@
         <source>(reset current expiration)</source><target state="new">(reset current expiration)</target>
         
         
-        
+
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">32</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">37</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">43</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="3604869065785906427" datatype="html">
         <source>Usable once</source><target state="new">Usable once</target>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -13,11 +13,11 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="contactUs" datatype="html">
         <source>If the problem persists, please contact us.</source><target state="new">If the problem persists, please contact us.</target>
-        
-        
-        
-        
-        
+
+
+
+
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">255</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.ts</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">122</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
         <source>Language mismatch</source><target state="new">Language mismatch</target>
 
@@ -303,7 +303,7 @@
         </context-group>
       </trans-unit><trans-unit id="7696186852546217048" datatype="html">
         <source>Display group code header</source><target>Afficher l'en-tête code de groupe</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="4088802997354529592" datatype="html">
         <source>Full screen</source><target state="new">Full screen</target>
         <context-group purpose="location">
@@ -312,7 +312,7 @@
         </context-group>
       </trans-unit><trans-unit id="5645834625950232099" datatype="html">
         <source>Participation</source><target state="new">Participation</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="649329754918782119" datatype="html">
         <source>Allow multiple attempts</source><target state="new">Allow multiple attempts</target>
         <context-group purpose="location">
@@ -375,7 +375,7 @@
         </context-group>
       </trans-unit><trans-unit id="1601880004921589799" datatype="html">
         <source>Could not load more results, are you connected to the internet?</source><target state="new">Could not load more results, are you connected to the internet?</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">37</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">108</context></context-group></trans-unit><trans-unit id="3768927257183755959" datatype="html">
         <source>Save</source><target state="translated">Sauvegarder</target>
         
@@ -485,10 +485,10 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="8679237608788920660" datatype="html">
         <source>It usually occurs when task url is invalid. If the task url is valid and the problem persists, please contact us.</source><target state="new">It usually occurs when task url is invalid. If the task url is valid and the problem persists, please contact us.</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="4031874298525415345" datatype="html">
         <source>Show task anyway (for debugging)</source><target state="new">Show task anyway (for debugging)</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">33</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
         <source>Unable to load the answer</source><target state="new">Unable to load the answer</target>
 
@@ -525,7 +525,7 @@
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">113</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
         <source>Hint request failed</source><target state="new">Hint request failed</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">118</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
         <source>Solve</source><target state="new">Solve</target>
         
@@ -898,7 +898,7 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="3665302231972354760" datatype="html">
         <source>The provided code is invalid</source><target state="new">The provided code is invalid</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="5278627882107105833" datatype="html">
         <source>Access</source><target state="translated">Rejoindre</target>
 
@@ -913,15 +913,15 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="6198202441206570236" datatype="html">
         <source>This activity requires explicit entry</source><target state="new">This activity requires explicit entry</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">68</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
         <source>(not implemented)</source><target state="new">(not implemented)</target>
-        
-        
-        
-        
-        
-        
+
+
+
+
+
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">69</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">181</context></context-group></trans-unit><trans-unit id="8227500063765912187" datatype="html">
         <source>Starting the activity</source><target state="new">Starting the activity</target>
         <context-group purpose="location">
@@ -954,16 +954,16 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.html</context><context context-type="linenumber">14</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="9165363087268857396" datatype="html">
         <source>This user is already a manager of this group.</source><target state="new">This user is already a manager of this group.</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="3254413422317172455" datatype="html">
         <source>Manager added!</source><target state="new">Manager added!</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.ts</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="465816649613134159" datatype="html">
         <source>The login you entered does not exist or is not visible to you.</source><target state="new">The login you entered does not exist or is not visible to you.</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.ts</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="7837985948560208725" datatype="html">
         <source>Unable to add this manager.</source><target state="new">Unable to add this manager.</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.ts</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="5932939510039092507" datatype="html">
         <source>Already added</source><target state="new">Already added</target>
 
@@ -1023,10 +1023,10 @@
        
      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-join-requests/pending-join-requests.component.ts</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="8979531771736981288" datatype="html">
        <source>TITLE</source><target state="translated">TITRE</target>
-       
+
      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/user-group-invitations/user-group-invitations.component.ts</context><context context-type="linenumber">21</context></context-group></trans-unit><trans-unit id="2880983087661811596" datatype="html">
        <source>TYPE</source><target state="translated">TYPE</target>
-       
+
      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/user-group-invitations/user-group-invitations.component.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="544102334421307622" datatype="html">
         <source>The group(s) must be empty</source><target state="new">The group(s) must be empty</target>
         
@@ -1313,20 +1313,20 @@
         </context-group>
       </trans-unit><trans-unit id="7210234374199239920" datatype="html">
         <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {             true: 'user',             other: 'group'           } }}"/> cannot currently view this content. </source><target state="new"> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'user',               other: 'group'             } }}"/> cannot currently view this content. </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="3905090940376140689" datatype="html">
         <source> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {             true: 'user',             other: 'group'           } }}"/> can list this <x id="INTERPOLATION_1" equiv-text="{{ itemData.item.type | i18nSelect : {             Skill: 'skill',             other: 'activity'           } }}"/> but cannot <x id="INTERPOLATION_2" equiv-text="{{ ['Skill', 'Chapter'].includes(itemData.item.type).toString() | i18nSelect : {             true: 'list its content.',             other: 'view its content.'           } }}"/> </source><target state="new"> The <x id="INTERPOLATION" equiv-text="{{ watchedGroup.route.isUser.toString() | i18nSelect : {               true: 'user',               other: 'group'             } }}"/> can list this <x id="INTERPOLATION_1" equiv-text="{{ itemData.item.type | i18nSelect : {               Skill: 'skill',               other: 'activity'             } }}"/> but cannot <x id="INTERPOLATION_2" equiv-text="{{ ['Skill', 'Chapter'].includes(itemData.item.type).toString() | i18nSelect : {               true: 'list its content.',               other: 'view its content.'             } }}"/> </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="3792349936860674133" datatype="html">
         <source> You cannot view the results or submissions of the group </source><target state="new"> You cannot view the results or submissions of the group </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="6629702976113303770" datatype="html">
         <source> Note that some subgroups or users of the groups may have higher permissions. </source><target state="new"> Note that some subgroups or users of the groups may have higher permissions. </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.html</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="permissionsUpdated" datatype="html">
         <source>Permissions successfully updated.</source><target state="new">Permissions successfully updated.</target>
-        
-        
+
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-permissions/item-permissions.component.ts</context><context context-type="linenumber">56</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.ts</context><context context-type="linenumber">269</context></context-group></trans-unit><trans-unit id="1519954996184640001" datatype="html">
         <source>Error</source><target state="translated">Erreur</target>
 
@@ -1341,7 +1341,13 @@
       </trans-unit><trans-unit id="7855013435783502943" datatype="html">
         <source>This skill does not have parent skills.</source><target state="translated">Cette compétence n'a pas de compétence parente.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/parent-skills/parent-skills.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="4475993768283951722" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/parent-skills/parent-skills.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="7599176768250828782" datatype="html">
+        <source>Error while loading path suggestion</source><target state="new">Error while loading path suggestion</target>
+
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="7136816175934806999" datatype="html">
+        <source>You have no path to this content.</source><target state="new">You have no path to this content.</target>
+
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="4475993768283951722" datatype="html">
         <source>Sub-skills</source><target state="translated">Sous-compétences</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="3303008548461857588" datatype="html">
@@ -1397,12 +1403,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="2577694282301310795" datatype="html">
         <source>Solution</source><target state="translated">Solution</target>
 
-
-&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">19</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">172</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
-=======
-      <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
-&gt;&gt;&gt;&gt;&gt;&gt;&gt; 6e0ed607 (add translations)
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog-texts.ts</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
@@ -1595,7 +1596,7 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">56</context></context-group></trans-unit><trans-unit id="9159686752653762421" datatype="html">
         <source>Could not load more members, are you connected to the internet?</source><target state="new">Could not load more members, are you connected to the internet?</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.ts</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="6377599608108067281" datatype="html">
         <source>Are you sure you want to permanently delete <x id="PH" equiv-text="getSelectedGroupChildCaptions(this.selection as GroupChild[])"/>?
        This operation cannot be undone.</source><target state="new">Are you sure you want to permanently delete <x id="PH" equiv-text="getSelectedGroupChildCaptions(this.selection as GroupChild[])"/>?
@@ -1631,7 +1632,7 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="33149636091572968" datatype="html">
         <source>Load more</source><target state="new">Load more</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">124</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">94</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="5077586677126527379" datatype="html">
         <source>This list is empty. Check below the different ways to add members or sub-groups.</source><target state="translated">La liste est vide. Voyez ci-dessous comment vous pouvez ajouter des membres et sous-groupes.</target>
 
@@ -1695,7 +1696,7 @@
         <source>Are you sure to remove yourself from the managers of this group? You may lose manager access and
           not be able to restore it.</source><target state="new">Are you sure to remove yourself from the managers of this group? You may lose manager access and
           not be able to restore it.</target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">109</context></context-group></trans-unit><trans-unit id="6365312852877051748" datatype="html">
         <source>Yes, remove me from the group managers</source><target state="new">Yes, remove me from the group managers</target>
 
@@ -1840,26 +1841,26 @@
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">30</context></context-group></trans-unit><trans-unit id="552571672657294742" datatype="html">
         <source>This code will never expire </source><target state="new">This code will never expire </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="resetCurrentExpiration" datatype="html">
         <source>(reset current expiration)</source><target state="new">(reset current expiration)</target>
         
         
         
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">32</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">37</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">43</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="3604869065785906427" datatype="html">
         <source>Usable once</source><target state="new">Usable once</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="6200326105084443165" datatype="html">
         <source>This code will be usable only once </source><target state="new">This code will be usable only once </target>
-        
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="7590013429208346303" datatype="html">
         <source>Custom</source><target state="new">Custom</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="expireDuration" datatype="html">
         <source>This code will expire after the given duration </source><target state="new">This code will expire after the given duration </target>
-        
-        
+
+
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">42</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-join-by-code/group-join-by-code.component.ts</context><context context-type="linenumber">48</context></context-group></trans-unit><trans-unit id="8388874893104562881" datatype="html">
         <source>You are not allowed to see this page.</source><target state="translated">Vous n'êtes pas autorisé à visiter cette page.</target>
 
@@ -1955,7 +1956,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">8</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="8115085152478832979" datatype="html">
         <source>There is no progress to report for this group/user.</source><target state="new">There is no progress to report for this group/user.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">72</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
         <source>Action</source><target state="translated">Opération</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -29,6 +29,7 @@
 @import 'assets/scss/components/group-join-by-code';
 @import 'assets/scss/components/block-ui';
 @import 'assets/scss/components/tooltip';
+@import 'assets/scss/components/path-suggestion-overlay';
 
 /* Custom themes */
 @import 'assets/scss/themes/coursera-pt';


### PR DESCRIPTION
## Description

Fixes #615

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

While BE going to add type to the root breadcrumbs response, we can consider all items are activity.

I've found that mapToFetchState doesn't change isFetching field to true for second request, you can see this affect when change hover from row to row in table. I can add merge fetchingState but not sure if it's correct and only one way. Let me know what you think

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/path-suggestion-overlay/en/#/groups/by-id/4322568739774621128;path=52767158366271444/details)
  3. And hover on one of row table
  4. Then I see overlay with path suggestion

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/path-suggestion-overlay/en/#/groups/by-id/49268055312628123;path=/details)
  3. And hover on one row with "Locked content"
  4. Then I see overlay with path suggestion with error message: "You are not allowed to view path suggestion."
