### PR TITLE
only load active tab content at launch

### DIFF
--- a/src/app/core/components/left-menu/left-menu.component.html
+++ b/src/app/core/components/left-menu/left-menu.component.html
@@ -1,4 +1,4 @@
 <alg-left-header></alg-left-header>
 <perfect-scrollbar class="left-nav-theme scrollbar" [ngClass]="{'dark': isNavThemeDark}">
-  <alg-left-nav (themeChange)="onNavThemeChange($event.isDark)"></alg-left-nav>
+  <alg-left-nav (themeChange)="onNavThemeChange($event.isDark)" (selectElement)="onSelectedElementChange($event)"></alg-left-nav>
 </perfect-scrollbar>


### PR DESCRIPTION
## Description

#1122 , the fix to #1109  has caused the activities, skills, and group menu data to load at app bootstrap. This was due to the subscription done for following the id to which to scroll.

This PR just implements a more correct way of doing the same action. 

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. And I open the network panel
  3. When I go to [the home page](https://dev.algorea.org/branch/only-load-active-tab-content/en/)
  4. Then I see skills and groups and not loaded
  5. If I click on the "skills" tab, they load

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to the [second element in the menu](https://dev.algorea.org/branch/only-load-active-tab-content/en/activities/by-id/6707691810849260111;path=;attempId=0)
  3. and I scroll down the menu
  4. if I navigate to previous element using the top right nav
  5. I see the menu auto scrolls to the new selected element
