### PR TITLE
Changes alignment to the top for task spinner and loading messages

### DIFF
--- a/src/app/modules/item/components/task-loader/task-loader.component.html
+++ b/src/app/modules/item/components/task-loader/task-loader.component.html
@@ -1,9 +1,7 @@
-<div [algFullHeightContent]="true">
-  <div class="loading text-center">
-    <div *ngIf="label" class="label">{{ label }}</div>
-    <alg-loading></alg-loading>
-    <div *ngIf="delayedLabel" class="sub-label" [style.visibility]="showDelayedLabel ? undefined : 'hidden'">
-      {{ delayedLabel }}
-    </div>
+<div class="loading text-center">
+  <div *ngIf="label" class="label">{{ label }}</div>
+  <alg-loading></alg-loading>
+  <div *ngIf="delayedLabel" class="sub-label" [style.visibility]="showDelayedLabel ? undefined : 'hidden'">
+    {{ delayedLabel }}
   </div>
 </div>

--- a/src/app/modules/item/components/task-loader/task-loader.component.scss
+++ b/src/app/modules/item/components/task-loader/task-loader.component.scss
@@ -4,13 +4,7 @@
 }
 
 .loading {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  width: 100%;
-  opacity: 0.9;
-  z-index: 10;
+  padding: 1rem;
 }
 
 .label {


### PR DESCRIPTION
## Description

Fixes #1051

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/top-align-task-loading-messages/en/#/activities/by-id/1048351160122080703;path=899800937596940136,413754475755414976;attempId=0/details)
  3. Then I see the spinner and loading messages are displayed top-aligned
