### PR TITLE
Disable hash routing

### DIFF
--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -13,7 +13,7 @@ export class AppPage {
   }
 
   async navigateTo(relativeUrl: string): Promise<void> {
-    const url = new URL(`/#${relativeUrl}`, browser.baseUrl);
+    const url = new URL(`${relativeUrl}`, browser.baseUrl);
     await browser.get(url.href);
     await browser.refresh(); // avoid stateful traumas
   }

--- a/e2e/src/app.po.ts
+++ b/e2e/src/app.po.ts
@@ -13,7 +13,7 @@ export class AppPage {
   }
 
   async navigateTo(relativeUrl: string): Promise<void> {
-    const url = new URL(`${relativeUrl}`, browser.baseUrl);
+    const url = new URL(relativeUrl, browser.baseUrl);
     await browser.get(url.href);
     await browser.refresh(); // avoid stateful traumas
   }

--- a/src/app/core/app-routing.module.ts
+++ b/src/app/core/app-routing.module.ts
@@ -33,7 +33,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [ RouterModule.forRoot(routes, { useHash: true }) ],
+  imports: [ RouterModule.forRoot(routes) ],
   exports: [ RouterModule ]
 })
 export class AppRoutingModule { }

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -61,6 +61,10 @@ export class AppComponent implements OnInit, OnDestroy {
       appConfig.languageSpecificTitles[this.localeService.currentLang.tag] : undefined;
     this.titleService.setTitle(title ?? appConfig.defaultTitle);
 
+    // Temp hack during the hash to non-hash routing transition. Redirect "#/abc/efg" to "/abc/efg"
+    const hashPath = window.location.hash.slice(1); // omit leading "#"
+    if (hashPath.length && hashPath.charAt(0) === '/') void this.router.navigateByUrl(hashPath, { replaceUrl: true });
+
     // Handle a redirect to sub path which can be used to redirect to a specific page when coming back on the app
     const redirectTo = urlToRedirectTo({ from: this.location.path() });
     if (redirectTo) void this.router.navigateByUrl(redirectTo, { replaceUrl: true });

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -13,6 +13,7 @@ import { urlToRedirectTo } from '../shared/helpers/redirect-to-sub-path-at-init'
 import { GroupWatchingService } from './services/group-watching.service';
 import { version } from 'src/version';
 import { CrashReportingService } from './services/crash-reporting.service';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'alg-root',
@@ -50,6 +51,7 @@ export class AppComponent implements OnInit, OnDestroy {
     private localeService: LocaleService,
     private layoutService: LayoutService,
     private crashReportingService: CrashReportingService,
+    private location: Location,
     private titleService: Title,
     private ngZone: NgZone,
     private renderer: Renderer2,
@@ -59,11 +61,10 @@ export class AppComponent implements OnInit, OnDestroy {
       appConfig.languageSpecificTitles[this.localeService.currentLang.tag] : undefined;
     this.titleService.setTitle(title ?? appConfig.defaultTitle);
 
-    const currentUrl = location.hash.slice(1); // omit leading "#"
-    const redirectTo = urlToRedirectTo(currentUrl);
-    if (redirectTo) {
-      void this.router.navigateByUrl(redirectTo, { replaceUrl: true });
-    }
+    // Handle a redirect to sub path which can be used to redirect to a specific page when coming back on the app
+    const redirectTo = urlToRedirectTo({ from: this.location.path() });
+    if (redirectTo) void this.router.navigateByUrl(redirectTo, { replaceUrl: true });
+
     if (appConfig.theme !== 'default') {
       this.renderer.setAttribute(this.el.nativeElement, 'data-theme', `${appConfig.theme}`);
     }

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, NgZone, OnDestroy, OnInit, Renderer2 } from '@angular/core';
 import { UserSessionService } from '../shared/services/user-session.service';
-import { delay, switchMap } from 'rxjs/operators';
+import { delay, switchMap, tap } from 'rxjs/operators';
 import { merge, Subscription } from 'rxjs';
 import { AuthService } from '../shared/auth/auth.service';
 import { Router } from '@angular/router';
@@ -27,6 +27,9 @@ export class AppComponent implements OnInit, OnDestroy {
     this.authService.failure$,
     this.sessionService.userProfileError$,
     this.localeService.currentLangError$,
+  ).pipe(
+    // eslint-disable-next-line no-console
+    tap(err => console.error(`fatal: ${err.message}`))
   );
 
   fullFrame$ = this.layoutService.fullFrame$.pipe(delay(0));

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent implements OnInit, OnDestroy {
     this.localeService.currentLangError$,
   ).pipe(
     // eslint-disable-next-line no-console
-    tap(err => console.error(`fatal: ${err.message}`))
+    tap(err => console.error('fatal:', err))
   );
 
   fullFrame$ = this.layoutService.fullFrame$.pipe(delay(0));

--- a/src/app/core/services/localeService.ts
+++ b/src/app/core/services/localeService.ts
@@ -10,7 +10,7 @@ export class LocaleService implements OnDestroy {
 
   readonly languages: LanguageConfig[];
   readonly currentLang?: LanguageConfig;
-  readonly currentLangError$: Observable<void>;
+  readonly currentLangError$: Observable<Error>;
 
   private navigating$ = new Subject<void>();
   readonly navigatingToNewLanguage$ = this.navigating$.asObservable();
@@ -18,7 +18,7 @@ export class LocaleService implements OnDestroy {
   constructor() {
     this.languages = appConfig.languages;
     this.currentLang = this.languages.find(l => window.location.pathname.endsWith(l.path));
-    this.currentLangError$ = this.currentLang ? EMPTY : of(undefined);
+    this.currentLangError$ = this.currentLang ? EMPTY : of(new Error('unable to set current lang'));
   }
 
   navigateTo(langTag: string): void {

--- a/src/app/modules/group/pages/current-user/current-user.component.ts
+++ b/src/app/modules/group/pages/current-user/current-user.component.ts
@@ -3,6 +3,7 @@ import { UserSessionService } from 'src/app/shared/services/user-session.service
 import { appConfig } from 'src/app/shared/helpers/config';
 import { ActionFeedbackService } from '../../../../shared/services/action-feedback.service';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'alg-current-user',
@@ -15,14 +16,11 @@ export class CurrentUserComponent {
   constructor(
     private userSessionService: UserSessionService,
     private actionFeedbackService: ActionFeedbackService,
+    private location: Location,
   ) {}
 
   onModify(userId: string): void {
-    const backUrl = new URL(
-      './update-profile.html',
-      location.href
-    ).href;
-
+    const backUrl = window.location.origin + this.location.prepareExternalUrl('update-profile.html');
     window.open(
       `${ appConfig.oauthServerUrl }?all=1&client_id=${ userId }&redirect_uri=${encodeURI(backUrl)}`,
       undefined,

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -1,8 +1,8 @@
+import { Location } from '@angular/common';
 import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { animationFrames, combineLatest, EMPTY, merge, Observable, Subject, throwError } from 'rxjs';
 import { catchError, map, mapTo, shareReplay, switchMap, take, tap } from 'rxjs/operators';
-import { LocaleService } from 'src/app/core/services/localeService';
 import { ActivityNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
 import { openNewTab, replaceWindowUrl } from 'src/app/shared/helpers/url';
 import { FullItemRoute, itemRoute } from 'src/app/shared/routing/item-route';
@@ -61,7 +61,7 @@ export class ItemTaskService {
     private itemRouter: ItemRouter,
     private activityNavTreeService: ActivityNavTreeService,
     private router: Router,
-    private localeService: LocaleService,
+    private location: Location,
     private askHintService: AskHintService,
   ) {}
 
@@ -167,8 +167,8 @@ export class ItemTaskService {
   }
 
   private navigate(href: string, newTab = false): void {
-    if (newTab) openNewTab(href, this.localeService.currentLang);
-    else replaceWindowUrl(href, this.localeService.currentLang);
+    if (newTab) openNewTab(href, this.location);
+    else replaceWindowUrl(href, this.location);
   }
 
   private askHint(hintToken: string): Observable<string> {

--- a/src/app/shared/auth/auth.service.ts
+++ b/src/app/shared/auth/auth.service.ts
@@ -36,7 +36,7 @@ export const maxInvalidToken = 6;
 export class AuthService implements OnDestroy {
 
   status$ = new BehaviorSubject<AuthStatus>(notAuthenticated());
-  failure$ = new Subject<void>();
+  failure$ = new Subject<Error>();
 
   private countInvalidToken = 0;
 
@@ -66,7 +66,7 @@ export class AuthService implements OnDestroy {
       },
       error: _e => {
         // if temp user creation fails, there is not much we can do
-        this.failure$.next();
+        this.failure$.next(new Error('temp user creation failed (1)'));
       }
     });
 
@@ -139,7 +139,7 @@ export class AuthService implements OnDestroy {
     this.countInvalidToken ++;
     this.status$.next(notAuthenticated());
     if (this.countInvalidToken > maxInvalidToken) {
-      this.failure$.next();
+      this.failure$.next(new Error('too many invalid token'));
       return;
     }
 
@@ -152,7 +152,7 @@ export class AuthService implements OnDestroy {
         this.status$.next(auth);
       },
       error: _e => {
-        this.failure$.next(); // if temp user creation fails, there is not much we can do
+        this.failure$.next(new Error('temp user creation failed (2)')); // if temp user creation fails, there is not much we can do
       }
     });
 

--- a/src/app/shared/auth/oauth.service.ts
+++ b/src/app/shared/auth/oauth.service.ts
@@ -71,7 +71,7 @@ export class OAuthService {
   }
 
   private appRedirectUri(): string {
-    return `${window.location.protocol}//${window.location.host}${window.location.pathname}#/`;
+    return `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
   }
 
   private parseState(state: string): {nonce: string, userState: string} {

--- a/src/app/shared/auth/oauth.service.ts
+++ b/src/app/shared/auth/oauth.service.ts
@@ -5,6 +5,7 @@ import { AuthHttpService } from '../http-services/auth.http-service';
 import { base64UrlEncode } from '../helpers/base64';
 import { appConfig } from '../helpers/config';
 import { AuthResult } from './auth-info';
+import { Location } from '@angular/common';
 
 // Use localStorage for nonce if possible localStorage is the only storage who survives a redirect in ALL browsers (also IE)
 const nonceStorage = localStorage;
@@ -15,7 +16,10 @@ const nonceStorageKey = 'oauth_nonce';
 })
 export class OAuthService {
 
-  constructor(private authHttp: AuthHttpService) {}
+  constructor(
+    private authHttp: AuthHttpService,
+    private location: Location,
+  ) {}
 
   /**
    * Init authorization code flow login anf redirect the user to the auth server login url.
@@ -71,7 +75,7 @@ export class OAuthService {
   }
 
   private appRedirectUri(): string {
-    return `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
+    return `${window.location.origin}${this.location.prepareExternalUrl('')}`;
   }
 
   private parseState(state: string): {nonce: string, userState: string} {

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -51,8 +51,8 @@ export type PartialDeep<T> = T extends Record<string, any>
 const presetQueryParam = 'config_preset';
 /**
  * Escape hatch to start the platform with the provided configuration preset. (presets are declared in each environment file)
- * @example `http://dev.algorea.org/#/?config_preset=demo`
- * @example `http://dev.algorea.org/#/activities/etc/?config_preset=demo`
+ * @example `http://dev.algorea.org/?config_preset=demo`
+ * @example `http://dev.algorea.org/activities/etc/?config_preset=demo`
  * Should be used only by Algorea teams, for testing or demo purposes only.
  */
 function getPresetNameFromQuery(): string | null {

--- a/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
+++ b/src/app/shared/helpers/redirect-to-sub-path-at-init.ts
@@ -20,9 +20,9 @@ export function appendUrlWithQuery(currentUrl: string, query: string, value: str
   return url.pathname + url.search;
 }
 
-export function urlToRedirectTo(currentUrl: string): string | null {
+export function urlToRedirectTo(options: { from: string }): string | null {
   const url = getRedirectToSubPathAtInit();
   if (!url) return null;
   removeSubPathRedirectionAtInit();
-  return appendUrlWithQuery(url, fromPathKey, currentUrl);
+  return appendUrlWithQuery(url, fromPathKey, options.from);
 }

--- a/src/app/shared/helpers/url.ts
+++ b/src/app/shared/helpers/url.ts
@@ -79,17 +79,18 @@ export function urlStringFromArray(urlAsArray: UrlCommand): string {
 }
 
 /**
- * Convert an absolute or relative href to a full url string
+ * Convert an absolute or relative path to a full url string
  */
-function hrefToUrl(href: string, location: Location): string {
-  return new RegExp('^(?:[a-z+]+:)?//', 'i').test(href) ? href : window.location.origin + location.prepareExternalUrl(href);
+function pathToUrl(href: string, location: Location): string {
+  const isAbsolute = new RegExp('^(?:[a-z+]+:)?//', 'i').test(href);
+  return isAbsolute ? href : window.location.origin + location.prepareExternalUrl(href);
 }
 
 export function replaceWindowUrl(href: string, location: Location): void {
-  window.location.href = hrefToUrl(href, location);
+  window.location.href = pathToUrl(href, location);
 }
 export function openNewTab(href: string, location: Location): void {
-  window.open(hrefToUrl(href, location), '_blank');
+  window.open(pathToUrl(href, location), '_blank');
 }
 
 /**

--- a/src/app/shared/helpers/url.ts
+++ b/src/app/shared/helpers/url.ts
@@ -1,4 +1,4 @@
-import { LanguageConfig } from './config';
+import { Location } from '@angular/common';
 import { isString } from './type-checkers';
 
 // Url array (`command` array used in some api of angular)
@@ -78,19 +78,18 @@ export function urlStringFromArray(urlAsArray: UrlCommand): string {
   }).join('');
 }
 
-function formatUrl(href: string, currentLang?: LanguageConfig): string {
-  const isAbsoluteHref = href.startsWith('http');
-  if (isAbsoluteHref) return href;
-  const url = new URL(currentLang?.path ?? '/', window.location.href);
-  url.hash = href;
-  return url.href;
+/**
+ * Convert an absolute or relative href to a full url string
+ */
+function hrefToUrl(href: string, location: Location): string {
+  return new RegExp('^(?:[a-z+]+:)?//', 'i').test(href) ? href : window.location.origin + location.prepareExternalUrl(href);
 }
 
-export function replaceWindowUrl(href: string, currentLang?: LanguageConfig): void {
-  window.location.href = formatUrl(href, currentLang);
+export function replaceWindowUrl(href: string, location: Location): void {
+  window.location.href = hrefToUrl(href, location);
 }
-export function openNewTab(href: string, currentLang?: LanguageConfig): void {
-  window.open(formatUrl(href, currentLang), '_blank');
+export function openNewTab(href: string, location: Location): void {
+  window.open(hrefToUrl(href, location), '_blank');
 }
 
 /**

--- a/src/app/shared/services/user-session.service.ts
+++ b/src/app/shared/services/user-session.service.ts
@@ -12,7 +12,7 @@ import { repeatLatestWhen } from '../helpers/repeatLatestWhen';
 export class UserSessionService implements OnDestroy {
 
   session$ = new BehaviorSubject<UserProfile|undefined>(undefined);
-  userProfileError$ = new Subject<void>();
+  userProfileError$ = new Subject<Error>();
 
   /** currently-connected user profile, temporary or not, excluding transient (undefined) states */
   userProfile$ = this.session$.pipe(
@@ -38,7 +38,7 @@ export class UserSessionService implements OnDestroy {
       distinctUntilChanged(), // skip two undefined values in a row
     ).subscribe({
       next: profile => this.session$.next(profile),
-      error: () => this.userProfileError$.next()
+      error: () => this.userProfileError$.next(new Error('unable to fetch user profile'))
     });
   }
 


### PR DESCRIPTION
## Description

Use default routing strategy instead of the hash one. I had to fix multiple places where the way to compute/retrieve the current url or the base was not really correct. It is very recommended to review commit per commit as they are some related changes.

One of the motivation is to be more search-engine crawler-friendly.

## Test cases

- [ ] Case 1:
  1. Given I am a temp user
  2. When I go to [any page](https://dev.algorea.org/branch/disable-hash-routing/fr/activities/by-id/4102;path=4702;parentAttempId=0/details)
  3. And I click switch to English
  4. Then I see I am on the same page in the English app
  5. And I switch to French
  4. Then I see I am on the same page in the French app

- [ ] Case 2:
  1. Given I am a temp user
  2. When I go to [any page](https://dev.algorea.org/branch/disable-hash-routing/en/activities/by-id/4102;path=4702;parentAttempId=0/details)
  3. And I click on "log in"
  4. Then I see the url I am redirected to contains an encoded `redirect_uri` corresponding to the base url `https%3A%2F%2Fdev.algorea.org%2Fbranch%2Fdisable-hash-routing%2Fen%2F`

- [ ] Case 3:
  1. Given I am a temp user
  2. When I visit a [task with link](https://dev.algorea.org/branch/disable-hash-routing/en/activities/by-id/837046206729127555;path=4702,1352246428241737349,314613032161178344;parentAttempId=0/details)
  3. And I click on the first "Activité en blockly"
  4. I am redirected on a new tab on a blockly task, on the same app, so starting with `https://dev.algorea.org/branch/disable-hash-routing/en/`


- [ ] Case 4:
  1. Given I am a temp user
  2. When I go to [any page](https://dev.algorea.org/branch/disable-hash-routing/en/activities/by-id/4102;path=4702;parentAttempId=0/details)
  3. And I add a session storage k/v: `redirect_to_sub_path`, `/somewhere` 
  4. And I refresh the page
  5. I end up on `https://dev.algorea.org/branch/disable-hash-routing/en/somewhere?from_path=%2Factivities%2Fby-id%2F4102;path%3D4702;parentAttempId%3D0%2Fdetails` as expected


- [ ] Case 5:
  1. Given I am the usual user
  2. When I go to [my profile page](https://dev.algorea.org/branch/disable-hash-routing/en/groups/users/670968966872011405/personal-data)
  3. And I click modify
  4. And I click "close" in the popup
  5. The popup is getting closed (because it redirected the "update-profile.html" which ask the app to close the popup) (don't worry about the failing backend profile update, that's not related to this PR)



- [ ] Case 6:
  1. Given I connect on the moodle test, on the usual topic: http://moodletest.algorea.org/course/view.php?id=3#section-1
  2. And I click the "Test dev.algorea.org (branch disable-hash-routing)" task
  3. I end up on the platform with LTI working 