### PR TITLE
ignore a firefox error when add-ons keep references to DOM objects af…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ Sentry.init({
   integrations: [],
   ignoreErrors: [
     "Cannot read properties of undefined (reading 'sendMessage')", // a chrome extension error
+    "can't access dead object", // a firefox error when add-ons keep references to DOM objects after their parent document was destroyed
   ]
 });
 


### PR DESCRIPTION
Ignore a firefox error when add-ons keep references to DOM objects after their parent document was destroyed

see https://blog.mozilla.org/addons/2012/09/12/what-does-cant-access-dead-object-mean/

Cannot reproduce myself but was triggered several times by users recently.
