### PR TITLE
fix: display observed-group scores in left menu

### DIFF
--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -110,12 +110,12 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     const route = fullItemRoute(typeCategoryOfItem(child), child.id, path, { attemptId: currentResult?.attemptId, parentAttemptId });
     let score = undefined;
     if (!child.noScore) {
-      if (child.watchedGroup && child.watchedGroup.avgScore && child.watchedGroup.allValidated) score = {
+      if (child.watchedGroup && child.watchedGroup.avgScore !== undefined && child.watchedGroup.allValidated !== undefined) score = {
         bestScore: child.watchedGroup.avgScore,
         currentScore: child.watchedGroup.avgScore,
         validated: child.watchedGroup.allValidated
       };
-      if (currentResult) score = {
+      else if (currentResult) score = {
         bestScore: child.bestScore,
         currentScore: currentResult.scoreComputed,
         validated: currentResult.validated


### PR DESCRIPTION
Was displaying the score of the current-user when it was not the current content.