### PR TITLE
Fixes reloading menu after add new group

### DIFF
--- a/src/app/modules/group/components/add-group/add-group.component.ts
+++ b/src/app/modules/group/components/add-group/add-group.component.ts
@@ -5,6 +5,7 @@ import { ActionFeedbackService } from '../../../../shared/services/action-feedba
 import { GroupRouter } from 'src/app/shared/routing/group-router';
 import { rawGroupRoute } from 'src/app/shared/routing/group-route';
 import { HttpErrorResponse } from '@angular/common/http';
+import { CurrentContentService } from '../../../../shared/services/current-content.service';
 
 type GroupType = 'Class'|'Team'|'Club'|'Friends'|'Other'|'Session';
 
@@ -47,6 +48,7 @@ export class AddGroupComponent {
     private groupCreationService: GroupCreationService,
     private actionFeedbackService: ActionFeedbackService,
     private groupRouter: GroupRouter,
+    private currentContentService: CurrentContentService,
   ) {}
 
   addChild(group: AddedContent<GroupType>): void {
@@ -55,6 +57,7 @@ export class AddGroupComponent {
       next: createdId => {
         this.state = 'ready';
         this.actionFeedbackService.success($localize`Group successfully created`);
+        this.currentContentService.forceNavMenuReload();
         this.groupRouter.navigateTo(rawGroupRoute({ ...group, id: createdId }));
       },
       error: err => {


### PR DESCRIPTION
## Description

Fixes #1244

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/new-group-does-not-appear-in-left-menu/en/groups/mine)
  3. And I scroll down to "Create a new group" section
  4. Then I type "TestAndRemove" caption
  5. And I click on "Other" option
  6. Then I see opened "TestAndRemove" group, and it appears in left menu
