### PR TITLE
Adds reload left menu after join a group

### DIFF
--- a/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.ts
+++ b/src/app/modules/group/components/user-group-invitations/user-group-invitations.component.ts
@@ -8,6 +8,7 @@ import { GetRequestsService, PendingRequest } from '../../http-services/get-requ
 import { Action, parseGroupInvitationResults, RequestActionsService } from '../../http-services/request-actions.service';
 import { ActionFeedbackService } from 'src/app/shared/services/action-feedback.service';
 import { HttpErrorResponse } from '@angular/common/http';
+import { CurrentContentService } from '../../../../shared/services/current-content.service';
 
 @Component({
   selector: 'alg-user-group-invitations',
@@ -32,6 +33,7 @@ export class UserGroupInvitationsComponent implements OnDestroy, OnInit {
     private getRequestsService: GetRequestsService,
     private requestActionService: RequestActionsService,
     private actionFeedbackService: ActionFeedbackService,
+    private currentContentService: CurrentContentService,
   ) {
     this.dataFetching.pipe(
       switchMap(params =>
@@ -70,6 +72,7 @@ export class UserGroupInvitationsComponent implements OnDestroy, OnInit {
           this.state = 'ready';
           displayResponseToast(this.actionFeedbackService, parseGroupInvitationResults(result), params.type);
           this.dataFetching.next({ sort: this.currentSort });
+          this.currentContentService.forceNavMenuReload();
         },
         error: err => {
           this.state = 'ready';


### PR DESCRIPTION
## Description

Fixes #1262 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Reload menu after group added https://github.com/France-ioi/AlgoreaFrontend/pull/1272

## Test cases

- [ ] Case 1:
  1. Given I am the demo user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/refresh-left-menu-after-joining-group/en/groups/mine)
  3. Then I see list of pending invitations
  4. And I check one of invitation
  5. Then I click on "Accept" button
  6. Then I see successful notification and left menu is reloaded
  7. Then I see added group in left menu
