### PR TITLE
Fix do not drop path when valid

### DIFF
--- a/cypress/e2e/item.e2e-spec.cy.ts
+++ b/cypress/e2e/item.e2e-spec.cy.ts
@@ -9,8 +9,8 @@ describe('item page', () => {
     const pageLoadUseCases = [
       { label: 'without path', path: undefined },
       { label: 'with correct path', path: motifArt.path },
-      { label: 'with incorrect path', path: [ '111', '999' ] },
-      { label: 'with incorrect path with non-numbers', path: [ 'invalid', 'path' ] },
+      { label: 'with incorrect path', path: [ '111', '999' ] }, // trigger forbidden
+      { label: 'with incorrect path with non-numbers', path: [ 'invalid', 'path' ] }, // trigger 404
     ];
     for (const useCase of pageLoadUseCases) {
       it(`should load ${useCase.label}`, () => {

--- a/cypress/e2e/item.e2e-spec.cy.ts
+++ b/cypress/e2e/item.e2e-spec.cy.ts
@@ -9,7 +9,8 @@ describe('item page', () => {
     const pageLoadUseCases = [
       { label: 'without path', path: undefined },
       { label: 'with correct path', path: motifArt.path },
-      { label: 'with incorrect path', path: [ 'invalid', 'path' ] },
+      { label: 'with incorrect path', path: [ '111', '999' ] },
+      { label: 'with incorrect path with non-numbers', path: [ 'invalid', 'path' ] },
     ];
     for (const useCase of pageLoadUseCases) {
       it(`should load ${useCase.label}`, () => {

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -119,6 +119,8 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
      * In practice, the fetches all have a `shareReplay` which protect them from cancellation as long as they are retained by the `scan`.
      * The shareReplay's use `{ refCount: true, bufferSize: 1 }` options so that the service call is cancelled when there are no more
      * subscribers, and so that new subscribers get the latest results on subscription.
+     * (Note: discussion related to shareReplay refCount: https://github.com/ReactiveX/rxjs/issues/5029 -> a completed (http) source
+     * will not be resubscribed (i.e., be re-executed) after its completion, even with refCount)
      *
      * Test case:
      * - normal navigation -> no request is cancelled to be re-executed

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -276,6 +276,8 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       }
     }),
 
+    this.itemDataSource.resultPathStarted$.subscribe(() => this.currentContent.forceNavMenuReload()),
+
     this.itemDataSource.state$.pipe(
       filter(s => s.isError),
     ).subscribe(state => {

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -242,53 +242,54 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     }),
 
     // on datasource state change, update the current content page info
-    this.itemDataSource.state$.subscribe(state => {
-      if (state.isReady) {
-        const fullRoute = routeWithSelfAttempt(state.data.route, state.data.currentResult?.attemptId);
-        this.hasRedirected = false;
-        this.currentContent.replace(itemInfo({
-          breadcrumbs: {
-            category: itemBreadcrumbCat,
-            path: state.data.breadcrumbs.map(el => ({
-              title: el.title,
-              hintNumber: el.attemptCnt,
-              navigateTo: ():UrlTree => this.itemRouter.url(el.route),
-            })),
-            currentPageIdx: state.data.breadcrumbs.length - 1,
-          },
-          title: state.data.item.string.title === null ? undefined : state.data.item.string.title,
-          route: fullRoute,
-          details: {
-            title: state.data.item.string.title,
-            type: state.data.item.type,
-            permissions: state.data.item.permissions,
-            attemptId: state.data.currentResult?.attemptId,
-            bestScore: state.data.item.watchedGroup ? state.data.item.watchedGroup.averageScore : state.data.item.bestScore,
-            currentScore: state.data.item.watchedGroup ? state.data.item.watchedGroup.averageScore : state.data.currentResult?.score,
-            validated: state.data.item.watchedGroup ?
-              state.data.item.watchedGroup.averageScore === 100 : state.data.currentResult?.validated,
-          },
-        }));
+    this.itemDataSource.state$.pipe(readyData()).subscribe(data => {
+      this.hasRedirected = false;
+      this.currentContent.replace(itemInfo({
+        breadcrumbs: {
+          category: itemBreadcrumbCat,
+          path: data.breadcrumbs.map(el => ({
+            title: el.title,
+            hintNumber: el.attemptCnt,
+            navigateTo: ():UrlTree => this.itemRouter.url(el.route),
+          })),
+          currentPageIdx: data.breadcrumbs.length - 1,
+        },
+        title: data.item.string.title === null ? undefined : data.item.string.title,
+        route: routeWithSelfAttempt(data.route, data.currentResult?.attemptId),
+        details: {
+          title: data.item.string.title,
+          type: data.item.type,
+          permissions: data.item.permissions,
+          attemptId: data.currentResult?.attemptId,
+          bestScore: data.item.watchedGroup ? data.item.watchedGroup.averageScore : data.item.bestScore,
+          currentScore: data.item.watchedGroup ? data.item.watchedGroup.averageScore : data.currentResult?.score,
+          validated: data.item.watchedGroup ?
+            data.item.watchedGroup.averageScore === 100 : data.currentResult?.validated,
+        },
+      }));
 
-        if (state.data.route.answer?.loadAsCurrent) {
-          this.itemRouter.navigateTo(
-            { ...state.data.route, answer: undefined },
-            { navExtras: { replaceUrl: true, state: { preventRefetch: true } } },
-          );
-        }
-
-      } else if (state.isError) {
-        // If path is incorrect, redirect to same page without path to trigger the solve missing path at next navigation
-        if (errorHasTag(state.error, breadcrumbServiceTag) && (errorIsHTTPForbidden(state.error) || errorIsHTTPNotFound(state.error))) {
-          if (this.hasRedirected) throw new Error('Too many redirections (unexpected)');
-          this.hasRedirected = true;
-          const { contentType, id, answer } = this.getItemRoute();
-          if (!id) throw new Error('Unexpected: item id should exist');
-          this.itemRouter.navigateTo({ contentType, id, answer }, { navExtras: { replaceUrl: true } });
-        }
-        this.currentContent.clear();
+      if (data.route.answer?.loadAsCurrent) {
+        this.itemRouter.navigateTo(
+          { ...data.route, answer: undefined },
+          { navExtras: { replaceUrl: true, state: { preventRefetch: true } } },
+        );
       }
     }),
+
+    this.itemDataSource.state$.pipe(
+      filter(s => s.isError),
+    ).subscribe(state => {
+      // If path is incorrect, redirect to same page without path to trigger the solve missing path at next navigation
+      if (errorHasTag(state.error, breadcrumbServiceTag) && (errorIsHTTPForbidden(state.error) || errorIsHTTPNotFound(state.error))) {
+        if (this.hasRedirected) throw new Error('Too many redirections (unexpected)');
+        this.hasRedirected = true;
+        const { contentType, id, answer } = this.getItemRoute();
+        if (!id) throw new Error('Unexpected: item id should exist');
+        this.itemRouter.navigateTo({ contentType, id, answer }, { navExtras: { replaceUrl: true } });
+      }
+      this.currentContent.clear();
+    }),
+
 
     this.itemDataSource.state$.pipe(
       readyData(),

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -1,6 +1,18 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { EMPTY, forkJoin, Observable, of, ReplaySubject, Subject, combineLatest } from 'rxjs';
-import { delayWhen, distinctUntilChanged, filter, map, scan, shareReplay, startWith, switchMap, takeUntil, } from 'rxjs/operators';
+import {
+  catchError,
+  delayWhen,
+  distinctUntilChanged,
+  filter,
+  map,
+  retry,
+  scan,
+  shareReplay,
+  startWith,
+  switchMap,
+  takeUntil
+} from 'rxjs/operators';
 import { bestAttemptFromResults, implicitResultStart } from 'src/app/shared/helpers/attempts';
 import { isRouteWithSelfAttempt, FullItemRoute } from 'src/app/shared/routing/item-route';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
@@ -14,6 +26,7 @@ import { FetchState } from 'src/app/shared/helpers/state';
 import { LocaleService } from 'src/app/core/services/localeService';
 import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
 import { canCurrentUserViewContent } from 'src/app/shared/models/domain/item-view-permission';
+import { errorIsHTTPForbidden } from 'src/app/shared/helpers/errors';
 
 export interface ItemData {
   route: FullItemRoute,
@@ -104,7 +117,7 @@ export class ItemDataSource implements OnDestroy {
     return forkJoin({
       route: of(itemRoute),
       item: this.getItemByIdService.get(itemRoute.id, watchedGroupId),
-      breadcrumbs: this.getBreadcrumbService.getBreadcrumb(itemRoute),
+      breadcrumbs: this.getBreadcrumb(itemRoute),
     }).pipe(
       buildUp(data => (canCurrentUserViewContent(data.item) ? this.fetchResults(data.route, data.item) : EMPTY)),
     );
@@ -138,6 +151,22 @@ export class ItemDataSource implements OnDestroy {
           )),
         );
       }),
+    );
+  }
+
+  private getBreadcrumb(itemRoute: FullItemRoute): Observable<BreadcrumbItem[]> {
+    return this.getBreadcrumbService.getBreadcrumb(itemRoute).pipe(
+      /**
+       * If the breadcrumb service fails with 'forbidden' error, try to start results for the item path. If this works, retry fetching
+       * the breadcrumbs. Otherwise, return the original breadcrumb error.
+       */
+      retry({
+        count: 1,
+        delay: (err: unknown) => {
+          if (!errorIsHTTPForbidden(err)) throw err;
+          return this.resultActionsService.startWithoutAttempt(itemRoute.path).pipe(catchError(() => of(err)));
+        }
+      })
     );
   }
 


### PR DESCRIPTION
## Description

Fixes 2 (related) issues:
1. when a temp user navigate to path he hasn't explored yet (if he receives a link not at the root)... (depending on the order of the requests) most of the time the navigation cannot be load in the left menu as parents have not be started (to reproduce: for instance go to [this page](https://dev.algorea.org/en/activities/by-id/1980584647557587953;path=4702,4102;parentAttempId=0) as a temp user (incognito/private mode))
2. when there was a failure because a path has not been started, the path was completely dropped to restart a new one... but this may cause to change path while it is not what we want

## Test cases

- [ ] Case 1:
  1. Given I am a **temp** user on a new incognito/private tab
  2. Then I open network panel 
  3. When I go to [a page not at root](https://dev.algorea.org/branch/fix-do-not-drop-path-when-valid/en/activities/by-id/1980584647557587953;path=4702,4102;parentAttempId=0)
  4. Then I see in the url bar that the path is not dropped and rebuilt
  5. Then I see the left menu is loaded 

- [ ] Case 2: The previous case is still working (invalid numeric path (forbidden))
  1. Given I am a **temp** user on a new incognito/private tab
  3. When I go to [a page with an invalid path](https://dev.algorea.org/branch/fix-do-not-drop-path-when-valid/en/activities/by-id/1980584647557587953;path=123,456;parentAttempId=0)
  4. Then I see in the url bar that the path is dropped and rebuilt to a correct one "4702, 4102"

- [ ] Case 3: The previous case is still working (char path)
  1. Given I am a **temp** user on a new incognito/private tab
  3. When I go to [a page with an invalid path](https://dev.algorea.org/branch/fix-do-not-drop-path-when-valid/en/activities/by-id/1980584647557587953;path=AB,cd;parentAttempId=0)
  4. Then I see in the url bar that the path is dropped and rebuilt to a correct one "4702, 4102"

