### PR TITLE
Fixes progress tabs for mobile

### DIFF
--- a/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html
+++ b/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html
@@ -11,7 +11,14 @@
   ></alg-error>
 
   <div *ngIf="state.data">
-    <p-table class="alg-table alg-table chapter-user-progress" [columns]="columns" [value]="state.data" [loading]="state.isFetching">
+    <p-table
+      class="alg-table chapter-user-progress"
+      [columns]="columns"
+      [value]="state.data"
+      [loading]="state.isFetching"
+      [tableStyle]="{'min-width': '479px'}"
+      responsiveLayout="scroll"
+    >
       <ng-template pTemplate="header" let-rowData let-columns>
         <tr>
           <th [colSpan]="columns.length">

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -11,7 +11,14 @@
   ></alg-error>
 
   <ng-container *ngIf="state.data">
-    <p-table class="alg-table" [columns]="state.data.columns" [value]="state.data.rowData" [loading]="state.isFetching">
+    <p-table
+      class="alg-table item-log-view"
+      [columns]="state.data.columns"
+      [value]="state.data.rowData"
+      [loading]="state.isFetching"
+      [tableStyle]="{'min-width': '479px'}"
+      responsiveLayout="scroll"
+    >
       <ng-template pTemplate="header" let-rowData let-columns>
         <tr>
           <th [colSpan]="columns.length">

--- a/src/app/modules/item/pages/item-progress/item-progress.component.scss
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
 
-  width: 56rem;
+  width: auto;
   max-width: 56rem;
 
   margin-left: auto;

--- a/src/app/modules/shared-components/components/section/section.component.scss
+++ b/src/app/modules/shared-components/components/section/section.component.scss
@@ -36,5 +36,9 @@
     // padding: 1.25rem 2rem 3rem 5.8333rem;
     padding: 2rem 2rem 3rem 5.8333rem;
     color: var(--base-text-color);
+
+    @media screen and (max-width: 479px) {
+      padding: 2rem 2rem 3rem 2rem;
+    }
   }
 }

--- a/src/assets/scss/components/table.scss
+++ b/src/assets/scss/components/table.scss
@@ -320,6 +320,12 @@
       }
     }
   }
+
+  &.item-log-view {
+    table {
+      table-layout: fixed !important;
+    }
+  }
 }
 
 .summary {


### PR DESCRIPTION
## Description

Fixes #1201

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/display-on-mobile-fix-the-progress-tab/en/activities/by-id/4702;path=;parentAttempId=0/progress/history)
  3. And I open device toolbar and chose any mobile device, or make browser width less than 479px
  4. And I close the menu
  5. Then I see the table with content by center position


- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/display-on-mobile-fix-the-progress-tab/en/activities/by-id/4702;path=;parentAttempId=0/progress/chapter-user-progress)
  3. And I open device toolbar and chose any mobile device, or make browser width less than 479px
  4. And I close the menu
  5. Then I see the table with content by center position
