### PR TITLE
Adds height compensation for floating save buttons

### DIFF
--- a/src/app/modules/shared-components/components/floating-save/floating-save.component.ts
+++ b/src/app/modules/shared-components/components/floating-save/floating-save.component.ts
@@ -1,17 +1,38 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, Renderer2 } from '@angular/core';
 
 @Component({
   selector: 'alg-floating-save',
   templateUrl: './floating-save.component.html',
   styleUrls: [ './floating-save.component.scss' ]
 })
-export class FloatingSaveComponent {
+export class FloatingSaveComponent implements OnInit, OnDestroy {
 
   @Input() saving = false;
   @Output() save = new EventEmitter<void>();
   @Output() cancel = new EventEmitter<void>();
 
-  constructor() {}
+  constructor(private renderer: Renderer2, private el: ElementRef<HTMLDivElement>) {}
+
+  ngOnInit(): void {
+    const deleteButtonWrapperHeight = this.el.nativeElement.clientHeight;
+    const contentEl = document.querySelector('.main-content');
+
+    if (!contentEl) {
+      throw new Error('Unexpected: Missed .main-content element');
+    }
+
+    this.renderer.setStyle(contentEl, 'padding-bottom', `${deleteButtonWrapperHeight}px`);
+  }
+
+  ngOnDestroy(): void {
+    const contentEl = document.querySelector('.main-content');
+
+    if (!contentEl) {
+      throw new Error('Unexpected: Missed .main-content element');
+    }
+
+    this.renderer.removeStyle(contentEl, 'padding-bottom');
+  }
 
   onSave(): void {
     this.save.emit();


### PR DESCRIPTION
## Description

Fixes #1152

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/save-cancel-buttons-overlap-other-buttons/en/activities/by-id/5581087923349592147;path=;attempId=0/details/edit-children)
  3. And I change order of list
  4. Then I see Save and Cancel Changes buttons
  5. Then I scroll down and I see padding for Save and Cancel Changes buttons

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/save-cancel-buttons-overlap-other-buttons/en/groups/by-id/8756193103213229306;path=/details/settings)
  3. And I make browser height size = 700px
  4. Then I change Name of Group
  5. Then I see Save and Cancel Changes buttons
  6. Then I scroll down and I see padding for Save and Cancel Changes buttons
