### PR TITLE
Redirect (hardcoded) paths to ids

### DIFF
--- a/src/app/core/app-routing.module.ts
+++ b/src/app/core/app-routing.module.ts
@@ -3,6 +3,7 @@ import { Routes, RouterModule } from '@angular/router';
 import { urlStringFromArray } from '../shared/helpers/url';
 import { appDefaultItemRoute, urlArrayForItemRoute } from '../shared/routing/item-route';
 import { PageNotFoundComponent } from './pages/page-not-found/page-not-found.component';
+import { RedirectToIdComponent } from './pages/redirect-to-id/redirect-to-id.component';
 
 const routes: Routes = [
   {
@@ -25,6 +26,10 @@ const routes: Routes = [
   {
     path: 'lti/:contentId',
     loadChildren: (): Promise<any> => import('../modules/lti/lti.module').then(m => m.LTIModule),
+  },
+  {
+    path: 'r/:path',
+    component: RedirectToIdComponent,
   },
   {
     path: '**',

--- a/src/app/core/app.module.ts
+++ b/src/app/core/app.module.ts
@@ -43,6 +43,7 @@ import { ContentTopBarComponent } from './components/content-top-bar/content-top
 import { AuthenticationInterceptor } from '../shared/interceptors/authentication.interceptor';
 import { AlgErrorHandler } from '../shared/error-handling/error-handler';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
+import { RedirectToIdComponent } from './pages/redirect-to-id/redirect-to-id.component';
 
 const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
   suppressScrollX: false,
@@ -63,6 +64,7 @@ const DEFAULT_PERFECT_SCROLLBAR_CONFIG: PerfectScrollbarConfigInterface = {
     LanguageMismatchComponent,
     TopBarComponent,
     ContentTopBarComponent,
+    RedirectToIdComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/core/pages/redirect-to-id/redirect-to-id.component.html
+++ b/src/app/core/pages/redirect-to-id/redirect-to-id.component.html
@@ -1,0 +1,11 @@
+<ng-container *ngIf="notExisting; else checking">
+  <p i18n>This page does not exist!</p>
+  <p>
+    <span i18n>Go back to the </span>
+    <a class="alg-link base-color" routerLink="/" i18n>home page</a>
+  </p>
+</ng-container>
+
+<ng-template #checking>
+  <alg-loading></alg-loading>
+</ng-template>

--- a/src/app/core/pages/redirect-to-id/redirect-to-id.component.ts
+++ b/src/app/core/pages/redirect-to-id/redirect-to-id.component.ts
@@ -1,0 +1,46 @@
+import { Component, OnDestroy } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs';
+import { appConfig } from 'src/app/shared/helpers/config';
+import { rawItemRoute } from 'src/app/shared/routing/item-route';
+import { ItemRouter } from 'src/app/shared/routing/item-router';
+import { CurrentContentService } from 'src/app/shared/services/current-content.service';
+import { LayoutService } from 'src/app/shared/services/layout.service';
+
+@Component({
+  selector: 'alg-redirect-to-id',
+  templateUrl: './redirect-to-id.component.html',
+})
+export class RedirectToIdComponent implements OnDestroy {
+
+  notExisting = false;
+
+  private path$ = this.activatedRoute.paramMap.pipe(
+    map(params => {
+      const path = params.get('path');
+      if (path === null) throw new Error('unexpected: path should be defined');
+      return path;
+    }),
+  );
+
+  private subscription = this.path$.pipe(
+    map(path => (appConfig.redirects ? appConfig.redirects[path] : undefined))
+  ).subscribe(id => {
+    if (id) this.itemRouter.navigateTo(rawItemRoute('activity', id));
+    else this.notExisting = true;
+  });
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private itemRouter: ItemRouter,
+    private layoutService: LayoutService,
+    private currentContentService: CurrentContentService,
+  ) {
+    this.layoutService.configure({ fullFrameActive: false });
+    this.currentContentService.clear();
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+}

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -41,6 +41,8 @@ export interface Environment {
     skillsDisabled: boolean,
     showGroupAccessTab?: boolean,
   },
+
+  redirects?: Record<string, string>,
 }
 
 type Config = Environment; // config may be someday an extension of the environment

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -28,6 +28,10 @@ export const environment: Environment = {
     skillsDisabled: false,
     showGroupAccessTab: true,
   },
+
+  redirects: {
+    'home': '4702'
+  }
 };
 
 type Preset = 'telecomParis';

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -30,6 +30,10 @@ export const environment: Environment = {
     skillsDisabled: false,
     showGroupAccessTab: true,
   },
+
+  redirects: {
+    'home': '4702'
+  }
 };
 
 type Preset = 'demo';


### PR DESCRIPTION
## Description

Introduce a mechanism for redirecting (hardcoded in config) path to ids. This can be used for migrating website to our platform... their urls "domain.com/something" can be converted to "domain.com/r/something" by the entry point (load balancer) which can then be redirected to any id via the config.

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [an existing label](https://dev.algorea.org/branch/redirect-labels-to-id/en/r/home)
  3. And I see I am redirected to the item "4702" as defined in the config

- [ ] Case 2:
  1. Given I am any user
  2. When I go to [an non-existing label](https://dev.algorea.org/branch/redirect-labels-to-id/en/r/notexisting/url)
  3. And I see I get an error page.
