### PR TITLE
Do not wait for answer to gen token

### DIFF
--- a/src/app/modules/item/pages/item-by-id/initial-answer-datasource.ts
+++ b/src/app/modules/item/pages/item-by-id/initial-answer-datasource.ts
@@ -2,6 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import {
   catchError,
   combineLatest,
+  concat,
   distinctUntilChanged,
   map,
   Observable,
@@ -45,9 +46,11 @@ export class InitialAnswerDataSource implements OnDestroy {
     distinctUntilChanged((s1, s2) => JSON.stringify(s1) === JSON.stringify(s2)),
     switchMap(strategy => {
       if (strategy.tag === 'EmptyInitialAnswer') return of(null); // null -> no initial answer
-      if (strategy.tag === 'LoadCurrent') return this.getCurrentAnswer(strategy.itemId, strategy.attemptId);
-      if (strategy.tag === 'LoadById') return this.getAnswerService.get(strategy.answerId);
-      if (strategy.tag === 'LoadBest') return this.getAnswerService.getBest(strategy.itemId, { watchedGroupId: strategy.participantId });
+      if (strategy.tag === 'LoadCurrent') return concat(of(undefined), this.getCurrentAnswer(strategy.itemId, strategy.attemptId));
+      if (strategy.tag === 'LoadById') return concat(of(undefined), this.getAnswerService.get(strategy.answerId));
+      if (strategy.tag === 'LoadBest') {
+        return concat(of(undefined), this.getAnswerService.getBest(strategy.itemId, { watchedGroupId: strategy.participantId }));
+      }
       return of(undefined); // "Wait" and "NotApplicable" cases - undefined -> not defined yet
     }),
     takeUntil(this.destroyed$),

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.html
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.html
@@ -101,7 +101,7 @@
         [@threadOpenClose]="(threadOpened$ | async) ? 'opened' : 'closed'"
       >
         <ng-container *ngIf="contentTab.isActive || editChildrenTab.isActive || taskTabs.length > 0">
-          <alg-error *ngIf="answerLoadingError$ | async as error">
+          <alg-error *ngIf="answerLoadingError$ | async as error; else noAnswerLoadingError">
             <ng-container *ngIf="!error.fallbackLink; else fallback" i18n>Unable to load the answer</ng-container>
             <ng-template #fallback>
               <ng-container i18n>
@@ -111,24 +111,27 @@
             <p *ngIf="!error.isForbidden">{{ errorMessageContactUs }}</p>
           </alg-error>
 
-          <ng-container *ngrxLet="taskConfig$ as taskConfig">
-            <div *ngIf="taskConfig && taskConfig.readOnly && contentTab.isActive" class="indicator">
-              <alg-answer-author-indicator *ngIf="taskConfig.initialAnswer" [answer]="taskConfig.initialAnswer"></alg-answer-author-indicator>
-            </div>
-            <alg-item-content
-              [hidden]="!contentTab.isActive && !editChildrenTab.isActive"
-              [itemData]="itemData"
-              [taskConfig]="taskConfig"
-              [savingAnswer]="(savingAnswer$ | async) ?? false"
-              [(taskView)]="taskView"
-              [editModeEnabled]="editChildrenTab.isActive"
-              (taskTabsChange)="setTaskTabs($event)"
-              (scoreChange)="onScoreChange($event)"
-              (skipSave)="skipBeforeUnload()"
-              (refresh)="reloadItem()"
-              (editorUrl)="editorUrl = $event"
-            ></alg-item-content>
-          </ng-container>
+          <ng-template #noAnswerLoadingError>
+            <ng-container *ngrxLet="taskConfig$ as taskConfig">
+              <div *ngIf="taskConfig && taskConfig.readOnly && contentTab.isActive" class="indicator">
+                <alg-answer-author-indicator *ngIf="taskConfig.initialAnswer" [answer]="taskConfig.initialAnswer"></alg-answer-author-indicator>
+              </div>
+              <alg-item-content
+                [hidden]="!contentTab.isActive && !editChildrenTab.isActive"
+                [itemData]="itemData"
+                [taskConfig]="taskConfig"
+                [savingAnswer]="(savingAnswer$ | async) ?? false"
+                [(taskView)]="taskView"
+                [editModeEnabled]="editChildrenTab.isActive"
+                (taskTabsChange)="setTaskTabs($event)"
+                (scoreChange)="onScoreChange($event)"
+                (skipSave)="skipBeforeUnload()"
+                (refresh)="reloadItem()"
+                (editorUrl)="editorUrl = $event"
+              ></alg-item-content>
+            </ng-container>
+          </ng-template>
+
         </ng-container>
         <alg-item-progress
           *ngIf="progressTab?.isActive"

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -160,7 +160,6 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     switchMap(data => {
       if (!isTask(data.item)) return of(null); // config for non-task's is null
       return this.initialAnswerDataSource.answer$.pipe(
-        filter(isNotUndefined), // undefined is for not-known-yet and so have to be skipped
         catchError(() => EMPTY), // error is handled by initialAnswerDataSource.error$
         map(initialAnswer => ({
           readOnly: !!data.route.answer && !data.route.answer.loadAsCurrent,
@@ -226,7 +225,6 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
 
     this.itemRouteState$.subscribe(state => {
       if (state.isReady) {
-        // configure initialAnswerDataSource
         // just publish to current content the new route we are navigating to (without knowing any info)
         this.currentContent.replace(itemInfo({
           route: state.data,

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -6,7 +6,6 @@ import {
   Input,
   OnChanges,
   OnDestroy,
-  OnInit,
   Output,
   SimpleChanges,
   ViewChild,
@@ -61,13 +60,13 @@ const heightSyncInterval = 0.2*SECONDS;
   styleUrls: [ './item-display.component.scss' ],
   providers: [ ItemTaskService, ItemTaskInitService, ItemTaskAnswerService, ItemTaskViewsService ],
 })
-export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges, OnDestroy {
+export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDestroy {
   @Input() route!: FullItemRoute;
   @Input() url!: string;
   @Input() editingPermission: ItemPermWithEdit = { canEdit: ItemEditPerm.None };
   @Input() attemptId!: string;
   @Input() view?: TaskTab['view'];
-  @Input() taskConfig: TaskConfig = { readOnly: false, initialAnswer: null };
+  @Input() taskConfig: TaskConfig = { readOnly: false, initialAnswer: undefined };
   @Input() savingAnswer = false;
 
   @Output() scoreChange = this.taskService.scoreChange$;
@@ -211,18 +210,14 @@ export class ItemDisplayComponent implements OnInit, AfterViewChecked, OnChanges
     private ltiDataSource: LTIDataSource,
   ) {}
 
-  ngOnInit(): void {
-    this.taskService.configure(this.route, this.url, this.attemptId, this.taskConfig);
-    this.taskService.showView(this.view ?? 'task');
-  }
-
   ngAfterViewChecked(): void {
     if (!this.iframe || this.taskService.initialized) return;
     this.taskService.initTask(this.iframe.nativeElement);
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.view && this.view) this.taskService.showView(this.view);
+    if (changes.taskConfig) this.taskService.configure(this.route, this.url, this.attemptId, this.taskConfig);
+    if (changes.view) this.taskService.showView(this.view ?? 'task');
     if (
       changes.route &&
       !changes.route.firstChange &&

--- a/src/app/modules/item/services/item-task-answer.service.ts
+++ b/src/app/modules/item/services/item-task-answer.service.ts
@@ -48,6 +48,7 @@ export class ItemTaskAnswerService implements OnDestroy {
 
   private initialAnswer$: Observable<Answer | null> = this.config$.pipe(
     switchMap(({ route, attemptId, initialAnswer }) => {
+      if (initialAnswer === undefined) return EMPTY;
       if (route.answer?.loadAsCurrent && initialAnswer) {
         return this.loadAsNewCurrentAnswer(route.id, attemptId, initialAnswer);
       }
@@ -61,7 +62,7 @@ export class ItemTaskAnswerService implements OnDestroy {
   private initializedTaskState$ = combineLatest([
     this.initialAnswer$.pipe(catchError(() => EMPTY)), // error is handled elsewhere
     this.task$,
-    this.config$,
+    this.config$.pipe(take(1)),
   ]).pipe(
     switchMap(([ initialAnswer, task, { readOnly }]) =>
       (initialAnswer?.state && !readOnly ? task.reloadState(initialAnswer.state).pipe(map(() => undefined)) : of(undefined))

--- a/src/app/modules/item/services/item-task.service.ts
+++ b/src/app/modules/item/services/item-task.service.ts
@@ -16,7 +16,7 @@ export type Answer = Pick<GetAnswerType, 'id'|'authorId'|'answer'|'state'|'score
 
 export interface TaskConfig {
   readOnly: boolean,
-  initialAnswer: Answer | null,
+  initialAnswer: Answer | undefined /* not defined yet */ | null /* no initial answer */,
   locale?: string,
 }
 


### PR DESCRIPTION
## Description

Do not wait for the answer fetching to start generating the token, so that we save 1-request time when loading a task.

In practice, it means that when it is possible (i.e., when the token generation does not need the answer), set the answer to `undefined` at first to let the task initialize (starting by generating token).

## Test cases

- [ ] Case 1: autoloading the last answr
  1. Given I am the usual user
  2. When I go to [this page](branch link)
  3. And I click on ...
  4. Then I see ...
  5. And

- [ ] Case 2: loading an existing answer
  1. Given I am the usual user
  2. When ...

- [ ] Case 3: loading an existing answer from another user
  1. Given I am the usual user
  2. When ...

- [ ] Case 4: loading a best answer
  1. Given I am the usual user
  2. When ...

- [ ] Case 4: loading a best answer from another user
  1. Given I am the usual user
  2. When ...

