### PR TITLE
temp fix: do not return 'users' among group roots (while backend is not fixed)

### DIFF
--- a/src/app/core/http-services/group-navigation.service.ts
+++ b/src/app/core/http-services/group-navigation.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import * as D from 'io-ts/Decoder';
 import { appConfig } from 'src/app/shared/helpers/config';
 import { decodeSnakeCase } from 'src/app/shared/operators/decode';
@@ -40,6 +40,8 @@ export class GroupNavigationService {
   getRoot(): Observable<GroupNavigationChild[]> {
     return this.http.get<unknown>(`${appConfig.apiUrl}/groups/roots`).pipe(
       decodeSnakeCase(D.array(groupNavigationChildDecoder)),
+      // temporary fix: do not list "User" (they should not be listed by the backend!)
+      map(children => children.filter(g => g.type !== 'User')),
     );
   }
 


### PR DESCRIPTION
temp fix: do not return 'users' among group roots (while backend is not fixed)
