### PR TITLE
fix: recover after an item error (invalid item)

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -15,7 +15,7 @@ import {
   takeUntil,
 } from 'rxjs/operators';
 import { defaultAttemptId } from 'src/app/shared/helpers/attempts';
-import { errorState, fetchingState, FetchState, isFetchingOrError } from 'src/app/shared/helpers/state';
+import { errorState, fetchingState, FetchState, isFetchingOrError, readyState } from 'src/app/shared/helpers/state';
 import { ResultActionsService } from 'src/app/shared/http-services/result-actions.service';
 import { CurrentContentService } from 'src/app/shared/services/current-content.service';
 import { breadcrumbServiceTag } from '../../http-services/get-breadcrumb.service';
@@ -31,7 +31,7 @@ import { isItemRouteError, itemRouteFromParams } from './item-route-validation';
 import { LayoutService } from 'src/app/shared/services/layout.service';
 import { mapStateData, mapToFetchState, readyData } from 'src/app/shared/operators/state';
 import { ensureDefined } from 'src/app/shared/helpers/assert';
-import { ItemRoute, RawItemRoute, routeWithSelfAttempt } from 'src/app/shared/routing/item-route';
+import { FullItemRoute, ItemRoute, RawItemRoute, routeWithSelfAttempt } from 'src/app/shared/routing/item-route';
 import { BeforeUnloadComponent } from 'src/app/shared/guards/before-unload-guard';
 import { ItemContentComponent } from '../item-content/item-content.component';
 import { ItemEditWrapperComponent } from '../../components/item-edit-wrapper/item-edit-wrapper.component';
@@ -100,11 +100,10 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       const item = this.getItemRoute(params);
       if (isItemRouteError(item)) {
         if (!item.id) throw new Error('unexpected: no id in item page');
-        return this.solveMissingPathAttempt(item.contentType, item.id, item.path, item.answer);
+        return this.solveMissingPathAttempt(item.contentType, item.id, item.path, item.answer).pipe(mapToFetchState());
       }
-      return of(item);
+      return of<FetchState<FullItemRoute>>(readyState(item));
     }),
-    mapToFetchState(),
     takeUntil(this.destroyed$),
     shareReplay(1),
   );


### PR DESCRIPTION
## Description

Fix the behavior shown in below cases.

## Test cases

- [ ] Case: BEFORE 
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/open-url-text_id/en/a/5515805070397494516;p=7528142386663912287,7523720120450464843,6963488196048051083;pa=0)
  3. And I click on "Test openUrl path (no newTab)"
  4. Then I see an error page (normal)
  5. And I click on browser "back"
  6. And I still see the error page (bug)
  5. And I click on "Go back to the home page "
  6. And I still see the error page (bug)

- [ ] Case 2: Fix
  1. Given I am the usual user
  2. When ...
