### PR TITLE
Improves flex values

### DIFF
--- a/src/app/core/components/top-bar/top-bar.component.scss
+++ b/src/app/core/components/top-bar/top-bar.component.scss
@@ -20,6 +20,6 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: start;
+  justify-content: flex-start;
   overflow: hidden;
 }

--- a/src/app/modules/group/pages/group-edit/group-edit.component.scss
+++ b/src/app/modules/group/pages/group-edit/group-edit.component.scss
@@ -26,6 +26,6 @@
 .remove-button-section {
   padding: 1rem 1rem;
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
 }

--- a/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.scss
+++ b/src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.scss
@@ -146,7 +146,7 @@
   height: 100%;
   display: flex;
   justify-content: center;
-  align-items: end;
+  align-items: flex-end;
 }
 
 .overlay-position {

--- a/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
+++ b/src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.scss
@@ -1,6 +1,6 @@
 .breadcrumbs-container {
   display: flex;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   padding: 0.571rem 1rem;
 }


### PR DESCRIPTION
## Description

Fixes #1133

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/change-start-end-flex-values/en/activities/by-id/4702;path=;parentAttempId=0/details)
  4. Then I see top bar without any changes

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/change-start-end-flex-values/en/groups/by-id/5121055722873780306;path=/settings)
  4. Then I see delete group section without any changes

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/change-start-end-flex-values/en/groups/by-id/6710944276987033666;path=5121055722873780306/settings)
  3. Then I start watch
  4. Then I see path suggestion without any changes

- [ ] Case 4:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/change-start-end-flex-values/en/groups/by-id/6710944276987033666;path=5121055722873780306/settings)
  3. Then I start watch
  4. Then I click on Item Title! (Pixal) of suggested list
  5. Then I click on "Progress" -> "Chapter View"
  6. Then I see group progress grid without any changes