### PR TITLE
fix type error on history state preventRefetch

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -59,7 +59,8 @@ export class ItemByIdComponent implements OnDestroy {
       // When loading a task with a former answerId, we need to remove the answerId from the url to avoid reloading
       // a former answer if the user refreshes the page
       // However, replacing the url should not retrigger an item fetch either, thus the use of history.state.preventRefetch
-      filter(() => !(history.state as Record<string, boolean> | null)?.preventRefetch),
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/strict-boolean-expressions
+      filter(() => !(typeof history.state === 'object' && history.state?.preventRefetch)),
     ).subscribe(params => this.fetchItemAtRoute(params)),
 
     this.subscriptions.push(
@@ -132,7 +133,8 @@ export class ItemByIdComponent implements OnDestroy {
         filter(([ previous, current ]) => (!!current && (!previous || isTask(previous.item) || isTask(current.item)))),
         map(([ , current ]) => ensureDefined(current).item),
       ).subscribe(item => {
-        const activateFullFrame = isTask(item) && !(history.state as Record<string, boolean | undefined>).preventFullFrame;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access,@typescript-eslint/strict-boolean-expressions
+        const activateFullFrame = isTask(item) && !(typeof history.state === 'object' && history.state?.preventFullFrame);
         this.layoutService.configure({ fullFrameActive: activateFullFrame });
       })
     );

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -59,7 +59,7 @@ export class ItemByIdComponent implements OnDestroy {
       // When loading a task with a former answerId, we need to remove the answerId from the url to avoid reloading
       // a former answer if the user refreshes the page
       // However, replacing the url should not retrigger an item fetch either, thus the use of history.state.preventRefetch
-      filter(() => !(history.state as Record<string, boolean>).preventRefetch),
+      filter(() => !(history.state as Record<string, boolean> | null)?.preventRefetch),
     ).subscribe(params => this.fetchItemAtRoute(params)),
 
     this.subscriptions.push(

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -25,7 +25,8 @@ export class ItemRouter {
   navigateTo(item: RawItemRoute, {
     page,
     navExtras,
-    preventFullFrame = (history.state as Record<string, boolean>).preventFullFrame ?? false,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    preventFullFrame = Boolean(typeof history.state === 'object' && history.state?.preventFullFrame),
   }: NavigateOptions = {}): void {
     void this.router.navigateByUrl(this.url(item, page), { ...navExtras, state: { ...navExtras?.state, preventFullFrame } });
   }


### PR DESCRIPTION
## Description

Fixes #1013 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

I could not reproduce the bug, but since `history.state` can be null, adding optional chaining should suffice.