### PR TITLE
fix the crash report which is triggered when leaving a component which h has not been shown because of loading or error

### DIFF
--- a/src/app/shared/guards/pending-changes-guard.ts
+++ b/src/app/shared/guards/pending-changes-guard.ts
@@ -27,14 +27,17 @@ export class PendingChangesGuard implements CanDeactivate<PendingChangesComponen
   ): Observable<boolean> {
     const dialogResponse = new Subject<boolean>();
 
+    // If a component is not defined in router, need to use the PendingChangesService as alternative approach
     const pendingChangesComponent = component || this.pendingChangesService.component;
 
-    // If a component is not defined in router, need to use the PendingChangesService as alternative approach
     if (!pendingChangesComponent) {
-      throw new Error('Unexpected: Component is not defined in router');
+      // The component may still be not set in some specific scenarios.
+      // Example: The routing leads to a "detail" component but its parent decides not to show it (for instance because there is an error
+      //   in the parent). In such a case, when we leave the page, the "detail" component is being deactivated while not existing.
+      return of(true);
     }
 
-    if (!pendingChangesComponent.isDirty()) return of(true) ;
+    if (!pendingChangesComponent.isDirty()) return of(true);
     this.confirmationService.confirm({
       message: $localize`This page has unsaved changes. Do you want to leave this page and lose its changes?`,
       header: $localize`Confirm Navigation`,


### PR DESCRIPTION
## Description

Fix the crash report which is triggered when leaving a component which has not been shown because of loading or error

```ts
// The component may still be not set in some specific scenarios.
// Example: The routing leads to a "detail" component but its parent decides not to show it (for instance because there is an error
//   in the parent). In such a case, when we leave the page, the "detail" component is being deactivated while not existing.
```

## Test cases

- [ ] Case 1: ON PREVIOUS VERSION
  1. Given I am any user
  2. When I go to [the root of the website](https://dev.algorea.org/en/)  
  3. Then I go to [this non existing page](https://dev.algorea.org/en/#/activities/by-id/47024/details)
  5. And I visit the first skill in the left menu > skill
  6. Then I see the crash report box

- [ ] Case 2: ON THIS BRANCH
  1. Given I am any user
  2. When I go to [the root of the website](https://dev.algorea.org/branch/fix-guard-crash/en/)  
  3. Then I go to [this non existing page](https://dev.algorea.org/branch/fix-guard-crash/en/#/activities/by-id/47024/details)
  5. And I visit the first skill in the left menu > skill
  6. Then I see NO crash report box
