### PR TITLE
disable ts checks which are inconvenient for dev ('ng serve' failing) and are done by eslint anyway

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,8 +28,6 @@
     // compiler linter checks
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
 
     // "strict" enables all strict type checking option


### PR DESCRIPTION
disable ts checks which are inconvenient for dev ('ng serve' failing) and are done by eslint anyway

I am bored by compilation failure because of unused import while developing (you put a block of code in comments, but then you first have to fix the import before testing)

cc @Iloveall 