### PR TITLE
fix the policy which should cause the left menu to close when we select a task

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -327,10 +327,11 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
 
     combineLatest([ this.itemDataSource.state$.pipe(readyData()), this.fullFrameContent$ ]).pipe(
       map(([ data, fullFrame ]) => {
-        if (fullFrame) return ContentDisplayType.ShowFullFrame;
-        return isTask(data.item) ? ContentDisplayType.Show : ContentDisplayType.Default;
+        if (fullFrame) return { id: data.route.id, display: ContentDisplayType.ShowFullFrame };
+        return { id: data.route.id, display: isTask(data.item) ? ContentDisplayType.Show : ContentDisplayType.Default };
       }),
-      distinctUntilChanged(),
+      distinctUntilChanged((x, y) => x.id === y.id && x.display === y.display), // emit once per item for a same display
+      map(({ display }) => display),
     ).subscribe(display => this.layoutService.configure({ contentDisplayType: display })),
 
   ];


### PR DESCRIPTION
Fix the policy which should cause the left menu to close when we select a task.

Bug: 
- open a task via the left menu -> menu hides
- close the menu manually
- click on another task -> menu does not hide
It was because the `distinctUntilChanged` was preventing any new emission on the display, so the there were no events that may close the menu.

