### PR TITLE
forum thread: add user info and separate user-me-outsider bubbles

### DIFF
--- a/src/app/modules/item/components/thread-message/thread-message.component.html
+++ b/src/app/modules/item/components/thread-message/thread-message.component.html
@@ -17,11 +17,18 @@
       </ng-container>
       <ng-container *ngIf="['result_started', 'submission'].includes(event.label)">
         <div class="classical-event">
-          <span *ngIf="userInfo?.isCurrentUser; else anotherUser" i18n>
+          <span *ngIf="userInfo?.isCurrentUser; else notCurrentUser" i18n>
             You
           </span>
+          <ng-template #notCurrentUser>
+            <span *ngIf="userInfo?.isThreadParticipant; else anotherUser" i18n>
+              The user
+            </span>
+          </ng-template>
           <ng-template #anotherUser>
-            {{ userInfo?.name }}
+            <span>
+              {{ userInfo?.name }}
+            </span>
           </ng-template>
           <span *ngIf="event.label === 'result_started'" i18n>started the activity</span>
           <ng-container *ngIf="event.label === 'submission'">

--- a/src/app/modules/item/components/thread-message/thread-message.component.html
+++ b/src/app/modules/item/components/thread-message/thread-message.component.html
@@ -1,40 +1,39 @@
-<ng-container *ngrxLet="isMessageCreatedByCurrentUser$; let isMessageCreatedByCurrentUser">
-  <div
-    class="message-container"
-    [ngClass]="{
-      'left': !isMessageCreatedByCurrentUser && event.label === 'message',
-      'right': isMessageCreatedByCurrentUser && event.label === 'message',
-      'full-width transparent': ['result_started', 'submission'].includes(event.label)
-    }"
-  >
-    <div class="message">
-      <div class="name" *ngIf="!isMessageCreatedByCurrentUser && event.label === 'message'">
-        <strong>{{ event.createdBy }}</strong>
-      </div>
-      <div class="bubble">
-        <ng-container *ngIf="event.label === 'message'">
-          <div class="message-event">{{ event.data.content }}</div>
-        </ng-container>
-        <ng-container *ngIf="['result_started', 'submission'].includes(event.label)">
-          <div class="classical-event">
-            <span *ngIf="isMessageCreatedByCurrentUser; else anotherUser" i18n>
-              You
-            </span>
-            <ng-template #anotherUser>
-              {{ event.createdBy }}
-            </ng-template>
-            <span *ngIf="event.label === 'result_started'" i18n>started the activity</span>
-            <ng-container *ngIf="event.label === 'submission'">
-              <span i18n>submitted a solution</span>
-              <span class="scored-text" *ngIf="event.data.score !== undefined" i18n>
-                which scored <strong>{{ event.data.score }}</strong>
-              </span>.
-            </ng-container>
-          </div>
-          <div class="date">{{ event.time | date : 'short' }}</div>
-        </ng-container>
-      </div>
-      <div class="date" *ngIf="event.label === 'message'" i18n>Sent at {{ event.time | date : 'short' }}</div>
+<div
+  class="message-container"
+  [ngClass]="{
+    'left': !userInfo?.isThreadParticipant && event.label === 'message',
+    'right': userInfo?.isThreadParticipant && event.label === 'message',
+    'highlighted': userInfo?.isCurrentUser && event.label === 'message',
+    'full-width transparent': ['result_started', 'submission'].includes(event.label)
+  }"
+>
+  <div class="message">
+    <div class="name" *ngIf="!userInfo?.isCurrentUser && event.label === 'message'">
+      <strong>{{ userInfo?.name }}</strong>
     </div>
+    <div class="bubble">
+      <ng-container *ngIf="event.label === 'message'">
+        <div class="message-event">{{ event.data.content }}</div>
+      </ng-container>
+      <ng-container *ngIf="['result_started', 'submission'].includes(event.label)">
+        <div class="classical-event">
+          <span *ngIf="userInfo?.isCurrentUser; else anotherUser" i18n>
+            You
+          </span>
+          <ng-template #anotherUser>
+            {{ userInfo?.name }}
+          </ng-template>
+          <span *ngIf="event.label === 'result_started'" i18n>started the activity</span>
+          <ng-container *ngIf="event.label === 'submission'">
+            <span i18n>submitted a solution</span>
+            <span class="scored-text" *ngIf="event.data.score !== undefined" i18n>
+              which scored <strong>{{ event.data.score }}</strong>
+            </span>.
+          </ng-container>
+        </div>
+        <div class="date">{{ event.time | date : 'short' }}</div>
+      </ng-container>
+    </div>
+    <div class="date" *ngIf="event.label === 'message'" i18n>Sent at {{ event.time | date : 'short' }}</div>
   </div>
