### PR TITLE
make sure the menu is displayed even if the item loading fails

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -191,6 +191,7 @@ export class ItemByIdComponent implements OnDestroy {
       error: err => {
         this.state = errorState(err instanceof Error ? err : new Error('unknown error'));
         this.layoutService.configure({ fullFrameActive: false });
+        this.currentContent.clear();
       }
     });
   }


### PR DESCRIPTION
## Description
make sure the menu is displayed even if the item loading fails

## Test cases

- [ ] Case 1: BEFORE
  1. Given I am any user
  2. When I go to [a non-existing item](https://dev.algorea.org/en/activities/by-id/434/details)
  4. Then I see the menu is empty

- [ ] Case 2: BRANCH
  1. Given I am any user
  2. When I go to [a non-existing item](https://dev.algorea.org/branch/fix-left-menu-on-error-item/en/activities/by-id/434/details)
  4. Then I see the menu has been loaded empty
