### PR TITLE
Fixes pending changes guard

### DIFF
--- a/src/app/shared/guards/pending-changes-guard.ts
+++ b/src/app/shared/guards/pending-changes-guard.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { ActivatedRouteSnapshot, CanDeactivate, RouterStateSnapshot } from '@angular/router';
 import { ConfirmationService } from 'primeng/api';
 import { Observable, of, Subject } from 'rxjs';
@@ -14,7 +14,7 @@ export interface PendingChangesComponent {
 @Injectable({
   providedIn: 'root'
 })
-export class PendingChangesGuard implements CanDeactivate<PendingChangesComponent> {
+export class PendingChangesGuard implements CanDeactivate<PendingChangesComponent>, OnDestroy {
 
   private dialogResponse = new Subject<boolean>();
 
@@ -22,6 +22,10 @@ export class PendingChangesGuard implements CanDeactivate<PendingChangesComponen
     private confirmationService: ConfirmationService,
     private pendingChangesService: PendingChangesService,
   ) {}
+
+  ngOnDestroy(): void {
+    this.dialogResponse.complete();
+  }
 
   canDeactivate(
     component: PendingChangesComponent | null,


### PR DESCRIPTION
## Description

Fixes #1151

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

In some cases guard declares 2 times, that's why for leave the page need to emit true 2 times (so in 2 guards), but we have only one confirmation modal (from one of guard). So it emits for first guard but doesn't for second.

I've created common state for fix this problem.

## Test cases

- [x] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/does-not-navigate-from-item-to-group/en/#/groups/by-id/5121055722873780306;path=/details/settings)
  3. Update the description
  4. Click on "4LTDI1819" in left menu
  5. Then I see confirmation modal
  6. And I click on "Yes, leave page"
  7. Then I see settings of "4LTDI1819" group page

- [x] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/does-not-navigate-from-item-to-group/en/#/groups/by-id/5121055722873780306;path=/details/settings)
  3. Update the description
  4. Click on "4LTDI1819" in left menu
  5. Then I see confirmation modal
  6. And I click on "No"
  7. Then I see settings of "A super new group" group page

- [x] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/does-not-navigate-from-item-to-group/en/#/groups/by-id/5121055722873780306;path=/details/settings)
  3. Update the description
  4. Click on "Activities" -> "Parcours officiels" in left menu
  5. Then I see confirmation modal
  6. And I click on "Yes, leave page"
  7. Then I see "Parcours officiels" item page

- [x] Case 4:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/does-not-navigate-from-item-to-group/en/#/activities/by-id/899800937596940136;path=;attempId=0/details)
  3. Then I click on switcher "Edit the list"
  4. Then I see edit list
  5. Then I change order of list and click on switcher "Edit the list"
  6. Then I see confirmation modal and click No
  7. Then I see edit list and switcher "Edit the list" is on

- [x] Case 5:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/does-not-navigate-from-item-to-group/en/#/activities/by-id/899800937596940136;path=;attempId=0/details)
  3. Then I click on switcher "Edit the list"
  4. Then I see edit list
  5. Then I change order of list and click on switcher "Edit the list"
  6. Then I see confirmation modal and click "Yes, leave page"
  7. Then I see Content list, switcher "Edit the list" is off

- [x] Case 6:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/does-not-navigate-from-item-to-group/en/#/activities/by-id/899800937596940136;path=;attempId=0/details)
  3. Then I click on switcher "Edit the list"
  4. Then I see edit list
  5. Then I change order of list
  6. And I click to "Groups" -> "!634"
  7. Then I see confirmation modal and click "Yes, leave page"
  8. Then I see "!634" group page 