-</ng-container>
+</div>

--- a/src/app/modules/item/components/thread-message/thread-message.component.scss
+++ b/src/app/modules/item/components/thread-message/thread-message.component.scss
@@ -18,10 +18,19 @@
       text-align: right;
     }
     .bubble {
+      color: black;
+      background-color: var(--secondary-color);
       border-radius: 1.5rem .3rem 1.5rem 1.5rem;
     }
     .date {
       text-align: right;
+    }
+  }
+
+  &.highlighted {
+    .bubble {
+      color: var(--base-text-color);
+      background-color: #fff;
     }
   }
 
@@ -53,8 +62,6 @@
 .bubble {
   display: inline-block;
   padding: .2rem 1rem;
-  color: var(--base-text-color);
-  background-color: #fff;
   border-radius: 1.5rem;
 }
 

--- a/src/app/modules/item/components/thread-message/thread-message.component.ts
+++ b/src/app/modules/item/components/thread-message/thread-message.component.ts
@@ -1,33 +1,20 @@
-import { Component, Input, OnChanges, OnDestroy } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { IncomingThreadEvent } from '../../services/threads-inbound-events';
-import { UserSessionService } from '../../../../shared/services/user-session.service';
-import { ReplaySubject, combineLatest } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { UserInfo } from './thread-user-info';
 
 @Component({
   selector: 'alg-thread-message[event]',
   templateUrl: './thread-message.component.html',
   styleUrls: [ './thread-message.component.scss' ],
 })
-export class ThreadMessageComponent implements OnChanges, OnDestroy {
+export class ThreadMessageComponent implements OnChanges {
   @Input() event!: IncomingThreadEvent;
-
-  event$ = new ReplaySubject<IncomingThreadEvent>(1);
-  isMessageCreatedByCurrentUser$ = combineLatest([
-    this.userSessionService.userProfile$,
-    this.event$,
-  ]).pipe(
-    map(([ currentUser, event ]) => currentUser.groupId === event.createdBy),
-  );
-
-  constructor(private userSessionService: UserSessionService) {
-  }
+  @Input() userCache: UserInfo[] = [];
+  userInfo?: UserInfo & { name: string };
 
   ngOnChanges(): void {
-    this.event$.next(this.event);
+    const userInfo = this.userCache.find(user => user.id === this.event.createdBy);
+    this.userInfo = userInfo ? { ...userInfo, name: userInfo.name ?? $localize`An unknown user` } : undefined;
   }
 
-  ngOnDestroy(): void {
-    this.event$.complete();
-  }
 }

--- a/src/app/modules/item/components/thread-message/thread-user-info.ts
+++ b/src/app/modules/item/components/thread-message/thread-user-info.ts
@@ -1,0 +1,8 @@
+
+export interface UserInfo {
+  id: string,
+  isCurrentUser: boolean,
+  isThreadParticipant: boolean,
+  notVisibleUser: boolean,
+  name?: string,
+}

--- a/src/app/modules/item/components/thread/thread.component.html
+++ b/src/app/modules/item/components/thread/thread.component.html
@@ -7,12 +7,14 @@
   <ng-template #eventsBlock>
     <div class="widget-body">
       <div class="widget-scroll" #messagesScroll>
-        <alg-thread-message
-          class="thread-message"
-          [event]="event"
-          [userCache]="(userCache | async) || []"
-          *ngFor="let event of state.data"
-        ></alg-thread-message>
+        <ng-container *ngIf="((userCache$ | async) || []) as userCache">
+          <alg-thread-message
+            class="thread-message"
+            [event]="event"
+            [userCache]="userCache"
+            *ngFor="let event of state.data"
+          ></alg-thread-message>
+        </ng-container>
         <form class="footer-panel" [formGroup]="form" (ngSubmit)="sendMessage()">
           <textarea
             class="textarea"

--- a/src/app/modules/item/components/thread/thread.component.html
+++ b/src/app/modules/item/components/thread/thread.component.html
@@ -10,6 +10,7 @@
         <alg-thread-message
           class="thread-message"
           [event]="event"
+          [userCache]="(userCache | async) || []"
           *ngFor="let event of state.data"
         ></alg-thread-message>
         <form class="footer-panel" [formGroup]="form" (ngSubmit)="sendMessage()">

--- a/src/app/modules/item/components/thread/thread.component.ts
+++ b/src/app/modules/item/components/thread/thread.component.ts
@@ -27,7 +27,7 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
   readonly state$ = this.threadService.state$;
 
   private distinctUsersInThread = this.state$.pipe(
-    readyData(),
+    map(state => state.data ?? []), // if there is no data, consider there is no events
     map(events => events.map(e => e.createdBy)),
     scan((acc: string[], val) => [ ...new Set([ ...acc, ...val ]) ].sort() , []),
     startWith([]),

--- a/src/app/modules/item/components/thread/thread.component.ts
+++ b/src/app/modules/item/components/thread/thread.component.ts
@@ -33,7 +33,7 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
     startWith([]),
     distinctUntilChanged((prev, cur) => JSON.stringify(prev) === JSON.stringify(cur))
   );
-  readonly userCache = combineLatest([
+  readonly userCache$ = combineLatest([
     this.distinctUsersInThread,
     this.userSessionService.userProfile$,
     this.groupWatchingService.watchedGroup$

--- a/src/app/modules/item/components/thread/thread.component.ts
+++ b/src/app/modules/item/components/thread/thread.component.ts
@@ -5,7 +5,7 @@ import { readyData } from '../../../../shared/operators/state';
 import { Subscription, filter, delay, combineLatest, of } from 'rxjs';
 import { DiscussionService } from '../../services/discussion.service';
 import { isNotUndefined } from '../../../../shared/helpers/null-undefined-predicates';
-import { catchError, distinctUntilChanged, map, mergeScan, scan, shareReplay, startWith, withLatestFrom } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, map, mergeScan, scan, startWith, withLatestFrom } from 'rxjs/operators';
 import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
 import { formatUser } from 'src/app/shared/helpers/user';
@@ -54,7 +54,6 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
         catchError(() => of({ ...u, notVisibleUser: true })),
       );
     })), [] /* scan seed */, 1 /* no concurrency */),
