### PR TITLE
Fix answer loading in obs

### DIFF
--- a/src/app/modules/item/http-services/task-token.service.ts
+++ b/src/app/modules/item/http-services/task-token.service.ts
@@ -34,4 +34,12 @@ export class TaskTokenService {
     );
   }
 
+  generateForAnswer(answerId: string): Observable<TaskToken> {
+    return this.http.post<ActionResponse<unknown>>(`${appConfig.apiUrl}/answers/${answerId}/generate-task-token`, undefined).pipe(
+      map(successData),
+      decodeSnakeCase(taskTokenDataDecoder),
+      map(data => data.taskToken),
+    );
+  }
+
 }

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -60,9 +60,10 @@ export class ItemTaskAnswerService implements OnDestroy {
   private initializedTaskState$ = combineLatest([
     this.initialAnswer$.pipe(catchError(() => EMPTY)), // error is handled elsewhere
     this.task$,
+    this.config$,
   ]).pipe(
-    switchMap(([ initialAnswer, task ]) =>
-      (initialAnswer?.state ? task.reloadState(initialAnswer.state).pipe(map(() => undefined)) : of(undefined))
+    switchMap(([ initialAnswer, task, { readOnly }]) =>
+      (initialAnswer?.state && !readOnly ? task.reloadState(initialAnswer.state).pipe(map(() => undefined)) : of(undefined))
     ),
     shareReplay(1),
   );

--- a/src/app/modules/item/services/item-task-init.service.ts
+++ b/src/app/modules/item/services/item-task-init.service.ts
@@ -28,7 +28,12 @@ export class ItemTaskInitService implements OnDestroy {
   readonly config$ = this.configFromItem$.asObservable();
   readonly iframe$ = this.configFromIframe$.pipe(map(config => config.iframe));
   readonly taskToken$: Observable<TaskToken> = this.config$.pipe(
-    switchMap(({ attemptId, route }) => this.taskTokenService.generate(route.id, attemptId)),
+    switchMap(({ readOnly, formerAnswer, attemptId, route }) => {
+      if (readOnly && formerAnswer) return this.taskTokenService.generateForAnswer(formerAnswer.id);
+      // if we are no observing (= not in readOnly) -> we need a token for our user and the task may be edited by ourself
+      // if there are no answer loaded -> we currently want an empty task, so using our own task token
+      else return this.taskTokenService.generate(route.id, attemptId);
+    }),
     shareReplay(1),
   );
 


### PR DESCRIPTION
## Description

Fix the loading of answers in observation which was incorrectly using the task token.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [a task which has been started by another user](https://dev.algorea.org/branch/fix-answer-loading-in-obs/en/activities/by-id/1357671178979168705;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0;answerId=5986937724744682977?watchedGroupId=4035378957038759250&watchUser=0)
  4. Then I see the ongoing code

- [ ] Case 2: the regular case is still working
  1. Given I am the usual user
  2. When I go to [the same task "as myself"](https://dev.algorea.org/branch/fix-answer-loading-in-obs/en/activities/by-id/1357671178979168705;path=4702,1625159049301502151,5207993233955027100;parentAttempId=0)
  3. I see my own edits.



