### PR TITLE
Adds forced scroll for app

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -37,6 +37,7 @@
 html {
   height: 100%;
   font-size: 62.5%;
+  overflow-y: scroll;
 }
 
 body {


### PR DESCRIPTION
## Description

Fixes #1327

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

I've just realised that we have `ngx-perfect-scrollbar`, so it could be solution as well

## Test cases

On Windows

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/prevent-scroll-bar-jump-forced-scroll/en/a/6379723280369399253;p=7528142386663912287,7523720120450464843;a=0)
  3. And I click on next in neighbour widget
  4. Then I see no scroll jumping 

ALTERNATIVE (Another branch) - activates forced scroll only for item pages, but jumping continue to be on other pages as group

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/prevent-scroll-bar-jump/en/a/6379723280369399253;p=7528142386663912287,7523720120450464843;a=0)
  3. And I click on next in neighbour widget
  4. Then I see no scroll jumping 
