### PR TITLE
fix: show score in collapsed-mode top bar when available

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -5,14 +5,15 @@
     <alg-breadcrumb [contentBreadcrumb]="currentContent?.breadcrumbs"></alg-breadcrumb>
   </div>
   <div class="full-frame-content-top-bar" *ngIf="fullFrameContent?.active || scrolled">
-    <ng-container *ngIf="currentContent.score">
+    <div class="score-placeholder">
       <alg-score-ring
-        [bestScore]="currentContent.score.bestScore"
-        [currentScore]="currentContent.score.currentScore"
-        [isValidated]="currentContent.score.isValidated"
+        *ngIf="currentContent.type === 'item' && $any(currentContent).details && $any(currentContent).details.bestScore !== undefined && $any(currentContent).details.currentScore !== undefined && $any(currentContent).details.validated !== undefined"
+        [bestScore]="$any(currentContent).details.bestScore"
+        [currentScore]="$any(currentContent).details.currentScore"
+        [isValidated]="$any(currentContent).details.validated"
         [diameter]="34"
       ></alg-score-ring>
-    </ng-container>
+    </div>
     <div class="right-pane-title">
       <p *ngIf="currentContent && currentContent.title">{{ currentContent.title }}</p>
     </div>

--- a/src/app/core/components/content-top-bar/content-top-bar.component.scss
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.scss
@@ -52,3 +52,7 @@
 .margin-right {
   margin-right: 1rem;
 }
+
+.score-placeholder {
+  width: 2.85rem;
+}

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.html
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.html
@@ -151,7 +151,7 @@
           <alg-item-edit-wrapper [itemData]="itemData"></alg-item-edit-wrapper>
         </ng-container>
       </div>
-      <alg-thread-container [topCompensation]="contentContainer.offsetTop" *ngIf="showItemThreadWidget"></alg-thread-container>
+      <alg-thread-container [topCompensation]="contentContainerTop" *ngIf="showItemThreadWidget"></alg-thread-container>
     </ng-container>
 
   </ng-container>


### PR DESCRIPTION
The score was not displayed anymore in the top bar when left-menu is collapsed.

Still TODO:  Fix the `ExpressionChangedAfterItHasBeenCheckedError: Expression has changed after it was checked.` error

Scenario:

- as the usual user
- I go on the [home page](https://dev.algorea.org/branch/fix-score-in-top-bar/)
- and I collapse the left menu
- I should see the score in the top bar
- And if I navigate to other item, there is no jump in the top bar when the score is known, thanks to the placeholder.
