### PR TITLE
Fixes text_id in item parameters page

### DIFF
--- a/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
+++ b/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
@@ -139,8 +139,8 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
     const usesApi = formControls.usesApi?.value as boolean;
     if (isNotUndefined(this.initialFormData.usesApi) && usesApi !== this.initialFormData.usesApi) itemFormValues.uses_api = usesApi;
 
-    const textId = formControls.textId?.value as string;
-    if (textId !== '') itemFormValues.text_id = textId;
+    const textId = formControls.textId?.value !== '' ? formControls.textId?.value as string : null;
+    if (textId !== this.initialFormData.textId) itemFormValues.text_id = textId;
 
     const validationType = formControls.validationType?.value as 'None' | 'All' | 'AllButOne' | 'Categories' | 'One' | 'Manual';
     if (validationType !== this.initialFormData.validationType) itemFormValues.validation_type = validationType;
@@ -324,7 +324,7 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
       image_url: item.string.imageUrl || '',
       subtitle: item.string.subtitle || '',
       url: item.url || '',
-      text_id: '',
+      text_id: item.textId,
       uses_api: item.usesApi || false,
       validation_type: item.validationType,
       no_score: item.noScore,

--- a/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
+++ b/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
@@ -139,7 +139,8 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
     const usesApi = formControls.usesApi?.value as boolean;
     if (isNotUndefined(this.initialFormData.usesApi) && usesApi !== this.initialFormData.usesApi) itemFormValues.uses_api = usesApi;
 
-    const textId = formControls.textId?.value !== '' ? formControls.textId?.value as string : null;
+    const textIdValue = (formControls.textId?.value as string).trim();
+    const textId = textIdValue !== '' ? textIdValue : null;
     if (textId !== this.initialFormData.textId) itemFormValues.text_id = textId;
 
     const validationType = formControls.validationType?.value as 'None' | 'All' | 'AllButOne' | 'Categories' | 'One' | 'Manual';


### PR DESCRIPTION
## Description

Fixes #1279

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/text-id-not-displayed-in-parameters/en/activities/by-id/8340190805761209501;path=;attempId=0/parameters)
  3. And I change "TextID" field
  4. Then I click on "Save" button
  5. Then I see saved "TextID" value
  6. Then I clear "TextID" filed
  7. Then I click on "Save" button
  8. Then I see empty "TextID" field
