### PR TITLE
Adds can deactivate guard for case when id of group is changing

### DIFF
--- a/src/app/modules/group/group-routing.module.ts
+++ b/src/app/modules/group/group-routing.module.ts
@@ -30,6 +30,7 @@ const routes: Routes = [
       {
         path: 'details',
         component: GroupDetailsComponent,
+        canDeactivate: [ PendingChangesGuard ],
         children: [
           {
             path: '',

--- a/src/app/modules/group/pages/group-details/group-details.component.html
+++ b/src/app/modules/group/pages/group-details/group-details.component.html
@@ -79,7 +79,7 @@
       <alg-group-composition *ngIf="!!compositionTab?.isActive" [groupData]="state.data" (groupRefreshRequired)="onGroupRefreshRequired()" (addedGroup)="refreshNav()" (removedGroup)="refreshNav()"></alg-group-composition>
       <alg-group-managers *ngIf="!!adminTab?.isActive" [groupData]="state.data"></alg-group-managers>
       <alg-group-access *ngIf="!!accessTab?.isActive" [group]="group"></alg-group-access>
-      <alg-group-edit *ngIf="!!settingsTab?.isActive"></alg-group-edit>
+      <alg-group-edit *ngIf="!!settingsTab?.isActive" #groupEdit></alg-group-edit>
     </div>
 
   </ng-container>

--- a/src/app/modules/group/pages/group-details/group-details.component.ts
+++ b/src/app/modules/group/pages/group-details/group-details.component.ts
@@ -5,13 +5,15 @@ import { RouterLinkActive } from '@angular/router';
 import { mapStateData } from 'src/app/shared/operators/state';
 import { LayoutService } from '../../../../shared/services/layout.service';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
+import { PendingChangesComponent } from '../../../../shared/guards/pending-changes-guard';
+import { GroupEditComponent } from '../group-edit/group-edit.component';
 
 @Component({
   selector: 'alg-group-details',
   templateUrl: './group-details.component.html',
   styleUrls: [ './group-details.component.scss' ],
 })
-export class GroupDetailsComponent {
+export class GroupDetailsComponent implements PendingChangesComponent {
 
   state$ = this.groupDataSource.state$.pipe(mapStateData(state => ({
     ...state,
@@ -25,6 +27,11 @@ export class GroupDetailsComponent {
   @ViewChild('adminTab') adminTab?: RouterLinkActive;
   @ViewChild('settingsTab') settingsTab?: RouterLinkActive;
   @ViewChild('accessTab') accessTab?: RouterLinkActive;
+  @ViewChild('groupEdit') groupEdit?: GroupEditComponent;
+
+  isDirty(): boolean {
+    return !!this.groupEdit?.isDirty();
+  }
 
   constructor(
     private groupDataSource: GroupDataSource,

--- a/src/app/shared/guards/pending-changes-guard.ts
+++ b/src/app/shared/guards/pending-changes-guard.ts
@@ -20,14 +20,19 @@ export class PendingChangesGuard implements CanDeactivate<PendingChangesComponen
   ) {}
 
   canDeactivate(
-    component: PendingChangesComponent,
+    component: PendingChangesComponent | null,
     _currentRoute: ActivatedRouteSnapshot,
     _currentState: RouterStateSnapshot,
     _nextState: RouterStateSnapshot
   ): Observable<boolean> {
     const dialogResponse = new Subject<boolean>();
 
-    const pendingChangesComponent = this.pendingChangesService.component || component;
+    const pendingChangesComponent = component || this.pendingChangesService.component;
+
+    // If a component is not defined in router, need to use the PendingChangesService as alternative approach
+    if (!pendingChangesComponent) {
+      throw new Error('Unexpected: Component is not defined in router');
+    }
 
     if (!pendingChangesComponent.isDirty()) return of(true) ;
     this.confirmationService.confirm({


### PR DESCRIPTION
## Description

Fixes #1055

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/group-settings-nav-not-blocked-when-navigating-to-siblings/en/#/groups/by-id/5121055722873780306;path=/details/settings)
  3. Update the description
  4. Click on "4LTDI1819" in left menu
  5. Then I see confirmation modal
  6. And I click on "Yes, leave page"
  7. Then I see settings of "4LTDI1819" group page

- [x] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/group-settings-nav-not-blocked-when-navigating-to-siblings/en/#/groups/by-id/5121055722873780306;path=/details/settings)
  3. Update the description
  4. Click on "4LTDI1819" in left menu
  5. Then I see confirmation modal
  6. And I click on "No"
  7. Then I see settings of "A super new group" group page

- [x] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/group-settings-nav-not-blocked-when-navigating-to-siblings/en/#/groups/by-id/52767158366271444;path=/details/settings)
  3. Then I see "You do not have the permissions to edit this content."
  4. Then I click on Managers tab
  5. Then I see "This group has no dedicated managers."