### PR TITLE
Feature/improve log view layout

### DIFF
--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -47,7 +47,19 @@
           <td *ngFor="let col of columns" (mouseleave)="onMouseLeave($event, col.field)">
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
-                {{ rowData.activityType | logActionDisplay : rowData.score }}
+                <div class="activity-container">
+                  <div class="activity-left">
+                    <span class="activity-progress">
+                      <alg-score-ring
+                        [currentScore]="rowData.score"
+                        [diameter]="32"
+                        *ngIf="rowData.score"
+                      ></alg-score-ring>
+                    </span>
+
+                    {{ rowData.activityType | logActionDisplay }}
+                  </div>
+                </div>
               </ng-container>
               <ng-container *ngSwitchCase="'item.string.title'">
                 <a

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.scss
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.scss
@@ -1,5 +1,20 @@
-:host {
-  .header-refresh {
-    justify-content: flex-end;
-  }
+.header-refresh {
+  justify-content: flex-end;
+}
+
+.activity-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.activity-left {
+  display: flex;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.activity-progress {
+  width: 2.66667rem;
+  margin-right: 1rem;
 }

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -62,7 +62,7 @@
 
                   <button
                     pButton
-                    class="alg-button p-button-rounded p-small-button"
+                    class="alg-button p-button-rounded p-small-button p-button-outlined"
                     i18n-label="text on button to load a submission" label="Load"
                     [routerLink]="rowData.item | rawItemLink:[]:rowData.answerId"
                     *ngIf="rowData.displayLoadButton"

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -63,7 +63,10 @@
                   <button
                     pButton
                     class="alg-button p-button-rounded p-small-button p-button-outlined"
-                    i18n-label="text on button to load a submission" label="Load"
+                    [label]="(rowData.isWatchingGroup ? 'watchingGroup' : '') | i18nSelect : {
+                      watchingGroup: 'View answer',
+                      other: 'Reload answer'
+                    }"
                     [routerLink]="rowData.item | rawItemLink:[]:rowData.answerId"
                     *ngIf="rowData.displayLoadButton"
                   ></button>

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -47,18 +47,27 @@
           <td *ngFor="let col of columns">
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
-                {{ rowData.activityType | logActionDisplay : rowData.score }}
-                <ng-container *ngIf="rowData.displayLoadButton">
-                  &nbsp;(
-                  <a
-                    class="alg-link"
+                <div class="activity-container">
+                  <div class="activity-left">
+                    <span class="activity-progress">
+                      <alg-score-ring
+                        [currentScore]="rowData.score"
+                        [diameter]="32"
+                        *ngIf="rowData.score"
+                      ></alg-score-ring>
+                    </span>
+
+                    {{ rowData.activityType | logActionDisplay }}
+                  </div>
+
+                  <button
+                    pButton
+                    class="alg-button p-button-rounded p-small-button"
+                    i18n-label="text on button to load a submission" label="Load"
                     [routerLink]="rowData.item | rawItemLink:[]:rowData.answerId"
-                    i18n="text on button to load a submission"
-                  >
-                    Load
-                  </a>
-                  )
-                </ng-container>
+                    *ngIf="rowData.displayLoadButton"
+                  ></button>
+                </div>
               </ng-container>
               <ng-container *ngSwitchCase="'item.string.title'">
                 <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | rawItemLink">

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.scss
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.scss
@@ -6,8 +6,25 @@
   display: block;
 
   padding-top: 2rem;
+}
 
-  .header-refresh {
-    justify-content: flex-end;
-  }
+.header-refresh {
+  justify-content: flex-end;
+}
+
+.activity-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.activity-left {
+  display: flex;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+.activity-progress {
+  width: 2.66667rem;
+  margin-right: 1rem;
 }

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -72,7 +72,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy {
         columns: this.getLogColumns(item.type, watchingGroup),
         rowData: data
           .filter(log => !this.isSelfCurrentAnswer(log, profile.groupId))
-          .map(log => ({ ...log, displayLoadButton: this.canDisplayLoadButton(log, profile.groupId) })),
+          .map(log => ({ ...log, displayLoadButton: this.canDisplayLoadButton(log, profile.groupId), isWatchingGroup: !!watchingGroup })),
       }))
     );
   }

