### PR TITLE
refresh left menu after score change so that 'lock' states are updated

### DIFF
--- a/src/app/modules/item/pages/item-details/item-details.component.html
+++ b/src/app/modules/item/pages/item-details/item-details.component.html
@@ -123,7 +123,7 @@
               [(taskView)]="taskView"
               [editModeEnabled]="editChildrenTab.isActive"
               (taskTabsChange)="setTaskTabs($event)"
-              (scoreChange)="patchStateWithScore($event)"
+              (scoreChange)="onScoreChange($event)"
               (skipSave)="skipBeforeUnload()"
               (refresh)="reloadItem()"
               (editorUrl)="editorUrl = $event"

--- a/src/app/modules/item/pages/item-details/item-details.component.ts
+++ b/src/app/modules/item/pages/item-details/item-details.component.ts
@@ -34,6 +34,7 @@ import {
 } from 'src/app/shared/models/domain/item-view-permission';
 import { ItemEditWrapperComponent } from '../../components/item-edit-wrapper/item-edit-wrapper.component';
 import { allowsWatchingResults } from 'src/app/shared/models/domain/item-watch-permission';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 
 const loadForbiddenAnswerError = new Error('load answer forbidden');
 
@@ -159,6 +160,7 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent, P
     private layoutService: LayoutService,
     private getAnswerService: GetAnswerService,
     private router: Router,
+    private currentContentService: CurrentContentService,
   ) {}
 
   ngOnDestroy(): void {
@@ -170,7 +172,8 @@ export class ItemDetailsComponent implements OnDestroy, BeforeUnloadComponent, P
     this.itemDataSource.refreshItem();
   }
 
-  patchStateWithScore(score: number): void {
+  onScoreChange(score: number): void {
+    this.currentContentService.forceNavMenuReload();
     this.itemDataSource.patchItemScore(score);
   }
 


### PR DESCRIPTION
## Description

Refresh the left menu when there is a score change so that the 'lock' states are updated

## Test cases

- [ ] Case 1:
  1. Given I am the anonymous user
  2. When I go to [this page](https://dev.algorea.org/branch/refresh-menu-after-scorechange/en/activities/by-id/784078458149384669;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0/details)
  3. And I open the left menu
  4. Then I solve the "****" problem (repeat 360x: avancer 1 pas, turn 1°. Then 'play')
  6. Then I see the "Bac à sable" in the left menu is unlocked
