### PR TITLE
fix the ordering of suggested activities

### DIFF
--- a/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
+++ b/src/app/modules/group/components/suggestion-of-activities/suggestion-of-activities.component.ts
@@ -17,9 +17,10 @@ export class SuggestionOfActivitiesComponent implements OnDestroy {
     filter(isNotNull),
     switchMap(watchedGroup =>
       this.itemNavigationService.getRootActivities(watchedGroup.route.id).pipe(
-        map(rootActivity =>
-          rootActivity.sort(item => (item.groupId === watchedGroup.route.id ? -1 : 1)).slice(0, 4)
-        ),
+        map(rootActivities => [
+          ...rootActivities.filter(act => act.groupId === watchedGroup.route.id),
+          ...rootActivities.filter(act => act.groupId !== watchedGroup.route.id),
+        ].slice(0, 4))
       )
     ),
     mapToFetchState({ resetter: this.refresh$ }),


### PR DESCRIPTION
## Description

Fixes #1088 

The order of suggested activities was not the same in Firefox and Chrome (Chrome was already giving the intended behavior). The reason was they do not handle the tie-breaking the same way. Anyway the sort block with a single arg seems to be out of the spec.

## Test cases

- [ ] Case 1: the conflicting case
  1. Given I am the usual user
  2. And I use firefox
  3. When I go to [this page](https://dev.algorea.org/branch/fix-deterministic-suggested-act-order/en/#/groups/by-id/123456;path=5121055722873780306,6710944276987033666/details)
  4. And I click on start observing
  5. Then I see 4 activities in the same order as we received them, starting with "test 2"
 

- [ ] Case 1: the conflicting case
  1. Given I am the usual user
  2. And I use firefox
  3. When I go to [this page](https://dev.algorea.org/branch/fix-deterministic-suggested-act-order/en/#/groups/by-id/4603869706499321180;path=52767158366271444,672913018859223173/details/access?watchedGroupId=4603869706499321180&watchUser=0)
  4. And I click on start observing
  5. Then I see the 4 activities starting with the activity on the current group, followed by the other  in the same order as we received them


