### PR TITLE
Fixes horizontal scroll bug

### DIFF
--- a/src/app/core/app.component.scss
+++ b/src/app/core/app.component.scss
@@ -38,6 +38,7 @@ a:hover {
 .container {
   width: 100%;
   position: relative;
+  overflow: hidden;
 
   .left {
     width: $left-panel-size;


### PR DESCRIPTION
## Description

Fixes #901

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/horizontal-scroll-content-overlaps-left-menu/en/#/groups/by-id/672913018859223173;path=52767158366271444/details/managers)
  3. Do horizontal scroll
  4. Then I can see no scroll

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/horizontal-scroll-content-overlaps-left-menu/en/#/groups/by-id/672913018859223173;path=52767158366271444/details/managers)
  3. Click on watch group then click on test (Pixal) in suggested component
  4. Then click on Progress tab -> Chapter View
  5. Do horizontal scroll
  6. Then I can see no scroll
