### PR TITLE
Bugfix/do not display score on children list for items with no score

### DIFF
--- a/src/app/modules/item/components/chapter-children/chapter-children.component.html
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.html
@@ -45,7 +45,7 @@
               <div></div>
               <div class="grid-card-activity-progress">
                 <alg-score-ring
-                  *ngIf="(!item.watchedGroup && item.result) || (item.watchedGroup && item.watchedGroup.avgScore !== undefined)"
+                  *ngIf="!item.noScore && ((!item.watchedGroup && item.result) || (item.watchedGroup && item.watchedGroup.avgScore !== undefined))"
                   [diameter]="30"
                   [currentScore]="(item.watchedGroup ? item.watchedGroup.avgScore : item.result?.score) ?? 0"
                   [isValidated]="(item.watchedGroup ? item.watchedGroup.allValidated : item.result?.validated) ?? false"

--- a/src/app/modules/item/components/item-children-list/item-children-list.component.html
+++ b/src/app/modules/item/components/item-children-list/item-children-list.component.html
@@ -6,7 +6,7 @@
   <li class="data-list-item" *ngFor="let item of children; let i = index">
     <div class="activity-progress" *ngIf="type === 'activity'">
       <alg-score-ring
-        *ngIf="(!item.watchedGroup && item.result) || (item.watchedGroup && item.watchedGroup.avgScore !== undefined)"
+        *ngIf="!item.noScore && (!item.watchedGroup && item.result) || (item.watchedGroup && item.watchedGroup.avgScore !== undefined)"
         [diameter]="30"
         [currentScore]="(item.watchedGroup ? item.watchedGroup.avgScore : item.result?.score) ?? 0"
         [isValidated]="(item.watchedGroup ? item.watchedGroup.allValidated : item.result?.validated) ?? false"

--- a/src/app/modules/item/components/item-children-list/item-children.ts
+++ b/src/app/modules/item/components/item-children-list/item-children.ts
@@ -19,4 +19,5 @@ export interface ItemChildWithAdditions {
     validated: boolean,
     score: number,
   },
+  noScore?: boolean,
 }

--- a/src/app/modules/item/http-services/get-item-children.service.ts
+++ b/src/app/modules/item/http-services/get-item-children.service.ts
@@ -43,6 +43,7 @@ const itemChildDecoder = pipe(
         scoreComputed: D.number,
         validated: D.boolean,
       })),
+      noScore: D.boolean,
     }),
   ),
   D.intersect(

--- a/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html
+++ b/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html
@@ -103,7 +103,7 @@
                 </ng-container>
               </ng-container>
               <ng-container *ngSwitchCase="'score'">
-                <div class="score-ring" *ngIf="rowData.latestActivityAt">
+                <div class="score-ring" *ngIf="!rowData.noScore && rowData.latestActivityAt">
                   <alg-score-ring [diameter]="42" [currentScore]="rowData.score"></alg-score-ring>
                 </div>
               </ng-container>

--- a/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts
+++ b/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts
@@ -49,6 +49,7 @@ export class ChapterUserProgressComponent implements OnChanges, OnDestroy {
           submissions: participantProgress.item.submissions,
           score: participantProgress.item.score,
           currentUserPermissions: item.permissions,
+          noScore: item.noScore,
         },
         ...participantProgress.children.map(itemData => ({
           id: itemData.itemId,
@@ -59,6 +60,7 @@ export class ChapterUserProgressComponent implements OnChanges, OnDestroy {
           submissions: itemData.submissions,
           score: itemData.score,
           currentUserPermissions: itemData.currentUserPermissions,
+          noScore: item.noScore,
         })),
       ])))
     ),


### PR DESCRIPTION
## Description

Fixes #1306

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/do-not-display-score-on-children-list-for-items-with-no-score/en/a/39530140456452546;p=4702,4102,1980584647557587953;a=0)
  3. Then I see cards with and with no score rings and it consist with left menu list

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/do-not-display-score-on-children-list-for-items-with-no-score/en/a/719603724335612644;p=4702,4102,686491270254002911;a=0)
  3. Then I see items with and with no score rings and it consist with left menu list

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/do-not-display-score-on-children-list-for-items-with-no-score/en/a/685350883824788268;p=899800937596940136;a=0/progress/chapter-user-progress)
  3. Then I see items with and with no score rings and it consist with left menu list