### PR TITLE
Forum: allow loading answers 

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -24,7 +24,7 @@
       pButton
       type="button"
       icon="pi pi-comments"
-      (click)="toggleThread()"
+      (click)="toggleThreadVisibility(!discussion.visible)"
     ></button>
     <alg-neighbor-widget
       class="neighbor-widget"

--- a/src/app/core/components/content-top-bar/content-top-bar.component.ts
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.ts
@@ -53,8 +53,8 @@ export class ContentTopBarComponent {
     private discussionService: DiscussionService
   ) {}
 
-  toggleThread(): void {
-    this.discussionService.toggleVisibility();
+  toggleThreadVisibility(visible: boolean): void {
+    this.discussionService.toggleVisibility(visible);
   }
 
 }

--- a/src/app/modules/item/components/item-header/item-header.component.html
+++ b/src/app/modules/item/components/item-header/item-header.component.html
@@ -35,7 +35,7 @@
       pButton
       type="button"
       icon="pi pi-comments"
-      (click)="toggleThread()"
+      (click)="toggleThreadVisibility(!discussion.visible)"
     ></button>
     <alg-page-navigator
       *ngIf="navigationNeighbors$ | async as navigationNeighbors"

--- a/src/app/modules/item/components/item-header/item-header.component.ts
+++ b/src/app/modules/item/components/item-header/item-header.component.ts
@@ -28,8 +28,8 @@ export class ItemHeaderComponent implements OnChanges {
     this.navigationNeighbors$ = isASkill(this.itemData.item) ? this.skillNavigationNeighbors$ : this.activityNavigationNeighbors$;
   }
 
-  toggleThread(): void {
-    this.discussionService.toggleVisibility();
+  toggleThreadVisibility(visible: boolean): void {
+    this.discussionService.toggleVisibility(visible);
   }
 
 }

--- a/src/app/modules/item/components/thread-message/thread-message.component.html
+++ b/src/app/modules/item/components/thread-message/thread-message.component.html
@@ -36,6 +36,9 @@
             <span class="scored-text" *ngIf="event.data.score !== undefined" i18n>
               which scored <strong>{{ event.data.score }}</strong>
             </span>.
+            <ng-container *ngIf="canCurrentUserLoadAnswers && itemRoute">
+              <a [routerLink]="itemRoute | itemRouteLink:[]:event.data.answerId" i18n>Load this submission</a>
+            </ng-container>
           </ng-container>
         </div>
         <div class="date">{{ event.time | date : 'short' }}</div>

--- a/src/app/modules/item/components/thread-message/thread-message.component.html
+++ b/src/app/modules/item/components/thread-message/thread-message.component.html
@@ -37,7 +37,11 @@
               which scored <strong>{{ event.data.score }}</strong>
             </span>.
             <ng-container *ngIf="canCurrentUserLoadAnswers && itemRoute">
-              <a [routerLink]="itemRoute | itemRouteLink:[]:event.data.answerId" i18n>Load this submission</a>
+              <div>
+                <a class="alg-link white-color hover-underline" [routerLink]="itemRoute | itemRouteLink:[]:event.data.answerId" i18n>
+                  <strong>Load this submission</strong>
+                </a>
+              </div>
             </ng-container>
           </ng-container>
         </div>

--- a/src/app/modules/item/components/thread-message/thread-message.component.ts
+++ b/src/app/modules/item/components/thread-message/thread-message.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnChanges } from '@angular/core';
+import { RawItemRoute } from 'src/app/shared/routing/item-route';
 import { IncomingThreadEvent } from '../../services/threads-inbound-events';
 import { UserInfo } from './thread-user-info';
 
