### PR TITLE
Feature/limit image url length to 2048 char

### DIFF
--- a/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
+++ b/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
@@ -139,7 +139,7 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
     const usesApi = formControls.usesApi?.value as boolean;
     if (isNotUndefined(this.initialFormData.usesApi) && usesApi !== this.initialFormData.usesApi) itemFormValues.uses_api = usesApi;
 
-    const textIdValue = (formControls.textId?.value as string).trim();
+    const textIdValue = ((formControls.textId?.value as string | null) || '').trim();
     const textId = textIdValue !== '' ? textIdValue : null;
     if (textId !== this.initialFormData.textId) itemFormValues.text_id = textId;
 

--- a/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
+++ b/src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.ts
@@ -29,7 +29,7 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
     title: [ '', [ Validators.required, Validators.minLength(3), Validators.maxLength(200) ] ],
     subtitle: [ '', Validators.maxLength(200) ],
     description: [ '' ],
-    image_url: [ '' ],
+    image_url: [ '', Validators.maxLength(2000) ],
     url: [ '', Validators.maxLength(2000) ],
     text_id: [ '', Validators.maxLength(200) ],
     uses_api: [ false ],


### PR DESCRIPTION
## Description

Fixes #1275

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Unfortunately, we've missed a bug with text_id, so I've add the fix

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/limit-image-url-length-to-2048-char/en/activities/by-id/5770807837681306905;path=6707691810849260111;attempId=0/parameters)
  3. And I open [this service](http://www.unit-conversion.info/texttools/random-string-generator/)
  4. Then I generate the string with length = 2001
  5. Then I copy this string and paste it into "Thumbnail url" field
  6. Then I see validation error
  7. Then I remove 1 letter
  8. Then I see the validation error is disappeared 
