### PR TITLE
Refresh left menu on perm update

### DIFF
--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.html
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.html
@@ -52,8 +52,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.label }}
-              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
-                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              <span *ngIf="node.data.associatedGroupNames && node.data.associatedGroupNames.length > 0">
+                (<span>{{ node.data.associatedGroupNames.length | i18nPlural: { '=1': 'via group', 'other': 'via groups' } }}:</span>
+                {{ node.data.associatedGroupNames.join(', ') }})
               </span>
             </span>
             <span
@@ -92,8 +93,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.label }}
-              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
-                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              <span *ngIf="node.data.associatedGroupNames && node.data.associatedGroupNames.length > 0">
+                (<span>{{ node.data.associatedGroupNames.length | i18nPlural: { '=1': 'via group', 'other': 'via groups' } }}:</span>
+                {{ node.data.associatedGroupNames.join(', ') }})
               </span>
             </span>
             <span class="node-state" *ngIf="node.data.locked">
@@ -135,8 +137,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.data.title }}
-              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
-                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              <span *ngIf="node.data.associatedGroupNames && node.data.associatedGroupNames.length > 0">
+                (<span>{{ node.data.associatedGroupNames.length | i18nPlural: { '=1': 'via group', 'other': 'via groups' } }}:</span>
+                {{ node.data.associatedGroupNames.join(', ') }})
               </span>
             </span>
             <span
@@ -239,8 +242,9 @@
           <span class="label-container">
             <span class="node-label-title">
               {{ node.data.title }}
-              <span *ngIf="!['Base', 'ContestParticipants'].includes(node.data.associatedGroupType) && node.data.associatedGroupName">
-                (<span i18n="@@viaGroup">via group</span> "{{ node.data.associatedGroupName }}")
+              <span *ngIf="node.data.associatedGroupNames && node.data.associatedGroupNames.length > 0">
+                (<span>{{ node.data.associatedGroupNames.length | i18nPlural: { '=1': 'via group', 'other': 'via groups' } }}:</span>
+                {{ node.data.associatedGroupNames.join(', ') }})
               </span>
             </span>
             <span