@@ -10,6 +11,8 @@ import { UserInfo } from './thread-user-info';
 export class ThreadMessageComponent implements OnChanges {
   @Input() event!: IncomingThreadEvent;
   @Input() userCache: UserInfo[] = [];
+  @Input() canCurrentUserLoadAnswers = false;
+  @Input() itemRoute?: RawItemRoute;
   userInfo?: UserInfo & { name: string };
 
   ngOnChanges(): void {

--- a/src/app/modules/item/components/thread/thread.component.html
+++ b/src/app/modules/item/components/thread/thread.component.html
@@ -7,11 +7,13 @@
   <ng-template #eventsBlock>
     <div class="widget-body">
       <div class="widget-scroll" #messagesScroll>
-        <ng-container *ngIf="((userCache$ | async) || []) as userCache">
+        <ng-container *ngIf="{ userCache: userCache$ | async, canCurrentUserLoadAnswers: canCurrentUserLoadAnswers$ | async, itemRoute: itemRoute$ | async } as threadMetadata">
           <alg-thread-message
             class="thread-message"
             [event]="event"
-            [userCache]="userCache"
+            [userCache]="threadMetadata.userCache ?? []"
+            [canCurrentUserLoadAnswers]="threadMetadata.canCurrentUserLoadAnswers ?? false"
+            [itemRoute]="threadMetadata.itemRoute ?? undefined"
             *ngFor="let event of state.data"
           ></alg-thread-message>
         </ng-container>

--- a/src/app/modules/item/components/thread/thread.component.ts
+++ b/src/app/modules/item/components/thread/thread.component.ts
@@ -11,6 +11,7 @@ import { GroupWatchingService } from 'src/app/core/services/group-watching.servi
 import { formatUser } from 'src/app/shared/helpers/user';
 import { GetUserService } from 'src/app/modules/group/http-services/get-user.service';
 import { UserInfo } from '../thread-message/thread-user-info';
+import { allowsWatchingAnswers } from 'src/app/shared/models/domain/item-watch-permission';
 
 @Component({
   selector: 'alg-thread',
@@ -54,6 +55,18 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
         catchError(() => of({ ...u, notVisibleUser: true })),
       );
     })), [] /* scan seed */, 1 /* no concurrency */),
+  );
+  private threadInfo$ = this.state$.pipe(
+    map(() => this.threadService.threadInfo),
+    distinctUntilChanged(),
+  );
+
+  readonly canCurrentUserLoadAnswers$ = this.threadInfo$.pipe(
+    map(t => !!t && (t.currentUserId === t.participant.id || allowsWatchingAnswers(t.contentWatchPermission)),
+    )
+  );
+  readonly itemRoute$ = this.threadInfo$.pipe(
+    map(t => t?.itemRoute),
   );
 
   private subscription?: Subscription;

--- a/src/app/modules/item/components/thread/thread.component.ts
+++ b/src/app/modules/item/components/thread/thread.component.ts
@@ -25,7 +25,7 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
     messageToSend: [ '' ],
   });
 
-  readonly state$ = this.threadService.state$;
+  readonly state$ = this.threadService.eventsState$;
 
   private distinctUsersInThread = this.state$.pipe(
     map(state => state.data ?? []), // if there is no data, consider there is no events
@@ -56,16 +56,11 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
       );
     })), [] /* scan seed */, 1 /* no concurrency */),
   );
