### PR TITLE
User-friendly item paths

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -8,7 +8,7 @@ Cypress.Commands.add('navigateTo', (relativeUrl: string) => {
 
 Cypress.Commands.add('navigateToActivity', (itemId: string, path?: string[]) => {
   const url = [
-    `/activities/${itemId}`,
+    `/a/${itemId}`,
     path && `;path=${path.join(',')}`,
     ';parentAttempId=0',
   ].filter(Boolean).join('');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -8,7 +8,7 @@ Cypress.Commands.add('navigateTo', (relativeUrl: string) => {
 
 Cypress.Commands.add('navigateToActivity', (itemId: string, path?: string[]) => {
   const url = [
-    `/activities/by-id/${itemId}`,
+    `/activities/${itemId}`,
     path && `;path=${path.join(',')}`,
     ';parentAttempId=0',
   ].filter(Boolean).join('');

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -9,8 +9,8 @@ Cypress.Commands.add('navigateTo', (relativeUrl: string) => {
 Cypress.Commands.add('navigateToActivity', (itemId: string, path?: string[]) => {
   const url = [
     `/a/${itemId}`,
-    path && `;path=${path.join(',')}`,
-    ';parentAttempId=0',
+    path && `;p=${path.join(',')}`,
+    ';pa=0',
   ].filter(Boolean).join('');
 
   cy.visit(url);

--- a/src/app/core/app-routing.module.ts
+++ b/src/app/core/app-routing.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule, UrlSegment } from '@angular/router';
 import { urlStringFromArray } from '../shared/helpers/url';
-import { appDefaultItemRoute, urlArrayForItemRoute } from '../shared/routing/item-route';
+import { activityPrefix, appDefaultItemRoute, skillPrefix, urlArrayForItemRoute } from '../shared/routing/item-route';
 import { PageNotFoundComponent } from './pages/page-not-found/page-not-found.component';
 import { RedirectToIdComponent } from './pages/redirect-to-id/redirect-to-id.component';
 
@@ -16,11 +16,11 @@ const routes: Routes = [
     loadChildren: (): Promise<any> => import('../modules/group/group.module').then(m => m.GroupModule)
   },
   {
-    path: 'activities',
+    path: activityPrefix,
     loadChildren: (): Promise<any> => import('../modules/item/item.module').then(m => m.ItemModule)
   },
   {
-    path: 'skills',
+    path: skillPrefix,
     loadChildren: (): Promise<any> => import('../modules/item/item.module').then(m => m.ItemModule)
   },
   {

--- a/src/app/modules/item/item-routing.module.ts
+++ b/src/app/modules/item/item-routing.module.ts
@@ -7,7 +7,7 @@ import { ItemByIdComponent } from './pages/item-by-id/item-by-id.component';
 @NgModule({
   imports: [ RouterModule.forChild([
     {
-      path: 'by-id/:id',
+      path: ':id',
       component: ItemByIdComponent,
       canDeactivate: [ BeforeUnloadGuard, PendingChangesGuard ],
       // Children below do not use routing but there are defined here so that the router can validate the route exists

--- a/src/app/modules/item/item-routing.module.ts
+++ b/src/app/modules/item/item-routing.module.ts
@@ -7,7 +7,7 @@ import { ItemByIdComponent } from './pages/item-by-id/item-by-id.component';
 @NgModule({
   imports: [ RouterModule.forChild([
     {
-      path: ':id',
+      path: ':idOrAlias',
       component: ItemByIdComponent,
       canDeactivate: [ BeforeUnloadGuard, PendingChangesGuard ],
       // Children below do not use routing but there are defined here so that the router can validate the route exists

--- a/src/app/shared/helpers/config.ts
+++ b/src/app/shared/helpers/config.ts
@@ -55,7 +55,7 @@ const presetQueryParam = 'config_preset';
 /**
  * Escape hatch to start the platform with the provided configuration preset. (presets are declared in each environment file)
  * @example `http://dev.algorea.org/?config_preset=demo`
- * @example `http://dev.algorea.org/activities/etc/?config_preset=demo`
+ * @example `http://dev.algorea.org/a/etc/?config_preset=demo`
  * Should be used only by Algorea teams, for testing or demo purposes only.
  */
 function getPresetNameFromQuery(): string | null {

--- a/src/app/shared/helpers/url.spec.ts
+++ b/src/app/shared/helpers/url.spec.ts
@@ -3,13 +3,13 @@ import { boolToQueryParamValue, queryParamValueToBool, urlStringFromArray } from
 
 describe('urlStringFromArray', () => {
   it('should convert correctly a complex absolute case', () => {
-    expect(urlStringFromArray([ '/', 'activities', 'by-id', '123', { attemptId: '99', path: [ '4','5','6' ] }]))
-      .toEqual('/activities/by-id/123;attemptId=99;path=4,5,6');
+    expect(urlStringFromArray([ '/', 'activities', '123', { attemptId: '99', path: [ '4','5','6' ] }]))
+      .toEqual('/activities/123;attemptId=99;path=4,5,6');
   });
 
   it('should convert correctly a complex relative case', () => {
-    expect(urlStringFromArray([ 'by-id', '123', { attemptId: '99', path: [ '4','5','6' ] }]))
-      .toEqual('by-id/123;attemptId=99;path=4,5,6');
+    expect(urlStringFromArray([ '123', { attemptId: '99', path: [ '4','5','6' ] }]))
+      .toEqual('123;attemptId=99;path=4,5,6');
   });
 
 });

--- a/src/app/shared/helpers/url.spec.ts
+++ b/src/app/shared/helpers/url.spec.ts
@@ -3,13 +3,13 @@ import { boolToQueryParamValue, queryParamValueToBool, urlStringFromArray } from
 
 describe('urlStringFromArray', () => {
   it('should convert correctly a complex absolute case', () => {
-    expect(urlStringFromArray([ '/', 'a', '123', { attemptId: '99', path: [ '4','5','6' ] }]))
-      .toEqual('/a/123;attemptId=99;path=4,5,6');
+    expect(urlStringFromArray([ '/', 'a', '123', { a: '99', p: [ '4','5','6' ] }]))
+      .toEqual('/a/123;a=99;p=4,5,6');
   });
 
   it('should convert correctly a complex relative case', () => {
-    expect(urlStringFromArray([ '123', { attemptId: '99', path: [ '4','5','6' ] }]))
-      .toEqual('123;attemptId=99;path=4,5,6');
+    expect(urlStringFromArray([ '123', { a: '99', p: [ '4','5','6' ] }]))
+      .toEqual('123;a=99;p=4,5,6');
   });
 
 });

--- a/src/app/shared/helpers/url.spec.ts
+++ b/src/app/shared/helpers/url.spec.ts
@@ -3,8 +3,8 @@ import { boolToQueryParamValue, queryParamValueToBool, urlStringFromArray } from
 
 describe('urlStringFromArray', () => {
   it('should convert correctly a complex absolute case', () => {
-    expect(urlStringFromArray([ '/', 'activities', '123', { attemptId: '99', path: [ '4','5','6' ] }]))
-      .toEqual('/activities/123;attemptId=99;path=4,5,6');
+    expect(urlStringFromArray([ '/', 'a', '123', { attemptId: '99', path: [ '4','5','6' ] }]))
+      .toEqual('/a/123;attemptId=99;path=4,5,6');
   });
 
   it('should convert correctly a complex relative case', () => {

--- a/src/app/shared/routing/content-route.ts
+++ b/src/app/shared/routing/content-route.ts
@@ -2,7 +2,7 @@ import { ParamMap } from '@angular/router';
 import { UrlCommandParameters } from '../helpers/url';
 
 /* for url */
-const pathParamName = 'path';
+const pathParamName = 'p';
 
 type Id = string;
 

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -9,8 +9,8 @@ import { UrlCommand } from '../helpers/url';
 // url parameter names
 export const activityPrefix = 'a';
 export const skillPrefix = 's';
-const parentAttemptParamName = 'parentAttempId';
-const attemptParamName = 'attempId';
+const parentAttemptParamName = 'pa';
+const attemptParamName = 'a';
 const answerParamName = 'answerId';
 const answerBestParamName = 'answerBest';
 const answerBestParticipantParamName = 'answerParticipantId';

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -7,8 +7,8 @@ import { isString } from '../helpers/type-checkers';
 import { UrlCommand } from '../helpers/url';
 
 // url parameter names
-const activityPrefix = 'activities';
-const skillPrefix = 'skills';
+export const activityPrefix = 'a';
+export const skillPrefix = 's';
 const parentAttemptParamName = 'parentAttempId';
 const attemptParamName = 'attempId';
 const answerParamName = 'answerId';

--- a/src/app/shared/routing/item-route.ts
+++ b/src/app/shared/routing/item-route.ts
@@ -142,5 +142,5 @@ export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] 
 
   const prefix = route.contentType === 'activity' ? activityPrefix : skillPrefix;
   const pagePath = isString(page) ? [ page ] : page;
-  return [ '/', prefix, 'by-id', route.id, params, ...pagePath ];
+  return [ '/', prefix, route.id, params, ...pagePath ];
 }

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -44,7 +44,7 @@ export class ItemRouter {
    * Return undefined if we are not on an "item" page
    */
   private currentItemPage(): string[]|undefined {
-    const page = this.currentItemPagePath()?.slice(3);
+    const page = this.currentItemPagePath()?.slice(2);
     return page && page.length > 0 ? page : undefined;
   }
 
@@ -53,9 +53,8 @@ export class ItemRouter {
     if (!primary) return undefined;
     const { segments } = primary;
     if (
-      segments.length < 3 ||
-      itemCategoryFromPrefix(ensureDefined(segments[0]).path) === null ||
-      ensureDefined(segments[1]).path !== 'by-id'
+      segments.length < 2 ||
+      itemCategoryFromPrefix(ensureDefined(segments[0]).path) === null
     ) return undefined;
     return segments.map(segment => segment.path);
   }


### PR DESCRIPTION
## Description

Use "user-friendly" path for item pages. 

From `/activities/by-id/1471479157476024035;path=4702;parentAttempId=0` 
To `/a/officiels-algorea-serious-game;pa=0`

In details: (roughly matching commits)
- remove the "by-id" part for items
- shorten activities/skills and parameter names in path
- if an alias exists ("redirects" config), use it instead of ids (and path if provided) in the path (id/path->alias and alias->id/path).

## Test cases

- [ ] Case: Has alias with path (path in config)
  1. Given I am any user
  2. When go to: https://dev.algorea.org/branch/user-friendly-item-path/en/a/officiels-algorea-serious-game
  3. Then I see "ALGOREA SERIOUS GAME" and the url keep the alias
  
- [ ] Case: Has alias without path (path in config)
  1. Given I am any user
  2. When go to: https://dev.algorea.org/branch/user-friendly-item-path/en/a/algorea-adventure
  3. Then I see "ALGOREA ADVENTURE" and the url keep the alias and the path appears in the url
  
- [ ] Case: Land with redirect 
  1. Given I am any user
  2. When go to: https://dev.algorea.org/branch/user-friendly-item-path/en/a/1471479157476024035
  3. Then I see "ALGOREA SERIOUS GAME" and the url uses the alias
  
- [ ] Case: Land without redirect
  1. Given I am any user (who has an attempt, so he has already visited the page)
  2. When I provide all raw parameters: https://dev.algorea.org/branch/user-friendly-item-path/en/a/4702;p=;pa=0
  3. Then I see "Parcours officiels" and the url does not change 

- [ ] Case: Links
  1. Given I am any user
  2. When go to root: https://dev.algorea.org/branch/user-friendly-item-path/en/
  3. When I navigate with the left menu to "ALGOREA ADVENTURE" 
  4. Then the alias is used with the path
  3. When I navigate with the neighbor nav to next: "ALGOREA SERIOUS GAME" 
  4. Then the alias is used without the path (in config)
  3. When I navigate with the neighbor nav to next: "MOTIF ART" 
  4. Then the ids are used

- [ ] Case: root
  1. Given I am any user
  2. When go to root: https://dev.algorea.org/branch/user-friendly-item-path/en/
  3. Then I see "Parcours officiels" and the url go to the alias without path
  