### PR TITLE
Keep 'path' to group/user in observation mode

### DIFF
--- a/src/app/core/services/group-watching.service.ts
+++ b/src/app/core/services/group-watching.service.ts
@@ -78,9 +78,9 @@ export class GroupWatchingService implements OnDestroy {
     this.cachedGroupInfo.complete();
   }
 
-  startUserWatching(user: User): void {
+  startUserWatching(route: RawGroupRoute, user: User): void {
     this.cachedGroupInfo.next({
-      route: rawGroupRoute(user),
+      route: route,
       name: formatUser(user),
       currentUserCanGrantAccess: user.currentUserCanGrantUserAccess || false,
     });

--- a/src/app/core/services/group-watching.service.ts
+++ b/src/app/core/services/group-watching.service.ts
@@ -7,7 +7,7 @@ import { GetGroupByIdService, Group } from 'src/app/modules/group/http-services/
 import { GetUserService, User } from 'src/app/modules/group/http-services/get-user.service';
 import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { boolToQueryParamValue, queryParamValueToBool } from 'src/app/shared/helpers/url';
-import { rawGroupRoute, RawGroupRoute } from 'src/app/shared/routing/group-route';
+import { GroupRoute, rawGroupRoute, RawGroupRoute } from 'src/app/shared/routing/group-route';
 import { formatUser } from '../../shared/helpers/user';
 
 const watchedGroupQueryParam = 'watchedGroupId';
@@ -87,9 +87,9 @@ export class GroupWatchingService implements OnDestroy {
     this.setWatchedGroupInUrlParams({ groupId: user.groupId, isUser: true });
   }
 
-  startGroupWatching(group: Group): void {
+  startGroupWatching(route: GroupRoute, group: Group): void {
     this.cachedGroupInfo.next({
-      route: rawGroupRoute(group),
+      route: route,
       name: group.name,
       currentUserCanGrantAccess: group.currentUserCanGrantGroupAccess || false,
     });

--- a/src/app/modules/group/components/group-header/group-header.component.ts
+++ b/src/app/modules/group/components/group-header/group-header.component.ts
@@ -52,7 +52,7 @@ export class GroupHeaderComponent implements OnChanges, OnDestroy {
 
   onStartWatchButtonClicked(event: Event): void {
     if (!this.groupData?.group) throw new Error("unexpected group not set in 'onWatchButtonClicked'");
-    this.groupWatchingService.startGroupWatching(this.groupData.group);
+    this.groupWatchingService.startGroupWatching(this.groupData.route, this.groupData.group);
     this.openSuggestionOfActivitiesOverlayPanel(event);
   }
 

--- a/src/app/modules/group/components/user-header/user-header.component.ts
+++ b/src/app/modules/group/components/user-header/user-header.component.ts
@@ -3,14 +3,16 @@ import { User } from '../../http-services/get-user.service';
 import { map } from 'rxjs/operators';
 import { ModeAction, ModeService } from '../../../../shared/services/mode.service';
 import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
+import { RawGroupRoute } from 'src/app/shared/routing/group-route';
 
 @Component({
-  selector: 'alg-user-header',
+  selector: 'alg-user-header[user][route]',
   templateUrl: './user-header.component.html',
   styleUrls: [ './user-header.component.scss' ],
 })
 export class UserHeaderComponent {
-  @Input() user?: User;
+  @Input() user!: User;
+  @Input() route!: RawGroupRoute;
 
   isCurrentGroupWatched$ = this.groupWatchingService.watchedGroup$.pipe(
     map(watchedGroup => !!(watchedGroup && watchedGroup.route.id === this.user?.groupId)),
@@ -27,8 +29,7 @@ export class UserHeaderComponent {
   }
 
   onStartWatchButtonClicked(): void {
-    if (!this.user) throw new Error("unexpected user not set in 'onWatchButtonClicked'");
-    this.groupWatchingService.startUserWatching(this.user);
+    this.groupWatchingService.startUserWatching(this.route, this.user);
   }
 
   onStopWatchButtonClicked(): void {

--- a/src/app/modules/group/pages/user/user.component.html
+++ b/src/app/modules/group/pages/user/user.component.html
@@ -11,11 +11,11 @@
     (refresh)="refresh()"
   ></alg-error>
 
-  <ng-container *ngIf="state.isReady && state.data as user">
+  <ng-container *ngIf="state.isReady">
 
-    <alg-user-header [user]="user" *ngIf="!(fullFrame$ | async)?.active"></alg-user-header>
+    <alg-user-header [user]="state.data.user" [route]="state.data.route" *ngIf="!(fullFrame$ | async)?.active"></alg-user-header>
 
-    <nav class="nav-tab" *ngIf="(currentUserGroupId$ | async) === user.groupId || (activeRoute$ | async) === 'personal-data' || (activeRoute$ | async) === 'settings'">
+    <nav class="nav-tab" *ngIf="(currentUserGroupId$ | async) === state.data.user.groupId || (activeRoute$ | async) === 'personal-data' || (activeRoute$ | async) === 'settings'">
       <a
           class="nav-tab-item"
           [routerLink]="'./'"
@@ -33,7 +33,7 @@
           [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
           [class.active]="personalData.isActive"
           i18n
-          [hidden]="(currentUserGroupId$ | async) !== user.groupId && (activeRoute$ | async) !== 'personal-data'"
+          [hidden]="(currentUserGroupId$ | async) !== state.data.user.groupId && (activeRoute$ | async) !== 'personal-data'"
       >
         Personal data
       </a>
@@ -44,7 +44,7 @@
           [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
           [class.active]="settings.isActive"
           i18n
-          [hidden]="(currentUserGroupId$ | async) !== user.groupId && (activeRoute$ | async) !== 'settings'"
+          [hidden]="(currentUserGroupId$ | async) !== state.data.user.groupId && (activeRoute$ | async) !== 'settings'"
       >
         Settings
       </a>
@@ -55,7 +55,7 @@
         <div class="bg-white" *ngIf="currentUserGroupId$ | async as currentUserGroupId">
           <alg-section icon="fa fa-chart-line" i18n-label label="Progress">
             <alg-group-log-view
-                [groupId]="currentUserGroupId !== user.groupId ? user.groupId : undefined"
+                [groupId]="currentUserGroupId !== state.data.user.groupId ? state.data.user.groupId : undefined"
                 [showUserColumn]="false"
             ></alg-group-log-view>
           </alg-section>
@@ -63,13 +63,13 @@
       </ng-container>
 
       <ng-container *ngIf="activeRoute === 'personal-data'">
-        <ng-container *ngIf="(currentUserGroupId$ | async) === user.groupId; else forbidden">
+        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.user.groupId; else forbidden">
           <alg-current-user></alg-current-user>
         </ng-container>
       </ng-container>
 
       <ng-container *ngIf="activeRoute === 'settings'">
-        <ng-container *ngIf="(currentUserGroupId$ | async) === user.groupId; else forbidden">
+        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.user.groupId; else forbidden">
           <alg-platform-settings></alg-platform-settings>
         </ng-container>
       </ng-container>

--- a/src/app/shared/routing/group-route.ts
+++ b/src/app/shared/routing/group-route.ts
@@ -36,8 +36,8 @@ export function groupRoute(group: GroupLike, path: string[]): GroupRoute {
   return { ...rawGroupRoute(group), path };
 }
 
-export function isGroupRoute(route: ContentRoute): route is GroupRoute {
-  return route.contentType === 'group';
+export function isGroupRoute(route: ContentRoute | RawGroupRoute): route is GroupRoute {
+  return route.contentType === 'group' && route.path !== undefined;
 }
 
 export function isRawGroupRoute(route?: unknown): route is RawGroupRoute {


### PR DESCRIPTION
## Description

Allow keeping the group/user path while observing. 

I recommend reviewing each commit independently as the second one has many (required) changes related with just cleaning up the user component.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [the Pixal group page](https://dev.algorea.org/branch/path-in-observation/en/#/groups/by-id/672913018859223173;path=52767158366271444/details)
  3. And I click on the observation button
  4. Then I see that the link to the Pixal group in the observation (yellow) bar has the path

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [the usr_5p020x2thuyu user page](https://dev.algorea.org/branch/path-in-observation/en/#/groups/users/752024252804317630;path=52767158366271444,672913018859223173)
  3. And I click on the observation button
  4. Then I see that the link to the user in the observation (yellow) bar has the path
