### PR TITLE
fix: non-error was reported as error as there were no filters

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -86,6 +86,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent, P
   );
 
   readonly formerAnswerError$ = this.formerAnswer$.pipe(
+    switchMap(() => EMPTY), // ignore non-errors
     catchError(error => of(errorIsHTTPForbidden(error) ? loadForbiddenAnswerError : error))
   );
   readonly formerAnswerLoadForbidden$ = this.formerAnswerError$.pipe(filter(error => error === loadForbiddenAnswerError));


### PR DESCRIPTION
## Description

Fix bug: see below 

## Test cases

- [ ] Case 1: BEFORE
  1. Given I am the usual user
  2. When I go to [this page loading an answer from a watched used](https://dev.algorea.org/en/activities/by-id/6379723280369399253;answerId=3700639321047855207/details?watchedGroupId=752024252804317630&watchUser=1)
  3. And I see an error

- [ ] Case 2: FIX
  1. Given I am the usual user
  2. When I go to [this page loading an answer from a watched used](https://dev.algorea.org/branch/fix-former-answer-loading-error/en/activities/by-id/6379723280369399253;answerId=3700639321047855207/details?watchedGroupId=752024252804317630&watchUser=1)
  3. And I do not see the error anymore
