### PR TITLE
Simpler task loading message

### DIFF
--- a/src/app/modules/item/components/task-loader/task-loader.component.html
+++ b/src/app/modules/item/components/task-loader/task-loader.component.html
@@ -2,6 +2,8 @@
   <div class="loading text-center">
     <div *ngIf="label" class="label">{{ label }}</div>
     <alg-loading></alg-loading>
-    <div class="sub-label" [style.visibility]="showDelayedLabel ? undefined : 'hidden'">{{ delayedLabel }}</div>
+    <div *ngIf="delayedLabel" class="sub-label" [style.visibility]="showDelayedLabel ? undefined : 'hidden'">
+      {{ delayedLabel }}
+    </div>
   </div>
 </div>

--- a/src/app/modules/item/components/task-loader/task-loader.component.html
+++ b/src/app/modules/item/components/task-loader/task-loader.component.html
@@ -2,5 +2,6 @@
   <div class="loading text-center">
     <div *ngIf="label" class="label">{{ label }}</div>
     <alg-loading></alg-loading>
+    <div class="sub-label" [style.visibility]="showDelayedLabel ? undefined : 'hidden'">{{ delayedLabel }}</div>
   </div>
 </div>

--- a/src/app/modules/item/components/task-loader/task-loader.component.scss
+++ b/src/app/modules/item/components/task-loader/task-loader.component.scss
@@ -17,3 +17,6 @@
   font-size: 1.6rem;
   color: var(--base-color);
 }
+.sub-label {
+  color: var(--base-text-color);
+}

--- a/src/app/modules/item/components/task-loader/task-loader.component.ts
+++ b/src/app/modules/item/components/task-loader/task-loader.component.ts
@@ -1,14 +1,31 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Subscription, timer } from 'rxjs';
+import { SECONDS } from 'src/app/shared/helpers/duration';
 
 @Component({
   selector: 'alg-task-loader',
   templateUrl: './task-loader.component.html',
   styleUrls: [ './task-loader.component.scss' ]
 })
-export class TaskLoaderComponent {
+export class TaskLoaderComponent implements OnInit, OnDestroy {
 
   @Input() label = '';
+  @Input() delayedLabel = '';
+  @Input() delay = 5;
+
+  showDelayedLabel = false;
+  subscription?: Subscription;
 
   constructor() { }
+
+  ngOnInit(): void {
+    this.subscription = timer(this.delay*SECONDS).subscribe(() => {
+      this.showDelayedLabel = true;
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
 
 }

--- a/src/app/modules/item/components/task-loader/task-loader.component.ts
+++ b/src/app/modules/item/components/task-loader/task-loader.component.ts
@@ -10,7 +10,9 @@ import { SECONDS } from 'src/app/shared/helpers/duration';
 export class TaskLoaderComponent implements OnInit, OnDestroy {
 
   @Input() label = '';
-  @Input() delayedLabel = '';
+  /** label displayed after a delay (by default 5s) */
+  @Input() delayedLabel?: string;
+  /** delay in seconds after which the delayedLabel is displayed */
   @Input() delay = 5;
 
   showDelayedLabel = false;
@@ -19,9 +21,9 @@ export class TaskLoaderComponent implements OnInit, OnDestroy {
   constructor() { }
 
   ngOnInit(): void {
-    this.subscription = timer(this.delay*SECONDS).subscribe(() => {
-      this.showDelayedLabel = true;
-    });
+    if (this.delayedLabel) {
+      this.subscription = timer(this.delay*SECONDS).subscribe(() => this.showDelayedLabel = true);
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -72,7 +72,6 @@
     <ng-template #noRequiresExplicitEntry>
       <alg-task-loader
         i18n-label label="Starting the activity"
-        i18n-delayedLabel delayedLabel="This should not take long. If you are stuck on this message, please retry and let us know if the problem persists."
       ></alg-task-loader>
     </ng-template>
   </ng-template>

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -72,6 +72,7 @@
     <ng-template #noRequiresExplicitEntry>
       <alg-task-loader
         i18n-label label="Starting the activity"
+        i18n-delayedLabel delayedLabel="This should not take long. If you are stuck on this message, please retry and let us know if the problem persists."
       ></alg-task-loader>
     </ng-template>
   </ng-template>

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -64,6 +64,7 @@
     <alg-task-loader
       *ngIf="state.isFetching"
       i18n-label label="Loading the task"
+      i18n-delayedLabel delayedLabel="The task is taking an unexpected long time to load... please wait..."
     ></alg-task-loader>
   </div>
 </div>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -497,6 +497,12 @@
           <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
           <context context-type="linenumber">66</context>
         </context-group>
+      </trans-unit><trans-unit id="8703959562849056209" datatype="html">
+        <source>The task is taking an unexpected long time to load... please wait...</source><target state="new">The task is taking an unexpected long time to load... please wait...</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
       </trans-unit><trans-unit id="7005243353550317116" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet?</target>
         
@@ -917,6 +923,12 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
           <context context-type="linenumber">74</context>
+        </context-group>
+      </trans-unit><trans-unit id="3019972560547445158" datatype="html">
+        <source>This should not take long. If you are stuck on this message, please retry and let us know if the problem persists.</source><target state="new">This should not take long. If you are stuck on this message, please retry and let us know if the problem persists.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
+          <context context-type="linenumber">75</context>
         </context-group>
       </trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="translated">Vos droits d'accès actuels ne vous permettent pas de lister le contenu de ce chapitre.</target>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -924,12 +924,6 @@
           <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
           <context context-type="linenumber">74</context>
         </context-group>
-      </trans-unit><trans-unit id="3019972560547445158" datatype="html">
-        <source>This should not take long. If you are stuck on this message, please retry and let us know if the problem persists.</source><target state="new">This should not take long. If you are stuck on this message, please retry and let us know if the problem persists.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
-          <context context-type="linenumber">75</context>
-        </context-group>
       </trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="translated">Vos droits d'accès actuels ne vous permettent pas de lister le contenu de ce chapitre.</target>
         


### PR DESCRIPTION
## Description

Fixes #948 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

:warning: The first use case cannot be tested because "Starting the activity" is displayed while waiting for an xhr request, which has a 3s timeout. Therefore, it will fall into an error state before actually displaying a message under "Starting the activity"

Here's how the message looks like:
![image](https://user-images.githubusercontent.com/16257159/165315170-ae2868d7-bb3d-49e9-a869-2c3d5394baa5.png)


## Test cases

- [ ] Case 1:
  1. Given I am any user with a throttled network
  2. When I go to [this item](https://dev.algorea.org/branch/simpler-task-loading-message/en/#/activities/by-id/2377619260689967292;path=4702,458602124916982205,4769434107088212490,8123435593727593341,5072731755477071719,8600972556668887052;parentAttempId=0/details)
  3. And I wait 5s after I see "Task loading"
  4. Then I see an additional message "The task is taking too long..."