-    shareReplay(1),
   );
 
   private subscription?: Subscription;

--- a/src/app/modules/item/components/thread/thread.component.ts
+++ b/src/app/modules/item/components/thread/thread.component.ts
@@ -2,10 +2,15 @@ import { AfterViewInit, Component, ElementRef, OnDestroy, ViewChild } from '@ang
 import { ThreadService } from '../../services/threads.service';
 import { FormBuilder } from '@angular/forms';
 import { readyData } from '../../../../shared/operators/state';
-import { Subscription, filter, delay } from 'rxjs';
+import { Subscription, filter, delay, combineLatest, of } from 'rxjs';
 import { DiscussionService } from '../../services/discussion.service';
 import { isNotUndefined } from '../../../../shared/helpers/null-undefined-predicates';
-import { withLatestFrom } from 'rxjs/operators';
+import { catchError, distinctUntilChanged, map, mergeScan, scan, shareReplay, startWith, withLatestFrom } from 'rxjs/operators';
+import { UserSessionService } from 'src/app/shared/services/user-session.service';
+import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
+import { formatUser } from 'src/app/shared/helpers/user';
+import { GetUserService } from 'src/app/modules/group/http-services/get-user.service';
+import { UserInfo } from '../thread-message/thread-user-info';
 
 @Component({
   selector: 'alg-thread',
@@ -19,13 +24,47 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
     messageToSend: [ '' ],
   });
 
