### PR TITLE
Fix item children menu reload (+ fix a related bug)

### DIFF
--- a/src/app/modules/item/components/item-children-edit-form/item-children-edit-form.component.ts
+++ b/src/app/modules/item/components/item-children-edit-form/item-children-edit-form.component.ts
@@ -14,6 +14,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ItemChanges, UpdateItemService } from '../../http-services/update-item.service';
 import { PendingChangesComponent } from '../../../../shared/guards/pending-changes-guard';
 import { PendingChangesService } from '../../../../shared/services/pending-changes-service';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 
 @Component({
   selector: 'alg-item-children-edit-form',
@@ -39,6 +40,7 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
     private itemDataSource: ItemDataSource,
     private actionFeedbackService: ActionFeedbackService,
     private pendingChangesService: PendingChangesService,
+    private currentContentService: CurrentContentService,
   ) {}
 
   ngOnInit(): void {
@@ -110,10 +112,12 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
       next: _status => {
         this.actionFeedbackService.success($localize`Changes successfully saved.`);
         this.itemDataSource.refreshItem(); // which will re-enable the form
+        this.currentContentService.forceNavMenuReload();
       },
       error: err => {
         this.disabled = false;
         this.actionFeedbackService.unexpectedError();
+        this.currentContentService.forceNavMenuReload();
         if (!(err instanceof HttpErrorResponse)) throw err;
       },
     });

--- a/src/app/modules/item/http-services/update-item.service.ts
+++ b/src/app/modules/item/http-services/update-item.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpContext } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { assertSuccess, SimpleActionResponse } from '../../../shared/http-services/action-response';
 import { appConfig } from '../../../shared/helpers/config';
 import { map } from 'rxjs/operators';
+import { requestTimeout } from 'src/app/shared/interceptors/interceptor_common';
+import { SECONDS } from 'src/app/shared/helpers/duration';
 
 export interface ItemChanges {
   children?: {
@@ -34,6 +36,8 @@ export interface ItemChanges {
   entry_min_admitted_members_ratio?: 'All' | 'Half' | 'One' | 'None',
 }
 
+const serviceTimeout = 5*SECONDS;
+
 @Injectable({
   providedIn: 'root',
 })
@@ -46,11 +50,9 @@ export class UpdateItemService {
     itemId: string,
     changes: ItemChanges,
   ): Observable<void> {
-    return this.http.put<SimpleActionResponse>(
-      `${appConfig.apiUrl}/items/${itemId}`,
-      changes,
-      { headers: { timeout: '20000' } },
-    ).pipe(
+    return this.http.put<SimpleActionResponse>(`${appConfig.apiUrl}/items/${itemId}`, changes, {
+      context: new HttpContext().set(requestTimeout, serviceTimeout),
+    }).pipe(
       map(assertSuccess),
     );
   }


### PR DESCRIPTION
## Description

Make sure the menu reload when item children have been changed.
 
Extra fix: this service was not working anymore on localhost due to a CORS problem (2nd commit)

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix-item-children-menu-reload/en/activities/by-id/6841500513635377116;path=;attempId=0/details/edit-children)
  3. And I reorder some children
  5. Then the left menu reloads
