### PR TITLE
remove unused assets rules (files are not there anymore)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -30,13 +30,6 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.app.json",
             "assets": [
-              "src/android-chrome-192x192.png",
-              "src/android-chrome-512x512.png",
-              "src/apple-touch-icon.png",
-              "src/favicon-16x16.png",
-              "src/favicon-32x32.png",
-              "src/favicon.ico",
-              "src/site.webmanifest",
               "src/update-profile.html",
               "src/assets"
             ],


### PR DESCRIPTION
## Description

Just removed part of the config which is not used anymore as these assets have been moved a few months ago to the `assets` directory.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [any page](https://dev.algorea.org/en/#/activities/by-id/4702;path=;parentAttempId=0/details)
  4. Then I see the favicon is still displayed
  5. And there is not asset loading error in the network panel 
