### PR TITLE
fix modal opening of edit manager form

### DIFF
--- a/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html
+++ b/src/app/modules/group/components/manager-permission-dialog/manager-permission-dialog.component.html
@@ -39,9 +39,9 @@
               [collapsed]="collapsed"
               type="simple"
             >
-              <ng-container #description>
-                <span description i18n>The permissions that the user(s) has on this group</span>
-              </ng-container>
+              <ng-template #description>
+                <span i18n>The permissions that the user(s) has on this group</span>
+              </ng-template>
             </alg-progress-select>
           </ng-template>
         </alg-collapsible-section>


### PR DESCRIPTION
## Description

Fixes #1025 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this group page](https://dev.algorea.org/branch/fix-edit-manager-modal/en/#/groups/by-id/3179835668434339048;path=5121055722873780306/details/managers)
  3. And I click on "edit manager button" (button with pencil icon)
  4. And I close the modal
  5. Then I see no sentry modal underneath & no error in the console.
