### PR TITLE
Improve menu closing workflow

### DIFF
--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -33,6 +33,21 @@ export class LayoutService implements OnDestroy {
   fullFrameContentDisplayed$ = this.contentDisplayType$.pipe(map(t => t === ContentDisplayType.ShowFullFrame));
   showTopRightControls$ = this.showTopRightControls.asObservable();
   canShowLeftMenu$ = this.canShowLeftMenu.asObservable();
+  /**
+   * Left menu: expected behavior
+   * (note that in the following, a narrow window as the same behavior as mobile)
+   * - cannot show left menu (e.g., using LTI) -> never show the menu
+   * - on app launch -> hide the menu on mobile, show otherwise
+   * - when reducing the window size to mobile: hide the menu
+   * - when enlarging the window size from mobile to non-mobile: show the menu if not showing a full-frame task
+   * - when clicking on the show/hide hamburger menu, show/hide the menu
+   * - on mobile, when clicking on a task in the left menu, close the menu
+   * - on non-mobile, hide the menu when opening a full-frame task (known when the task has been loaded), except if the it was open using
+   *   the left menu
+   * - otherwise, leave the menu as it is
+   * Interesting case to be tested: on mobile, if opening a task via the menu (the menu hides) and closing the menu manually, the menu does
+   * not re-hide when it knows it is a full-frame task
+   */
   leftMenu$ = combineLatest([
     this.isNarrowScreen$,
     this.canShowLeftMenu,

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -51,7 +51,12 @@ export class LayoutService implements OnDestroy {
         return { shown: !isNarrowScreen && displayType !== ContentDisplayType.ShowFullFrame, animated: true, isNarrowScreen };
       }
       if (manualMenuToggle !== undefined) return { shown: manualMenuToggle, animated: true, isNarrowScreen };
-      if (displayType === ContentDisplayType.ShowFullFrame || (isNarrowScreen && displayType === ContentDisplayType.Show)) {
+      if (isNarrowScreen && displayType === ContentDisplayType.Show) {
+        return { shown: false, animated: true, isNarrowScreen };
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      const preventFullFrame = typeof history.state === 'object' && Boolean(history.state?.preventFullFrame);
+      if (!preventFullFrame && displayType === ContentDisplayType.ShowFullFrame) {
         return { shown: false, animated: true, isNarrowScreen };
       }
       return { ...prev, isNarrowScreen };


### PR DESCRIPTION
## Description

Small improvement: do not close the left menu on non-mobile if the task was accessed using the left menu

Side-effect improvements: on mobile, if opening a task via the menu (the menu hides) and closing the menu manually, the menu does not re-hide when it knows it is a full-frame task

Bonus: All cases are now documented