### PR TITLE
prevent 403 on answer (e.g. if you reuse a link loading an answer while being logged out) to cause a crash

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -104,7 +104,7 @@
 
           <ng-container *ngIf="taskConfig$ | async as taskConfig">
             <div *ngIf="taskConfig.readOnly && contentTab.isActive" class="indicator">
-              <alg-answer-author-indicator *ngIf="formerAnswer$ | async as answer" [answer]="answer"></alg-answer-author-indicator>
+              <alg-answer-author-indicator *ngIf="taskConfig.formerAnswer" [answer]="taskConfig.formerAnswer"></alg-answer-author-indicator>
             </div>
             <alg-item-content
               [hidden]="!contentTab.isActive && !editChildrenTab.isActive"

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -5,7 +5,7 @@ import { mapStateData, readyData } from 'src/app/shared/operators/state';
 import { LayoutService } from '../../../../shared/services/layout.service';
 import { Router, RouterLinkActive } from '@angular/router';
 import { TaskTab } from '../item-display/item-display.component';
-import { combineLatest, fromEvent, merge, Observable, of, ReplaySubject, Subject } from 'rxjs';
+import { combineLatest, EMPTY, fromEvent, merge, Observable, of, ReplaySubject, Subject } from 'rxjs';
 import {
   catchError,
   distinctUntilChanged,
@@ -91,7 +91,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent, P
 
   readonly taskReadOnly$ = this.groupWatchingService.isWatching$;
   readonly taskConfig$: Observable<TaskConfig> = combineLatest([
-    this.formerAnswer$,
+    this.formerAnswer$.pipe(catchError(() => EMPTY)), // error is handled by formerAnswerError$
     this.taskReadOnly$,
     this.itemData$.pipe(readyData()),
   ]).pipe(map(([ formerAnswer, readOnly, data ]) => ({ readOnly, formerAnswer, locale: data.item.string.languageTag })));


### PR DESCRIPTION
## Description

Prevent 403 on the get-answer service (e.g. if you reuse a link loading an answer while being logged out) to cause a crash

## Test cases

- [ ] Case 1: PREVIOUSLY
  1. Given I am a temp user
  2. If I visit [a task with an answer](https://dev.algorea.org/en/#/activities/by-id/8917346722548000260;answerId=4535732193455462762/details)
  3. I get a crash

- [ ] Case 2: ON THE BRANCH
  1. Given I am the usual user
  1. Given I am a temp user
  2. If I visit [a task with an answer](https://dev.algorea.org/branch/fix-forbidden-answer-crash/en/#/activities/by-id/8917346722548000260;answerId=4535732193455462762/details)
  3. I do not get a crash
