### PR TITLE
Adds neighbor navigation into top for groups

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.ts
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.ts
@@ -8,6 +8,8 @@ import { isItemInfo } from '../../../shared/models/content/item-info';
 import { FullFrameContent } from 'src/app/shared/services/layout.service';
 import { GroupWatchingService } from '../../services/group-watching.service';
 import { DiscussionService } from 'src/app/modules/item/services/discussion.service';
+import { GroupNavTreeService } from '../../services/navigation/group-nav-tree.service';
+import { isGroupInfo } from '../../../shared/models/content/group-info';
 
 @Component({
   selector: 'alg-content-top-bar',
@@ -28,6 +30,10 @@ export class ContentTopBarComponent {
 
   navigationNeighbors$ = this.currentContentService.content$.pipe(
     switchMap(content => {
+      if (isGroupInfo(content)) {
+        return this.groupNavTreeService.navigationNeighbors$;
+      }
+
       if (!isItemInfo(content) || !content.route?.contentType) {
         return of(undefined);
       }
@@ -43,6 +49,7 @@ export class ContentTopBarComponent {
     private currentContentService: CurrentContentService,
     private activityNavTreeService: ActivityNavTreeService,
     private skillNavTreeService: SkillNavTreeService,
+    private groupNavTreeService: GroupNavTreeService,
     private discussionService: DiscussionService
   ) {}
 


### PR DESCRIPTION
## Description

Fixes #1111

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/neighbor-navigation-among-groups/en/groups/by-id/4035378957038759250)
  3. And I click on collapse the left menu button
  4. Then I see neighbors widget in top right corner
  5. And click on next arrow
  6. Then I see next group page

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/neighbor-navigation-among-groups/en/groups/by-id/672913018859223173;path=52767158366271444)
  3. And I click on collapse the left menu button
  4. Then I see neighbors widget in top right corner with up arrow button
  5. And click on up arrow button
  6. Then I see parent group page
