### PR TITLE
do not fetch a new result list after a start result as all values can be guessed

### DIFF
--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -144,15 +144,10 @@ export class ItemDataSource implements OnDestroy {
         const attemptId = isRouteWithSelfAttempt(itemRoute) ? itemRoute.attemptId : itemRoute.parentAttemptId;
         if (!attemptId) return EMPTY; // unexpected
         return this.resultActionsService.start(itemRoute.path.concat([ itemRoute.id ]), attemptId).pipe(
-          // once a result has been created, fetch it
-          switchMap(() => this.getResultsService.getResults(itemRoute).pipe(
-            map(results => {
-              // this time we are sure to have a started result as we just started it
-              const currentResult = bestAttemptFromResults(results);
-              if (currentResult === null) throw new Error('Unexpected: result just created not found');
-              return { results: results, currentResult: currentResult };
-            }),
-          )),
+          map(() => {
+            const result = { attemptId, latestActivityAt: new Date(), startedAt: new Date(), score: 0, validated: false };
+            return { results: [ ...results, result ], currentResult: result };
+          })
         );
       }),
     );


### PR DESCRIPTION
## Description

When opening a content for the first time, the workflow was looking like this:

![Screenshot 2023-03-29 at 15 26 56](https://user-images.githubusercontent.com/1053150/228553076-239dfd91-88d9-4940-9bfb-0c976d503e8c.png)

The 2nd "GET attempts" was for getting the results after the creation of one with the "POST start-result", but actually the response can be inferred from the previous "GET attempts" and what we have requested to create.

## Test cases

- [ ] Case 1: BEFORE
  1. Given I am the *temp* (new private window) user
  2. When I open the network pane
  3. When I go to any page I can view, for instance [this one](https://dev.algorea.org/en/a/4102;p=4702;pa=0)
  5. Then I see 2 calls "GET /attempts?..."
 
- [ ] Case 2: AFTER
  1. Given I am the *temp* (new private window) user
  2. When I open the network pane
  3. When I go to any page I can view, for instance [this one](https://dev.algorea.org/branch/do-not-refetch-result-after-start/en/a/4102;p=4702;pa=0)
  5. Then I see 1 call "GET /attempts?..."
 
