### PR TITLE
support slashes in paths with 'r/*' + allow providing path

### DIFF
--- a/src/app/core/app-routing.module.ts
+++ b/src/app/core/app-routing.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { Routes, RouterModule } from '@angular/router';
+import { Routes, RouterModule, UrlSegment } from '@angular/router';
 import { urlStringFromArray } from '../shared/helpers/url';
 import { appDefaultItemRoute, urlArrayForItemRoute } from '../shared/routing/item-route';
 import { PageNotFoundComponent } from './pages/page-not-found/page-not-found.component';
@@ -28,7 +28,11 @@ const routes: Routes = [
     loadChildren: (): Promise<any> => import('../modules/lti/lti.module').then(m => m.LTIModule),
   },
   {
-    path: 'r/:path',
+    // "r/**" -> the parameter may contain slashes
+    matcher: url => (url[0]?.path === 'r' ? {
+      consumed: url,
+      posParams: { path: new UrlSegment(url.slice(1).map(s => s.path).join('/'), {}) },
+    } : null) ,
     component: RedirectToIdComponent,
   },
   {

--- a/src/app/core/pages/redirect-to-id/redirect-to-id.component.ts
+++ b/src/app/core/pages/redirect-to-id/redirect-to-id.component.ts
@@ -25,8 +25,8 @@ export class RedirectToIdComponent implements OnDestroy {
 
   private subscription = this.path$.pipe(
     map(path => (appConfig.redirects ? appConfig.redirects[path] : undefined))
-  ).subscribe(id => {
-    if (id) this.itemRouter.navigateTo(rawItemRoute('activity', id));
+  ).subscribe(route => {
+    if (route) this.itemRouter.navigateTo({ ...rawItemRoute('activity', route.id), path: route.path });
     else this.notExisting = true;
   });
 

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -42,7 +42,7 @@ export interface Environment {
     showGroupAccessTab?: boolean,
   },
 
-  redirects?: Record<string, string>,
+  redirects?: Record<string, { id: string, path?: string[] }>,
 }
 
 type Config = Environment; // config may be someday an extension of the environment

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -29,9 +29,12 @@ export const environment: Environment = {
     showGroupAccessTab: true,
   },
 
+  /* eslint-disable @typescript-eslint/naming-convention */
   redirects: {
-    'home': '4702'
+    'home': '4702',
+    'algorea/adventure': '100575556387408660',
   }
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 type Preset = 'telecomParis';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -31,8 +31,9 @@ export const environment: Environment = {
 
   /* eslint-disable @typescript-eslint/naming-convention */
   redirects: {
-    'home': '4702',
-    'algorea/adventure': '100575556387408660',
+    'home': { id: '4702', path: [] },
+    'algorea/adventure': { id: '100575556387408660' },
+    'officiels/algorea-serious-game': { id: '1471479157476024035', path: [ '4702' ] },
   }
   /* eslint-enable @typescript-eslint/naming-convention */
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -31,9 +31,12 @@ export const environment: Environment = {
     showGroupAccessTab: true,
   },
 
+  /* eslint-disable @typescript-eslint/naming-convention */
   redirects: {
-    'home': '4702'
+    'home': '4702',
+    'algorea/adventure': '100575556387408660',
   }
+  /* eslint-enable @typescript-eslint/naming-convention */
 };
 
 type Preset = 'demo';

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -33,8 +33,9 @@ export const environment: Environment = {
 
   /* eslint-disable @typescript-eslint/naming-convention */
   redirects: {
-    'home': '4702',
-    'algorea/adventure': '100575556387408660',
+    'home': { id: '4702', path: [] },
+    'algorea/adventure': { id: '100575556387408660' },
+    'officiels/algorea-serious-game': { id: '1471479157476024035', path: [ '4702' ] },
   }
   /* eslint-enable @typescript-eslint/naming-convention */
 };


### PR DESCRIPTION
## Description

- Support for slashes in the path... see example below.
- Allow provides a content path in configuration.

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. I open the network dev panel
  3. When I go to [an existing label](https://dev.algorea.org/branch/redirect-labels-to-id2/en/r/algorea/adventure)
  4. And I see "path-from-root" service is called (as the path is not given in the config)
  5. And I see I am redirected to the item "100575556387408660" as defined in the config

- [ ] Case 2:
  1. Given I am any user
  2. I open the network dev panel
  3. When I go to [an existing label](https://dev.algorea.org/branch/redirect-labels-to-id2/en/r/home)
  4. And I see "path-from-root" service is NOT called  (as the path is given in the config)
  5. And I see I am redirected to the item "4702" as defined in the config

- [ ] Case 3:
  1. Given I am any user
  2. I open the network dev panel
  3. When I go to [an existing label](https://dev.algorea.org/branch/redirect-labels-to-id2/en/r/officiels/algorea-serious-game)
  4. And I see "path-from-root" service is not called  (as the path is given in the config)
  5. And I see I am redirected to to 1471479157476024035

- [ ] Case 4:
  1. Given I am any user
  2. When I go to [an non-existing label](https://dev.algorea.org/branch/redirect-labels-to-id/en/r/notexisting/url)
  3. And I see I get an error page.
