### PR TITLE
Children list: add watched-group scores

### DIFF
--- a/src/app/modules/item/components/chapter-children/chapter-children.component.html
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.html
@@ -20,11 +20,11 @@
       <li *ngFor="let item of data.children; index as ln">
       <span class="activity-progress">
         <alg-score-ring
-          *ngIf="!item.isLocked && item.result"
+          *ngIf="(!item.watchedGroup && item.result) || (item.watchedGroup && item.watchedGroup.avgScore !== undefined)"
           [diameter]="30"
-          [currentScore]="item.result.score"
-          [isValidated]="item.result.validated"
-          [bestScore]="item.bestScore"
+          [currentScore]="(item.watchedGroup ? item.watchedGroup.avgScore : item.result?.score) ?? 0"
+          [isValidated]="(item.watchedGroup ? item.watchedGroup.allValidated : item.result?.validated) ?? false"
+          [bestScore]="item.watchedGroup ? (item.watchedGroup.avgScore ?? 0) : item.bestScore"
         ></alg-score-ring>
       </span>
       <span


### PR DESCRIPTION
## Description

As the usual user, if you visit [this page](https://dev.algorea.org/en/activities/by-id/4102;path=4702;attempId=0?watchedGroupId=253763885501324109&watchUser=1), you can see that children scores are not the same in the left menu and in the children list. That's because the children list still use the current user's own scores. Fix that.

## Test cases

- [ ] Case 1: FIX
  1. Given I am the usual user
  2. When I go to [this same page](https://dev.algorea.org/branch/children-add-watched-scores/en/activities/by-id/4102;path=4702;attempId=0?watchedGroupId=253763885501324109&watchUser=1)
  4. Then I see that the scores of the children list match the scores of the left menu.

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this same page, without observation](https://dev.algorea.org/branch/children-add-watched-scores/en/activities/by-id/4102;path=4702;attempId=0?watchedGroupId=none&watchUser=1)
  4. Then I see that the scores of the children list match the scores of the left menu. (and different from previous scenario)

