### PR TITLE
Answer loading refactoring

### DIFF
--- a/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.ts
+++ b/src/app/modules/item/components/answer-author-indicator/answer-author-indicator.component.ts
@@ -5,7 +5,7 @@ import { GetUserService } from 'src/app/modules/group/http-services/get-user.ser
 import { mapToFetchState, readyData } from 'src/app/shared/operators/state';
 import { groupRoute } from 'src/app/shared/routing/group-route';
 import { GroupRouter } from 'src/app/shared/routing/group-router';
-import { Answer } from '../../http-services/get-answer.service';
+import { Answer } from '../../services/item-task.service';
 
 @Component({
   selector: 'alg-answer-author-indicator[answer]',

--- a/src/app/modules/item/pages/item-by-id/initial-answer-datasource.ts
+++ b/src/app/modules/item/pages/item-by-id/initial-answer-datasource.ts
@@ -1,0 +1,102 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import {
+  BehaviorSubject,
+  catchError,
+  combineLatest,
+  distinctUntilChanged,
+  EMPTY,
+  filter,
+  map,
+  Observable,
+  of,
+  shareReplay,
+  Subject,
+  switchMap
+} from 'rxjs';
+import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
+import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
+import { FullItemRoute } from 'src/app/shared/routing/item-route';
+import { CurrentAnswerService } from '../../http-services/current-answer.service';
+import { GetAnswerService } from '../../http-services/get-answer.service';
+import { Answer } from '../../services/item-task.service';
+
+const loadForbiddenAnswerError = new Error('load answer forbidden');
+
+type Strategy =
+  { tag: 'EmptyInitialAnswer'|'Wait'|'NotApplicable' } |
+  { tag: 'LoadCurrent', itemId: string, attemptId: string } |
+  { tag: 'LoadById', answerId: string } |
+  { tag: 'LoadBest', itemId: string, participantId?: string};
+
+@Injectable()
+export class InitialAnswerDataSource implements OnDestroy {
+
+  private readonly itemRoute$ = new Subject<FullItemRoute>();
+  private readonly isTask$ = new BehaviorSubject<boolean|undefined>(undefined);
+
+  readonly answer$ = combineLatest([ this.itemRoute$, this.isTask$, this.groupWatchingService.isWatching$ ]).pipe(
+    /* we do the computation in 2 stages to prevent cancelling requests which shouldn't have been cancelled */
+    map(([ route, isTask, isWatching ]): Strategy => {
+      if (!route.answer) {
+        if (isWatching) return { tag: 'EmptyInitialAnswer' };
+        if (isTask === undefined) return { tag: 'Wait' };
+        if (isTask) return route.attemptId ? { tag: 'LoadCurrent', itemId: route.id, attemptId: route.attemptId } : { tag: 'Wait' };
+        else /* isTask === false */ return { tag: 'NotApplicable' };
+      }
+      if (route.answer.id) return { tag: 'LoadById', answerId: route.answer.id };
+      return { tag: 'LoadBest', itemId: route.id, participantId: route.answer.participantId };
+    }),
+    distinctUntilChanged((s1, s2) => JSON.stringify(s1) === JSON.stringify(s2)),
+    switchMap(strategy => {
+      if (strategy.tag === 'EmptyInitialAnswer') return of(null);
+      if (strategy.tag === 'LoadCurrent') return this.getCurrentAnswer(strategy.itemId, strategy.attemptId);
+      if (strategy.tag === 'LoadById') return this.getAnswerService.get(strategy.answerId);
+      if (strategy.tag === 'LoadBest') return this.getAnswerService.getBest(strategy.itemId, { watchedGroupId: strategy.participantId });
+      // "Wait" and "NotApplicable" cases:
+      return EMPTY;
+    }),
+    shareReplay(1),
+  );
+
+  readonly error$ = this.answer$.pipe(
+    switchMap(() => EMPTY), // ignore non-errors
+    catchError(error => of(errorIsHTTPForbidden(error) ? loadForbiddenAnswerError : error))
+  );
+  readonly forbidden$ = this.error$.pipe(filter(error => error === loadForbiddenAnswerError));
+  readonly unknownError$: Observable<unknown> = this.error$.pipe(filter(error => error !== loadForbiddenAnswerError));
+
+  subscription = this.itemRoute$.pipe(
+    map(route => route.id),
+    distinctUntilChanged()
+  ).subscribe(() => this.isTask$.next(undefined)); // each time the item change, reset 'isTask$'
+
+  constructor(
+    private groupWatchingService: GroupWatchingService,
+    private currentAnswerService: CurrentAnswerService,
+    private getAnswerService: GetAnswerService,
+  ) {}
+
+  setRoute(route: FullItemRoute): void {
+    this.itemRoute$.next(route);
+  }
+
+  setIsTask(isTask: boolean|undefined): void {
+    this.isTask$.next(isTask);
+  }
+
+  ngOnDestroy(): void {
+    this.itemRoute$.complete();
+    this.isTask$.complete();
+  }
+
+  private getCurrentAnswer(itemId: string, attemptId: string): Observable<Answer | null> {
+    return this.currentAnswerService.get(itemId, attemptId).pipe(
+      catchError(error => {
+        // currently, the backend returns a 403 status when no current answer exist for user+item+attempt
+        if (errorIsHTTPForbidden(error)) return of(null);
+        throw error;
+      })
+    );
+  }
+
+}

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.html
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.html
@@ -106,18 +106,18 @@
         ></alg-error>
 
         <ng-container *ngIf="contentTab.isActive || editChildrenTab.isActive || taskTabs.length > 0">
-          <alg-error *ngIf="answerFallbackLink$ | async as fallbackLink">
-            <ng-container *ngIf="(taskReadOnly$ | async); else fallback" i18n>Unable to load the answer</ng-container>
+          <alg-error *ngIf="answerError$ | async as error">
+            <ng-container *ngIf="!error.fallbackLink; else fallback" i18n>Unable to load the answer</ng-container>
             <ng-template #fallback>
               <ng-container i18n>
-                Unable to load the answer, <a [routerLink]="fallbackLink" class="alg-link">load your most recent answer</a>
+                Unable to load the answer, <a [routerLink]="error.fallbackLink" class="alg-link">back to the regular task page</a>
               </ng-container>
             </ng-template>
           </alg-error>
 
-          <ng-container *ngIf="taskConfig$ | async as taskConfig">
-            <div *ngIf="taskConfig.readOnly && contentTab.isActive" class="indicator">
-              <alg-answer-author-indicator *ngIf="taskConfig.formerAnswer" [answer]="taskConfig.formerAnswer"></alg-answer-author-indicator>
+          <ng-container *ngrxLet="taskConfig$ as taskConfig">
+            <div *ngIf="taskConfig && taskConfig.readOnly && contentTab.isActive" class="indicator">
+              <alg-answer-author-indicator *ngIf="taskConfig.initialAnswer" [answer]="taskConfig.initialAnswer"></alg-answer-author-indicator>
             </div>
             <alg-item-content
               [hidden]="!contentTab.isActive && !editChildrenTab.isActive"
@@ -137,7 +137,6 @@
         <alg-item-progress
           *ngIf="progressTab?.isActive"
           [itemData]="itemData"
-          [isTaskReadOnly]="(taskReadOnly$ | async) ?? false"
           [savingAnswer]="(savingAnswer$ | async) ?? false"
           (skipSave)="skipBeforeUnload()"
         ></alg-item-progress>

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -210,6 +210,17 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       }),
     this.initialAnswerDataSource.unknownError$.subscribe(e => this.unknownError = e),
 
