### PR TITLE
deny errors from extensions/add-ons as recommended by sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,26 @@ Sentry.init({
   ignoreErrors: [
     "Cannot read properties of undefined (reading 'sendMessage')", // a chrome extension error
     "can't access dead object", // a firefox error when add-ons keep references to DOM objects after their parent document was destroyed
-  ]
+  ],
+  // from https://docs.sentry.io/clients/javascript/tips/
+  denyUrls: [
+    // Google Adsense
+    /pagead\/js/i,
+    // Facebook flakiness
+    /graph\.facebook\.com/i,
+    // Facebook blocked
+    /connect\.facebook\.net\/en_US\/all\.js/i,
+    // Woopra flakiness
+    /eatdifferent\.com\.woopra-ns\.com/i,
+    /static\.woopra\.com\/js\/woopra\.js/i,
+    // Chrome extensions
+    /extensions\//i,
+    /^chrome:\/\//i,
+    // Other plugins
+    /127\.0\.0\.1:4001\/isrunning/i, // Cacaoweb
+    /webappstoolbarba\.texthelp\.com\//i,
+    /metrics\.itunes\.apple\.com\.edgesuite\.net\//i
+  ],
 });
 
 if (appConfig.production) {


### PR DESCRIPTION
Deny errors from extensions/add-ons as recommended by sentry.

See https://docs.sentry.io/clients/javascript/tips/ 

We start having more and more random errors reported.