### PR TITLE
openUrl: choose the closest breadcrumbs when several ones

### DIFF
--- a/src/app/shared/routing/content-route.spec.ts
+++ b/src/app/shared/routing/content-route.spec.ts
@@ -1,0 +1,37 @@
+import { closestBreadcrumbs } from './content-route';
+
+const basePath = [ '1', '2', '3' ];
+
+function wrap(path: string[]): { id: string }[] {
+  return path.map(e => ({ id: e }));
+}
+
+describe('closestPath', () => {
+  it('should throw an exception if the list is empty', () => {
+    expect(function () {
+      closestBreadcrumbs(basePath, []);
+    }).toThrow();
+  });
+
+  it('should return the only path if there is only one path', () => {
+    expect(closestBreadcrumbs(basePath, [ wrap([ '1', '2', '3' ]) ])).toEqual(wrap([ '1', '2', '3' ]));
+    expect(closestBreadcrumbs(basePath, [ wrap([ '4', '5' ]) ])).toEqual(wrap([ '4', '5' ]));
+  });
+
+  it('should return the path with the longest subpath', () => {
+    expect(closestBreadcrumbs(basePath, [ [ '4', '5' ], [ '1', '2', '5' ], [ '1', '5' ] ].map(wrap))).toEqual(wrap([ '1', '2', '5' ]));
+  });
+
+  it('should return the shortest if there are several ones with the same prefix length', () => {
+    expect(closestBreadcrumbs(basePath, [ [ '1' ], [ '1', '2', '5' ], [ '1', '2', '4', '5' ] ].map(wrap))).toEqual(wrap([ '1', '2', '5' ]));
+    expect(closestBreadcrumbs(basePath, [ [ '1' ], [ '1', '2', '4', '5' ], [ '1', '2', '5' ] ].map(wrap))).toEqual(wrap([ '1', '2', '5' ]));
+  });
+
+  it('should return the shortest if there is a full match of the base', () => {
+    expect(closestBreadcrumbs(basePath, [ [ '1' ], [ '1', '2', '3', '5' ], [ '1', '2', '3', '4', '5' ] ].map(wrap)))
+      .toEqual(wrap([ '1', '2', '3', '5' ]));
+    expect(closestBreadcrumbs(basePath, [ [ '1', '2', '3', '4', '5' ], [ '1', '2', '3', '5' ], [ '1' ] ].map(wrap)))
+      .toEqual(wrap([ '1', '2', '3', '5' ]));
+  });
+
+});

--- a/src/app/shared/routing/content-route.ts
+++ b/src/app/shared/routing/content-route.ts
@@ -23,3 +23,22 @@ export function pathAsParameter(value: string[]): UrlCommandParameters {
   params[pathParamName] = value;
   return params;
 }
+
+/*
+ * Returns, among the given list of breadcrumbs, the one which is the closest from the base.
+ * The closest path is the shortest path with the longest common prefix. (if several ones, any of these is returned)
+ * `list` must not be empty, otherwise throw an exception!
+ */
+export function closestBreadcrumbs<T extends { id: Id }>(base: Id[], list: T[][]): T[] {
+  const sol = list.map(breadcrumbs => {
+    for (let i = 0; i < base.length; i++) {
+      if (base[i] !== breadcrumbs[i]?.id) return { common: i, breadcrumbs };
+    }
+    return { common: base.length, breadcrumbs };
+  }).reduce((prev, cur) => {
+    if (prev.common > cur.common) return prev;
+    if (cur.common > prev.common) return cur;
+    return prev.breadcrumbs.length > cur.breadcrumbs.length ? cur : prev;
+  });
+  return sol.breadcrumbs;
+}


### PR DESCRIPTION
## Description

When there are several paths to an item page, choose the closest one.

## Test cases

- [ ] Case 1: BEFORE
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/open-url-text_id/en/a/5515805070397494516;p=7528142386663912287,7523720120450464843,6963488196048051083;a=0/edit-children)
  3. And I click on "Test openUrl text_id test_text_id_with_multiple_paths"
  4. Then I see I have navigated to the item in the "Chapter for multiple paths" chapter while I had one sibling matching

- [ ] Case 2: AFTER
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/openurl-choose-closest-breadcrumbs/en/a/5515805070397494516;p=7528142386663912287,7523720120450464843,6963488196048051083;a=0/edit-children)
  3. And I click on "Test openUrl text_id test_text_id_with_multiple_paths"
  4. Then I see I have navigated to the sibling item (closest from the initial page)
