### PR TITLE
Left nav rework for group observation update

### DIFF
--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -53,7 +53,7 @@ export class NavTreeData {
    * If the element is not found, return this unchanged.
    */
   withUpdatedElement(route: ContentRoute, update: (el:NavTreeElement)=>NavTreeElement): NavTreeData {
-    if (!arraysEqual(route.path, this.pathToElements)) return this; // the element in not in tree as their paths do not match
+    if (!arraysEqual(route.path, this.pathToElements)) throw new Error('unexpected: updated element not among tree elements');
     const idx = this.elements.findIndex(i => i.route.id === route.id);
     if (idx === -1) return this;
     const elements = [ ...this.elements ];
@@ -66,7 +66,7 @@ export class NavTreeData {
    * If the element is not found, return this unchanged.
    */
   withChildren(route: ContentRoute, children: NavTreeElement[]): NavTreeData {
-    if (!arraysEqual(route.path, this.pathToElements)) return this; // the element in not in tree as their paths do not match
+    if (!arraysEqual(route.path, this.pathToElements)) throw new Error('unexpected: children parent not among tree elements');
     const elements = this.elements.map(e => (e.route.id === route.id ? { ...e, children: children } : e));
     return new NavTreeData(elements, this.pathToElements, this.parent, this.selectedElementId);
   }

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -37,15 +37,15 @@ export class NavTreeData {
   constructor(
     public readonly elements: NavTreeElement[], // level 1 elements (which may have children)
     public readonly pathToElements: Id[], // path from root to the elements (so including the parent if any)
-    public readonly selectedElementId?: Id, // the selected element is among elements
     public readonly parent?: NavTreeElement, // level 0 element
+    public readonly selectedElementId?: Id, // the selected element is among elements
   ) {}
 
   /**
    * Return this with selected element changed
    */
   withSelection(id: Id): NavTreeData {
-    return new NavTreeData(this.elements, this.pathToElements, id, this.parent);
+    return new NavTreeData(this.elements, this.pathToElements, this.parent, id);
   }
 
   /**
@@ -58,7 +58,7 @@ export class NavTreeData {
     if (idx === -1) return this;
     const elements = [ ...this.elements ];
     elements[idx] = update(ensureDefined(elements[idx]));
-    return new NavTreeData(elements, this.pathToElements, this.selectedElementId, this.parent);
+    return new NavTreeData(elements, this.pathToElements, this.parent, this.selectedElementId);
   }
 
   /**
@@ -68,7 +68,7 @@ export class NavTreeData {
   withChildren(route: ContentRoute, children: NavTreeElement[]): NavTreeData {
     if (!arraysEqual(route.path, this.pathToElements)) return this; // the element in not in tree as their paths do not match
     const elements = this.elements.map(e => (e.route.id === route.id ? { ...e, children: children } : e));
-    return new NavTreeData(elements, this.pathToElements, this.selectedElementId, this.parent);
+    return new NavTreeData(elements, this.pathToElements, this.parent, this.selectedElementId);
   }
 
   /**
@@ -77,7 +77,7 @@ export class NavTreeData {
    */
   withNoSelection(): NavTreeData {
     if (!this.selectedElementId) return this;
-    return new NavTreeData(this.elements, this.pathToElements, undefined, this.parent);
+    return new NavTreeData(this.elements, this.pathToElements, this.parent);
   }
 
   /**
@@ -87,7 +87,7 @@ export class NavTreeData {
   subNavMenuData(route: ContentRoute): NavTreeData {
     const newParent = this.elements.find(e => e.route.id === route.path[route.path.length-1]);
     if (!newParent || !newParent.children /* unexpected */) throw new Error('Unexpected: subNavMenuData did not find parent');
-    return new NavTreeData(newParent.children, this.pathToElements.concat([ newParent.route.id ]), route.id, newParent);
+    return new NavTreeData(newParent.children, this.pathToElements.concat([ newParent.route.id ]), newParent, route.id);
   }
 
   hasElement(route: ContentRoute): boolean {

--- a/src/app/core/services/navigation/group-nav-tree.service.ts
+++ b/src/app/core/services/navigation/group-nav-tree.service.ts
@@ -60,6 +60,10 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     );
   }
 
+  dummyRootContent(): GroupInfo {
+    return groupInfo({ route: groupRoute({ id: 'dummy', isUser: false }, []) });
+  }
+
   private mapChild(child: GroupNavigationChild, path: string[]): NavTreeElement {
     const route = groupRoute({ id: child.id, isUser: false }, path);
     return {

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -82,6 +82,10 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     };
   }
 
+  dummyRootContent(): ItemInfo {
+    return itemInfo({ route: fullItemRoute(this.category, 'dummy', [], { parentAttemptId: defaultAttemptId }) });
+  }
+
   private mapChild(child: ItemNavigationChild, parentAttemptId: string, path: string[]): NavTreeElement {
     const currentResult = bestAttemptFromResults(child.results);
     const route = fullItemRoute(typeCategoryOfItem(child), child.id, path, { attemptId: currentResult?.attemptId, parentAttemptId });

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -198,7 +198,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
 
   private fetchDefaultNav(): Observable<FetchState<NavTreeData>> {
     return this.fetchRootTreeData().pipe(
-      map(elements => new NavTreeData(elements, [], undefined, undefined)),
+      map(elements => new NavTreeData(elements, [])),
       mapToFetchState(),
     );
   }
@@ -208,12 +208,12 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
     const parentId = route.path[route.path.length-1];
     if (isDefined(parentId)) {
       return this.fetchNavDataFromChild(parentId, content).pipe(
-        map(data => new NavTreeData(data.elements, route.path, route.id, data.parent)),
+        map(data => new NavTreeData(data.elements, route.path, data.parent, route.id)),
         mapToFetchState(),
       );
     } else {
       return this.fetchRootTreeData().pipe(
-        map(items => new NavTreeData(items, route.path, route.id)),
+        map(items => new NavTreeData(items, route.path, undefined, route.id)),
         mapToFetchState(),
       );
     }
@@ -227,7 +227,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
     if (!prevNav.parent) return this.fetchDefaultNav();
     // as the nav was previously loaded with a parent, we are sure it has children
     return this.fetchNavData(prevNav.parent.route).pipe(
-      map(data => new NavTreeData(data.elements, prevNav.pathToElements, undefined, data.parent)),
+      map(data => new NavTreeData(data.elements, prevNav.pathToElements, data.parent)),
       mapToFetchState(),
     );
   }

--- a/src/app/shared/models/content/content-info.ts
+++ b/src/app/shared/models/content/content-info.ts
@@ -1,5 +1,6 @@
 import { ContentBreadcrumb } from './content-breadcrumb';
 import { ContentRoute } from '../../routing/content-route';
+import { arraysEqual } from '../../helpers/array';
 
 export interface ContentInfo {
   type: string,
@@ -18,4 +19,16 @@ export interface RoutedContentInfo extends ContentInfo {
  */
 export function contentInfo(c: Omit<ContentInfo, 'type'>): ContentInfo {
   return { ...c, type: 'misc' };
+}
+
+export function areSiblings(c1: RoutedContentInfo, c2: RoutedContentInfo): boolean {
+  return c1.type === c2.type && arraysEqual(c1.route.path, c2.route.path);
+}
+
+export function areParentChild(c: { parent: RoutedContentInfo, child: RoutedContentInfo }): boolean {
+  return c.parent.type === c.child.type && arraysEqual([ ...c.parent.route.path, c.parent.route.id ], c.child.route.path);
+}
+
+export function areSameElements(c1: RoutedContentInfo, c2: RoutedContentInfo): boolean {
+  return c1.type === c2.type && c1.route.id === c2.route.id && arraysEqual(c1.route.path, c2.route.path);
 }


### PR DESCRIPTION
## Description

In order to prepare for implementing #422, I needed to refactor (once again) the handling of the left menu. The idea is to use the same nice idea from last time (a `scan` followed by a `switchMap`) but for both first and second level elements. I think it is simplify a bit further the service. 

Additional benefits:
- When navigating menu "upstream" (to the parent): the full menu (level 1 and 2) is not reloading as we already have the level 2 (the previous level 1 elements become the children of the selected element). It ends up in a not-so-negligible saving /speed boost when navigating.
- If navigating quickly not using the menu (quite rare probably), the ongoing requests will be cancelled in favor of the new ones. The previous version was "queuing" the menu updates (not even done in parallel). So we can expect a small perf improvement here as well.

## Test cases
 
Tests cases are included as comments in the nav tree service.