### PR TITLE
fix permission dialog when watching group

### DIFF
--- a/src/app/modules/item/components/item-permissions/item-permissions.component.html
+++ b/src/app/modules/item/components/item-permissions/item-permissions.component.html
@@ -81,7 +81,7 @@
           Note that some subgroups or users of the groups may have higher permissions.
         </div>
 
-        <ng-container *ngIf="permissions.canGrantView !== 'none' && watchedGroup.currentUserCanGrantGroupAccess">
+        <ng-container *ngIf="permissions.canGrantView !== 'none' && watchedGroup.currentUserCanGrantGroupAccess && itemData?.item?.permissions">
           <div class="give-access-button">
             <button
                 pButton
@@ -98,6 +98,7 @@
               [title]="watchedGroup.name"
               [targetType]="'Groups'"
               [permissions]="permissions"
+              [giverPermissions]="itemData?.item?.permissions"
               (close)="closePermissionsDialog()"
               (save)="onPermissionsDialogSave($event)"
           ></alg-permissions-edit-dialog>

--- a/src/app/modules/item/components/item-permissions/item-permissions.component.html
+++ b/src/app/modules/item/components/item-permissions/item-permissions.component.html
@@ -99,7 +99,7 @@
               [title]="watchedGroup.name"
               [targetType]="'Groups'"
               [permissions]="permissions"
-              [giverPermissions]="itemData?.item?.permissions"
+              [giverPermissions]="itemData.item.permissions"
               (close)="closePermissionsDialog()"
               (save)="onPermissionsDialogSave($event)"
           ></alg-permissions-edit-dialog>

--- a/src/app/modules/item/components/item-permissions/item-permissions.component.html
+++ b/src/app/modules/item/components/item-permissions/item-permissions.component.html
@@ -93,6 +93,7 @@
             ></button>
           </div>
 
+          <!-- NOTE: For now, we can assume that giver permissions is equivalent to user permissions on item. -->
           <alg-permissions-edit-dialog
               [visible]="isPermissionsDialogOpened"
               [title]="watchedGroup.name"

--- a/src/app/modules/item/components/item-permissions/item-permissions.component.html
+++ b/src/app/modules/item/components/item-permissions/item-permissions.component.html
@@ -93,7 +93,6 @@
             ></button>
           </div>
 
-          <!-- NOTE: For now, we can assume that giver permissions is equivalent to user permissions on item. -->
           <alg-permissions-edit-dialog
               [visible]="isPermissionsDialogOpened"
               [title]="watchedGroup.name"

--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -8,7 +8,7 @@ import { PermissionsDialogData, generateValues } from '../../helpers/permissions
 import { TypeFilter } from '../composition-filter/composition-filter.component';
 
 @Component({
-  selector: 'alg-permissions-edit-dialog',
+  selector: 'alg-permissions-edit-dialog[giverPermissions]',
   templateUrl: './permissions-edit-dialog.component.html',
   styleUrls: [ './permissions-edit-dialog.component.scss' ]
 })
@@ -17,7 +17,7 @@ export class PermissionsEditDialogComponent implements OnChanges, OnDestroy {
   @Input() visible?: boolean;
   @Input() title?: string;
   @Input() permissions?: Omit<GroupPermissions,'canEnterFrom'|'canEnterUntil'>;
-  @Input() giverPermissions?: PermissionsInfo;
+  @Input() giverPermissions!: PermissionsInfo;
   @Input() targetType: TypeFilter = 'Users';
   @Output() close = new EventEmitter<void>();
   @Output() save = new EventEmitter<Partial<GroupPermissions>>();
@@ -48,7 +48,7 @@ export class PermissionsEditDialogComponent implements OnChanges, OnDestroy {
       this.form.valueChanges,
       this.regenerateValues.asObservable()
     ).subscribe(() => {
-      if (this.permissions && this.giverPermissions) {
+      if (this.permissions) {
         const receiverPermissions = this.form.value as GroupPermissions;
         this.permissionsDialogData = generateValues(this.targetType, receiverPermissions, this.giverPermissions);
       }
@@ -62,7 +62,7 @@ export class PermissionsEditDialogComponent implements OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.permissions || changes.giverPermissions) {
-      if (this.permissions && this.giverPermissions) {
+      if (this.permissions) {
         this.form.setValidators(permissionsConstraintsValidator(this.giverPermissions, this.targetType));
         this.form.updateValueAndValidity();
         this.form.reset({ ...this.permissions }, { emitEvent: false });

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html
@@ -111,11 +111,12 @@
       </ng-container>
 
     <alg-permissions-edit-dialog
+      *ngIf="itemData"
       [visible]="dialog === 'opened'"
       [title]="dialogTitle"
       [targetType]="currentFilter"
       [permissions]="dialogPermissions.permissions"
-      [giverPermissions]="itemData?.item?.permissions"
+      [giverPermissions]="itemData.item.permissions"
       (close)="onDialogClose()"
       (save)="onDialogSave($event)"
     ></alg-permissions-edit-dialog>


### PR DESCRIPTION
## Description

Fixes #...

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

From my understanding, in this context (watching a group) `giverPermissions=item.permissions`, can you confirm that @smadbe and @GabrielVidal1 ?

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this group](https://dev.algorea.org/branch/fix-watchedgroup-permissions-dialog/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)
  3. And I watch group
  4. And I click on first suggestion "Test 2"
  5. And I open collapsible section "Pixal can access this activity"
  6. And I click on "Edit permissions"
  7. Then I see the permissions dialog is displayed
  8. And I edit the first value of the form and save
  9. Then I see permissions are saved (network panel) and the item is reloaded seamlessly

