### PR TITLE
Feature/allow to disable skills

### DIFF
--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -1,37 +1,41 @@
 <ng-container *ngIf="activeTab$ | async as activeTab;">
 
-  <p-tabView
-    styleClass="dark tab-left-nav"
-    (onChange)="onSelectionChangedByIdx($event)"
-    [activeIndex]="activeTab.index"
-    *ngIf="currentUser$|async as currentUser"
-  >
+  <ng-container *ngIf="currentUser$ | async as currentUser">
 
-    <p-tabPanel>
-      <ng-template pTemplate="header" tabindex="5">
-        <span class="indicator dark"></span>
-        <i class="fa fa-hand-paper"></i>
-        <span class="p-tabview-title" i18n="|Tab name">Activities</span>
-      </ng-template>
-    </p-tabPanel>
+    <p-tabView
+      styleClass="dark tab-left-nav"
+      (onChange)="onSelectionChangedByIdx($event)"
+      [activeIndex]="activeTab.index"
+      *ngIf="!skillsDisabled || activeTab.index === 2 || !currentUser.tempUser"
+    >
 
-    <p-tabPanel>
-      <ng-template pTemplate="header" tabindex="6">
-        <span class="indicator dark"></span>
-        <i class="fa fa-graduation-cap"></i>
-        <span class="p-tabview-title" i18n="|Tab name">Skills</span>
-      </ng-template>
-    </p-tabPanel>
+      <p-tabPanel>
+        <ng-template pTemplate="header" tabindex="5">
+          <span class="indicator dark"></span>
+          <i class="fa fa-hand-paper"></i>
+          <span class="p-tabview-title" i18n="|Tab name">Activities</span>
+        </ng-template>
+      </p-tabPanel>
 
-    <p-tabPanel *ngIf="activeTab.index === 2 || !currentUser.tempUser">
-      <ng-template pTemplate="header" tabindex="7">
-        <span class="indicator dark"></span>
-        <i class="fa fa-users"></i>
-        <span class="p-tabview-title" i18n="|Tab name">Groups</span>
-      </ng-template>
-    </p-tabPanel>
+      <p-tabPanel [headerStyleClass]="skillsDisabled ? 'hidden' : ''">
+        <ng-template pTemplate="header" tabindex="6">
+          <span class="indicator dark"></span>
+          <i class="fa fa-graduation-cap"></i>
+          <span class="p-tabview-title" i18n="|Tab name">Skills</span>
+        </ng-template>
+      </p-tabPanel>
 
-  </p-tabView>
+      <p-tabPanel *ngIf="activeTab.index === 2 || !currentUser.tempUser">
+        <ng-template pTemplate="header" tabindex="7">
+          <span class="indicator dark"></span>
+          <i class="fa fa-users"></i>
+          <span class="p-tabview-title" i18n="|Tab name">Groups</span>
+        </ng-template>
+      </p-tabPanel>
+
+    </p-tabView>
+
+  </ng-container>
 
   <ng-container *ngIf="navTreeServices[activeTab.index]!.state$ | async as state">
 

--- a/src/app/core/components/left-nav/left-nav.component.ts
+++ b/src/app/core/components/left-nav/left-nav.component.ts
@@ -10,6 +10,7 @@ import { CurrentContentService } from 'src/app/shared/services/current-content.s
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { GroupNavTreeService } from '../../services/navigation/group-nav-tree.service';
 import { ActivityNavTreeService, SkillNavTreeService } from '../../services/navigation/item-nav-tree.service';
+import { environment } from '../../../../environments/environment';
 
 const activitiesTabIdx = 0;
 const skillsTabIdx = 1;
@@ -46,6 +47,8 @@ export class LeftNavComponent {
 
   readonly navTreeServices = [ this.activityNavTreeService, this.skillNavTreeService, this.groupNavTreeService ];
   currentUser$ = this.sessionService.userProfile$.pipe(delay(0));
+
+  skillsDisabled = environment.skillsDisabled;
 
   constructor(
     private sessionService: UserSessionService,

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -38,6 +38,8 @@ export interface Environment {
   featureFlags: {
     hideTaskTabs: string[],
   },
+
+  skillsDisabled: boolean,
 }
 
 type Config = Environment; // config may be someday an extension of the environment

--- a/src/assets/scss/components/tab-left-nav.scss
+++ b/src/assets/scss/components/tab-left-nav.scss
@@ -36,6 +36,10 @@
           border-width: 0px;
         }
 
+        &.hidden {
+          display: none;
+        }
+
         &:first-child {
           border-top-left-radius: $border-radius;
           a {

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -25,7 +25,7 @@ export const environment: Environment = {
   featureFlags: {
     hideTaskTabs: [],
   },
-  skillsDisabled: false,
+  skillsDisabled: true,
 };
 
 type Preset = 'telecomParis';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -24,7 +24,8 @@ export const environment: Environment = {
   theme: 'default',
   featureFlags: {
     hideTaskTabs: [],
-  }
+  },
+  skillsDisabled: false,
 };
 
 type Preset = 'telecomParis';

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -27,6 +27,7 @@ export const environment: Environment = {
   featureFlags: {
     hideTaskTabs: [],
   },
+  skillsDisabled: true,
 };
 
 type Preset = 'demo';


### PR DESCRIPTION
## Description

Fixes #1009

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

I've done disappearing tabs through css style as we have dependency on tab index in current implementation. *ngIf directive moves indexes to not correct positions when cut skills tab 

## Test cases

With skillsDisabled = true option

- [ ] Case 1:
  1. When I go to [this page](https://dev.algorea.org/branch/feature/allow-to-disable-skills/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  2. Then I see no tabs

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/allow-to-disable-skills/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  3. Then I see 2 tabs: Activities and Groups

With skillsDisabled = false option (Another branch)

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page] (https://dev.algorea.org/branch/feature/allow-to-disable-skills-false/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  3. Then I see 3 tabs: Activities, Skills and Groups
