### PR TITLE
Fixes Composition tab

### DIFF
--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -14,7 +14,7 @@
     >
     </alg-group-indicator>
     <!-- tabs -- if only the first tab is visible, do not show the tab bar -->
-    <div [hidden]="!group.isCurrentUserManager && group.currentUserMembership === 'none' && !adminTab.isActive && !accessTab?.isActive && !compositionTab.isActive">
+    <div [hidden]="!group.isCurrentUserManager && group.currentUserMembership === 'none' && !adminTab.isActive && !accessTab?.isActive && !compositionTab.isActive && !settingsTab.isActive">
       <div class="nav-tab">
         <a
           class="nav-tab-item"

--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -14,7 +14,7 @@
     >
     </alg-group-indicator>
     <!-- tabs -- if only the first tab is visible, do not show the tab bar -->
-    <div [hidden]="!group.isCurrentUserManager && group.currentUserMembership === 'none' && !adminTab.isActive && !accessTab?.isActive">
+    <div [hidden]="!group.isCurrentUserManager && group.currentUserMembership === 'none' && !adminTab.isActive && !accessTab?.isActive && !compositionTab.isActive">
       <div class="nav-tab">
         <a
           class="nav-tab-item"


### PR DESCRIPTION
## Description

Fixes #1073

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/no-tab-when-navigating-to-group/en/#/groups/by-id/6884210558506774905;path=/details/members)
  3. Then I see the message "You are not allowed to see this page." and "Composition" tab
  4. Then I click "Overview" tab
  5. Then I see "Composition" is disappeared
