### PR TITLE
handle refresh token error

### DIFF
--- a/src/app/shared/auth/auth-info.ts
+++ b/src/app/shared/auth/auth-info.ts
@@ -19,9 +19,8 @@ function tokenAuthenticated(accessToken: string, expiration: Date, creation: Dat
 }
 
 /* Cookie-specific functions */
-export function cookieAuthFromServiceResp(_expiresIn: number): CookieAuthenticated {
-  return cookieAuthenticated(expiresInToDate(3)); // expires in 3 seconds
-  // return cookieAuthenticated(expiresInToDate(expiresIn));
+export function cookieAuthFromServiceResp(expiresIn: number): CookieAuthenticated {
+  return cookieAuthenticated(expiresInToDate(expiresIn));
 }
 
 /* Token-specific functions */

--- a/src/app/shared/auth/auth-info.ts
+++ b/src/app/shared/auth/auth-info.ts
@@ -19,9 +19,9 @@ function tokenAuthenticated(accessToken: string, expiration: Date, creation: Dat
 }
 
 /* Cookie-specific functions */
-export function cookieAuthFromServiceResp(expiresIn: number): CookieAuthenticated {
-  // return cookieAuthenticated(expiresInToDate(3)); // expires in 3 seconds
-  return cookieAuthenticated(expiresInToDate(expiresIn));
+export function cookieAuthFromServiceResp(_expiresIn: number): CookieAuthenticated {
+  return cookieAuthenticated(expiresInToDate(3)); // expires in 3 seconds
+  // return cookieAuthenticated(expiresInToDate(expiresIn));
 }
 
 /* Token-specific functions */

--- a/src/app/shared/auth/auth-info.ts
+++ b/src/app/shared/auth/auth-info.ts
@@ -19,8 +19,9 @@ function tokenAuthenticated(accessToken: string, expiration: Date, creation: Dat
 }
 
 /* Cookie-specific functions */
-export function cookieAuthFromServiceResp(expiresIn: number): CookieAuthenticated {
-  return cookieAuthenticated(expiresInToDate(expiresIn));
+export function cookieAuthFromServiceResp(_expiresIn: number): CookieAuthenticated {
+  return cookieAuthenticated(expiresInToDate(3)); // expires in 3 seconds
+  // return cookieAuthenticated(expiresInToDate(expiresIn));
 }
 
 /* Token-specific functions */

--- a/src/app/shared/auth/auth-info.ts
+++ b/src/app/shared/auth/auth-info.ts
@@ -19,9 +19,9 @@ function tokenAuthenticated(accessToken: string, expiration: Date, creation: Dat
 }
 
 /* Cookie-specific functions */
-export function cookieAuthFromServiceResp(_expiresIn: number): CookieAuthenticated {
-  return cookieAuthenticated(expiresInToDate(3)); // expires in 3 seconds
-  // return cookieAuthenticated(expiresInToDate(expiresIn));
+export function cookieAuthFromServiceResp(expiresIn: number): CookieAuthenticated {
+  // return cookieAuthenticated(expiresInToDate(3)); // expires in 3 seconds
+  return cookieAuthenticated(expiresInToDate(expiresIn));
 }
 
 /* Token-specific functions */

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -82,15 +82,15 @@ export class AuthService implements OnDestroy {
         return timer(Math.min(refreshIn, maxDelay), 1*MINUTES).pipe(map(() => auth));
       }),
       switchMap(auth =>
-        this.authHttp.refreshAuth(auth)
+        this.authHttp.refreshAuth(auth).pipe(
+          catchError(() => {
+            this.invalidToken(auth);
+            return EMPTY;
+          })
+        )
       )
-    ).subscribe({
-      next: auth => {
-        this.status$.next(auth);
-      },
-      error: () => {
-        this.failure$.next();
-      },
+    ).subscribe(auth => {
+      this.status$.next(auth);
     });
   }
 

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -83,15 +83,15 @@ export class AuthService implements OnDestroy {
         return timer(Math.min(refreshIn, maxDelay), 1*MINUTES).pipe(map(() => auth));
       }),
       switchMap(auth => {
-        const tokenIsExpired = auth.expiration.valueOf() < Date.now();
-        if (tokenIsExpired) return of({ auth, tokenIsExpired }); // don't even try to refresh the token if it is expired
+        const isExpired = auth.expiration.valueOf() < Date.now();
+        if (isExpired) return of({ auth, tokenIsExpired: true }); // don't even try to refresh the token if it is expired
         return this.authHttp.refreshAuth(auth).pipe(
           catchError(err => {
             // For any http error, ignore it since the token is valid. Another try will occur the next minute.
             if (err instanceof HttpErrorResponse) return EMPTY;
             else throw err; // rethrow any JS error to let our error monitor catch it.
           }),
-          map(auth => ({ auth, tokenIsExpired })),
+          map(auth => ({ auth, tokenIsExpired: false })),
         );
       })
     ).subscribe(result => {

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -77,9 +77,8 @@ export class AuthService implements OnDestroy {
         const maxDelay = 2147483647; // 2^31-1
         if (!auth.authenticated) return EMPTY;
         // Refresh if the token is valid < `minTokenLifetime` or when it will have reached 50% of its lifetime. Retry every minute.
-        // const refreshIn = auth.expiration.getTime() - Date.now() <= minTokenLifetime ? 0 :
-        //   Math.max((auth.expiration.getTime() + auth.creation.getTime())/2 - Date.now(), 0);
-        const refreshIn = 5000;
+        const refreshIn = auth.expiration.getTime() - Date.now() <= minTokenLifetime ? 0 :
+          Math.max((auth.expiration.getTime() + auth.creation.getTime())/2 - Date.now(), 0);
         return timer(Math.min(refreshIn, maxDelay), 1*MINUTES).pipe(map(() => auth));
       }),
       switchMap(auth => {

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -84,8 +84,13 @@ export class AuthService implements OnDestroy {
       switchMap(auth =>
         this.authHttp.refreshAuth(auth)
       )
-    ).subscribe(auth => {
-      this.status$.next(auth);
+    ).subscribe({
+      next: auth => {
+        this.status$.next(auth);
+      },
+      error: () => {
+        this.failure$.next();
+      },
     });
   }
 

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -76,8 +76,9 @@ export class AuthService implements OnDestroy {
         const maxDelay = 2147483647; // 2^31-1
         if (!auth.authenticated) return EMPTY;
         // Refresh if the token is valid < `minTokenLifetime` or when it will have reached 50% of its lifetime. Retry every minute.
-        const refreshIn = auth.expiration.getTime() - Date.now() <= minTokenLifetime ? 0 :
-          Math.max((auth.expiration.getTime() + auth.creation.getTime())/2 - Date.now(), 0);
+        // const refreshIn = auth.expiration.getTime() - Date.now() <= minTokenLifetime ? 0 :
+        //   Math.max((auth.expiration.getTime() + auth.creation.getTime())/2 - Date.now(), 0);
+        const refreshIn = 5000;
         return timer(Math.min(refreshIn, maxDelay), 1*MINUTES).pipe(map(() => auth));
       }),
       switchMap(auth =>


### PR DESCRIPTION
## Description

Fixes #989

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

> Make sure HTTP response errors are considered as Error

In the end this part is not handled because it needs further investigation without adding much value to the platform.

## Test cases

- [ ] Case 1: the reproduced bug
  1. Given I am an anonymous user
  2. When I visit the [app](https://dev.algorea.org/branch/reproduce-refresh-token-bug/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  3. And I quickly remove my authentication token http-only cookie in less than 5s (feasible in firefox, not in chrome)
  4. Then I see after 5s max the sentry modal appear

- [ ] Case 2: fix the reproduced bug
  1. Given I am an anonymous user
  2. When I visit the [app](https://dev.algorea.org/branch/fix-refresh-token-xhr/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  3. And I quickly remove my authentication token http-only cookie in less than 5s (feasible in firefox, not in chrome)
  4. Then I see after 5s max the sentry modal still does __not__ appear, the platform is loaded normally
  5. In the network logs, I see no 401 because the refresh call is omitted, and I see a temp-user call which corresponds to invalidating the token.
