### PR TITLE
Bugfix/error report modal on profile refresh error

### DIFF
--- a/src/app/modules/group/pages/current-user/current-user.component.ts
+++ b/src/app/modules/group/pages/current-user/current-user.component.ts
@@ -27,7 +27,12 @@ export class CurrentUserComponent {
     );
 
     const onProfileUpdated = (): void => {
-      this.userSessionService.refresh().subscribe();
+      this.userSessionService.refresh().subscribe({
+        error: err => {
+          this.actionFeedbackService.unexpectedError();
+          if (!(err instanceof HttpErrorResponse)) throw err;
+        }
+      });
       window.removeEventListener('profileUpdated', onProfileUpdated);
     };
 

--- a/src/app/modules/group/pages/current-user/current-user.component.ts
+++ b/src/app/modules/group/pages/current-user/current-user.component.ts
@@ -1,6 +1,8 @@
 import { Component } from '@angular/core';
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { environment } from '../../../../../environments/environment';
+import { ActionFeedbackService } from '../../../../shared/services/action-feedback.service';
+import { HttpErrorResponse } from '@angular/common/http';
 
 @Component({
   selector: 'alg-current-user',
@@ -12,6 +14,7 @@ export class CurrentUserComponent {
 
   constructor(
     private userSessionService: UserSessionService,
+    private actionFeedbackService: ActionFeedbackService,
   ) {}
 
   onModify(userId: string): void {

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -63,6 +63,7 @@ export class UserSessionService implements OnDestroy {
     const refresh$ = this.currentUserService.refresh().pipe(shareReplay(1));
     refresh$.subscribe({
       next: () => this.userProfileUpdated$.next(),
+      // Required for avoid to show Sentry modal
       error: () => {},
     });
     return refresh$;

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -63,7 +63,7 @@ export class UserSessionService implements OnDestroy {
     const refresh$ = this.currentUserService.refresh().pipe(shareReplay(1));
     refresh$.subscribe({
       next: () => this.userProfileUpdated$.next(),
-      // Required for avoid to show Sentry modal
+      // error has to be handled in the caller of the `refresh()` function 
       error: () => {},
     });
     return refresh$;

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -61,7 +61,10 @@ export class UserSessionService implements OnDestroy {
 
   refresh(): Observable<void> {
     const refresh$ = this.currentUserService.refresh().pipe(shareReplay(1));
-    refresh$.subscribe(() => this.userProfileUpdated$.next());
+    refresh$.subscribe({
+      next: () => this.userProfileUpdated$.next(),
+      error: () => {},
+    });
     return refresh$;
   }
 

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -63,7 +63,7 @@ export class UserSessionService implements OnDestroy {
     const refresh$ = this.currentUserService.refresh().pipe(shareReplay(1));
     refresh$.subscribe({
       next: () => this.userProfileUpdated$.next(),
-      // error has to be handled in the caller of the `refresh()` function 
+      // error has to be handled in the caller of the `refresh()` function
       error: () => {},
     });
     return refresh$;


### PR DESCRIPTION
## Description

Fixes #1050

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/error-report-modal-on-profile-refresh-error/en/#/groups/users/670968966872011405/personal-data)
  3. And I click on "Modify" button
  4. Then I see "LOGIN MODULE" modal
  5. And I click on "Fermer" in top right corner
  6. Then I see error notifier without sentry modal
