### PR TITLE
Adds refresh button for task when failed

### DIFF
--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -27,6 +27,7 @@
             (tabsChange)="taskTabsChange.emit($event)"
             (scoreChange)="scoreChange.emit($event)"
             (skipSave)="skipSave.emit()"
+            (refresh)="refresh.emit()"
           ></alg-item-display>
         </ng-container>
 

--- a/src/app/modules/item/pages/item-content/item-content.component.ts
+++ b/src/app/modules/item/pages/item-content/item-content.component.ts
@@ -20,6 +20,7 @@ export class ItemContentComponent implements OnChanges {
   @Output() taskViewChange = new EventEmitter<TaskTab['view']>();
   @Output() scoreChange = new EventEmitter<number>();
   @Output() skipSave = new EventEmitter<void>();
+  @Output() refresh = new EventEmitter<void>();
 
   attemptId?: string;
 

--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -83,6 +83,7 @@
               (taskTabsChange)="setTaskTabs($event)"
               (scoreChange)="patchStateWithScore($event)"
               (skipSave)="skipBeforeUnload()"
+              (refresh)="reloadItem()"
             ></alg-item-content>
           </ng-container>
         </ng-container>

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -27,7 +27,7 @@
       </ng-template>
     </ng-container>
 
-    <div class="text-center error-buttons">
+    <div class="error-buttons">
       <alg-button
         class="error-button"
         i18n-label label="Show task anyway (for debugging)"

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -3,8 +3,6 @@
     <ng-template #defaultErrorMessage>
       <alg-error
         i18n-message message="Unable to load the task"
-        [showRefreshButton]="true"
-        (refresh)="refresh.emit()"
       ></alg-error>
     </ng-template>
 
@@ -12,8 +10,6 @@
       <alg-error
         *ngIf="initError$ | async; else urlError"
         i18n-message message="It usually occurs when task url is invalid. If the task url is valid and the problem persists, please contact us."
-        [showRefreshButton]="true"
-        (refresh)="refresh.emit()"
       ></alg-error>
 
       <ng-template #urlError>
@@ -27,16 +23,20 @@
         <alg-error
           *ngIf="unknownError$ | async as error"
           [message]="errorMessage"
-          [showRefreshButton]="true"
-          (refresh)="refresh.emit()"
         ></alg-error>
       </ng-template>
     </ng-container>
 
-    <div class="text-center">
+    <div class="text-center error-buttons">
       <alg-button
+        class="error-button"
         i18n-label label="Show task anyway (for debugging)"
         (click)="showTaskAnyway = true"
+      ></alg-button>
+      <alg-button
+        class="error-button"
+        i18n-label label="Retry"
+        (click)="refresh.emit()"
       ></alg-button>
     </div>
   </div>

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -8,6 +8,8 @@
       <alg-error
         *ngIf="initError$ | async; else urlError"
         i18n-message message="It usually occurs when task url is invalid. If the task url is valid and the problem persists, please contact us."
+        [showRefreshButton]="true"
+        (refresh)="refresh.emit()"
       ></alg-error>
 
       <ng-template #urlError>
@@ -21,6 +23,8 @@
         <alg-error
           *ngIf="unknownError$ | async as error"
           [message]="errorMessage"
+          [showRefreshButton]="true"
+          (refresh)="refresh.emit()"
         ></alg-error>
       </ng-template>
     </ng-container>

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -1,7 +1,11 @@
 <div class="item-display" *ngIf="state$ | async as state">
   <div *ngIf="state.isError && !showTaskAnyway" class="errors">
     <ng-template #defaultErrorMessage>
-      <alg-error i18n-message message="Unable to load the task"></alg-error>
+      <alg-error
+        i18n-message message="Unable to load the task"
+        [showRefreshButton]="true"
+        (refresh)="refresh.emit()"
+      ></alg-error>
     </ng-template>
 
     <ng-container *ngIf="['all', 'all_with_grant'].includes(canEdit); else defaultErrorMessage">

--- a/src/app/modules/item/pages/item-display/item-display.component.scss
+++ b/src/app/modules/item/pages/item-display/item-display.component.scss
@@ -57,4 +57,16 @@
     width: 100%;
     border: none;
   }
+
+  .error-buttons {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  .error-button {
+    &:first-child {
+      margin-right: 1rem;
+    }
+  }
 }

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -53,6 +53,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
 
   @Output() scoreChange = this.taskService.scoreChange$;
   @Output() skipSave = new EventEmitter<void>();
+  @Output() refresh = new EventEmitter<void>();
 
   @ViewChild('iframe') iframe?: ElementRef<HTMLIFrameElement>;
 


### PR DESCRIPTION
## Description

Fixes #786

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/add-refresh-button-for-tasks/en/#/activities/by-id/6379723280369399253;path=;attempId=0/details)
  3. In network tab of browser switch to slow 3g
  4. While loading the task, switch slow 3g to offline
  5. Then I see error message with refresh button
  6. Switch offline mode to on
  7. Click on refresh button
  8. Then I see the task
