### PR TITLE
make sure the left menu is loaded even on a non existing page

### DIFF
--- a/src/app/core/pages/page-not-found/page-not-found.component.ts
+++ b/src/app/core/pages/page-not-found/page-not-found.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { LayoutService } from '../../../shared/services/layout.service';
 
 @Component({
@@ -9,7 +10,9 @@ import { LayoutService } from '../../../shared/services/layout.service';
 export class PageNotFoundComponent {
   constructor(
     private layoutService: LayoutService,
+    private currentContentService: CurrentContentService,
   ) {
     this.layoutService.configure({ fullFrameActive: false });
+    this.currentContentService.clear();
   }
 }


### PR DESCRIPTION
## Description
make sure the menu is displayed even if the route is not valid 

## Test cases

- [ ] Case 1: BEFORE
  1. Given I am any user
  2. When I go to [a non-existing item](https://dev.algorea.org/en/non-existing-content)
  4. Then I see the menu is empty

- [ ] Case 2: BRANCH
  1. Given I am any user
  2. When I go to [a non-existing item](https://dev.algorea.org/branch/fix-left-menu-on-404/en/non-existing-content)
  4. Then I see the menu has been loaded empty