-  state$ = this.threadService.state$;
+  readonly state$ = this.threadService.state$;
+
+  private distinctUsersInThread = this.state$.pipe(
+    readyData(),
+    map(events => events.map(e => e.createdBy)),
+    scan((acc: string[], val) => [ ...new Set([ ...acc, ...val ]) ].sort() , []),
+    startWith([]),
+    distinctUntilChanged((prev, cur) => JSON.stringify(prev) === JSON.stringify(cur))
+  );
+  readonly userCache = combineLatest([
+    this.distinctUsersInThread,
+    this.userSessionService.userProfile$,
+    this.groupWatchingService.watchedGroup$
+  ]).pipe(
+    map(([ users, currentUser, watchedGroup ]) => users.map(id => ({
+      id,
+      isCurrentUser: id === currentUser.groupId,
+      isThreadParticipant: id === watchedGroup?.route.id || (!watchedGroup && id === currentUser.groupId),
+      name: id === currentUser.groupId ? formatUser(currentUser) : id === watchedGroup?.route.id ? watchedGroup.name : undefined,
+    }))),
+    mergeScan((acc: UserInfo[], users) => combineLatest(users.map(u => {
+      if (u.name !== undefined) return of({ ...u, notVisibleUser: false });
+      const lookup = acc.find(user => user.id === u.id);
+      if (lookup?.name !== undefined || lookup?.notVisibleUser) return of(lookup);
+      return this.userService.getForId(u.id).pipe(
+        map(user => ({ ...u, notVisibleUser: false, name: formatUser(user) })),
+        startWith({ ...u, notVisibleUser: false }),
+        catchError(() => of({ ...u, notVisibleUser: true })),
+      );
+    })), [] /* scan seed */, 1 /* no concurrency */),
+    shareReplay(1),
+  );
 
   private subscription?: Subscription;
 
   constructor(
     private threadService: ThreadService,
     private discussionService: DiscussionService,
+    private userSessionService: UserSessionService,
+    private groupWatchingService: GroupWatchingService,
+    private userService: GetUserService,
     private fb: FormBuilder,
   ) {}
 

--- a/src/app/modules/item/services/threads.service.ts
+++ b/src/app/modules/item/services/threads.service.ts
@@ -86,6 +86,7 @@ export class ThreadService implements OnDestroy {
     this.threadSub?.unsubscribe(); // stop sending subscribes on ws open
     // send 'unsubscribe' only if the ws is open
     if (this.tokenData) this.forumService.isWsOpen$.pipe(take(1), filter(open => open)).subscribe(() => this.send(UNSUBSCRIBE));
+    this.clearEvents$.next();
     this.tokenData = undefined;
   }
 

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -18,7 +18,7 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">271</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">127</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">271</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">129</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
         <source>Language mismatch</source><target state="translated">Mauvaise langue?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/language-mismatch/language-mismatch.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="6895619751331935307" datatype="html">
@@ -488,7 +488,7 @@
         <source>An unknown error occurred. </source><target state="translated">Une erreur est survenue. </target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">270</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">126</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">270</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="8679237608788920660" datatype="html">
@@ -522,28 +522,28 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">77</context></context-group></trans-unit><trans-unit id="7005243353550317116" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
         <source>You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.</source><target state="new">You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">117</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
         <source>An unknown error occurred while publishing your result</source><target state="new">An unknown error occurred while publishing your result</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">118</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">120</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
         <source>Hint request failed</source><target state="new">Hint request failed</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">123</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">125</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
         <source>Solve</source><target state="new">Solve</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">174</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">176</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="new">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">175</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">177</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">176</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">178</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">120</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">74</context></context-group></trans-unit><trans-unit id="2738733136413289671" datatype="html">
@@ -693,10 +693,10 @@
       </trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">178</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">180</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
         <source>Statement</source><target state="new">Statement</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">179</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">181</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -966,28 +966,28 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">52</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
         <source>Edit content</source><target state="new">Edit content</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
         <source> You do not have the permissions to edit this content. </source><target state="new"> You do not have the permissions to edit this content. </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit-form/item-children-edit-form.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
         <source> This activity has not been correctly configured. </source><target state="new"> This activity has not been correctly configured. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">71</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
         <source> You need to set a url in editing mode. </source><target state="new"> You need to set a url in editing mode. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">65</context></context-group></trans-unit><trans-unit id="9152383970834327178" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">74</context></context-group></trans-unit><trans-unit id="9152383970834327178" datatype="html">
         <source> Your current access rights do not allow you to list the content of this chapter. </source><target state="new"> Your current access rights do not allow you to list the content of this chapter. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="6557565374286675560" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="6557565374286675560" datatype="html">
         <source> Your current access rights do not allow you to list the content of this skill. </source><target state="new"> Your current access rights do not allow you to list the content of this skill. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="8944765970586595001" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="8944765970586595001" datatype="html">
         <source> Your current access rights do not allow you to start the activity. </source><target state="new"> Your current access rights do not allow you to start the activity. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="6198202441206570236" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">93</context></context-group></trans-unit><trans-unit id="6198202441206570236" datatype="html">
         <source>This activity requires explicit entry</source><target state="new">This activity requires explicit entry</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">108</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
         <source>(not implemented)</source><target state="new">(not implemented)</target>
 
 
