### PR TITLE
Makes left menu on mobile as full size

### DIFF
--- a/src/app/core/app.component.scss
+++ b/src/app/core/app.component.scss
@@ -124,4 +124,15 @@ a:hover {
       }
     }
   }
+
+  @media screen and (max-width: 479px) {
+    .left {
+      width: 100%;
+      z-index: 999;
+
+      &.collapsed {
+        left: -100%;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Description

Fixes #1200

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am any user
  3. When I go to [this page](https://dev.algorea.org/branch/feature/display-mobile-full-width-left-menu/en/activities/by-id/4702;path=;parentAttempId=0)
  4. And I open device toolbar and chose any mobile device, or make browser width less than 479px
  5. Then I see left menu is full width
  6. Then I click on collapse left menu button
  7. Then I see left menu is disappeared 

Mobile screens:

![IMG_6546](https://user-images.githubusercontent.com/7044736/204829054-98ebc6d6-2e94-4ec8-a2b4-8582c2df3d8f.PNG)
![IMG_6545](https://user-images.githubusercontent.com/7044736/204829089-101600d2-79d2-43c8-acb2-33e227579a0d.PNG)

