### PR TITLE
refresh nav when associated activity changes

### DIFF
--- a/src/app/modules/group/pages/group-edit/group-edit.component.ts
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.ts
@@ -95,6 +95,7 @@ export class GroupEditComponent implements OnDestroy, PendingChangesComponent {
     ).subscribe({
       next: () => {
         this.groupDataSource.refetchGroup(); // will re-enable the form
+        this.refreshNav();
         this.actionFeedbackService.success($localize`Changes successfully saved.`);
       },
       error: err => {


### PR DESCRIPTION
## Description

Fixes #1082 

## Notes (out of scope, known issues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this group](https://dev.algorea.org/branch/feat-associated-activity-refresh-nav/en/#/groups/by-id/6710944276987033666;path=52767158366271444,672913018859223173/details/settings)
  3. And I click on "Activities" tab in the left nav
  4. And I remove the associated activity "Blockly Basic Task"
  5. Then I see the left nav is updated and does **not** contain item "Blockly Basic Task"
  6. And I click "Save"
  7. And I re-add the activity by searching "Basic" and selecting the 2nd option and clicking "Save"
  8. Then I see the left nav is updated and contains item "Blockly Basic Task"
