### PR TITLE
Left menu: reload on content change

### DIFF
--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
@@ -20,8 +20,8 @@ export class LeftNavTreeComponent implements OnChanges {
 
   private mapItemToNodes(data: NavTreeData): TreeNode<NavTreeElement>[] {
     return data.elements.map(e => {
-      const isSelected = !!data.selectedElementId && data.selectedElementId === e.id;
-      const pathToChildren = data.pathToElements.concat([ e.id ]);
+      const isSelected = !!data.selectedElementId && data.selectedElementId === e.route.id;
+      const pathToChildren = data.pathToElements.concat([ e.route.id ]);
       return {
         data: e,
         label: e.title,

--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
@@ -38,17 +38,12 @@ export class LeftNavTreeComponent implements OnChanges {
     if (!this.data) throw new Error('Unexpected: missing data for left nav tree (navigateToParent)');
     if (!this.data.parent) throw new Error('Unexpected: missing parent when navigating to parent');
     const parent = this.data.parent;
-    parent.navigateTo(this.data.pathToElements.slice(0, -1), true);
+    parent.navigateTo(true);
   }
 
   selectNode(node: TreeNode<NavTreeElement>): void {
     if (!this.data) throw new Error('Unexpected: missing data for left nav tree (selectNode)');
-    let path = this.data.pathToElements;
-    if (node.parent) {
-      if (!node.parent.data) throw new Error('Unexpected: missing data in parent for left nav tree (selectNode)');
-      path = [ ...path, node.parent.data.id ];
-    }
-    node.data?.navigateTo(path, true);
+    node.data?.navigateTo(true);
   }
 
   private typeForElement(e: NavTreeElement): string {

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -8,12 +8,11 @@ export enum GroupManagership { False = 'false', True = 'true', Descendant = 'des
 
 export interface NavTreeElement {
   // generic
-  id: Id,
+  route: ContentRoute,
   title: string,
   hasChildren: boolean,
   children?: this[],
   navigateTo: (preventFullFrame?: boolean) => void,
-  route: ContentRoute,
 
   // specific uses
   locked?: boolean, // considering 'not set' as false
@@ -55,7 +54,7 @@ export class NavTreeData {
    */
   withUpdatedElement(route: ContentRoute, update: (el:NavTreeElement)=>NavTreeElement): NavTreeData {
     if (!arraysEqual(route.path, this.pathToElements)) return this; // the element in not in tree as their paths do not match
-    const idx = this.elements.findIndex(i => i.id === route.id);
+    const idx = this.elements.findIndex(i => i.route.id === route.id);
     if (idx === -1) return this;
     const elements = [ ...this.elements ];
     elements[idx] = update(ensureDefined(elements[idx]));
@@ -68,7 +67,7 @@ export class NavTreeData {
    */
   withChildren(route: ContentRoute, children: NavTreeElement[]): NavTreeData {
     if (!arraysEqual(route.path, this.pathToElements)) return this; // the element in not in tree as their paths do not match
-    const elements = this.elements.map(e => (e.id === route.id ? { ...e, children: children } : e));
+    const elements = this.elements.map(e => (e.route.id === route.id ? { ...e, children: children } : e));
     return new NavTreeData(elements, this.pathToElements, this.selectedElementId, this.parent);
   }
 
@@ -86,9 +85,9 @@ export class NavTreeData {
    * If the element is not found, return this unchanged.
    */
   subNavMenuData(route: ContentRoute): NavTreeData {
-    const newParent = this.elements.find(e => e.id === route.path[route.path.length-1]);
+    const newParent = this.elements.find(e => e.route.id === route.path[route.path.length-1]);
     if (!newParent || !newParent.children /* unexpected */) throw new Error('Unexpected: subNavMenuData did not find parent');
-    return new NavTreeData(newParent.children, this.pathToElements.concat([ newParent.id ]), route.id, newParent);
+    return new NavTreeData(newParent.children, this.pathToElements.concat([ newParent.route.id ]), route.id, newParent);
   }
 
   hasElement(route: ContentRoute): boolean {
@@ -96,26 +95,26 @@ export class NavTreeData {
   }
 
   hasLevel1Element(route: ContentRoute): boolean {
-    return arraysEqual(route.path, this.pathToElements) && this.elements.some(e => e.id === route.id);
+    return arraysEqual(route.path, this.pathToElements) && this.elements.some(e => e.route.id === route.id);
   }
 
   hasLevel2Element(route: ContentRoute): boolean {
     if (!arraysEqual(route.path.slice(0,-1), this.pathToElements)) return false;
-    const parent = this.elements.find(e => e.id === route.path[route.path.length-1]);
+    const parent = this.elements.find(e => e.route.id === route.path[route.path.length-1]);
     if (!parent || !parent.children) return false;
-    return parent.children.some(c => c.id === route.id);
+    return parent.children.some(c => c.route.id === route.id);
   }
 
   selectedElement(): NavTreeElement|undefined {
     if (this.selectedElement === undefined) return undefined;
-    return this.elements.find(e => e.id === this.selectedElementId);
+    return this.elements.find(e => e.route.id === this.selectedElementId);
   }
 
   /**
    * Search among the elements (level 1) for the given id
    */
   elementWithId(id: Id): NavTreeElement|undefined {
-    return this.elements.find(i => i.id === id);
+    return this.elements.find(i => i.route.id === id);
   }
 
 }

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -13,6 +13,7 @@ export interface NavTreeElement {
   hasChildren: boolean,
   children?: this[],
   navigateTo: (path: Id[], preventFullFrame?: boolean) => void,
+  route: ContentRoute,
 
   // specific uses
   locked?: boolean, // considering 'not set' as false

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -12,7 +12,7 @@ export interface NavTreeElement {
   title: string,
   hasChildren: boolean,
   children?: this[],
-  navigateTo: (path: Id[], preventFullFrame?: boolean) => void,
+  navigateTo: (preventFullFrame?: boolean) => void,
   route: ContentRoute,
 
   // specific uses

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -27,9 +27,9 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     return !content.route.isUser;
   }
 
-  fetchChildren(content: GroupInfo): Observable<NavTreeElement[]> {
+  fetchNavData(content: GroupInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
     return this.groupNavigationService.getGroupNavigation(content.route.id).pipe(
-      map(data => this.mapNavData(data).elements)
+      map(data => this.mapNavData(data))
     );
   }
 
@@ -49,12 +49,6 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
 
   fetchNavDataFromChild(id: string, _child: GroupInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
     return this.groupNavigationService.getGroupNavigation(id).pipe(
-      map(data => this.mapNavData(data))
-    );
-  }
-
-  fetchNavData(el: NavTreeElement): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
-    return this.groupNavigationService.getGroupNavigation(el.id).pipe(
       map(data => this.mapNavData(data))
     );
   }

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -57,11 +57,10 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
   private mapChild(child: GroupNavigationChild, path: string[]): NavTreeElement {
     const route = groupRoute({ id: child.id, isUser: false }, path);
     return {
-      id: child.id,
+      route: route,
       title: child.name,
       hasChildren: child.type !== 'User',
       navigateTo: (): void => this.groupRouter.navigateTo(route),
-      route: route,
       groupRelation: { isMember: child.currentUserMembership !== 'none', managership: child.currentUserManagership }
     };
   }
@@ -70,11 +69,10 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     const parentRoute = groupRoute({ id: data.id, isUser: false }, pathToParent);
     return {
       parent: {
-        id: data.id,
+        route: parentRoute,
         title: data.name,
         hasChildren: data.children.length > 0,
         navigateTo: (): void => this.groupRouter.navigateTo(parentRoute),
-        route: parentRoute,
       },
       elements: data.children.map(g => this.mapChild(g, [ ...pathToParent, data.id ]))
     };

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -29,7 +29,7 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
 
   fetchNavData(content: GroupInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
     return this.groupNavigationService.getGroupNavigation(content.route.id).pipe(
-      map(data => this.mapNavData(data))
+      map(data => this.mapNavData(data, content.route.path))
     );
   }
 
@@ -43,35 +43,40 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
 
   fetchRootTreeData(): Observable<NavTreeElement[]> {
     return this.groupNavigationService.getRoot().pipe(
-      map(groups => groups.map(g => this.mapChild(g)))
+      map(groups => groups.map(g => this.mapChild(g, [])))
     );
   }
 
-  fetchNavDataFromChild(id: string, _child: GroupInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
+  fetchNavDataFromChild(id: string, child: GroupInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
+    if (child.route.path.length === 0) throw new Error('expected non-empty path for group child in left menu');
     return this.groupNavigationService.getGroupNavigation(id).pipe(
-      map(data => this.mapNavData(data))
+      map(data => this.mapNavData(data, child.route.path.slice(0, -1)))
     );
   }
 
-  private mapChild(child: GroupNavigationChild): NavTreeElement {
+  private mapChild(child: GroupNavigationChild, path: string[]): NavTreeElement {
+    const route = groupRoute({ id: child.id, isUser: false }, path);
     return {
       id: child.id,
       title: child.name,
       hasChildren: child.type !== 'User',
-      navigateTo: (path): void => this.groupRouter.navigateTo(groupRoute({ id: child.id, isUser: false }, path)),
+      navigateTo: (_path): void => this.groupRouter.navigateTo(route),
+      route: route,
       groupRelation: { isMember: child.currentUserMembership !== 'none', managership: child.currentUserManagership }
     };
   }
 
-  private mapNavData(data: GroupNavigationData): { parent: NavTreeElement, elements: NavTreeElement[] } {
+  private mapNavData(data: GroupNavigationData, pathToParent: string[]): { parent: NavTreeElement, elements: NavTreeElement[] } {
+    const parentRoute = groupRoute({ id: data.id, isUser: false }, pathToParent);
     return {
       parent: {
         id: data.id,
         title: data.name,
         hasChildren: data.children.length > 0,
-        navigateTo: (path): void => this.groupRouter.navigateTo(groupRoute({ id: data.id, isUser: false }, path))
+        navigateTo: (_path): void => this.groupRouter.navigateTo(parentRoute),
+        route: parentRoute,
       },
-      elements: data.children.map(g => this.mapChild(g))
+      elements: data.children.map(g => this.mapChild(g, [ ...pathToParent, data.id ]))
     };
   }
 

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -60,7 +60,7 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
       id: child.id,
       title: child.name,
       hasChildren: child.type !== 'User',
-      navigateTo: (_path): void => this.groupRouter.navigateTo(route),
+      navigateTo: (): void => this.groupRouter.navigateTo(route),
       route: route,
       groupRelation: { isMember: child.currentUserMembership !== 'none', managership: child.currentUserManagership }
     };
@@ -73,7 +73,7 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
         id: data.id,
         title: data.name,
         hasChildren: data.children.length > 0,
-        navigateTo: (_path): void => this.groupRouter.navigateTo(parentRoute),
+        navigateTo: (): void => this.groupRouter.navigateTo(parentRoute),
         route: parentRoute,
       },
       elements: data.children.map(g => this.mapChild(g, [ ...pathToParent, data.id ]))

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ContentInfo } from 'src/app/shared/models/content/content-info';
-import { GroupInfo, isGroupInfo } from 'src/app/shared/models/content/group-info';
-import { groupRoute } from 'src/app/shared/routing/group-route';
+import { groupInfo, GroupInfo, isGroupInfo } from 'src/app/shared/models/content/group-info';
+import { ContentRoute } from 'src/app/shared/routing/content-route';
+import { groupRoute, isGroupRoute } from 'src/app/shared/routing/group-route';
 import { GroupRouter } from 'src/app/shared/routing/group-router';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { GroupNavigationService, GroupNavigationChild, GroupNavigationData } from '../../http-services/group-navigation.service';
@@ -23,13 +24,18 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     super(currentContent);
   }
 
+  contentInfoFromNavTreeParent(e: NavTreeElement): GroupInfo {
+    if (!isGroupRoute(e.route)) throw new Error('expect group nav tree to use group routes');
+    return groupInfo({ route: e.route });
+  }
+
   canFetchChildren(content: GroupInfo): boolean {
     return !content.route.isUser;
   }
 
-  fetchNavData(content: GroupInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
-    return this.groupNavigationService.getGroupNavigation(content.route.id).pipe(
-      map(data => this.mapNavData(data, content.route.path))
+  fetchNavData(route: ContentRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
+    return this.groupNavigationService.getGroupNavigation(route.id).pipe(
+      map(data => this.mapNavData(data, route.path))
     );
   }
 

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -73,7 +73,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     const currentResult = bestAttemptFromResults(child.results);
     const route = fullItemRoute(typeCategoryOfItem(child), child.id, path, { attemptId: currentResult?.attemptId, parentAttemptId });
     return {
-      id: child.id,
+      route,
       title: child.string.title ?? '',
       hasChildren: child.hasVisibleChildren && ![ 'none', 'info' ].includes(child.permissions.canView),
       navigateTo: (preventFullFrame = false): void => this.itemRouter.navigateTo(route, { preventFullFrame }),
@@ -83,7 +83,6 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
         currentScore: currentResult.scoreComputed,
         validated: currentResult.validated
       } : undefined,
-      route
     };
   }
 
@@ -91,12 +90,11 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     const parentRoute = fullItemRoute(typeCategoryOfItem(data), data.id, pathToParent, { attemptId: data.attemptId });
     return {
       parent: {
-        id: data.id,
+        route: parentRoute,
         title: data.string.title ?? '',
         hasChildren: data.children.length > 0,
         navigateTo: (preventFullFrame = false): void => this.itemRouter.navigateTo(parentRoute, { preventFullFrame }),
         locked: data.permissions.canView === 'info',
-        route: parentRoute
       },
       elements: data.children.map(c => this.mapChild(c, data.attemptId, [ ...pathToParent, data.id ])),
     };

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -27,13 +27,12 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
   canFetchChildren(content: ItemInfo): boolean {
     if (!content.details) return false; // no item detail yet -> no children
     if (!mayHaveChildren(content.details)) return false; // only chapters or skills may have children
-    return !!(content.route.attemptId || content.details.attemptId); // an attempt is required to fetch children
+    return !!content.route.attemptId; // an attempt is required to fetch children
   }
 
   fetchNavData(content: ItemInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
-    const attemptId = content.route.attemptId ?? content.details?.attemptId;
-    if (!attemptId) throw new Error('attemptId cannot be determined (should have been checked by canFetchChildren)');
-    return this.itemNavService.getItemNavigation(content.route.id, attemptId, isSkill(content.route.contentType)).pipe(
+    if (!content.route.attemptId) throw new Error('attemptId cannot be determined (should have been checked by canFetchChildren)');
+    return this.itemNavService.getItemNavigation(content.route.id, content.route.attemptId, isSkill(content.route.contentType)).pipe(
       map(data => this.mapNavData(data)),
     );
   }

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -30,11 +30,11 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     return !!(content.route.attemptId || content.details.attemptId); // an attempt is required to fetch children
   }
 
-  fetchChildren(content: ItemInfo): Observable<NavTreeElement[]> {
+  fetchNavData(content: ItemInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
     const attemptId = content.route.attemptId ?? content.details?.attemptId;
     if (!attemptId) throw new Error('attemptId cannot be determined (should have been checked by canFetchChildren)');
     return this.itemNavService.getItemNavigation(content.route.id, attemptId, isSkill(content.route.contentType)).pipe(
-      map(data => this.mapNavData(data).elements),
+      map(data => this.mapNavData(data)),
     );
   }
 

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -60,7 +60,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     return {
       ...treeElement,
       title: details.title ?? '',
-      navigateTo: (_path: string[], preventFullFrame = false): void => this.itemRouter.navigateTo(contentInfo.route, { preventFullFrame }),
+      navigateTo: (preventFullFrame = false): void => this.itemRouter.navigateTo(contentInfo.route, { preventFullFrame }),
       score: details.bestScore !== undefined && details.currentScore !== undefined && details.validated !== undefined ? {
         bestScore: details.bestScore,
         currentScore: details.bestScore,
@@ -76,7 +76,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
       id: child.id,
       title: child.string.title ?? '',
       hasChildren: child.hasVisibleChildren && ![ 'none', 'info' ].includes(child.permissions.canView),
-      navigateTo: (_path, preventFullFrame = false): void => this.itemRouter.navigateTo(route, { preventFullFrame }),
+      navigateTo: (preventFullFrame = false): void => this.itemRouter.navigateTo(route, { preventFullFrame }),
       locked: child.permissions.canView === 'info',
       score: !child.noScore && currentResult ? {
         bestScore: child.bestScore,
@@ -94,7 +94,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
         id: data.id,
         title: data.string.title ?? '',
         hasChildren: data.children.length > 0,
-        navigateTo: (_path, preventFullFrame = false): void => this.itemRouter.navigateTo(parentRoute, { preventFullFrame }),
+        navigateTo: (preventFullFrame = false): void => this.itemRouter.navigateTo(parentRoute, { preventFullFrame }),
         locked: data.permissions.canView === 'info',
         route: parentRoute
       },

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -142,7 +142,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
   navigationNeighbors$: Observable<FetchState<NavigationNeighbors|undefined>> = this.state$.pipe(
     mapStateData(navData => {
       if (!navData.selectedElementId) return undefined;
-      const idx = navData.elements.findIndex(e => e.id === navData.selectedElementId);
+      const idx = navData.elements.findIndex(e => e.route.id === navData.selectedElementId);
       if (idx < 0) return undefined;
 
       const parent = navData.parent;
@@ -151,7 +151,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
       const next = navData.elements[idx+1];
 
       return {
-        parent: parent && parent.id !== this.navigationNeighborsRestrictedToDescendantOfElementId
+        parent: parent && parent.route.id !== this.navigationNeighborsRestrictedToDescendantOfElementId
           ? { navigateTo: (): void => parent.navigateTo() }
           : null,
         previous: prev ? { navigateTo: (): void => prev.navigateTo() } : null,

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -184,11 +184,11 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
    */
    protected abstract canFetchChildren(content: ContentInfo): boolean;
 
-  /**
-   * Emits children of the given content
-   * Must be called after ensuring that `canFetchChildren` return `true`.
-   */
-  protected abstract fetchChildren(content: ContentInfo): Observable<NavTreeElement[]>;
+  protected abstract fetchNavData(content: ContentInfo): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }>;
+
+  private fetchChildren(content: ContentInfo): Observable<NavTreeElement[]> {
+    return this.fetchNavData(content).pipe(map(navData => navData.elements));
+  }
 
   private fetchDefaultNav(): Observable<FetchState<NavTreeData>> {
     return this.fetchRootTreeData().pipe(

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -23,7 +23,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
   private reloadTrigger = new Subject<void>();
   private reload$ = merge(
     this.reloadTrigger,
-    this.currentContent.reload$,
+    this.currentContent.navMenuReload$,
   );
 
   state$ = this.currentContent.content$.pipe(

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -152,10 +152,10 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
 
       return {
         parent: parent && parent.id !== this.navigationNeighborsRestrictedToDescendantOfElementId
-          ? { navigateTo: (): void => parent.navigateTo(navData.pathToElements.slice(0,-1)) }
+          ? { navigateTo: (): void => parent.navigateTo() }
           : null,
-        previous: prev ? { navigateTo: (): void => prev.navigateTo(navData.pathToElements) } : null,
-        next: next ? { navigateTo: (): void => next.navigateTo(navData.pathToElements) } : null,
+        previous: prev ? { navigateTo: (): void => prev.navigateTo() } : null,
+        next: next ? { navigateTo: (): void => next.navigateTo() } : null,
       };
     }),
   );

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -1,7 +1,6 @@
 import { Observable, of, Subject } from 'rxjs';
 import { delay, distinctUntilChanged, map, switchMap, mergeScan, shareReplay, startWith, scan } from 'rxjs/operators';
 import { isDefined } from 'src/app/shared/helpers/null-undefined-predicates';
-import { repeatLatestWhen } from 'src/app/shared/helpers/repeatLatestWhen';
 import { fetchingState, FetchState, readyState } from 'src/app/shared/helpers/state';
 import { ContentInfo, RoutedContentInfo } from 'src/app/shared/models/content/content-info';
 import { mapStateData, mapToFetchState } from 'src/app/shared/operators/state';
@@ -31,16 +30,17 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
     map(content => (this.isOfContentType(content) ? content : undefined)), // map those which are not of interest to `undefined`
     distinctUntilChanged(), // remove multiple `undefined`
     startWith(undefined),
-    repeatLatestWhen(this.reloadTrigger),
+    // emits the content+reload:false immediately, emit content+reload:true when/if `reloadTrigger` emits
+    switchMap(content => this.reloadTrigger.pipe(map(() => ({ content, reload: true })), startWith({ content, reload: false }))),
 
     /**
      * PART 2 - ADDING CHILDREN
      * For each content, "attach his children" (if any).
      * Attaching the children is combining each content with the fetching of its children, which goes through a fetching state, emitted
      * immediately, and a ready/error state. Difficulties/constraints are that:
-     * - for each emitted (content, children state) pair by this "PART 2", the children state should correspond to the content at any
+     * - for each emitted (content, children state, reload) by this "PART 2", the children state should correspond to the content at any
      *   moment
-     * - these 2 successive children fetching states have to end up in 2 emissions of (content, children state) pairs, not more, not less
+     * - these 2 successive children fetching states have to end up in 2 emissions of (content, children state, reload), not more, not less
      * - the content may not have the required information to fetch its children initially, this information may come up with an update
      * - the content gets updated, so it is emitted several time with more data... when children fetching has been started, it has not to
      *   be cancelled by the next content update (as a classic `switchMap` would do)
@@ -66,28 +66,34 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
      * We have to make sure the behavior is correct when the children fetching response arrives after attempts, and the other way around
      */
 
-    // First, we generate a (content, observable-for-fetching-children) pair using a `scan` as we need to be able to reuse/share the
+    // First, we generate (content, observable-for-fetching-children, reload) using a `scan` as we need to be able to reuse/share the
     // observable from the previous emission (so without cancelling it).
-    scan((prev: { content: ContentT|undefined, childrenState$: Observable<FetchState<NavTreeElement[]> | undefined> }, content) => {
+    scan((
+      prev: { content: ContentT|undefined, childrenState$: Observable<FetchState<NavTreeElement[]> | undefined>, reload: boolean },
+      { content, reload }
+    ) => {
       // CASE a: there is no content selected, or it may not have children, or it miss data to fetch its children -> `undefined` state
-      if (!content || !this.canFetchChildren(content)) return { content, childrenState$: of(undefined) };
+      if (!content || !this.canFetchChildren(content)) return { content, childrenState$: of(undefined), reload };
 
-      // CASE b: the current content has children to be fetched while the previous one did not or was related to another content
-      //         -> create a new fetching for children
+      // CASE b: the current content has children to be fetched while the previous one did not or was related to another content,
+      //         or reload case -> create a new fetching for children
       //         (the `shareReplay(1)` is important as it allows a future emission to reuse this fetch state just keeping its latest value)
-      if (!prev.content || content.route.id !== prev.content.route.id || !this.canFetchChildren(prev.content))
-        return { content, childrenState$: this.fetchChildren(content).pipe(mapToFetchState(), shareReplay(1)) };
+      if (!prev.content || content.route.id !== prev.content.route.id || !this.canFetchChildren(prev.content) || reload)
+        return { content, childrenState$: this.fetchChildren(content).pipe(mapToFetchState(), shareReplay(1)), reload };
 
       // CASE c: the previous emission had already created a fetching state (possibly still fetching, or ready/error) that can be reuse here
-      return { content, childrenState$: prev.childrenState$ };
-    }, ({ content: undefined, childrenState$: of(undefined) })),
+      return { content, childrenState$: prev.childrenState$, reload };
+    }, ({ content: undefined, childrenState$: of(undefined), reload: false })),
     // Here we "play" the observable-for-fetching-children in a `switchMap` so that the next part can use the children state.
-    switchMap(({ content, childrenState$ }) => childrenState$.pipe(map(childrenState => ({ content, childrenState })))),
+    switchMap(({ content, childrenState$, reload }) => childrenState$.pipe(
+      // Build (content, children state, reload) based on fetching. Only send reload if the first state change
+      map((childrenState, idx) => ({ content, childrenState, reload: idx === 0 ? reload : false }))
+    )),
 
     /**
-     * PART 3 - Apply the current (content, children state) on the previous version of the nav tree
+     * PART 3 - Apply the current (content, children state, reload) on the previous version of the nav tree
      */
-    mergeScan((prevState: FetchState<NavTreeData>, { content, childrenState }) => {
+    mergeScan((prevState: FetchState<NavTreeData>, { content, childrenState, reload }) => {
       // CASE 1: the current-content does not match the type of this nav tree (so `content` has been mapped to `undefined`)
       if (!content) {
         // CASE 1A: the menu has already an element displayed -> just deselect what is selected if there was a selection
@@ -99,8 +105,8 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
       // CASE 2: the content type matches the type of this nav tree
         const route = content.route;
 
-        // CASE 2A: the content is not among the displayed elements -> fetch all nav
-        if (!(prevState.isReady && prevState.data.hasElement(route))) {
+        // CASE 2A: reload or the content is not among the displayed elements -> fetch all nav
+        if (reload || !prevState.isReady || !prevState.data.hasElement(route)) {
           return this.fetchNewNav(content).pipe(
             mapStateData(data => {
               if (childrenState?.isReady) data = data.withChildren(route, childrenState.data);

--- a/src/app/modules/group/components/group-remove-button/group-remove-button.component.ts
+++ b/src/app/modules/group/components/group-remove-button/group-remove-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output } from '@angular/core';
 import { Group } from '../../http-services/get-group-by-id.service';
 import { distinctUntilChanged, switchMap, map } from 'rxjs/operators';
 import { Observable, ReplaySubject, Subject } from 'rxjs';
@@ -16,6 +16,8 @@ import { mapToFetchState } from '../../../../shared/operators/state';
 })
 export class GroupRemoveButtonComponent implements OnChanges, OnDestroy {
   @Input() group?: Group;
+
+  @Output() groupDeleted = new EventEmitter<void>();
 
   deletionInProgress$ = new Subject<boolean>();
 
@@ -83,6 +85,7 @@ export class GroupRemoveButtonComponent implements OnChanges, OnDestroy {
         next: () => {
           this.deletionInProgress$.next(false);
           this.actionFeedbackService.success($localize`You have deleted "${groupName}"`);
+          this.groupDeleted.emit();
           this.navigateToMyGroups();
         },
         error: _err => {

--- a/src/app/modules/group/components/member-list/member-list.component.ts
+++ b/src/app/modules/group/components/member-list/member-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { ConfirmationService, SortEvent } from 'primeng/api';
 import { Table } from 'primeng/table';
 import { Observable, ReplaySubject } from 'rxjs';
@@ -69,6 +69,7 @@ type Row = (Member|GroupChild|{ login: string, parentGroups: string }|{ name: st
 export class MemberListComponent implements OnChanges, OnDestroy {
 
   @Input() groupData? : GroupData;
+  @Output() removedGroup = new EventEmitter<void>();
 
   defaultFilter: Filter = { type: TypeFilter.Users, directChildren: true };
 
@@ -303,6 +304,7 @@ export class MemberListComponent implements OnChanges, OnDestroy {
         this.unselectAll();
         this.fetchRows();
         this.removalInProgress$.next(false);
+        this.removedGroup.emit();
       },
       error: err => {
         this.removalInProgress$.next(false);

--- a/src/app/modules/group/pages/group-composition/group-composition.component.html
+++ b/src/app/modules/group/pages/group-composition/group-composition.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="groupWithPermissions">
   <ng-container *ngIf="groupWithPermissions.isCurrentUserManager; else noPermission">
     <alg-section icon="fa fa-users" i18n-label label="Current Composition">
-      <alg-member-list #memberList [groupData]="groupData"></alg-member-list>
+      <alg-member-list #memberList [groupData]="groupData" (removedGroup)="removedGroup.emit()"></alg-member-list>
       <alg-add-sub-group
           *ngIf="groupData?.group?.currentUserCanManage !== 'none'"
           [loading]="state === 'addingGroup'"

--- a/src/app/modules/group/pages/group-composition/group-composition.component.ts
+++ b/src/app/modules/group/pages/group-composition/group-composition.component.ts
@@ -26,6 +26,9 @@ export class GroupCompositionComponent implements OnChanges {
   @Input() groupData?: GroupData;
 
   @Output() groupRefreshRequired = new EventEmitter<void>();
+  @Output() addedGroup = new EventEmitter<void>();
+  @Output() removedGroup = new EventEmitter<void>();
+
   groupWithPermissions?: Group & ManagementAdditions;
 
   @ViewChild('memberList') private memberList?: MemberListComponent;
@@ -58,6 +61,7 @@ export class GroupCompositionComponent implements OnChanges {
         this.actionFeedbackService.success($localize`Group successfully added as child group`);
         this.memberList?.setFilter({ directChildren: true, type: TypeFilter.Groups });
         this.state = 'ready';
+        this.addedGroup.emit();
       },
       error: err => {
         this.state = 'ready';

--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -75,7 +75,7 @@
         [group]="group"
         (groupRefreshRequired)="onGroupRefreshRequired()"
       ></alg-group-overview>
-      <alg-group-composition *ngIf="!!compositionTab?.isActive" [groupData]="state.data" (groupRefreshRequired)="onGroupRefreshRequired()"></alg-group-composition>
+      <alg-group-composition *ngIf="!!compositionTab?.isActive" [groupData]="state.data" (groupRefreshRequired)="onGroupRefreshRequired()" (addedGroup)="refreshNav()" (removedGroup)="refreshNav()"></alg-group-composition>
       <alg-group-managers *ngIf="!!adminTab?.isActive" [groupData]="state.data"></alg-group-managers>
       <alg-group-access *ngIf="!!accessTab?.isActive" [group]="group"></alg-group-access>
       <alg-group-edit *ngIf="!!settingsTab?.isActive"></alg-group-edit>

--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -74,6 +74,7 @@
         *ngIf="overviewTab?.isActive || !overviewTab && group.currentUserManagership === 'none' && group.currentUserMembership === 'none'"
         [group]="group"
         (groupRefreshRequired)="onGroupRefreshRequired()"
+        (leftGroup)="refreshNav()"
       ></alg-group-overview>
       <alg-group-composition *ngIf="!!compositionTab?.isActive" [groupData]="state.data" (groupRefreshRequired)="onGroupRefreshRequired()" (addedGroup)="refreshNav()" (removedGroup)="refreshNav()"></alg-group-composition>
       <alg-group-managers *ngIf="!!adminTab?.isActive" [groupData]="state.data"></alg-group-managers>

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -4,6 +4,7 @@ import { withManagementAdditions } from '../../helpers/group-management';
 import { RouterLinkActive } from '@angular/router';
 import { mapStateData } from 'src/app/shared/operators/state';
 import { LayoutService } from '../../../../shared/services/layout.service';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 
 @Component({
   selector: 'alg-group-details',
@@ -28,9 +29,15 @@ export class GroupDetailsComponent {
   constructor(
     private groupDataSource: GroupDataSource,
     private layoutService: LayoutService,
+    private currentContentService: CurrentContentService,
   ) {}
+
+  refreshNav(): void {
+    this.currentContentService.forceReload();
+  }
 
   onGroupRefreshRequired(): void {
     this.groupDataSource.refetchGroup();
+    this.refreshNav();
   }
 }

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -33,7 +33,7 @@ export class GroupDetailsComponent {
   ) {}
 
   refreshNav(): void {
-    this.currentContentService.forceReload();
+    this.currentContentService.forceNavMenuReload();
   }
 
   onGroupRefreshRequired(): void {

--- a/src/app/modules/group/pages/group-edit/group-edit.component.html
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.html
@@ -33,7 +33,7 @@
       <alg-associated-activity formControlName="rootActivity"></alg-associated-activity>
 
       <div class="remove-button-section">
-        <alg-group-remove-button [group]="state.data"></alg-group-remove-button>
+        <alg-group-remove-button [group]="state.data" (groupDeleted)="refreshNav()"></alg-group-remove-button>
       </div>
     </form>
 

--- a/src/app/modules/group/pages/group-edit/group-edit.component.ts
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.ts
@@ -106,7 +106,7 @@ export class GroupEditComponent implements OnDestroy, PendingChangesComponent {
   }
 
   refreshNav(): void {
-    this.currentContentService.forceReload();
+    this.currentContentService.forceNavMenuReload();
   }
 
   resetForm(): void {

--- a/src/app/modules/group/pages/group-edit/group-edit.component.ts
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.ts
@@ -15,6 +15,7 @@ import { withManagementAdditions } from '../../helpers/group-management';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
 import { PendingChangesService } from '../../../../shared/services/pending-changes-service';
 import { HttpErrorResponse } from '@angular/common/http';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 
 @Component({
   selector: 'alg-group-edit',
@@ -36,6 +37,7 @@ export class GroupEditComponent implements OnDestroy, PendingChangesComponent {
 
   constructor(
     private modeService: ModeService,
+    private currentContentService: CurrentContentService,
     private groupDataSource: GroupDataSource,
     private actionFeedbackService: ActionFeedbackService,
     private formBuilder: FormBuilder,
@@ -101,6 +103,10 @@ export class GroupEditComponent implements OnDestroy, PendingChangesComponent {
         if (!(err instanceof HttpErrorResponse)) throw err;
       }
     });
+  }
+
+  refreshNav(): void {
+    this.currentContentService.forceReload();
   }
 
   resetForm(): void {

--- a/src/app/modules/group/pages/group-overview/group-overview.component.ts
+++ b/src/app/modules/group/pages/group-overview/group-overview.component.ts
@@ -9,6 +9,7 @@ import { Router } from '@angular/router';
 })
 export class GroupOverviewComponent {
   @Output() groupRefreshRequired = new EventEmitter<void>();
+  @Output() leftGroup = new EventEmitter<void>();
 
   @Input() group?: Group;
 
@@ -19,6 +20,7 @@ export class GroupOverviewComponent {
       this.groupRefreshRequired.emit();
       return;
     }
+    this.leftGroup.emit();
     void this.router.navigate([ '/groups/mine' ]);
   }
 

--- a/src/app/modules/group/pages/my-groups/my-groups.component.ts
+++ b/src/app/modules/group/pages/my-groups/my-groups.component.ts
@@ -35,6 +35,7 @@ export class MyGroupsComponent implements OnDestroy {
 
   onGroupJoined(): void {
     this.joinedGroupList?.refresh();
+    this.currentContent.forceReload();
   }
 
 }

--- a/src/app/modules/group/pages/my-groups/my-groups.component.ts
+++ b/src/app/modules/group/pages/my-groups/my-groups.component.ts
@@ -35,7 +35,7 @@ export class MyGroupsComponent implements OnDestroy {
 
   onGroupJoined(): void {
     this.joinedGroupList?.refresh();
-    this.currentContent.forceReload();
+    this.currentContent.forceNavMenuReload();
   }
 
 }

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -20,6 +20,7 @@ import { isItemRouteError, itemRouteFromParams } from './item-route-validation';
 import { LayoutService } from 'src/app/shared/services/layout.service';
 import { readyData } from 'src/app/shared/operators/state';
 import { ensureDefined } from 'src/app/shared/helpers/assert';
+import { routeWithSelfAttempt } from 'src/app/shared/routing/item-route';
 
 const itemBreadcrumbCat = $localize`Items`;
 
@@ -81,7 +82,7 @@ export class ItemByIdComponent implements OnDestroy {
               currentPageIdx: state.data.breadcrumbs.length - 1,
             },
             title: state.data.item.string.title === null ? undefined : state.data.item.string.title,
-            route: state.data.route,
+            route: routeWithSelfAttempt(state.data.route, state.data.currentResult?.attemptId),
             details: {
               title: state.data.item.string.title,
               type: state.data.item.type,

--- a/src/app/modules/item/pages/item-edit/item-edit.component.ts
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.ts
@@ -349,7 +349,7 @@ export class ItemEditComponent implements OnDestroy, PendingChangesComponent {
       next: _status => {
         this.actionFeedbackService.success($localize`Changes successfully saved.`);
         this.itemDataSource.refreshItem(); // which will re-enable the form
-        this.currentContentService.forceReload();
+        this.currentContentService.forceNavMenuReload();
       },
       error: err => {
         this.itemForm.enable();

--- a/src/app/modules/item/pages/item-edit/item-edit.component.ts
+++ b/src/app/modules/item/pages/item-edit/item-edit.component.ts
@@ -16,6 +16,7 @@ import { Duration } from '../../../../shared/helpers/duration';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
 import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { HttpErrorResponse } from '@angular/common/http';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 
 export const DEFAULT_ENTERING_TIME_MIN = '1000-01-01T00:00:00Z';
 export const DEFAULT_ENTERING_TIME_MAX = '9999-12-31T23:59:59Z';
@@ -82,6 +83,7 @@ export class ItemEditComponent implements OnDestroy, PendingChangesComponent {
 
   constructor(
     private modeService: ModeService,
+    private currentContentService: CurrentContentService,
     private itemDataSource: ItemDataSource,
     private formBuilder: FormBuilder,
     private createItemService: CreateItemService,
@@ -347,6 +349,7 @@ export class ItemEditComponent implements OnDestroy, PendingChangesComponent {
       next: _status => {
         this.actionFeedbackService.success($localize`Changes successfully saved.`);
         this.itemDataSource.refreshItem(); // which will re-enable the form
+        this.currentContentService.forceReload();
       },
       error: err => {
         this.itemForm.enable();

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -36,6 +36,10 @@ export function groupRoute(group: GroupLike, path: string[]): GroupRoute {
   return { ...rawGroupRoute(group), path };
 }
 
+export function isGroupRoute(route: ContentRoute): route is GroupRoute {
+  return route.contentType === 'group';
+}
+
 export function isRawGroupRoute(route?: unknown): route is RawGroupRoute {
   return typeof route === 'object' && (route as Record<string, unknown> | null)?.contentType === 'group';
 }

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -39,6 +39,14 @@ type ItemRouteWithParentAttempt = ItemRoute & { parentAttemptId: AttemptId };
 export type FullItemRoute = ItemRouteWithSelfAttempt | ItemRouteWithParentAttempt;
 export type RawItemRoute = Omit<ItemRoute, 'path'> & Partial<Pick<ItemRoute, 'path'>>;
 
+export function isItemRoute(route: ContentRoute): route is ItemRoute {
+  return ([ 'activity', 'skill' ].includes(route.contentType));
+}
+
+export function isFullItemRoute(route: ItemRoute): route is FullItemRoute {
+  return !!route.attemptId || !!route.parentAttemptId;
+}
+
 export function isRouteWithSelfAttempt(item: FullItemRoute): item is ItemRouteWithSelfAttempt {
   return item.attemptId !== undefined;
 }

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -56,6 +56,13 @@ export function fullItemRoute(contentType: ItemTypeCategory, id: ItemId, path: s
 }
 
 /**
+ * Add to the given route, the given self attempt id (if any) (used when only the parent id was know until now)
+ */
+export function routeWithSelfAttempt(route: FullItemRoute, attemptId: string|undefined): FullItemRoute {
+  return isRouteWithSelfAttempt(route) ? route : { ...route, attemptId };
+}
+
+/**
  * The route to the app default (see config) item
  */
 export const appDefaultItemRoute: FullItemRoute = {

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { ContentInfo } from '../models/content/content-info';
 
 /**
@@ -15,6 +15,9 @@ export class CurrentContentService implements OnDestroy {
   private content = new BehaviorSubject<ContentInfo|null>(null);
   content$ = this.content.asObservable();
 
+  private reload = new Subject<void>();
+  reload$ = this.reload.asObservable();
+
   /**
    * The current content
    */
@@ -27,6 +30,10 @@ export class CurrentContentService implements OnDestroy {
    */
   replace(content: ContentInfo): void {
     this.content.next(content);
+  }
+
+  forceReload(): void {
+    this.reload.next();
   }
 
   /**

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -15,8 +15,8 @@ export class CurrentContentService implements OnDestroy {
   private content = new BehaviorSubject<ContentInfo|null>(null);
   content$ = this.content.asObservable();
 
-  private reload = new Subject<void>();
-  reload$ = this.reload.asObservable();
+  private navMenuReload = new Subject<void>();
+  navMenuReload$ = this.navMenuReload.asObservable();
 
   /**
    * The current content
@@ -32,8 +32,11 @@ export class CurrentContentService implements OnDestroy {
     this.content.next(content);
   }
 
-  forceReload(): void {
-    this.reload.next();
+  /**
+   * Order the nav menu to full reload. To be used when more than the current content has changed.
+   */
+  forceNavMenuReload(): void {
+    this.navMenuReload.next();
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #951

Basically, based on worked done in #1071 , implement the "reload", reusing commits and ideas from #963.

Unlike #963 , we do not currently assume the "fetching"  (of the reload) should be hidden... so the menu briefly goes through a loader. Anyway, the reload was not preserving scroll so it was looking strange. Can be improved later is needed.

It is highly recommended to review commit per commit, as some of them are just basic required reorganisation of code, some are Thomas's commit related to triggering reload, ... Taken commit per commit, the review is short and easy.

There is an interesting testing branch on https://dev.algorea.org/branch/left-menu-reload-testing/. It adds a reload button in the menu to test reloading at many different places. Also, it makes item "[4102](https://dev.algorea.org/branch/left-menu-reload-testing/en/#/activities/by-id/4102;path=4702;parentAttempId=0/details)" fail the loading of its children in the left menu.

Notes:
- I haven't done the nav menu reload on group edit as I do not see how it may impact other content in the menu (element itself is already refreshed by the current content mechanism)

## Test cases (menu only)

- Use the testing branch with the usual user: https://dev.algorea.org/branch/left-menu-reload-testing/.
- on activities, skills, groups:
  - reload at root
  - reload in a chapter
  - reload in a leaf
  - reload when no content is selected (the current content is of another type)

## Test cases (Thomas' cases, updated)

- [ ] Case 1: edit group
  1. Given I am the usual user
  2. When I go to [this group settings](https://dev.algorea.org/branch/left-menu-reload/en/#/groups/by-id/5648167580972785132;path=/details/settings)
  3. And I change the group name and save (throttle network if you want)
  4. Then I ~see~ don't see the group nav refreshed after a while, the group name is updated in the nav

- [ ] Case 2: add subgroup then remove subgroup
  1. Given I am the usual user
  2. When I go to [this group](https://dev.algorea.org/branch/left-menu-reload/en/#/groups/by-id/681265191377636279;path=52767158366271444,672913018859223173,6710944276987033666/details/members)
  3. And I create the subgroup "RefreshNavDemo" (throttle network if you want)
  4. Then I see the group nav is refreshed after a while, "RefreshNavDemo" is added in current group children in the nav
  5. And I click on "sub group" tab and remove "RefreshNavDemo" from the sub-groups list
  6. Then I see the group nav is refreshed after a while, "RefreshNavDemo" is removed from current group children in the nav

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this group](https://dev.algorea.org/branch/left-menu-reload/en/#/groups/by-id/681265191377636279;path=52767158366271444,672913018859223173,6710944276987033666/details/members)
  3. And I create the subgroup "RefreshNavDemo" (throttle network if you want)
  4. Then I see the group nav is refreshed after a while, "RefreshNavDemo" is added in current group children in the nav
  5. And I navigate to "RefreshNavDemo"
  6. And I edit "RefreshNavDemo"
  7. And I delete "RefreshNavDemo"
  8. Then I see the nav is refreshed while I'm redirected to "My groups"

- [ ] Case 4: Add group-at-root by code and leave it
  1. Given I am the usual user
  2. When I visit [this group](https://dev.algorea.org/branch/left-menu-reload/en/#/groups/by-id/2012793249973596086;path=/details/members)
  3. And I copy the join code
  4. And as demo user I visit [my groups page](https://dev.algorea.org/branch/left-menu-reload/en/#/groups/mine)
  5. And I join the group by code
  6. Then I see "Another" is added to the "my groups" list
  7. And I click on "Another" group
  8. And I leave the group
  9. Then I see "Another" is removed from the left nav

- [ ] Case 5: Leave not-at-root-group
  1. Given I am the usual user
  2. When I visit [this group](https://dev.algorea.org/branch/left-menu-reload/en/#/groups/by-id/4322568739774621128;path=52767158366271444/details/members)
  3. And I copy the join code
  4. And as demo user I visit [my groups page](https://dev.algorea.org/branch/left-menu-reload/en/#/groups/mine)
  5. And I join the group by code
  6. And I navigate to group "4LTDI1819" > "Sea"
  8. And I leave the group
  9. Then I see "Sea" is removed from the left nav

### Item use cases

- [ ] Case 1: not-at-root item (chapter)
  1. Given I am the usual user
  2. When I go to [this item edit page](https://dev.algorea.org/branch/left-menu-reload/en/#/activities/by-id/5207993233955027100;path=4702,1625159049301502151;attempId=0/edit)
  3. And I edit the title
  4. And I save
  5. Then the title is updated in the left nav
  6. And I add a new content "Subtask 1" and save
  8. Then the item "Subtask 1" appears in the left nav under "Thomas Tasks"
  9. And I remove the item "Subtask 1" and save
  10. Then the item "Subtask 1" is removed from the left nav

- [ ] Case 1b: at-root item (task)
  1. Given I am the usual user
  2. When I go to [this item edit page](https://dev.algorea.org/branch/left-menu-reload/en/#/activities/by-id/6707691810849260111;path=;attempId=0/edit)
  3. And I edit the title and save
  4. Then I see the title is updated in the left nav

- [ ] Case 2: not-at-root skill
  1. Given I am the usual user
  5. [this skill edit page](https://dev.algorea.org/branch/left-menu-reload/en/#/skills/by-id/1133373964112078654;path=3000,3002;attempId=0/edit)
  6. And I edit the title
  7. And I save
  8. Then the title is updated in the left nav
  9. And I add a new content "Subskill 1" and save
  10. Then the item "Subskill 1" appears in the left nav under "Thomas Tasks"
  11. And I remote the item "Subskill 1" and save
  12. Then the item "Subskill 1" is removed from the left nav

- [ ] Case 2b: at-root skill
  1. :warning: There's only one skill at the root, and it is uneditable.