### PR TITLE
Handle request timeouts

### DIFF
--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { combineLatest, EMPTY, forkJoin, Observable } from 'rxjs';
-import { catchError, filter, map, shareReplay, switchMap, withLatestFrom } from 'rxjs/operators';
+import { catchError, filter, map, retry, shareReplay, switchMap, withLatestFrom } from 'rxjs/operators';
 import { ActivityNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
 import { GetItemChildrenService, ItemChild } from 'src/app/modules/item/http-services/get-item-children.service';
 import { GetItemPathService } from 'src/app/modules/item/http-services/get-item-path.service';
@@ -68,6 +68,7 @@ export class LTIComponent implements OnDestroy {
       if (!loginId) throw loginError;
       return this.checkLoginService.check(loginId);
     }),
+    retry(3),
     shareReplay(1),
   );
 

--- a/src/app/shared/http-services/check-login.service.ts
+++ b/src/app/shared/http-services/check-login.service.ts
@@ -21,7 +21,7 @@ export class CheckLoginService {
     const params = new HttpParams({ fromObject: { login_id: loginId } });
 
     return this.http
-      .get<unknown>(`${appConfig.apiUrl}/current-user/check-login-id`, { params, headers: ++count <= 2 ? { timeout: '50' } : {} })
+      .get<unknown>(`${appConfig.apiUrl}/current-user/check-login-id`, { params })
       .pipe(
         decodeSnakeCase(dataDecoder),
         map(data => data.loginIdMatched),
@@ -29,5 +29,3 @@ export class CheckLoginService {
   }
 
 }
-
-let count = 0;

--- a/src/app/shared/http-services/check-login.service.ts
+++ b/src/app/shared/http-services/check-login.service.ts
@@ -21,7 +21,7 @@ export class CheckLoginService {
     const params = new HttpParams({ fromObject: { login_id: loginId } });
 
     return this.http
-      .get<unknown>(`${appConfig.apiUrl}/current-user/check-login-id`, { params })
+      .get<unknown>(`${appConfig.apiUrl}/current-user/check-login-id`, { params, headers: ++count <= 2 ? { timeout: '50' } : {} })
       .pipe(
         decodeSnakeCase(dataDecoder),
         map(data => data.loginIdMatched),
@@ -29,3 +29,5 @@ export class CheckLoginService {
   }
 
 }
+
+let count = 0;


### PR DESCRIPTION
## Description

Fixes #1012 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

This initial problem should have been fixed by #1018, anyway some enhancement might benefit us:
- Because timeout error stacks are a hell to read, and since we already apply a client-side timeout, I suggest we also intercept timeout errors and replace them by http error 408 timeout. Such errors will be much more readable in the future than rxjs timeouts.
- Since the check login call looks like a source of trouble, I added a retry strategy (3 times) to avoid breaking the whole page when network is temporarily slower.

## Test cases

:warning: can be tested locally only!

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [moodle test "Test LTI 2"](http://moodletest.algorea.org/course/view.php?id=3)
  3. And I click on "Test dev.algorea.org (new platform localhost)"
  4. Then I am redirected to algorea platform
  5. And I open the network panel and refresh]
  6. Then I see 2 fails on check-login service, 3rd is a success, and the platform is loaded normally.
