### PR TITLE
hide automatically the left menu on mobile (narrow) when we select a task in the left menu

### DIFF
--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -1,7 +1,7 @@
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { Injectable, OnDestroy } from '@angular/core';
 import { CanActivate } from '@angular/router';
-import { BehaviorSubject, Subject, combineLatest, concat, distinctUntilChanged } from 'rxjs';
+import { BehaviorSubject, Subject, combineLatest, distinctUntilChanged } from 'rxjs';
 import { debounceTime, map, scan, startWith, switchMap } from 'rxjs/operators';
 
 export interface FullFrameContent {
@@ -40,7 +40,7 @@ export class LayoutService implements OnDestroy {
   ]).pipe(
     debounceTime(0), // as the sources are not independant, prevent some very-transient inconsistent cases
     // each time manualMenuToggle$ emits, emit its (bool) value, otherwise emit `undefined`
-    switchMap(values => concat(this.manualMenuToggle$).pipe(
+    switchMap(values => this.manualMenuToggle$.pipe(
       map<boolean,[ boolean, boolean, ContentDisplayType, boolean|undefined ]>(manualMenuToggle => [ ...values, manualMenuToggle ]),
       startWith<[ boolean, boolean, ContentDisplayType, boolean|undefined ]>([ ...values, undefined ])
     )),

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -10,13 +10,15 @@ export interface FullFrameContent {
   animated: boolean,
 }
 
+export enum ContentDisplayType { Default, Show, ShowFullFrame }
+
 @Injectable({
   providedIn: 'root'
 })
 export class LayoutService implements OnDestroy {
 
   /* state variables used to make decisions */
-  private fullFrameContentDisplayed = new BehaviorSubject<boolean>(false);
+  private contentDisplayType$ = new BehaviorSubject<ContentDisplayType>(ContentDisplayType.Default);
   private manualMenuToggle$ = new Subject<boolean>();
 
   /* independant variables */
@@ -28,26 +30,30 @@ export class LayoutService implements OnDestroy {
     map(results => results.matches),
     distinctUntilChanged(),
   );
-  fullFrameContentDisplayed$ = this.fullFrameContentDisplayed.asObservable();
+  fullFrameContentDisplayed$ = this.contentDisplayType$.pipe(map(t => t === ContentDisplayType.ShowFullFrame));
   showTopRightControls$ = this.showTopRightControls.asObservable();
   canShowLeftMenu$ = this.canShowLeftMenu.asObservable();
   leftMenu$ = combineLatest([
     this.isNarrowScreen$,
     this.canShowLeftMenu,
-    this.fullFrameContentDisplayed$
+    this.contentDisplayType$
   ]).pipe(
     debounceTime(0), // as the sources are not independant, prevent some very-transient inconsistent cases
     // each time manualMenuToggle$ emits, emit its (bool) value, otherwise emit `undefined`
-    switchMap(values => concat(this.manualMenuToggle$, this.fullFrameContentDisplayed$.pipe(map(() => true))).pipe(
-      map<boolean,[ boolean, boolean, boolean, boolean|undefined ]>(manualMenuToggle => [ ...values, manualMenuToggle ]),
-      startWith<[ boolean, boolean, boolean, boolean|undefined ]>([ ...values, undefined ])
+    switchMap(values => concat(this.manualMenuToggle$).pipe(
+      map<boolean,[ boolean, boolean, ContentDisplayType, boolean|undefined ]>(manualMenuToggle => [ ...values, manualMenuToggle ]),
+      startWith<[ boolean, boolean, ContentDisplayType, boolean|undefined ]>([ ...values, undefined ])
     )),
-    scan((prev, [ isNarrowScreen, canShowLeftMenu, isFullFrameContent, manualMenuToggle ], idx) => {
+    scan((prev, [ isNarrowScreen, canShowLeftMenu, displayType, manualMenuToggle ], idx) => {
       if (!canShowLeftMenu) return { shown: false, animated: false, isNarrowScreen };
       if (idx === 0) return { shown: !isNarrowScreen, animated: false, isNarrowScreen };
-      if (prev.isNarrowScreen !== isNarrowScreen) return { shown: !isNarrowScreen && !isFullFrameContent, animated: true, isNarrowScreen };
+      if (prev.isNarrowScreen !== isNarrowScreen) {
+        return { shown: !isNarrowScreen && displayType !== ContentDisplayType.ShowFullFrame, animated: true, isNarrowScreen };
+      }
       if (manualMenuToggle !== undefined) return { shown: manualMenuToggle, animated: true, isNarrowScreen };
-      if (isFullFrameContent) return { shown: false, animated: true, isNarrowScreen };
+      if (displayType === ContentDisplayType.ShowFullFrame || (isNarrowScreen && displayType === ContentDisplayType.Show)) {
+        return { shown: false, animated: true, isNarrowScreen };
+      }
       return { ...prev, isNarrowScreen };
     }, { shown: false, animated: false, isNarrowScreen: false }),
     map(({ shown, animated }) => ({ shown, animated })),
@@ -59,7 +65,7 @@ export class LayoutService implements OnDestroy {
   ){}
 
   ngOnDestroy(): void {
-    this.fullFrameContentDisplayed.complete();
+    this.contentDisplayType$.complete();
     this.manualMenuToggle$.complete();
     this.showTopRightControls.complete();
     this.canShowLeftMenu.complete();
@@ -69,12 +75,12 @@ export class LayoutService implements OnDestroy {
    * Configure layout.
    * The layout is considered not initialized (so not using animation) only until the first call.
    */
-  configure({ fullFrameContent, canShowLeftMenu, showTopRightControls }: {
-    fullFrameContent?: boolean,
+  configure({ contentDisplayType, canShowLeftMenu, showTopRightControls }: {
+    contentDisplayType?: ContentDisplayType,
     canShowLeftMenu?: boolean,
     showTopRightControls?: boolean,
   }): void {
-    if (fullFrameContent !== undefined) this.fullFrameContentDisplayed.next(fullFrameContent);
+    if (contentDisplayType !== undefined) this.contentDisplayType$.next(contentDisplayType);
     if (canShowLeftMenu !== undefined) this.canShowLeftMenu.next(canShowLeftMenu);
     if (showTopRightControls !== undefined) this.showTopRightControls.next(showTopRightControls);
   }


### PR DESCRIPTION
## Description

Hide automatically the left menu on mobile (narrow) when we select a task in the left menu

## Test cases

- use mobile layout
- show the left menu  
- the left menu auto-hide when navigating to a task
