### PR TITLE
improve a bit the top bar layout to reduce the left margin for groups

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -5,9 +5,9 @@
     <alg-breadcrumb [contentBreadcrumb]="currentContent?.breadcrumbs"></alg-breadcrumb>
   </div>
   <div class="full-frame-content-top-bar" *ngIf="fullFrameContent?.active || scrolled">
-    <div class="score-placeholder">
+    <div class="score-placeholder" *ngIf="currentContent.type === 'item'">
       <alg-score-ring
-        *ngIf="currentContent.type === 'item' && $any(currentContent).details && $any(currentContent).details.bestScore !== undefined && $any(currentContent).details.currentScore !== undefined && $any(currentContent).details.validated !== undefined"
+        *ngIf="$any(currentContent).details && $any(currentContent).details.bestScore !== undefined && $any(currentContent).details.currentScore !== undefined && $any(currentContent).details.validated !== undefined"
         [bestScore]="$any(currentContent).details.bestScore"
         [currentScore]="$any(currentContent).details.currentScore"
         [isValidated]="$any(currentContent).details.validated"

--- a/src/app/core/components/content-top-bar/content-top-bar.component.scss
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.scss
@@ -22,7 +22,7 @@
 }
 
 .full-frame-content-top-bar {
-  margin-left: 1rem;
+  margin-left: 0.8rem;
   display: flex;
   align-items: center;
   height: 3.75rem;
@@ -30,7 +30,6 @@
   min-width: 0;
 
   .right-pane-title {
-    margin-left: 1.25rem;
     flex: 1;
     font-size: 1.6rem;
     margin-bottom: 0.4167rem;
@@ -54,5 +53,5 @@
 }
 
 .score-placeholder {
-  width: 2.85rem;
+  width: 3.45rem;
 }


### PR DESCRIPTION
## Description
improve a bit the top bar layout to reduce the left margin for groups

BEFORE
![Screenshot 2022-12-22 at 16 27 54](https://user-images.githubusercontent.com/1053150/209167468-2c4b0797-be8e-4e5c-94b3-2455213f787d.png)
![Screenshot 2022-12-22 at 16 28 24](https://user-images.githubusercontent.com/1053150/209167554-6aeeac86-60fe-4e21-9ebd-fb30eef7273b.png)



AFTER
![Screenshot 2022-12-22 at 16 28 43](https://user-images.githubusercontent.com/1053150/209167610-d871e1a2-cd26-4dd6-b86a-ca9869a85a56.png)
![Screenshot 2022-12-22 at 16 29 02](https://user-images.githubusercontent.com/1053150/209167685-3de024fe-4382-4ac5-9af3-c6658f785af7.png)