@@ -995,10 +995,10 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">100</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">181</context></context-group></trans-unit><trans-unit id="8227500063765912187" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">109</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">181</context></context-group></trans-unit><trans-unit id="8227500063765912187" datatype="html">
         <source>Starting the activity</source><target state="new">Starting the activity</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">114</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
@@ -1518,28 +1518,31 @@
           <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context>
           <context context-type="linenumber">20,22</context>
         </context-group>
+      </trans-unit><trans-unit id="3033931349682055221" datatype="html">
+        <source> The user </source><target state="new"> The user </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context>
+          <context context-type="linenumber">24,26</context>
+        </context-group>
       </trans-unit><trans-unit id="6769997291593114032" datatype="html">
         <source>started the activity</source><target state="new">started the activity</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context>
-          <context context-type="linenumber">26</context>
-        </context-group>
-      </trans-unit><trans-unit id="4202564758883774190" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">33</context></context-group></trans-unit><trans-unit id="4202564758883774190" datatype="html">
         <source>submitted a solution</source><target state="new">submitted a solution</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context>
-          <context context-type="linenumber">28</context>
-        </context-group>
-      </trans-unit><trans-unit id="6891776217114642276" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="6891776217114642276" datatype="html">
         <source> which scored <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{ event.data.score }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></source><target state="new"> which scored <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{ event.data.score }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context>
-          <context context-type="linenumber">29,30</context>
-        </context-group>
-      </trans-unit><trans-unit id="5078919999921089039" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="5078919999921089039" datatype="html">
         <source>Sent at <x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></source><target state="new">Sent at <x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">44</context></context-group></trans-unit><trans-unit id="4672292365306876208" datatype="html">
+        <source>An unknown user</source><target state="new">An unknown user</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.ts</context>
+          <context context-type="linenumber">17</context>
+        </context-group>
+      </trans-unit><trans-unit id="4902361762285353004" datatype="html">
         <source>Error while loading this chapter's children</source><target state="translated">Erreur lors du chargement des enfants de ce chapitre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="7143643956716496978" datatype="html">
@@ -1583,7 +1586,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">65</context></context-group></trans-unit><trans-unit id="2577694282301310795" datatype="html">
         <source>Solution</source><target state="translated">Solution</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">19</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">177</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">19</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">179</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
@@ -2124,7 +2127,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="4902817035128594900" datatype="html">
         <source>Description</source><target state="translated">Description</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">26</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-content/item-edit-content.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="5521027790445234919" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">26</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">6</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-content/item-edit-content.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="5521027790445234919" datatype="html">
         <source>Unable to load the recent activity</source><target state="translated">Erreur lors du chargement les activités récentes</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">15</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="8115085152478832979" datatype="html">


### PR DESCRIPTION
## Description

Add missing user information in the forum threads.

### Changes: 

* Use "The user  submitted a solution which ..." instead of repeating the user name each time

* Implement the fetching of missing user info  + adding metadata whether the user is the current user and is the watched user

* Bubble:
  - The trainee's messages are always on the right. They are white if we are this user, orange if we are watched.
  - The trainer's messages are always on the left. They are white if you are the user, light blue if not (another trainer).

* Do not use Rx in the thread message component anymore

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this task](https://dev.algorea.org/branch/forum-bind-user/en/activities/by-id/6379723280369399253;path=;parentAttempId=0?watchedGroupId=752024252804317630&watchUser=1)
  3. And I open the thread 
  5. Then I see the trainee's messages on the right in orange
  6. And I see my messages on the left in white
  7. And I see the other's messages on the left in blue/transparent

- [ ] Case 2:
  1. Given I am the demo user 
  2. When I go to [this same task](https://dev.algorea.org/branch/forum-bind-user/en/activities/by-id/6379723280369399253;path=;parentAttempId=0)
  3. And I open the thread 
  6. And I see my messages on the right in white
  7. And I see the other's messages on the left in blue/transparent

