### PR TITLE
refactor lti boolean query params

### DIFF
--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -13,6 +13,7 @@ import {
   getRedirectToSubPathAtInit,
   setRedirectToSubPathAtInit,
 } from 'src/app/shared/helpers/redirect-to-sub-path-at-init';
+import { boolToQueryParamValue, queryParamValueToBool } from 'src/app/shared/helpers/url';
 import { CheckLoginService } from 'src/app/shared/http-services/check-login.service';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { mapToFetchState, readyData } from 'src/app/shared/operators/state';
@@ -47,11 +48,11 @@ export class LTIComponent implements OnDestroy {
   private loginId$ = this.activatedRoute.queryParamMap.pipe(map(queryParams => queryParams.get(loginIdParam)));
 
   private isRedirection$ = this.activatedRoute.queryParamMap.pipe(
-    map(queryParams => queryParams.get(isRedirectionParam) === '1'),
+    map(queryParams => queryParamValueToBool(queryParams.get(isRedirectionParam))),
   );
 
   private fromPath$ = this.activatedRoute.queryParamMap.pipe(
-    map(queryParams => (queryParams.get(useFromPathKey) === '1' ? queryParams.get(fromPathKey) : null)),
+    map(queryParams => (queryParamValueToBool(queryParams.get(useFromPathKey)) ? queryParams.get(fromPathKey) : null)),
   );
 
   private contentId$ = this.activatedRoute.paramMap.pipe(
@@ -100,7 +101,7 @@ export class LTIComponent implements OnDestroy {
       this.contentId$,
       this.loginId$.pipe(filter(isNotNull)),
     ]).subscribe(([ contentId, loginId ]) => {
-      setRedirectToSubPathAtInit(`/lti/${contentId}?${loginIdParam}=${loginId}&${isRedirectionParam}=1`);
+      setRedirectToSubPathAtInit(`/lti/${contentId}?${loginIdParam}=${loginId}&${isRedirectionParam}=${boolToQueryParamValue(true)}`);
       this.activityNavTreeService.navigationNeighborsRestrictedToDescendantOfElementId = contentId;
     }),
 
@@ -115,7 +116,7 @@ export class LTIComponent implements OnDestroy {
 
         const redirectUrl = getRedirectToSubPathAtInit();
         if (!redirectUrl) throw new Error('redirect url should be set by now');
-        setRedirectToSubPathAtInit(appendUrlWithQuery(redirectUrl, useFromPathKey, '1'));
+        setRedirectToSubPathAtInit(appendUrlWithQuery(redirectUrl, useFromPathKey, boolToQueryParamValue(true)));
 
         if (fromPath) {
           void this.router.navigateByUrl(fromPath);


### PR DESCRIPTION
## Description

Fixes #874 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

In the meantime, another boolean query param `use-from-path` was added to LTI, so I handled it as well. It adds a use case.

## Test cases

:warning: Test cases can only be tested on localhost.

- [ ] Case 1:
  1. Given I am the any user
  2. When I go to [our moodle test page](http://moodletest.algorea.org/course/view.php?id=3)
  3. And I login on moodle
  4. And I click on "Test dev.algorea.org (new platform localhost)"
  5. Then I am redirected to Algorea platform on item "Les boucles bornées ou boucles à compteur"
  6. --- **Use case 2 from here** ---
  7. And I navigate to next sibling "Les boucles imbriquées"
  8. And I refresh the tab
  9. Then I am redirected from lti to item "Les boucles imbriquées"
