### PR TITLE
fix progress tab content showing in cases it shouldn't

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -121,7 +121,7 @@
           </ng-container>
         </ng-container>
         <alg-item-progress
-          *ngIf="progressTab?.isActive || !!(watchedGroup$ | async) && !contentTab.isActive && !editChildrenTab.isActive"
+          *ngIf="progressTab?.isActive"
           [itemData]="itemData"
           [isTaskReadOnly]="(taskReadOnly$ | async) ?? false"
           [savingAnswer]="(savingAnswer$ | async) ?? false"


### PR DESCRIPTION
## Description

Fix the problem shown in test cases

## Test cases

- [ ] Case 1: BEFORE
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/en/activities/by-id/6707691810849260111;path=;parentAttempId=0/details/dependencies?watchedGroupId=6710944276987033666&watchUser=0)
  3. And I see some progress tab content displayed while it shouldn't

- [ ] Case 2: FIXED
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix-progress-tab-content/en/activities/by-id/6707691810849260111;path=;parentAttempId=0/details/dependencies?watchedGroupId=6710944276987033666&watchUser=0)
  3. And I see no progress tab content as expected
 