-  private threadInfo$ = this.state$.pipe(
-    map(() => this.threadService.threadInfo),
-    distinctUntilChanged(),
-  );
-
-  readonly canCurrentUserLoadAnswers$ = this.threadInfo$.pipe(
+  readonly canCurrentUserLoadAnswers$ = this.threadService.threadInfo$.pipe(
     map(t => !!t && (t.currentUserId === t.participant.id || allowsWatchingAnswers(t.contentWatchPermission)),
     )
   );
-  readonly itemRoute$ = this.threadInfo$.pipe(
+  readonly itemRoute$ = this.threadService.threadInfo$.pipe(
     map(t => t?.itemRoute),
   );
 

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -65,7 +65,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy {
 
   private getData$(item: Item, watchingGroup: WatchedGroup|null): Observable<Data> {
     return combineLatest([
-      this.activityLogService.getActivityLog(item.id, watchingGroup?.route.id),
+      this.activityLogService.getActivityLog(item.id, { watchedGroupId: watchingGroup?.route.id }),
       this.sessionService.userProfile$,
     ]).pipe(
       map(([ data, profile ]) => ({

--- a/src/app/modules/item/services/discussion.service.ts
+++ b/src/app/modules/item/services/discussion.service.ts
@@ -1,32 +1,8 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, Injector, OnDestroy } from '@angular/core';
-import {
-  BehaviorSubject,
-  combineLatest,
-  combineLatestWith,
-  debounceTime,
-  distinctUntilChanged,
-  EMPTY,
-  filter,
-  fromEvent,
-  map,
-  pairwise,
-  shareReplay,
-  startWith,
-  Subscription,
-  switchMap,
-  take,
-} from 'rxjs';
-import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
+import { combineLatestWith, EMPTY, filter, map, merge, Observable, of, Subject, Subscription, switchMap, take, } from 'rxjs';
 import { appConfig } from 'src/app/shared/helpers/config';
-import { isATask } from 'src/app/shared/helpers/item-type';
-import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
-import { formatUser } from 'src/app/shared/helpers/user';
-import { isItemInfo } from 'src/app/shared/models/content/item-info';
-import { allowsWatchingResults } from 'src/app/shared/models/domain/item-watch-permission';
 import { readyData } from 'src/app/shared/operators/state';
-import { CurrentContentService } from 'src/app/shared/services/current-content.service';
-import { UserSessionService } from 'src/app/shared/services/user-session.service';
 import { ThreadService } from './threads.service';
 
 /**
@@ -39,89 +15,52 @@ export class DiscussionService implements OnDestroy {
 
   private readonly enabled = !!appConfig.forumServerUrl;
 
-  private visible = new BehaviorSubject<boolean>(false);
+  private manualVisibilityToggle = new Subject<boolean>();
 
   private readonly threadService?: ThreadService; // only injected if forum is enabled
-
-  private threadInfo$ = combineLatest([
-    this.userSessionService.userProfile$,
-    this.currentContentService.content$,
-    this.groupWatchingService.watchedGroup$,
-    fromEvent(window, 'beforeunload').pipe(map(() => true), startWith(false)),
-  ]).pipe(
-    debounceTime(0), // as the source are not independant, prevent some very-transient inconsistent cases
-    map(([ session, content, watching, unloading ]) => {
-      // window is unloading -> no thread anymore
-      if (unloading) return undefined;
-      // only tasks
-      if (!isItemInfo(content) || !content.details || !isATask(content.details)) return undefined;
-      // only non temp users
-      if (session.tempUser) return undefined;
-      // if watching, only for users (not group) and for content we can watch
-      if (watching && (!watching.route.isUser || !allowsWatchingResults(content.details.permissions))) return undefined;
-      return {
-        participant: {
-          id: watching ? watching.route.id : session.groupId,
-          name: watching ? watching.name : formatUser(session),
-        },
-        currentUserId: session.groupId,
-        itemRoute: content.route,
-        canWatchParticipant: !!watching,
-        contentWatchPermission: content.details.permissions,
-      };
-    }),
-    startWith(undefined),
-    distinctUntilChanged((x, y) => JSON.stringify(x) === JSON.stringify(y)),
-    shareReplay(1),
-  );
 
   /**
     * Whether a thread is currently available (i.e., enabled at app level + allowed for the current page) and
     * visible (i.e., currently shown) for this page.
     * Emit `undefined` if not available, `{ visible: boolean }` otherwise.
     */
-  state$ = combineLatest([ this.visible, this.threadInfo$.pipe(map(isNotUndefined)) ]).pipe(
-    map(([ visible, hasThread ]) => (this.enabled && hasThread ? { visible } : undefined)));
+  state$: Observable<{ visible: boolean }|undefined>; // set in constructor when the threadService has been injected
 
   /**
    * When a thread is available but currently not visible, the number of events that arrive since the thread was last opened in this session
    */
-  unreadCount$ = this.visible.pipe(
-    map(visible => (visible ? Number.MAX_SAFE_INTEGER : Date.now())),
-    combineLatestWith(this.threadService?.state$ ?? EMPTY),
-    map(([ lastOpen, state ]) => {
-      if (lastOpen === Number.MAX_SAFE_INTEGER || !state.isReady) return 0;
-      return state.data.filter(e => e.time.valueOf() > lastOpen).length;
-    })
-  );
-
+  unreadCount$: Observable<number>; // set in constructor when the threadService has been injected
 
   private subscriptions = new Subscription();
 
   constructor(
     private injector : Injector,
-    private userSessionService: UserSessionService,
-    private currentContentService: CurrentContentService,
-    private groupWatchingService: GroupWatchingService,
   ) {
-    if (!this.enabled) return;
+    if (!this.enabled) {
+      this.state$ = of(undefined);
+      this.unreadCount$ = EMPTY;
+      return;
+    }
 
     this.threadService = this.injector.get<ThreadService>(ThreadService);
 
-    this.subscriptions.add(
-      this.threadInfo$.pipe(pairwise()).subscribe(
-        ([ prevTokenData, thread ]) => {
-          this.toggleVisibility(false); // always hide the previous discussion on thread change
-          if (prevTokenData) this.threadService?.leaveThread();
-          if (thread) this.threadService?.setThread(thread);
-        }
-      )
+    this.state$ = merge(
+      this.manualVisibilityToggle.pipe(map(visible => ({ visible }))),
+      this.threadService.threadInfo$.pipe(map(info => (info ? { visible: false } : undefined)))
     );
-
+    this.unreadCount$ = this.state$.pipe(
+      // when hidden (manually or because thread changes), store the current time as the last read time
+      map(state => (state && !state.visible ? Date.now() : Number.MAX_SAFE_INTEGER)),
+      combineLatestWith(this.threadService.eventsState$ ?? EMPTY),
+      map(([ lastOpen, state ]) => {
+        if (lastOpen === Number.MAX_SAFE_INTEGER || !state.isReady) return 0;
+        return state.data.filter(e => e.time.valueOf() > lastOpen).length;
+      })
+    );
     this.subscriptions.add(
-      this.visible.pipe(
-        filter(v => v), // each time a discussion becomes visible
-        switchMap(() => this.threadService?.state$.pipe(readyData(), take(1)) ?? EMPTY), // take the next ready data
+      this.state$.pipe(
+        filter(state => !!state && state.visible), // each time a discussion becomes visible
+        switchMap(() => this.threadService?.eventsState$.pipe(readyData(), take(1)) ?? EMPTY), // take the next ready data
         filter(events => events.length === 0), // if there were no event in the list
         switchMap(() => this.threadService?.syncEvents() ?? EMPTY), // resync the event log with the server
       ).subscribe({
@@ -134,11 +73,11 @@ export class DiscussionService implements OnDestroy {
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
-    this.visible.complete();
+    this.manualVisibilityToggle.complete();
   }
 
-  toggleVisibility(visible?: boolean): void {
-    if (visible === undefined || this.visible.value !== visible) this.visible.next(!this.visible.value);
+  toggleVisibility(visible: boolean): void {
+    this.manualVisibilityToggle.next(visible);
   }
 
   resyncEventLog(): void {

--- a/src/app/modules/item/services/discussion.service.ts
+++ b/src/app/modules/item/services/discussion.service.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, Injector, OnDestroy } from '@angular/core';
-import { combineLatestWith, EMPTY, filter, map, merge, Observable, of, Subject, Subscription, switchMap, take, } from 'rxjs';
+import { combineLatestWith, EMPTY, filter, map, merge, Observable, of, shareReplay, Subject, Subscription, switchMap, take } from 'rxjs';
 import { appConfig } from 'src/app/shared/helpers/config';
 import { readyData } from 'src/app/shared/operators/state';
 import { ThreadService } from './threads.service';
@@ -47,7 +47,7 @@ export class DiscussionService implements OnDestroy {
     this.state$ = merge(
       this.manualVisibilityToggle.pipe(map(visible => ({ visible }))),
       this.threadService.threadInfo$.pipe(map(info => (info ? { visible: false } : undefined)))
-    );
+    ).pipe(shareReplay(1)); // keep the last value for latecomers
     this.unreadCount$ = this.state$.pipe(
       // when hidden (manually or because thread changes), store the current time as the last read time
       map(state => (state && !state.visible ? Date.now() : Number.MAX_SAFE_INTEGER)),

--- a/src/app/modules/item/services/threads-outbound-actions.ts
+++ b/src/app/modules/item/services/threads-outbound-actions.ts
@@ -1,13 +1,25 @@
 import { ThreadEvent } from './threads-events';
 
-export type ThreadAction =
-  | typeof UNSUBSCRIBE
-  | typeof SUBSCRIBE
-  | { action: 'publish', events: (ThreadEvent & { time?: number })[] };
+export interface ThreadToken {
+  participantId: string,
+  itemId: string,
+  userId: string,
+  isMine: boolean,
+  canWatchParticipant: boolean,
+}
 
-export const UNSUBSCRIBE = { action: 'unsubscribe' as const };
-export const SUBSCRIBE = { action: 'subscribe' as const };
+export type ThreadAction = (
+  | { action: 'unsubscribe' }
+  | { action: 'subscribe' }
+  | { action: 'publish', events: (ThreadEvent & { time?: number })[] }
+) & { token: ThreadToken };
 
-export function publishEventsAction(events: (ThreadEvent & { time?: number })[]): ThreadAction {
-  return { action: 'publish', events: events };
+export function unsubscribeAction(token: ThreadToken): ThreadAction {
+  return { action: 'unsubscribe', token };
+}
+export function subscribeAction(token: ThreadToken): ThreadAction {
+  return { action: 'subscribe', token };
+}
+export function publishEventsAction(token: ThreadToken, events: (ThreadEvent & { time?: number })[]): ThreadAction {
+  return { action: 'publish', events: events, token };
 }

--- a/src/app/modules/item/services/threads.service.ts
+++ b/src/app/modules/item/services/threads.service.ts
@@ -151,7 +151,7 @@ export class ThreadService implements OnDestroy {
         watchedGroupId: t.participant.id === t.currentUserId ? undefined : t.participant.id,
         token: threadInfoToToken(t),
       })),
-      switchMap(({ itemId, watchedGroupId, token }) => this.activityLogService.getActivityLog(itemId, watchedGroupId).pipe(
+      switchMap(({ itemId, watchedGroupId, token }) => this.activityLogService.getActivityLog(itemId, { watchedGroupId, limit: 100 }).pipe(
         map(log => log.map(e => {
           switch (e.activityType) {
             case 'result_started': return { label: 'result_started' as const, time: e.at.valueOf(), data: { attemptId: e.attemptId } };

--- a/src/app/modules/item/services/threads.service.ts
+++ b/src/app/modules/item/services/threads.service.ts
@@ -3,28 +3,39 @@ import * as D from 'io-ts/Decoder';
 import { decode, decodeOrNull } from 'src/app/shared/helpers/decoders';
 import {
   catchError,
+  combineLatest,
+  concat,
+  debounceTime,
+  distinctUntilChanged,
   EMPTY,
   filter,
+  fromEvent,
   map,
   Observable,
+  pairwise,
   ReplaySubject,
   scan,
   shareReplay,
   startWith,
-  SubscriptionLike,
   switchMap,
   take,
   tap
 } from 'rxjs';
 import { ActivityLogService } from 'src/app/shared/http-services/activity-log.service';
-import { isNotNull } from 'src/app/shared/helpers/null-undefined-predicates';
+import { isNotNull, isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { ForumService } from './forum.service';
-import { publishEventsAction, SUBSCRIBE, ThreadAction, UNSUBSCRIBE } from './threads-outbound-actions';
+import { publishEventsAction, subscribeAction, ThreadToken, unsubscribeAction } from './threads-outbound-actions';
 import { mapToFetchState } from 'src/app/shared/operators/state';
 import { messageEvent } from './threads-events';
 import { IncomingThreadEvent, incomingThreadEventDecoder } from './threads-inbound-events';
-import { ItemPermWithWatch } from 'src/app/shared/models/domain/item-watch-permission';
+import { allowsWatchingResults, ItemPermWithWatch } from 'src/app/shared/models/domain/item-watch-permission';
 import { RawItemRoute } from 'src/app/shared/routing/item-route';
+import { isItemInfo } from 'src/app/shared/models/content/item-info';
+import { isATask } from 'src/app/shared/helpers/item-type';
+import { UserSessionService } from 'src/app/shared/services/user-session.service';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
+import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
+import { formatUser } from 'src/app/shared/helpers/user';
 
 interface ThreadInfo {
   participant: {
@@ -37,15 +48,67 @@ interface ThreadInfo {
   contentWatchPermission: ItemPermWithWatch,
 }
 
+function threadInfoToToken(t: ThreadInfo): ThreadToken {
+  return {
+    participantId: t.participant.id,
+    itemId: t.itemRoute.id,
+    userId: t.currentUserId,
+    isMine: t.participant.id === t.currentUserId,
+    canWatchParticipant: t.canWatchParticipant,
+  };
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class ThreadService implements OnDestroy {
 
   private clearEvents$ = new ReplaySubject<void>(1);
-  threadInfo?: ThreadInfo;
 
-  private threadSub?: SubscriptionLike;
+  threadInfo$ = combineLatest([
+    this.userSessionService.userProfile$,
+    this.currentContentService.content$,
+    this.groupWatchingService.watchedGroup$,
+    fromEvent(window, 'beforeunload').pipe(map(() => true), startWith(false)),
+  ]).pipe(
+    debounceTime(0), // as the source are not independant, prevent some very-transient inconsistent cases
+    map(([ session, content, watching, unloading ]) => {
+      // window is unloading -> no thread anymore
+      if (unloading) return undefined;
+      // only tasks
+      if (!isItemInfo(content) || !content.details || !isATask(content.details)) return undefined;
+      // only non temp users
+      if (session.tempUser) return undefined;
+      // if watching, only for users (not group) and for content we can watch
+      if (watching && (!watching.route.isUser || !allowsWatchingResults(content.details.permissions))) return undefined;
+      return {
+        participant: {
+          id: watching ? watching.route.id : session.groupId,
+          name: watching ? watching.name : formatUser(session),
+        },
+        currentUserId: session.groupId,
+        itemRoute: content.route,
+        canWatchParticipant: !!watching,
+        contentWatchPermission: content.details.permissions,
+      };
+    }),
+    startWith(undefined),
+    distinctUntilChanged((x, y) => JSON.stringify(x) === JSON.stringify(y)),
+    shareReplay(1),
+  );
+  private threadSubscriptionSub = this.threadInfo$.pipe(
+    map(t => (t ? threadInfoToToken(t) : undefined)),
+    pairwise(),
+    switchMap(([ prevToken, newToken ]) => concat(...[
+      // if there was a thread before: if the WS connection is open, emit unsubscribe once
+      ...(prevToken ? [ this.forumService.isWsOpen$.pipe(take(1), filter(open => open), map(() => unsubscribeAction(prevToken))) ] : []),
+      // if there is a new thread: each time the WS reopen, send a subscribe
+      ...(newToken ? [ this.forumService.isWsOpen$.pipe(filter(open => open), map(() => subscribeAction(newToken))) ] : [])
+    ])),
+  ).subscribe(msg => {
+    this.clearEvents$.next();
+    this.forumService.send(msg); // send the subscribe or unsubscribe
+  });
 
   private incomingEvents$: Observable<IncomingThreadEvent[]> = this.forumService.inputMessages$.pipe(
     // if the incoming message is not array, just ignore it. Otherwise return a list of messages which we were able to decode as events
@@ -53,7 +116,7 @@ export class ThreadService implements OnDestroy {
     catchError(() => EMPTY), // ignore undecoded messages
   );
 
-  state$ = this.clearEvents$.pipe(
+  eventsState$ = this.clearEvents$.pipe(
     startWith(undefined),
     switchMap(() => this.incomingEvents$.pipe(
       scan((acc, newEvents) => [ ...acc, ...newEvents ]),
@@ -69,71 +132,53 @@ export class ThreadService implements OnDestroy {
   constructor(
     private forumService: ForumService,
     private activityLogService: ActivityLogService,
+    private userSessionService: UserSessionService,
+    private currentContentService: CurrentContentService,
+    private groupWatchingService: GroupWatchingService,
   ) {}
 
   ngOnDestroy(): void {
     this.clearEvents$.complete();
-    this.threadSub?.unsubscribe();
-  }
-
-  setThread(threadInfo: ThreadInfo): void {
-    if (this.threadInfo) throw new Error('"leaveThread" should be called before setThread when changing thread');
-    if (this.threadSub && !this.threadSub.closed) throw new Error('unexpected: threadSub has not been closed');
-    this.threadInfo = threadInfo;
-    // send 'subscribe' each time the ws is reopened
-    this.threadSub = this.forumService.isWsOpen$.pipe(filter(open => open)).subscribe(() => {
-      this.clearEvents$.next();
-      this.send(SUBSCRIBE);
-    });
-  }
-
-  leaveThread(): void {
-    this.threadSub?.unsubscribe(); // stop sending subscribes on ws open
-    // send 'unsubscribe' only if the ws is open
-    if (this.threadInfo) this.forumService.isWsOpen$.pipe(take(1), filter(open => open)).subscribe(() => this.send(UNSUBSCRIBE));
-    this.clearEvents$.next();
-    this.threadInfo = undefined;
-  }
-
-  private send(action: ThreadAction): void {
-    if (!this.threadInfo) throw new Error('service must be initialized');
-    const token = {
-      participantId: this.threadInfo.participant.id,
-      itemId: this.threadInfo.itemRoute.id,
-      userId: this.threadInfo.currentUserId,
-      isMine: this.threadInfo.participant.id === this.threadInfo.currentUserId,
-      canWatchParticipant: this.threadInfo.canWatchParticipant,
-    };
-    this.forumService.send({ ...action, token });
+    this.threadSubscriptionSub.unsubscribe();
   }
 
   syncEvents(): Observable<void> {
-    if (!this.threadInfo) throw new Error('cannot sync thread without token data');
-    const { participant, currentUserId, itemRoute } = this.threadInfo;
-    const watchedGroupId = participant.id === currentUserId ? undefined : participant.id;
-
-    return this.activityLogService.getActivityLog(itemRoute.id, watchedGroupId).pipe(
-      map(log => log.map(e => {
-        switch (e.activityType) {
-          case 'result_started': return { label: 'result_started' as const, time: e.at.valueOf(), data: { attemptId: e.attemptId } };
-          case 'submission': {
-            if (!e.answerId) return null;
-            const { attemptId, answerId, at, score } = e;
-            return { label: 'submission' as const, time: at.valueOf(), data: { attemptId, answerId, score } };
+    return this.threadInfo$.pipe(
+      take(1),
+      filter(isNotUndefined),
+      map(t => ({
+        itemId: t.itemRoute.id,
+        watchedGroupId: t.participant.id === t.currentUserId ? undefined : t.participant.id,
+        token: threadInfoToToken(t),
+      })),
+      switchMap(({ itemId, watchedGroupId, token }) => this.activityLogService.getActivityLog(itemId, watchedGroupId).pipe(
+        map(log => log.map(e => {
+          switch (e.activityType) {
+            case 'result_started': return { label: 'result_started' as const, time: e.at.valueOf(), data: { attemptId: e.attemptId } };
+            case 'submission': {
+              if (!e.answerId) return null;
+              const { attemptId, answerId, at, score } = e;
+              return { label: 'submission' as const, time: at.valueOf(), data: { attemptId, answerId, score } };
+            }
+            default: return null;
           }
-          default: return null;
-        }
-      }).filter(isNotNull)),
-      tap(events => {
-        this.send(publishEventsAction(events));
+        }).filter(isNotNull)),
+        map(log => ({ log, token })),
+      )),
+      tap(({ log, token }) => {
+        this.forumService.send(publishEventsAction(token, log));
       }),
-      map(() => undefined)
+      map(() => undefined),
     );
   }
 
   sendMessage(message: string): void {
     if (!message) throw new Error('Cannot send an empty message');
-    this.send(publishEventsAction([ messageEvent(message) ]));
+    this.threadInfo$.pipe(
+      take(1), // send on the current thread (if any) only
+      filter(isNotUndefined),
+      map(threadInfoToToken),
+    ).subscribe(token => this.forumService.send(publishEventsAction(token, [ messageEvent(message) ])));
   }
 
 }

--- a/src/app/modules/item/services/threads.service.ts
+++ b/src/app/modules/item/services/threads.service.ts
@@ -94,7 +94,7 @@ export class ThreadService implements OnDestroy {
       };
     }),
     startWith(undefined),
-    distinctUntilChanged((x, y) => JSON.stringify(x) === JSON.stringify(y)),
+    distinctUntilChanged((x, y) => x?.participant.id === y?.participant.id && x?.itemRoute.id === y?.itemRoute.id),
     shareReplay(1),
   );
   private threadSubscriptionSub = this.threadInfo$.pipe(

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -71,6 +71,7 @@ import { AllowsEditingAllItemPipe, AllowsEditingChildrenItemPipe } from 'src/app
 import { AllowsWatchingItemResultsPipe } from 'src/app/shared/models/domain/item-watch-permission';
 import { MessageInfoComponent } from './components/message-info/message-info.component';
 import { HasHTMLDirective } from '../../shared/directives/has-html.directive';
+import { ItemRouteLinkPipe } from 'src/app/shared/pipes/itemRouteLink';
 
 @NgModule({
   declarations: [
@@ -92,6 +93,7 @@ import { HasHTMLDirective } from '../../shared/directives/has-html.directive';
     ProgressLevelComponent,
     FormErrorComponent,
     RawItemLinkPipe,
+    ItemRouteLinkPipe,
     GroupLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,
@@ -171,6 +173,7 @@ import { HasHTMLDirective } from '../../shared/directives/has-html.directive';
     ProgressLevelComponent,
     FormErrorComponent,
     RawItemLinkPipe,
+    ItemRouteLinkPipe,
     GroupLinkPipe,
     UserCaptionPipe,
     LogActionDisplayPipe,

--- a/src/app/shared/http-services/activity-log.service.ts
+++ b/src/app/shared/http-services/activity-log.service.ts
@@ -50,6 +50,7 @@ const activityLogDecoder = pipe(
 export type ActivityLog = D.TypeOf<typeof activityLogDecoder>;
 
 const logServicesTimeout = 10 * SECONDS; // log services may be very slow
+const logDefaultLimit = 20;
 
 @Injectable({
   providedIn: 'root'
@@ -58,15 +59,13 @@ export class ActivityLogService {
 
   constructor(private http: HttpClient) { }
 
-  getActivityLog(
-    itemId: string,
-    watchedGroupId?: string,
-  ): Observable<ActivityLog[]> {
+  getActivityLog(itemId: string, options?: { watchedGroupId?: string, limit?: number }): Observable<ActivityLog[]> {
     let params = new HttpParams();
-    params = params.set('limit', '20');
+    const limit = options?.limit ?? logDefaultLimit;
+    params = params.set('limit', limit.toString());
 
-    if (watchedGroupId) {
-      params = params.set('watched_group_id', watchedGroupId);
+    if (options?.watchedGroupId) {
+      params = params.set('watched_group_id', options.watchedGroupId);
     }
 
     return this.http

--- a/src/app/shared/pipes/itemRouteLink.ts
+++ b/src/app/shared/pipes/itemRouteLink.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { UrlCommand } from '../helpers/url';
+import { RawItemRoute, urlArrayForItemRoute } from '../routing/item-route';
+
+@Pipe({ name: 'itemRouteLink', pure: true })
+export class ItemRouteLinkPipe implements PipeTransform {
+  transform(route: RawItemRoute, page?: string|string[], answerId?: string): UrlCommand {
+    return urlArrayForItemRoute({ ...route, answerId }, page);
+  }
+}

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1524,16 +1524,19 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="6891776217114642276" datatype="html">
         <source> which scored <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{ event.data.score }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></source><target state="new"> which scored <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/><x id="INTERPOLATION" equiv-text="{{ event.data.score }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="5078919999921089039" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">36</context></context-group></trans-unit><trans-unit id="6028326590794704051" datatype="html">
+        <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>Load this submission<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></source><target state="new"><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>Load this submission<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context>
+          <context context-type="linenumber">42</context>
+        </context-group>
+      </trans-unit><trans-unit id="5078919999921089039" datatype="html">
         <source>Sent at <x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></source><target state="new">Sent at <x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">44</context></context-group></trans-unit><trans-unit id="4672292365306876208" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="4672292365306876208" datatype="html">
         <source>An unknown user</source><target state="new">An unknown user</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.ts</context>
-          <context context-type="linenumber">17</context>
-        </context-group>
-      </trans-unit><trans-unit id="4902361762285353004" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.ts</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">
         <source>Error while loading this chapter's children</source><target state="translated">Erreur lors du chargement des enfants de ce chapitre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="7143643956716496978" datatype="html">


### PR DESCRIPTION
## Description

At start, the goal of this PR was just to allow loading answers which are listed in a thread... but that requires to get the item id and current user permissions... so change the way the thread info are given (was just the token before)... then I realize the thread info was not computed at the right place... it ends up as a major refactoring of the discussion and thread services.

TODO: there is no styling around the "load this submission" link which looks like this for the moment:
![Screenshot 2022-12-15 at 17 36 57](https://user-images.githubusercontent.com/1053150/207917022-b397caed-ca99-4cff-bb34-55dd9773a1c6.png)


## Test cases

New behaviors:

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this usual task on observation](https://dev.algorea.org/branch/forum-load-answers/en/activities/by-id/6379723280369399253;path=;parentAttempId=0?watchedGroupId=752024252804317630&watchUser=1)
  3. And I open the thread
  4. Then I see can test loading the submission with 50 pts or 25 pts, it loads (as read-only) as expected

Previous behavior to recheck:

- show/hide buttons from top bar and item header
- observing another user's thread, posting a message
- having the observed user submitting, info posted to everybody
