### PR TITLE
Prevent the root-activities services to be always called when loading the app

### DIFF
--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -34,7 +34,6 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
      */
     map(content => (this.isOfContentType(content) ? content : undefined)), // map those which are not of interest to `undefined`
     distinctUntilChanged(), // remove multiple `undefined`
-    startWith(undefined),
     // emits the content+reload:false immediately, emit content+reload:true when/if `reloadTrigger` emits
     switchMap(content => this.reload$.pipe(map(() => ({ content, reload: true })), startWith({ content, reload: false }))),
 

--- a/src/app/shared/services/current-content.service.ts
+++ b/src/app/shared/services/current-content.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { ReplaySubject, Subject } from 'rxjs';
 import { ContentInfo } from '../models/content/content-info';
 
 /**
@@ -12,18 +12,11 @@ import { ContentInfo } from '../models/content/content-info';
 })
 export class CurrentContentService implements OnDestroy {
 
-  private content = new BehaviorSubject<ContentInfo|null>(null);
+  private content = new ReplaySubject<ContentInfo | null>(1);
   content$ = this.content.asObservable();
 
   private navMenuReload = new Subject<void>();
   navMenuReload$ = this.navMenuReload.asObservable();
-
-  /**
-   * The current content
-   */
-  current(): ContentInfo|null {
-    return this.content.value;
-  }
 
   /**
    * Replace the current content by the given content.


### PR DESCRIPTION
## Description

Currently, at app start, the root-activities service (`/current-user/group-memberships/activities`) is always called whatever the actual destination is.  Fix that.

## Test cases

- [x] Case 1:
  1. Given I am any user
  2. When I open network dev panel
  3. When I go to [this activity which is not in the root](https://dev.algorea.org/branch/left-nav-no-initial-request/en/#/activities/by-id/100575556387408660;path=4702;attempId=0/details
)
  5. Then I see the root-activities services is not called

No regression:

- [x] I can press prev/next on item and the navigation works as expected
- [x] I can navigate to the root
- [x] I can switch left menu tab
- [x] I can enable/disable the edit mode
- [x] I can land on a group page directly
