### PR TITLE
Fix breadcrumb error handling

### DIFF
--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -166,7 +166,9 @@ export class ItemDataSource implements OnDestroy {
           const path = itemRoute.attemptId !== undefined ? [ ...itemRoute.path, itemRoute.id ] : itemRoute.path;
           return this.resultActionsService.startWithoutAttempt(path).pipe(
             tap(() => this.resultPathStarted.next()), // side effect: inform this operation has been done
-            catchError(() => of(err))
+            catchError(() => {
+              throw err; // if `startWithoutAttempt` fails as well, do not retry and fail with the initial breadcrumb error
+            })
           );
         }
       })

--- a/src/app/modules/item/services/item-datasource.service.ts
+++ b/src/app/modules/item/services/item-datasource.service.ts
@@ -163,7 +163,8 @@ export class ItemDataSource implements OnDestroy {
         count: 1,
         delay: (err: unknown) => {
           if (!errorIsHTTPForbidden(err)) throw err;
-          return this.resultActionsService.startWithoutAttempt(itemRoute.path).pipe(
+          const path = itemRoute.attemptId !== undefined ? [ ...itemRoute.path, itemRoute.id ] : itemRoute.path;
+          return this.resultActionsService.startWithoutAttempt(path).pipe(
             tap(() => this.resultPathStarted.next()), // side effect: inform this operation has been done
             catchError(() => of(err))
           );


### PR DESCRIPTION
## Description

Two minor improvements to the error handling in the breadcrumb request.

## Test cases

- [ ] Case: BEFORE
  1. Given I am an anonymous user (on a new private tab)
  2. And I open the network panel
  3. When I go to [a page using an attempt](https://dev.algorea.org/en/a/1410985367628944162;p=4702,100575556387408660;pa=0)
  4. Then I see several 403 requests to the breadcrumb service

- [ ] Case: AFTER
  1. Given I am an anonymous user (on a new private tab)
  2. And I open the network panel
  3. When I go to [a page using an attempt](https://dev.algorea.org/branch/fix-breadcrumb-error-handling/en/a/1410985367628944162;p=4702,100575556387408660;pa=0)
  4. Then I see one 403 request to the breadcrumb service
