### PR TITLE
Fixes group and user pages for mobile

### DIFF
--- a/src/app/modules/group/components/add-sub-group/add-sub-group.component.html
+++ b/src/app/modules/group/components/add-sub-group/add-sub-group.component.html
@@ -1,4 +1,4 @@
-<alg-sub-section icon="sign-in-alt" i18n-label label="Add subgroups">
+<alg-sub-section class="sub-section" icon="sign-in-alt" i18n-label label="Add subgroups">
   <alg-add-content
     [allowedTypesForNewContent]="allowedNewGroupTypes"
     [searchFunction]="searchFunction"

--- a/src/app/modules/group/components/add-sub-group/add-sub-group.component.scss
+++ b/src/app/modules/group/components/add-sub-group/add-sub-group.component.scss
@@ -1,0 +1,5 @@
+@media screen and (max-width: 479px) {
+  .sub-section {
+    margin-left: -2.8333rem;
+  }
+}

--- a/src/app/modules/group/components/group-indicator/group-indicator.component.scss
+++ b/src/app/modules/group/components/group-indicator/group-indicator.component.scss
@@ -9,6 +9,8 @@
   color: var(--base-color);
   background-color: var(--section-color);
   border-radius: $border-radius;
+  white-space: nowrap;
+  overflow-x: scroll;
 }
 
 .content {

--- a/src/app/modules/group/components/group-join-by-code/group-join-by-code.component.scss
+++ b/src/app/modules/group/components/group-join-by-code/group-join-by-code.component.scss
@@ -59,6 +59,14 @@
       margin-right: 2rem;
     }
 
+    @media screen and (max-width: 479px) {
+      flex-direction: column;
+      align-items: start;
+
+      .validity-selector {
+        margin: 1rem 0 0 0;
+      }
+    }
   }
 
   // .auto-create {

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -17,7 +17,14 @@
   </alg-error>
 
   <ng-container *ngIf="state.data">
-    <p-table class="alg-table" [columns]="state.data.columns" [value]="state.data.rowData" [loading]="state.isFetching">
+    <p-table
+      class="alg-table"
+      [columns]="state.data.columns"
+      [value]="state.data.rowData"
+      [loading]="state.isFetching"
+      [tableStyle]="{'min-width': '479px'}"
+      responsiveLayout="scroll"
+    >
       <ng-template pTemplate="header" let-rowData let-columns>
         <tr>
           <th [colSpan]="columns.length">

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
@@ -121,6 +121,10 @@
   tr {
     height: 5rem;
   }
+
+  @media screen and (max-width: 479px) {
+    margin-left: -1.8rem;
+  }
 }
 
 .error {

--- a/src/app/modules/group/components/member-list/member-list.component.html
+++ b/src/app/modules/group/components/member-list/member-list.component.html
@@ -22,6 +22,8 @@
       [(selection)]="selection"
       selectionMode="multiple"
       dataKey="id"
+      [tableStyle]="{'min-width': '479px'}"
+      responsiveLayout="scroll"
     >
       <ng-template pTemplate="header" let-columns>
         <tr *ngIf="state.data && state.data.length > 0">

--- a/src/app/modules/group/components/user-indicator/user-indicator.component.scss
+++ b/src/app/modules/group/components/user-indicator/user-indicator.component.scss
@@ -9,6 +9,8 @@
   color: var(--base-color);
   background-color: var(--section-color);
   border-radius: $border-radius;
+  white-space: nowrap;
+  overflow-x: scroll;
 }
 
 .content {

--- a/src/app/modules/shared-components/components/grid/grid.component.html
+++ b/src/app/modules/shared-components/components/grid/grid.component.html
@@ -18,6 +18,8 @@
   (onRowSelect)="onRowSelect()"
   (onRowUnselect)="onRowUnselect()"
   (onHeaderCheckboxToggle)="onHeaderCheckbox()"
+  [tableStyle]="{'min-width': '479px'}"
+  responsiveLayout="scroll"
 >
   <!-- <ng-container *ngTemplateOutlet="headerTemplate; context: {$implicit: columns}"></ng-container> -->
   <ng-template *ngIf="frozenHeaderTemplate && frozenWidth && frozenWidth.length > 0" pTemplate="frozenheader">

--- a/src/app/modules/shared-components/components/input/input.component.scss
+++ b/src/app/modules/shared-components/components/input/input.component.scss
@@ -71,8 +71,8 @@
   }
 
   .clear-button {
-    margin-left:-30px;
-    margin-top: 8px;
+    margin-left: -3rem;
+    margin-top: .6rem;
 
     button {
       cursor: pointer;


### PR DESCRIPTION
## Description

Fixes #1248

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

From mobile (width < 479px):

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-group-page-for-mobile/en/groups/by-id/52767158366271444;path=)
  3. Then I see "As manager" section with horizontal scroll

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-group-page-for-mobile/en/groups/by-id/4035378957038759250;path=)
  3. Then I see "Progress" table with horizontal scroll

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-group-page-for-mobile/en/groups/users/752024252804317630)
  3. Then I see "As manager" section with horizontal scroll

- [ ] Case 4:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-group-page-for-mobile/en/groups/users/670968966872011405)
  3. Then I see "Progress" table with horizontal scroll

- [ ] Case 5:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-group-page-for-mobile/en/groups/by-id/4035378957038759250;path=/members)
  3. Then I see "Users" table with horizontal scroll
  4. And I see "Adds subgroups" is displaying correct
  5. And I see "Let user join using a code" is displaying correct