+
+    // drop "answer" route arg when switching "watching" off
+    this.groupWatchingService.isWatching$.pipe(
+      pairwise(),
+      filter(([ old, cur ]) => old && !cur), // was "on", become "off"
+      switchMap(() => this.itemRouteState$.pipe(take(1), readyData())),
+      delay(0),
+    ).subscribe(route => {
+      this.itemRouter.navigateTo({ ...route, answer: undefined });
+    }),
+
     this.itemRouteState$.subscribe(state => {
       if (state.isReady) {
         // configure initialAnswerDataSource

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -40,7 +40,6 @@ import { PendingChangesComponent } from 'src/app/shared/guards/pending-changes-g
 import { TaskTab } from '../item-display/item-display.component';
 import { TaskConfig } from '../../services/item-task.service';
 import { urlArrayForItemRoute } from 'src/app/shared/routing/item-route';
-import { GetAnswerService } from '../../http-services/get-answer.service';
 import { appConfig } from 'src/app/shared/helpers/config';
 import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
 import { allowsWatchingResults } from 'src/app/shared/models/domain/item-watch-permission';
@@ -324,7 +323,6 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     private groupWatchingService: GroupWatchingService,
     private resultActionsService: ResultActionsService,
     private getItemPathService: GetItemPathService,
-    private getAnswerService: GetAnswerService,
     private layoutService: LayoutService,
     private currentContentService: CurrentContentService,
     private discussionService: DiscussionService,

--- a/src/app/modules/item/pages/item-by-id/item-route-validation.ts
+++ b/src/app/modules/item/pages/item-by-id/item-route-validation.ts
@@ -10,10 +10,11 @@ interface ItemRouteError extends Partial<ItemRoute> {
 export function itemRouteFromParams(prefix: string, params: ParamMap): FullItemRoute|ItemRouteError {
   const contentType = itemCategoryFromPrefix(prefix);
   if (contentType === null) throw new Error('Unexpected item path prefix');
-  const { id, path, attemptId, parentAttemptId, answerId, answerBest, answerParticipantId } = decodeItemRouterParameters(params);
+  const { id, path, attemptId, parentAttemptId, answerId, answerBest, answerParticipantId, answerLoadAsCurrent }
+    = decodeItemRouterParameters(params);
   let answer: ItemRoute['answer']|undefined;
   if (answerBest) answer = { best: true, participantId: answerParticipantId ?? undefined };
-  else if (answerId) answer = { id: answerId };
+  else if (answerId) answer = { id: answerId, loadAsCurrent: answerLoadAsCurrent ? true : undefined };
 
   if (!id) return { tag: 'error', contentType };
   if (path === null) return { tag: 'error', contentType, id, answer };

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -47,7 +47,7 @@
         <alg-parent-skills [itemData]="itemData" *ngIf="itemData.item.type === 'Skill'"></alg-parent-skills>
       </ng-container>
 
-      <ng-container *ngIf="itemData.item.type === 'Task'">
+      <ng-container *ngIf="taskConfig">
         <ng-container *ngIf="itemData.item.url; else noUrl">
           <alg-item-display
             *ngIf="attemptId; else noCurrentResult"

--- a/src/app/modules/item/pages/item-content/item-content.component.ts
+++ b/src/app/modules/item/pages/item-content/item-content.component.ts
@@ -22,7 +22,7 @@ export class ItemContentComponent implements OnChanges, PendingChangesComponent 
 
   @Input() itemData?: ItemData;
   @Input() taskView?: TaskTab['view'];
-  @Input() taskConfig: TaskConfig = { readOnly: false, formerAnswer: null };
+  @Input() taskConfig: TaskConfig|null = null;
   @Input() savingAnswer = false;
   @Input() editModeEnabled = false;
 

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -48,7 +48,7 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
   @Input() editingPermission: ItemPermWithEdit = { canEdit: ItemEditPerm.None };
   @Input() attemptId!: string;
   @Input() view?: TaskTab['view'];
-  @Input() taskConfig: TaskConfig = { readOnly: false, formerAnswer: null };
+  @Input() taskConfig: TaskConfig = { readOnly: false, initialAnswer: null };
   @Input() savingAnswer = false;
 
   @Output() scoreChange = this.taskService.scoreChange$;

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -18,6 +18,7 @@
       [loading]="state.isFetching"
       [tableStyle]="{'min-width': '479px'}"
       responsiveLayout="scroll"
+      *ngIf="{ isWatching: isWatching$ | async, canWatchAnswers: canWatchAnswers$ | async } as meta"
     >
       <ng-template pTemplate="header" let-rowData let-columns>
         <tr>
@@ -63,12 +64,12 @@
                   <button
                     pButton
                     class="alg-button p-button-rounded p-small-button p-button-outlined"
-                    [label]="(rowData.isWatchingGroup ? 'watchingGroup' : '') | i18nSelect : {
-                      watchingGroup: 'View answer',
+                    [label]="(meta.isWatching ? 'watchingMode' : '') | i18nSelect : {
+                      watchingMode: 'View answer',
                       other: 'Reload answer'
                     }"
-                    [routerLink]="rowData.item | rawItemRoute | withAnswer: { id: rowData.answerId} | url"
-                    *ngIf="rowData.displayLoadButton"
+                    [routerLink]="rowData.item | rawItemRoute | withAnswer: { id: rowData.answerId, loadAsCurrent: meta.isWatching ? undefined : true } | url"
+                    *ngIf="(!meta.isWatching || meta.canWatchAnswers) && rowData.answerId"
                   ></button>
                 </div>
               </ng-container>

--- a/src/app/modules/item/pages/item-progress/item-progress.component.html
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.html
@@ -56,7 +56,6 @@
           <alg-item-log-view
             *ngIf="!!historyTab?.isActive"
             [itemData]="itemData"
-            [isTaskReadOnly]="isTaskReadOnly"
           ></alg-item-log-view>
 
           <div class="chapter-group-progress">

--- a/src/app/modules/item/pages/item-progress/item-progress.component.ts
+++ b/src/app/modules/item/pages/item-progress/item-progress.component.ts
@@ -14,7 +14,6 @@ import { combineLatest, ReplaySubject } from 'rxjs';
 export class ItemProgressComponent implements OnChanges {
 
   @Input() itemData?: ItemData;
-  @Input() isTaskReadOnly = false;
   @Input() savingAnswer = false;
 
   @Output() skipSave = new EventEmitter<void>();

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -8,15 +8,17 @@ import { openNewTab, replaceWindowUrl } from 'src/app/shared/helpers/url';
 import { FullItemRoute, itemRoute } from 'src/app/shared/routing/item-route';
 import { ItemRouter } from 'src/app/shared/routing/item-router';
 import { AskHintService } from '../http-services/ask-hint.service';
-import { Answer } from '../http-services/get-answer.service';
+import { Answer as GetAnswerType } from '../http-services/get-answer.service';
 import { Task, TaskPlatform } from '../task-communication/task-proxy';
 import { ItemTaskAnswerService } from './item-task-answer.service';
 import { ItemTaskInitService } from './item-task-init.service';
 import { ItemTaskViewsService } from './item-task-views.service';
 
+export type Answer = Pick<GetAnswerType, 'id'|'authorId'|'answer'|'state'|'score'> & Partial<Pick<GetAnswerType, 'createdAt'>>;
+
 export interface TaskConfig {
   readOnly: boolean,
-  formerAnswer: Answer | null,
+  initialAnswer: Answer | null,
   locale?: string,
 }
 
@@ -68,7 +70,7 @@ export class ItemTaskService {
   configure(route: FullItemRoute, url: string, attemptId: string, options: TaskConfig): void {
     this.readOnly = options.readOnly;
     this.attemptId = attemptId;
-    this.initService.configure(route, url, attemptId, options.formerAnswer, options.locale, options.readOnly);
+    this.initService.configure(route, url, attemptId, options.initialAnswer, options.locale, options.readOnly);
   }
 
   initTask(iframe: HTMLIFrameElement): void {

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -14,6 +14,7 @@ const attemptParamName = 'attempId';
 const answerParamName = 'answerId';
 const answerBestParamName = 'answerBest';
 const answerBestParticipantParamName = 'answerParticipantId';
+const answerLoadAsCurrentParamName = 'answerLoadAsCurrent';
 
 // alias for better readibility
 type ItemId = string;
@@ -35,8 +36,8 @@ export interface ItemRoute extends ContentRoute {
   attemptId?: AttemptId,
   parentAttemptId?: AttemptId,
   answer?:
-    { best?: undefined, id: AnswerId, participantId?: undefined } |
-    { best: true, id?: undefined, participantId?: string /* not set if mine */ },
+    { best?: undefined, id: AnswerId, participantId?: undefined, loadAsCurrent?: true } |
+    { best: true, id?: undefined, participantId?: string /* not set if mine */, loadAsCurrent?: undefined },
 }
 type ItemRouteWithSelfAttempt = ItemRoute & { attemptId: AttemptId };
 type ItemRouteWithParentAttempt = ItemRoute & { parentAttemptId: AttemptId };
@@ -96,6 +97,7 @@ export function decodeItemRouterParameters(params: ParamMap): {
   answerId: string|null,
   answerBest: boolean,
   answerParticipantId: string|null,
+  answerLoadAsCurrent: boolean,
 } {
   return {
     id: params.get('id'),
@@ -105,6 +107,7 @@ export function decodeItemRouterParameters(params: ParamMap): {
     answerId: params.get(answerParamName),
     answerBest: params.get(answerBestParamName) === '1',
     answerParticipantId: params.get(answerBestParticipantParamName),
+    answerLoadAsCurrent: params.get(answerLoadAsCurrentParamName) === '1',
   };
 }
 
@@ -131,7 +134,10 @@ export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] 
     if (route.answer.best) {
       params[answerBestParamName] = '1';
       if (route.answer.participantId) params[answerBestParticipantParamName] = route.answer.participantId;
-    } else params[answerParamName] = route.answer.id;
+    } else {
+      params[answerParamName] = route.answer.id;
+      if (route.answer.loadAsCurrent) params[answerLoadAsCurrentParamName] = '1';
+    }
   }
 
   const prefix = route.contentType === 'activity' ? activityPrefix : skillPrefix;

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -27,7 +27,7 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">58</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">311</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">129</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">58</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">312</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">129</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
         <source>Language mismatch</source><target state="translated">Mauvaise langue?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/language-mismatch/language-mismatch.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="6895619751331935307" datatype="html">
@@ -66,7 +66,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">148</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{ node.data.groupRelation.managership === 'descendant' ? 'You are a manager of one of the descendant of the group' : 'You are a manager of the group' }}"/></source><target state="translated"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'Vous êtes gestionnaire d'un des descendants de ce groupe' : 'Vous êtes gestionnaire de ce groupe' }}"/></target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">194</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">194</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">121</context></context-group></trans-unit><trans-unit id="1298975301426242340" datatype="html">
         <source>You are a member of the group</source><target state="translated">Vous êtes membre de ce groupe</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">199</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
@@ -105,20 +105,14 @@
         </context-group>
       </trans-unit><trans-unit id="6592131321269769114" datatype="html">
         <source>This page does not exist!</source><target state="translated">Cette page n'existe pas!</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context>
-          <context context-type="linenumber">1</context>
-        </context-group>
-      </trans-unit><trans-unit id="569741268651615075" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">1</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">172</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">3</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">4</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">171</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
         <source>home page</source><target state="translated">accueil</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context>
-          <context context-type="linenumber">4</context>
-        </context-group>
-      </trans-unit><trans-unit id="9167217071684260011" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/page-not-found/page-not-found.component.html</context><context context-type="linenumber">4</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="9167217071684260011" datatype="html">
         <source>Create a new group</source><target state="translated">Créer un nouveau groupe</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/components/add-group/add-group.component.html</context>
@@ -133,7 +127,7 @@
       </trans-unit><trans-unit id="6673660887182833564" datatype="html">
         <source>Customize</source><target state="translated">Personnaliser</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="796732026436524919" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/grid/grid.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="796732026436524919" datatype="html">
         <source>There is currently no way for you to access this content.</source><target state="new">There is currently no way for you to access this content.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context>
@@ -142,7 +136,7 @@
       </trans-unit><trans-unit id="7463044993322326313" datatype="html">
         <source> This content does not exist or you are not allowed to view it. </source><target state="translated"> Ce contenu n'existe pas ou vous n'êtes pas autorisé à le voir. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">168</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">167</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">48</context></context-group></trans-unit><trans-unit id="7296226328505512523" datatype="html">
@@ -482,28 +476,23 @@
       </trans-unit><trans-unit id="2250922476634643797" datatype="html">
         <source>Parameters</source><target state="new">Parameters</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
-
-      <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">113</context></context-group></trans-unit><trans-unit id="7319979892477125831" datatype="html">
-        <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot; class=&quot;alg-link&quot;>"/>load your most recent answer<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="translated"> Erreur lors du chargement de la réponse, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;fallbackLink&quot;>"/>charger votre dernière réponse<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-details/item-details.component.html</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
         <source>Leave unsaved task</source><target state="translated">Ne pas sauvegarder la réponse</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">192</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">191</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
         <source>You do not appear to be connected to the Internet, if you leave this task you may loose your progress. Are you sure you want to continue?</source><target state="translated">Vous ne semblez pas être connecté à Internet, si vous quittez cette tâche, vous perdrez vos changements. Êtes-vous sûr de vouloir continuer ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">194</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">193</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
         <source>Loose progress and leave the task</source><target state="translated">Perdre les changement et quitter la tâche</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">199</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">198</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
         <source>Retry</source><target state="translated">Réessayer</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">205</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">204</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">49</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
         <source>An unknown error occurred. </source><target state="translated">Une erreur est survenue. </target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">310</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">311</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">128</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="8679237608788920660" datatype="html">
@@ -521,7 +510,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">42</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
         <source>Unable to load the answer</source><target state="new">Unable to load the answer</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">110</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">110</context></context-group></trans-unit><trans-unit id="8386959747515123064" datatype="html">
+        <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;error.fallbackLink&quot; class=&quot;alg-link&quot;>"/>back to the regular task page<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></source><target state="new"> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;error.fallbackLink&quot; class=&quot;alg-link&quot;>"/>back to the regular task page<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
+          <context context-type="linenumber">113,114</context>
+        </context-group>
+      </trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="new">Saving answer...</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
@@ -765,35 +760,26 @@
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="4483782490109214722" datatype="html">
         <source>You are not allowed to view the progress of other users on this content.</source><target state="new">You are not allowed to view the progress of other users on this content.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context>
-          <context context-type="linenumber">78,79</context>
-        </context-group>
-      </trans-unit><trans-unit id="4495565209134031333" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">77</context></context-group></trans-unit><trans-unit id="4495565209134031333" datatype="html">
         <source>You are not allowed to view this content.</source><target state="new">You are not allowed to view this content.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context>
-          <context context-type="linenumber">79,80</context>
-        </context-group>
-      </trans-unit><trans-unit id="7069121178850359614" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.html</context><context context-type="linenumber">78</context></context-group></trans-unit><trans-unit id="7069121178850359614" datatype="html">
         <source>Situation of <x id="PH" equiv-text="g.name"/></source><target state="new">Situation of <x id="PH" equiv-text="watchedGroup.name"/></target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="853471125604435384" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="853471125604435384" datatype="html">
         <source>Your situation</source><target state="new">Your situation</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="1125515177419706232" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-progress/item-progress.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="1125515177419706232" datatype="html">
         <source>Maformed url: "<x id="PH" equiv-text="url"/>"</source><target state="new">Maformed url: "<x id="PH" equiv-text="url"/>"</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="1648546115727864611" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">104</context></context-group></trans-unit><trans-unit id="1648546115727864611" datatype="html">
         <source>Invalid url "<x id="PH" equiv-text="url"/>": please provide an http(s) link</source><target state="new">Invalid url "<x id="PH" equiv-text="url"/>": please provide an http(s) link</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-      </trans-unit><trans-unit id="4370087843628009533" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="4370087843628009533" datatype="html">
         <source>Invalid url, please provide a secure task url (https)</source><target state="new">Invalid url, please provide a secure task url (https)</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="2232338005256831495" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">112</context></context-group></trans-unit><trans-unit id="2232338005256831495" datatype="html">
         <source>Unable to load this task. Either you have a connection issue or this task is not correctly configured. Please retry, if the problem persists, contact us.</source><target state="new">Unable to load this task. Either you have a connection issue or this task is not correctly configured. Please retry, if the problem persists, contact us.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context>
@@ -987,7 +973,7 @@
       <note from="description" priority="1">Button label for joining an item by (group) code</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
         <source>Edit content</source><target state="new">Edit content</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
@@ -1028,7 +1014,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">63</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">180</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">179</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -1043,7 +1029,7 @@
       </trans-unit><trans-unit id="9041444757418829014" datatype="html">
         <source>Error while loading the item.</source><target state="translated">Erreur lors du chargement du contenu.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">170</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">169</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
         <source>Add</source><target state="translated">Ajouter</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.html</context><context context-type="linenumber">14</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="9165363087268857396" datatype="html">
@@ -1077,7 +1063,7 @@
       <source> Select all </source>
       <target state="translated"> Tout sélectionner </target>
 
-    <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">114</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-request/pending-request.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="8905995985388209337" datatype="html">
+    <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">116</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-request/pending-request.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="8905995985388209337" datatype="html">
        <source>Accept</source><target state="translated">Accepter</target>
 
      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-request/pending-request.component.html</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="7378878529334768232" datatype="html">
@@ -1627,7 +1613,7 @@
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">108</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">66</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">95</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -1891,10 +1877,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="33149636091572968" datatype="html">
         <source>Load more</source><target state="new">Load more</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">124</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">94</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit><trans-unit id="5077586677126527379" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">124</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">96</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit><trans-unit id="5077586677126527379" datatype="html">
         <source>This list is empty. Check below the different ways to add members or sub-groups.</source><target state="translated">La liste est vide. Voyez ci-dessous comment vous pouvez ajouter des membres et sous-groupes.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="1916930465370171483" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">108</context></context-group></trans-unit><trans-unit id="1916930465370171483" datatype="html">
         <source> Select all </source><target state="translated"> Tout sélectionner </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="6306138344256927663" datatype="html">
@@ -2182,7 +2168,7 @@
       </trans-unit><trans-unit id="1734171097636944073" datatype="html">
         <source>There is no progress to report for this item.</source><target state="new">There is no progress to report for this item.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">97</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
         <source>You do not have the permissions to edit this content.</source><target state="translated">Vous n'avez pas les permissions d'éditer ce contenu.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">49</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5676044567873886390" datatype="html">
@@ -2204,16 +2190,16 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">15</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="8115085152478832979" datatype="html">
         <source>There is no progress to report for this group/user.</source><target state="new">There is no progress to report for this group/user.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">91</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">79</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">98</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">79</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
         <source>Action</source><target state="translated">Opération</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">103</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
         <source>User</source><target state="new">User</target>
 
-      <note from="description" priority="1">User column label</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">88</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">113</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
+      <note from="description" priority="1">User column label</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">88</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
         <source>Time</source><target state="translated">Date/Heure</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">118</context></context-group></trans-unit><trans-unit id="2739370419840410792" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="2739370419840410792" datatype="html">
         <source>Add a manager</source><target state="new">Add a manager</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.html</context>


### PR DESCRIPTION
## Description

Refactor answer loading which was spread between 2 places: item-by-id and item-task-answer.

- do not remove answer-related url parameters when it is not related to loading an answer 

## Test cases

- [ ] Case 1: The previous case still work
  1. Given I am the usual user
  3. When I go to [this page which load the 100pts solution](https://dev.algorea.org/branch/answer-reorg/en/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0;answerId=4952918079239152196)
  4. Then I see the answer which scores 100 pts loaded and the answerId still in the url
  3. When I go to [this page which load the 75pts solution](https://dev.algorea.org/branch/answer-reorg/en/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0;answerId=4979411964075363655)
  4. Then I see the answer which scores 75 pts loaded and the answerId still in the url

- [ ] Case 2: Loading the user's best answer 
  1. Given I am the usual user
  3. When I go to [this page to opening user's best answer (`answerBest=1` in url)](https://dev.algorea.org/branch/answer-reorg/en/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0;answerBest=1)
  4. Then I see the answer which scores 100 pts loaded **in read-only mode and the answerId still in the url**

- [ ] Case 2bis: Loading the user's best answer 
  1. Given I am the usual user
  3. When I go to [this page to reload (= instead of the current one) user's best answer (`answerBest=1` and `answerLoadAsCurrent=1` in url)](https://dev.algorea.org/branch/answer-reorg/en/activities/by-id/1975719871120702120;path=4702,1352246428241737349,314613032161178344,34689573454313988;parentAttempId=0;answerBest=1;answerLoadAsCurrent=1)
  4. Then I see the answer which scores 100 pts loaded **not in read-only mode and the answerId NOT in the url**

- [ ] Case 3: in observation mode, being able to load the best answer of a user + leaving observation mode
  1. Given I am the usual user
  2. When I go on: https://dev.algorea.org/branch/answer-reorg/en/activities/by-id/6379723280369399253;path=7528142386663912287,7523720120450464843;attempId=0;answerBest=1;answerParticipantId=752024252804317630?watchedGroupId=4035378957038759250&watchUser=0 which load a task in observation mode (of group "!634") and load the best answer of user "usr_5p020x2thuyu"
  3. Then I see user's best answer has been loaded (50pts) (in read-only)
  4. If I leave watching mode (top right button in the observation bar)
  5. I am back on my own answer

- [ ] Case 4: previous loading from progress list (observation) still work 
  1. Given I am the usual user
  3. When I go to [on a task in observation mode](https://dev.algorea.org/branch/answer-reorg/en/activities/by-id/6379723280369399253;path=;parentAttempId=0/progress/history?watchedGroupId=4035378957038759250&watchUser=0)
  6. I load the answer of usr_5p020x2thuyu with score of 25pts
  7. I see the answer which scored 25pts,  **in read-only mode and the answerId still in the url**

- [ ] Case 5: previous loading from progress list (not observation) still work
  1. Given I am the usual user
  3. When I go to [on a task in observation mode](https://dev.algorea.org/branch/answer-reorg/en/activities/by-id/6379723280369399253;path=;parentAttempId=0/progress/history)
  4. I load one of my answers which scored of 25pts
  5. I see my answer which scored 25pts  **not in read-only mode and the answerId NOT in the url**
