### PR TITLE
Left menu: recover on children fetching error

### DIFF
--- a/e2e/src/group-page.e2e-spec.ts
+++ b/e2e/src/group-page.e2e-spec.ts
@@ -50,11 +50,9 @@ describe('groups/users page', () => {
     });
 
     it('should have an empty left nav with an error message and retry cta', async () => {
-      // the lines below assert the state is correct and will fail otherwise, no "expect()" is required here.
-      await Promise.all([
-        page.waitUntilVisible(page.getLeftNavErrorMessage()),
-        page.waitUntilVisible(page.getLeftNavErrorRetryCta()),
-      ]);
+      const activeTab = page.getLeftNavActiveTab();
+      await page.waitUntilTextIsPresent(activeTab, 'GROUPS');
+      await retry(() => expect(activeTab.getText()).toBe('GROUPS'));
     });
   });
 });

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { EMPTY, Observable, OperatorFunction, pipe } from 'rxjs';
-import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { ContentInfo } from 'src/app/shared/models/content/content-info';
 import { GroupInfo, isGroupInfo } from 'src/app/shared/models/content/group-info';
 import { groupRoute } from 'src/app/shared/routing/group-route';
@@ -23,13 +23,13 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     super(currentContent);
   }
 
-  childrenNavData(): OperatorFunction<GroupInfo|undefined,NavTreeElement[]> {
-    return pipe(
-      distinctUntilChanged((g1, g2) => g1?.route.id === g2?.route.id),
-      switchMap(group => {
-        if (!group || group.route.isUser) return EMPTY;
-        return this.groupNavigationService.getGroupNavigation(group.route.id).pipe(map(data => this.mapNavData(data).elements));
-      })
+  canFetchChildren(content: GroupInfo): boolean {
+    return !content.route.isUser;
+  }
+
+  fetchChildren(content: GroupInfo): Observable<NavTreeElement[]> {
+    return this.groupNavigationService.getGroupNavigation(content.route.id).pipe(
+      map(data => this.mapNavData(data).elements)
     );
   }
 


### PR DESCRIPTION
## Description

PR  #984 and especially commit https://github.com/France-ioi/AlgoreaFrontend/pull/984/commits/789e616399c9a28687cd0fe245a0ea52906f76c4 does not really recover on children fetching error:
  1. Given I am any user
  2. When I go to [the root](https://dev.algorea.org/branch/left-menu-children-problem-demo/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  3. Item children loads correctly
  4. And I click on the "Parcours officiels " child in the left menu (4102)
  5. Then I see that the menu fails (this branch forces this fetching to fail)
  6. Then I click on "L1S1 Computer science" through the right part
  7. This "L1S1 Computer science" item does not expand anymore in the left menu (as any item)s not recover.

- This PR solves that by using "fetch state" for children. 
- In addition, it helps simplifying the children-related part (even it looks much longer, but it is just because of the comments) of the left nav menu code. 
- The change allows to prevent "many" useless transient processing of the "mergeScan" where children were not corresponding to the content. These were immediately followed by a consistent processing, but still.
- I've tried to add a much more comments so that we can remember most of the things when doing the next change.


## Out-of-scope

Children fetching errors are now silently ignored so that the app is still usable while just a subpart is not available. As we are now using fetch state, it would be "easy" to include the fetching/error state in the UI somehow (as it was done in the past actually, but without cases which do not work). But it is out-of-scope of this PR.

## Test cases

- [x] Case 1 (on specific branch where children fetching fail on item 4102)
  1. Given I am any user
  2. When I go to [the root](https://dev.algorea.org/branch/left-menu-recover-error-on-children-demoerror/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  3. Item children loads correctly
  4. And I click on the "Parcours officiels " child in the left menu (4102)
  5. Then I see in the console that it fails, and the menu does not load its children
  6. Then I click on "ALGOREA ADVENTURE" in the left menu 
  7. Then I see that the children load as expected

- [x] Case 2:
  1. Given I am the usual user
  2. If I visit[ a non existing group on the master branch](https://dev.algorea.org/en/#/groups/by-id/1234;path=/details), I get a menu error (only because of the children fetching fail)
  3. If I visit a [non existing group on this branch](https://dev.algorea.org/branch/left-menu-recover-error-on-children/en/#/groups/by-id/1234;path=/details), the menu is displayed
