### PR TITLE
refresh the left menu content when permissions have been updated

### DIFF
--- a/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -8,6 +8,7 @@ import { ActionFeedbackService } from '../../../../shared/services/action-feedba
 import { HttpErrorResponse } from '@angular/common/http';
 import { TypeFilter } from '../../helpers/composition-filter';
 import { mapToFetchState } from '../../../../shared/operators/state';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 
 @Component({
   selector: 'alg-permissions-edit-dialog[currentUserPermissions][item][group][permReceiverName]',
@@ -40,6 +41,7 @@ export class PermissionsEditDialogComponent implements OnDestroy, OnChanges {
   constructor(
     private groupPermissionsService: GroupPermissionsService,
     private actionFeedbackService: ActionFeedbackService,
+    private currentContentService: CurrentContentService,
   ) {
   }
 
@@ -84,11 +86,13 @@ export class PermissionsEditDialogComponent implements OnDestroy, OnChanges {
         next: () => {
           this.updateInProcess = false;
           this.actionFeedbackService.success($localize`:@@permissionsUpdated:Permissions successfully updated.`);
+          this.currentContentService.forceNavMenuReload();
           this.closeDialog(true);
         },
         error: err => {
           this.updateInProcess = false;
           this.actionFeedbackService.unexpectedError();
+          this.currentContentService.forceNavMenuReload();
           if (!(err instanceof HttpErrorResponse)) throw err;
         },
       });


### PR DESCRIPTION
## Description

When permissions are changed, the left menu is not updated... however if some content were not available (lock icon), these permission change may impact these item (lock icon removed/added).

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/refresh-left-menu-on-perm-update/en/activities/by-id/6707691810849260111;path=;parentAttempId=0?watchedGroupId=672913018859223173&watchUser=0)
  3. And I edit permission
  4. And change the view permissions
  5. I see the left menu is refetched
  6. ... and I restore the view permission as it was before