--- a/src/app/core/http-services/item-navigation.service.ts
+++ b/src/app/core/http-services/item-navigation.service.ts
@@ -71,26 +71,22 @@ const itemNavigationDataDecoder = D.struct({
 
 export type ItemNavigationData = D.TypeOf<typeof itemNavigationDataDecoder>;
 
-const rootActivityDecoder = D.struct({
+const rootItemGroupInfoDecoder = D.struct({
   groupId: D.string,
   name: D.string,
   type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base', 'ContestParticipants'),
-  activity: itemNavigationChildDecoderBase
 });
 
-export type RootActivity = D.TypeOf<typeof rootActivityDecoder>;
+const rootActivityDecoder = D.intersect(rootItemGroupInfoDecoder)(D.struct({ activity: itemNavigationChildDecoderBase }));
+type GroupWithRootActivity = D.TypeOf<typeof rootActivityDecoder>;
 
-const rootSkillDecoder = D.struct({
-  groupId: D.string,
-  name: D.string,
-  type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base', 'ContestParticipants'),
-  skill: itemNavigationChildDecoderBase
-});
-
-export type RootSkill = D.TypeOf<typeof rootSkillDecoder>;
+const rootSkillDecoder = D.intersect(rootItemGroupInfoDecoder)(D.struct({ skill: itemNavigationChildDecoderBase }));
+type GroupWithRootSkill = D.TypeOf<typeof rootSkillDecoder>;
 
 // common type to RootActivity and RootSkill if the activity/skill key is renamed 'item'
-export type RootItem = Omit<RootActivity, 'activity'> & { item: RootActivity['activity']};
+export type GroupWithRootItem = Omit<GroupWithRootActivity, 'activity'> & { item: GroupWithRootActivity['activity']};
+
+
 
 @Injectable({
   providedIn: 'root'
@@ -115,7 +111,7 @@ export class ItemNavigationService {
     );
   }
 
-  getRootActivities(watchedGroupId?: string): Observable<RootActivity[]> {
+  getRootActivities(watchedGroupId?: string): Observable<GroupWithRootActivity[]> {
     let httpParams = new HttpParams();
 
     if (watchedGroupId) {
@@ -127,7 +123,7 @@ export class ItemNavigationService {
     );
   }
 
-  getRootSkills(watchedGroupId?: string): Observable<RootSkill[]> {
+  getRootSkills(watchedGroupId?: string): Observable<GroupWithRootSkill[]> {
     let httpParams = new HttpParams();
 
     if (watchedGroupId) {
@@ -139,7 +135,7 @@ export class ItemNavigationService {
     );
   }
 
-  getRoots(type: ItemTypeCategory, watchedGroupId?: string): Observable<RootItem[]> {
+  getRoots(type: ItemTypeCategory, watchedGroupId?: string): Observable<GroupWithRootItem[]> {
     return isSkill(type) ?
       this.getRootSkills(watchedGroupId).pipe(map(groups => groups.map(g => ({ ...g, item: g.skill })))) :
       this.getRootActivities(watchedGroupId).pipe(map(groups => groups.map(g => ({ ...g, item: g.activity }))));

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -1,7 +1,6 @@
 import { arraysEqual } from 'src/app/shared/helpers/array';
 import { ensureDefined } from 'src/app/shared/helpers/assert';
 import { ContentRoute } from 'src/app/shared/routing/content-route';
-import { GroupWithRootItem } from '../../http-services/item-navigation.service';
 
 type Id = string;
 export enum GroupManagership { False = 'false', True = 'true', Descendant = 'descendant' }
@@ -16,8 +15,7 @@ export interface NavTreeElement {
 
   // specific uses
   locked?: boolean, // considering 'not set' as false
-  associatedGroupName?: string,
-  associatedGroupType?: GroupWithRootItem['type'],
+  associatedGroupNames?: string[],
   score?: { bestScore: number, currentScore: number, validated: boolean },
   groupRelation?: { isMember: boolean, managership: 'none'|'direct'|'ancestor'|'descendant' },
 }

--- a/src/app/core/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/core/models/left-nav-loading/nav-tree-data.ts
@@ -1,7 +1,7 @@
 import { arraysEqual } from 'src/app/shared/helpers/array';
 import { ensureDefined } from 'src/app/shared/helpers/assert';
 import { ContentRoute } from 'src/app/shared/routing/content-route';
-import { RootItem } from '../../http-services/item-navigation.service';
+import { GroupWithRootItem } from '../../http-services/item-navigation.service';
 
 type Id = string;
 export enum GroupManagership { False = 'false', True = 'true', Descendant = 'descendant' }
@@ -17,7 +17,7 @@ export interface NavTreeElement {
   // specific uses
   locked?: boolean, // considering 'not set' as false
   associatedGroupName?: string,
-  associatedGroupType?: RootItem['type'],
+  associatedGroupType?: GroupWithRootItem['type'],
   score?: { bestScore: number, currentScore: number, validated: boolean },
   groupRelation?: { isMember: boolean, managership: 'none'|'direct'|'ancestor'|'descendant' },
 }

--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -15,6 +15,7 @@ import { NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
 import { NavTreeService } from './nav-tree.service';
 import { allowsViewingContent, canCurrentUserViewContent } from 'src/app/shared/models/domain/item-view-permission';
 import { GroupWatchingService } from '../group-watching.service';
+import { isGroupTypeVisible } from 'src/app/shared/models/domain/group-types';
 
 abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
 
@@ -67,10 +68,9 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     return this.groupWatchingService.watchedGroup$.pipe(
       take(1),
       switchMap(watchedGroup => this.itemNavService.getRoots(this.category, watchedGroup?.route.id)),
-      map(groups => groups.map(g => ({
-        ...this.mapChild(g.item, defaultAttemptId, []),
-        associatedGroupName: g.name,
-        associatedGroupType: g.type,
+      map(items => items.map(i => ({
+        ...this.mapChild(i, defaultAttemptId, []),
+        associatedGroupNames: i.groups.filter(g => isGroupTypeVisible(g.type)).map(g => g.name),
       })))
     );
   }

--- a/src/app/shared/helpers/array.ts
+++ b/src/app/shared/helpers/array.ts
@@ -6,3 +6,25 @@ export function arraysEqual<T>(arr1: T[], arr2: T[]): boolean {
   if (arr1.length !== arr2.length) return false;
   return arr1.every((id, idx) => id === arr2[idx]);
 }
+
+/**
+ * @description
+ * Takes an Array<V>, and a grouping function,
+ * and returns a Map of the array grouped by the grouping function.
+ *
+ * @param list An array of type V.
+ * @param keyGetter A Function that takes the the Array type V as an input, and returns a value of type K.
+ *                  K is generally intended to be a property key of V.
+ *
+ * @returns Map of the array grouped by the grouping function.
+ */
+export function groupBy<K, V>(list: Array<V>, keyGetter: (input: V) => K): Map<K, Array<V>> {
+  const map = new Map<K, Array<V>>();
+  list.forEach(item => {
+    const key = keyGetter(item);
+    const collection = map.get(key);
+    if (!collection) map.set(key, [ item ]);
+    else collection.push(item);
+  });
+  return map;
+}

--- a/src/app/shared/models/domain/group-types.ts
+++ b/src/app/shared/models/domain/group-types.ts
@@ -1,0 +1,4 @@
+
+export function isGroupTypeVisible(type: string): boolean {
+  return type !== 'Base' && type !== 'ContestParticipants';
+}

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -18,7 +18,7 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">278</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">129</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">41</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">310</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">129</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
         <source>Language mismatch</source><target state="translated">Mauvaise langue?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/language-mismatch/language-mismatch.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="6895619751331935307" datatype="html">
@@ -50,39 +50,21 @@
       <trans-unit id="1939752001297092762" datatype="html">
         <source>There is no content to display</source><target state="translated">Il n'y a rien à afficher</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="viaGroup" datatype="html">
-        <source>via group</source><target state="translated">via le groupe</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
-          <context context-type="linenumber">56</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
-          <context context-type="linenumber">96</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
-          <context context-type="linenumber">139</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context>
-          <context context-type="linenumber">243</context>
-        </context-group>
-      </trans-unit><trans-unit id="1679971178283595016" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="1679971178283595016" datatype="html">
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="translated">Vos permissions actuelles ne vous permettent pas d'afficher le contenu de cette compétence.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">145</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">148</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ node.data.groupRelation.managership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></source><target state="translated"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'Vous êtes gestionnaire d'un des descendants de ce groupe' : 'Vous êtes gestionnaire de ce groupe' }}"/></target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">191</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">194</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
         <source>You are a member of the group</source><target state="translated">Vous êtes membre de ce groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">196</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">199</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
         <source>Your current access rights do not allow you to start the activity.</source><target state="translated">Vos permissions actuelles ne vous permettent pas de commencer l'activité.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">249</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">253</context></context-group></trans-unit><trans-unit id="2309808536212982229" datatype="html">
         <source>Activities</source><target state="translated">Activités</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -121,7 +103,7 @@
       </trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">167</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">168</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
         <source>home page</source><target state="translated">accueil</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context>
@@ -151,7 +133,7 @@
       </trans-unit><trans-unit id="7463044993322326313" datatype="html">
         <source> This content does not exist or you are not allowed to view it. </source><target state="translated"> Ce contenu n'existe pas ou vous n'êtes pas autorisé à le voir. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">163</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">164</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">48</context></context-group></trans-unit><trans-unit id="7296226328505512523" datatype="html">
@@ -475,26 +457,26 @@
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
 
-      <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">112</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
+      <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">113</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
         <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="translated"> Erreur lors du chargement de la réponse, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>charger votre dernière réponse<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
         <source>Leave unsaved task</source><target state="translated">Ne pas sauvegarder la réponse</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">187</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">188</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
         <source>You do not appear to be connected to the Internet, if you leave this task you may loose your progress. Are you sure you want to continue?</source><target state="translated">Vous ne semblez pas être connecté à Internet, si vous quittez cette tâche, vous perdrez vos changements. Êtes-vous sûr de vouloir continuer ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">189</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">190</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
         <source>Loose progress and leave the task</source><target state="translated">Perdre les changement et quitter la tâche</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">194</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">195</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
         <source>Retry</source><target state="translated">Réessayer</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">200</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">201</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
         <source>An unknown error occurred. </source><target state="translated">Une erreur est survenue. </target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">277</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">309</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="8679237608788920660" datatype="html">
@@ -512,7 +494,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
         <source>Unable to load the answer</source><target state="new">Unable to load the answer</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">109</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">110</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="new">Saving answer...</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
@@ -978,7 +960,7 @@
       <note from="description" priority="1">Button label for joining an item by (group) code</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">52</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
         <source>Edit content</source><target state="new">Edit content</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
@@ -1016,10 +998,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">114</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">63</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">175</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">176</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -1034,7 +1016,7 @@
       </trans-unit><trans-unit id="9041444757418829014" datatype="html">
         <source>Error while loading the item.</source><target state="translated">Erreur lors du chargement du contenu.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">165</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">166</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
         <source>Add</source><target state="translated">Ajouter</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.html</context><context context-type="linenumber">14</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="9165363087268857396" datatype="html">
@@ -1486,7 +1468,7 @@
         <source>Permissions successfully updated.</source><target state="new">Permissions successfully updated.</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="1519954996184640001" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.ts</context><context context-type="linenumber">88</context></context-group></trans-unit><trans-unit id="1519954996184640001" datatype="html">
         <source>Error</source><target state="translated">Erreur</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">88</context></context-group></trans-unit><trans-unit id="429958371655094287" datatype="html">


### PR DESCRIPTION
## Description

Avoid item duplication at the root the left menu due to the fact that a item can be the root activity of 2 groups. When selected, it was selected and expanded twice, which looked strange.

Before:
![Screenshot 2022-12-21 at 14 36 49](https://user-images.githubusercontent.com/1053150/208918096-25d1d8ae-fc54-4d2f-92dc-1a6af3c008ff.png)


## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [TestTask](https://dev.algorea.org/branch/refresh-left-menu-on-perm-update/en/activities/by-id/2268458803184278714;path=;attempId=0)
  3. And I expend the menu
  4. Then I see "TestTask" appears only once with the 3 three groups listed