--- a/src/assets/scss/components/button.scss
+++ b/src/assets/scss/components/button.scss
@@ -34,6 +34,18 @@
       text-transform: uppercase;
     }
 
+    &.p-button-outlined {
+      background-color: unset;
+
+      &:hover {
+        background-color: var(--base-color);
+
+        .p-button-label {
+          color: #fff;
+        }
+      }
+    }
+
     &.p-button-warning {
       background-color: var(--warning-color);
       border-color: var(--warning-color);

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -247,7 +247,14 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="8524969483776993832" datatype="html">
         <source>None of the members has to be admitted</source><target state="translated">Aucun des membres n'a à être admis</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="186460519743457757" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="9131913350495870905" datatype="html">
+        <source>Load</source><target state="new">Load</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context>
+          <context context-type="linenumber">67</context>
+        </context-group>
+        <note priority="1" from="description">text on button to load a submission</note>
+      </trans-unit><trans-unit id="186460519743457757" datatype="html">
         <source>Global parameters</source><target>Paramètres globaux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context>
@@ -2131,14 +2138,10 @@
           <context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context>
           <context context-type="linenumber">19,20</context>
         </context-group>
-      </trans-unit><trans-unit id="1373156324893977078" datatype="html">
-        <source> Load </source><target state="new"> Load </target>
-
-        <note priority="1" from="description">text on button to load a submission</note>
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="1734171097636944073" datatype="html">
+      </trans-unit><trans-unit id="1734171097636944073" datatype="html">
         <source>There is no progress to report for this item.</source><target state="new">There is no progress to report for this item.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">93</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
         <source>You do not have the permissions to edit this content.</source><target state="translated">Vous n'avez pas les permissions d'éditer ce contenu.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">49</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5676044567873886390" datatype="html">
@@ -2160,7 +2163,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">15</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="8115085152478832979" datatype="html">
         <source>There is no progress to report for this group/user.</source><target state="new">There is no progress to report for this group/user.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">79</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">79</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">91</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">79</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
         <source>Action</source><target state="translated">Opération</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">103</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -247,14 +247,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="8524969483776993832" datatype="html">
         <source>None of the members has to be admitted</source><target state="translated">Aucun des membres n'a à être admis</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="9131913350495870905" datatype="html">
-        <source>Load</source><target state="new">Load</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context>
-          <context context-type="linenumber">67</context>
-        </context-group>
-        <note priority="1" from="description">text on button to load a submission</note>
-      </trans-unit><trans-unit id="186460519743457757" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="186460519743457757" datatype="html">
         <source>Global parameters</source><target>Paramètres globaux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context>
@@ -2141,7 +2134,7 @@
       </trans-unit><trans-unit id="1734171097636944073" datatype="html">
         <source>There is no progress to report for this item.</source><target state="new">There is no progress to report for this item.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">93</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
         <source>You do not have the permissions to edit this content.</source><target state="translated">Vous n'avez pas les permissions d'éditer ce contenu.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">49</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5676044567873886390" datatype="html">


### PR DESCRIPTION
## Description

Fixes #1240

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-log-view-layout/en/activities/by-id/4702;path=;parentAttempId=0/progress/history)
  3. Then I see the table with score widget, Reload Answer button in action column
  4. And I click on Reload Answer button
  5. Then I see opened item page

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-log-view-layout/en/groups/by-id/377276138499648407;path=5121055722873780306,6710944276987033666)
  3. Then I see the table with score widget in action column

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-log-view-layout/en/activities/by-id/6379723280369399253;path=;parentAttempId=0?watchedGroupId=6710944276987033666&watchUser=0)
  3. Then I click on Progress tab
  4. Then I see the table with score widget, View Answer button in action column
  5. Then I stop watching mode
  4. Then I see the table with score widget, Reload Answer button in action column