### PR TITLE
New design/group page 1

### DIFF
--- a/src/app/modules/group/components/add-group/add-group.component.ts
+++ b/src/app/modules/group/components/add-group/add-group.component.ts
@@ -18,25 +18,25 @@ export class AddGroupComponent {
   allowedNewGroupTypes: NewContentType<GroupType>[] = [
     {
       type: 'Class',
-      icon: 'fa fa-book',
+      icon: 'ph-duotone ph-chalkboard-teacher',
       title: $localize`Class`,
       description: '',
     },
     {
       type: 'Club',
-      icon: 'fa fa-book',
+      icon: 'ph-duotone ph-address-book',
       title: $localize`Club`,
       description: '',
     },
     {
       type: 'Friends',
-      icon: 'fa fa-users',
+      icon: 'ph-duotone ph-users',
       title: $localize`Friends`,
       description: '',
     },
     {
       type: 'Other',
-      icon: 'fa fa-book',
+      icon: 'ph-duotone ph-users-three',
       title: $localize`Other`,
       description: '',
     },

--- a/src/app/modules/group/components/add-sub-group/add-sub-group.component.html
+++ b/src/app/modules/group/components/add-sub-group/add-sub-group.component.html
@@ -1,4 +1,4 @@
-<alg-sub-section class="sub-section" icon="sign-in-alt" i18n-label label="Add subgroups">
+<alg-sub-section i18n-label label="Add subgroups">
   <alg-add-content
     [allowedTypesForNewContent]="allowedNewGroupTypes"
     [searchFunction]="searchFunction"

--- a/src/app/modules/group/components/add-sub-group/add-sub-group.component.scss
+++ b/src/app/modules/group/components/add-sub-group/add-sub-group.component.scss
@@ -1,5 +1,1 @@
-@media screen and (max-width: 599.98px) {
-  .sub-section {
-    margin-left: -2.8333rem;
-  }
-}
+

--- a/src/app/modules/group/components/add-sub-group/add-sub-group.component.ts
+++ b/src/app/modules/group/components/add-sub-group/add-sub-group.component.ts
@@ -33,25 +33,25 @@ export class AddSubGroupComponent {
   allowedNewGroupTypes: NewContentType<GroupType>[] = [
     {
       type: 'Class',
-      icon: 'fa fa-book',
+      icon: 'ph-duotone ph-chalkboard-teacher',
       title: $localize`Class`,
       description: '',
     },
     {
       type: 'Club',
-      icon: 'fa fa-book',
+      icon: 'ph-duotone ph-address-book',
       title: $localize`Club`,
       description: '',
     },
     {
       type: 'Friends',
-      icon: 'fa fa-users',
+      icon: 'ph-duotone ph-users',
       title: $localize`Friends`,
       description: '',
     },
     {
       type: 'Other',
-      icon: 'fa fa-book',
+      icon: 'ph-duotone ph-users-three',
       title: $localize`Other`,
       description: '',
     },

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.html
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.html
@@ -1,8 +1,8 @@
 <ng-container *ngIf="state$ | async as state">
-  <alg-loading size="medium" *ngIf="state.isFetching && !state.data"></alg-loading>
-
+  <alg-loading class="alg-flex-1" size="medium" *ngIf="state.isFetching && !state.data"></alg-loading>
   <alg-error
     *ngIf="state.isError"
+    class="alg-flex-1"
     [class.dark]="$any(state).error.status !== 403"
     [icon]="$any(state).error.status !== 403 ? 'fa fa-exclamation-triangle' : undefined"
     [showRefreshButton]="$any(state).error.status !== 403"
@@ -17,6 +17,11 @@
   </alg-error>
 
   <ng-container *ngIf="state.data">
+    <div class="refresh-button">
+      <button class="alg-button basic" pButton icon="ph-duotone ph-arrows-clockwise" (click)="refresh()">
+        Refresh
+      </button>
+    </div>
     <p-table
       class="alg-table"
       [columns]="state.data.columns"
@@ -26,13 +31,6 @@
       responsiveLayout="scroll"
     >
       <ng-template pTemplate="header" let-rowData let-columns>
-        <tr>
-          <th [colSpan]="columns.length">
-            <div class="header-container header-refresh">
-              <p-button icon="pi pi-refresh" (click)="refresh()"></p-button>
-            </div>
-          </th>
-        </tr>
         <tr *ngIf="rowData.length > 0">
           <ng-container *ngFor="let col of columns">
             <th>
@@ -54,17 +52,22 @@
           <td *ngFor="let col of columns" (mouseleave)="onMouseLeave($event, col.field)">
             <ng-container [ngSwitch]="col.field">
               <ng-container *ngSwitchCase="'activityType'">
-                <div class="activity-container">
-                  <div class="activity-left">
-                    <span class="activity-progress">
-                      <alg-score-ring
-                        [currentScore]="rowData.score"
-                        [diameter]="32"
-                        *ngIf="rowData.score"
-                      ></alg-score-ring>
-                    </span>
-
-                    {{ rowData.activityType | logActionDisplay }}
+                <div class="item-title-section">
+                  <div class="item-title-section-left">
+                    <alg-score-ring
+                      [currentScore]="rowData.score"
+                      [diameter]="32"
+                      *ngIf="rowData.score; else iconSection"
+                    ></alg-score-ring>
+                    <ng-template #iconSection>
+                      <i class="ph-duotone item-icon" [ngClass]="{
+                        'ph-flag-checkered': rowData.activityType === 'result_started',
+                        'ph-floppy-disk-back': rowData.activityType === 'saved_answer'
+                      }"></i>
+                    </ng-template>
+                  </div>
+                  <div class="item-title">
+                    <p class="item-title-caption">{{ rowData.activityType | logActionDisplay }}</p>
                   </div>
                 </div>
               </ng-container>

--- a/src/app/modules/group/components/group-log-view/group-log-view.component.scss
+++ b/src/app/modules/group/components/group-log-view/group-log-view.component.scss
@@ -1,20 +1,41 @@
-.header-refresh {
+@import 'src/assets/scss/functions';
+
+:host {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.refresh-button {
+  display: flex;
   justify-content: flex-end;
+  align-items: center;
+  margin-bottom: toRem(13);
 }
 
-.activity-container {
+.item-title-section {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+}
+
+.item-title-section-left {
+  margin-right: toRem(20);
+  width: toRem(34);
+  display: flex;
+  justify-content: center;
   align-items: center;
 }
 
-.activity-left {
-  display: flex;
-  align-items: center;
-  margin-right: 1rem;
+.item-icon {
+  color: var(--alg-primary-color);
+  font-size: toRem(24);
 }
 
-.activity-progress {
-  width: 2.66667rem;
-  margin-right: 1rem;
+.item-title-caption {
+  margin: 0;
+}
+
+.item-title-link {
+  display: inline-block;
+  margin-top: toRem(5);
 }

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.html
@@ -1,158 +1,162 @@
 <ng-container *ngIf="state$ | async as state">
-  <alg-loading size="medium" *ngIf="state.isFetching && !state.data"></alg-loading>
+  <alg-loading class="alg-flex-1" *ngIf="state.isFetching && !state.data"></alg-loading>
 
   <alg-error
     *ngIf="state.isError"
+    class="alg-flex-1"
     i18n-message message="Error while loading the group managers"
     [showRefreshButton]="true"
     (refresh)="fetchData()"
   ></alg-error>
 
   <ng-container *ngIf="state.data as managers">
-    <alg-section icon="fa fa-users" i18n-label label="Managers of this group">
-      <alg-grid
-        tableStyle="--group-manager-list"
-        class="slanted-grid"
-        *ngIf="managers.length > 0; else noManagers"
-        [loading]="removalInProgress || state.isFetching"
-        [data]="managers"
-        [(selection)]="selection"
-        sortMode="single"
-        [showGear]="false"
-        [scrollable]="false"
-        dataKey="id"
-      >
-        <ng-template #headerTemplate let-columns>
-          <tr style="border: none; height: 100%">
-            <th class="thin" *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'"></th>
-            <th style="min-width: 160px;">
-              <div class="slanted-header">
-                <div class="slanted-header-content" i18n>
-                  Name
-                </div>
-              </div>
-            </th>
-            <th style="min-width: 110px;">
-              <div class="slanted-header">
-                <div class="slanted-header-content" i18n>
-                  Can Manage
-                </div>
-              </div>
-            </th>
-            <th style="width: 5rem; max-width: 5rem;">
-              <div class="slanted-header">
-                <div class="slanted-header-content" i18n>
-                  Can grant group access
-                </div>
-              </div>
-            </th>
-            <th style="width: 5rem; max-width: 5rem;">
-              <div class="slanted-header">
-                <div class="slanted-header-content" i18n>
-                  Can watch members
-                </div>
-              </div>
-            </th>
-            <th style="width: 11rem; max-width: 11rem;"></th>
-          </tr>
-        </ng-template>
+    <h2 class="alg-h2" i18n>Managers of this group</h2>
 
-        <ng-template
-          #bodyTemplate
-          let-rowData
-          let-columns="columns"
-          let-rowIndex="rowIndex"
-        >
-          <tr [pSelectableRow]="rowData" [pSelectableRowIndex]="rowIndex">
-            <td class="thin" *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'">
-              <p-tableCheckbox class="p-chkbox" [value]="rowData"></p-tableCheckbox>
-            </td>
-            <td
-              style="text-align: left; min-width: 160px; padding-left: 0.5rem; justify-content: left"
-              tooltipPosition="top"
-              tooltipStyleClass="tooltip-custom"
+    <alg-grid
+      tableStyle="slanted"
+      *ngIf="managers.length > 0; else noManagers"
+      [loading]="removalInProgress || state.isFetching"
+      [data]="managers"
+      [(selection)]="selection"
+      sortMode="single"
+      [showGear]="false"
+      [scrollable]="false"
+      dataKey="id"
+    >
+      <ng-template #headerTemplate let-columns>
+        <tr style="border: none; height: 100%">
+          <th class="alg-table-selection-col" *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'"></th>
+          <th style="min-width: 160px">
+            <div class="alg-table-slanted-header">
+              <div class="alg-table-slanted-header-content" i18n>
+                Name
+              </div>
+            </div>
+          </th>
+          <th style="min-width: 110px;">
+            <div class="alg-table-slanted-header">
+              <div class="alg-table-slanted-header-content" i18n>
+                Can Manage
+              </div>
+            </div>
+          </th>
+          <th style="width: 5rem; max-width: 5rem;">
+            <div class="alg-table-slanted-header">
+              <div class="alg-table-slanted-header-content" i18n>
+                Can grant group access
+              </div>
+            </div>
+          </th>
+          <th style="width: 5rem; max-width: 5rem;">
+            <div class="alg-table-slanted-header">
+              <div class="alg-table-slanted-header-content" i18n>
+                Can watch members
+              </div>
+            </div>
+          </th>
+          <th style="width: 11rem; max-width: 11rem;"></th>
+        </tr>
+      </ng-template>
+
+      <ng-template
+        #bodyTemplate
+        let-rowData
+        let-columns="columns"
+        let-rowIndex="rowIndex"
+      >
+        <tr [pSelectableRow]="rowData" [pSelectableRowIndex]="rowIndex">
+          <td class="alg-table-selection-col" *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'">
+            <div class="alg-table-selection-width">
+              <p-tableCheckbox [value]="rowData"></p-tableCheckbox>
+            </div>
+          </td>
+          <td
+            style="text-align: left; min-width: 160px; padding-left: 0.5rem; justify-content: left"
+            tooltipPosition="top"
+            tooltipStyleClass="tooltip-custom"
+          >
+            <a class="alg-link"
+              [routerLink]="rowData | groupLink"
             >
-              <a class="alg-link"
-                [routerLink]="rowData | groupLink"
-              >
-                {{ rowData.login ? (rowData | userCaption) : rowData.name }}
-              </a>
-            </td>
-            <td style="min-width: 110px;">
-              {{ rowData.canManageAsText }}
-            </td>
-            <td style="width: 5rem; max-width: 5rem;">
-              <span class="table-icon"
-                [ngClass]="{
-                  locked: rowData.canGrantGroupAccess,
-                  unlocked: !rowData.canGrantGroupAccess
-                }">
-                <i *ngIf="!rowData.canGrantGroupAccess" class="fa fa-times"></i>
-                <i *ngIf="rowData.canGrantGroupAccess" class="fa fa-check"></i>
-              </span>
-            </td>
-            <td style="width: 5rem; max-width: 5rem;">
-              <span class="table-icon"
-                [ngClass]="{
-                  locked: rowData.canWatchMembers,
-                  unlocked: !rowData.canWatchMembers
-                }">
-                <i *ngIf="!rowData.canWatchMembers" class="fa fa-times"></i>
-                <i *ngIf="rowData.canWatchMembers" class="fa fa-check"></i>
-              </span>
-            </td>
-            <td style="width: 11rem; max-width: 11rem;">
+              {{ rowData.login ? (rowData | userCaption) : rowData.name }}
+            </a>
+          </td>
+          <td style="min-width: 110px;">
+            {{ rowData.canManageAsText }}
+          </td>
+          <td style="width: 5rem; max-width: 5rem;">
+            <div
+              class="table-icon"
+              [ngClass]="{ 'icon-unlocked': rowData.canGrantGroupAccess, 'icon-locked': !rowData.canGrantGroupAccess }"
+            >
+              <i *ngIf="!rowData.canGrantGroupAccess" class="fa fa-times"></i>
+              <i *ngIf="rowData.canGrantGroupAccess" class="fa fa-check"></i>
+            </div>
+          </td>
+          <td style="width: 5rem; max-width: 5rem;">
+            <span
+              class="table-icon"
+              [ngClass]="{ 'icon-unlocked': rowData.canWatchMembers, 'icon-locked': !rowData.canWatchMembers }"
+            >
+              <i *ngIf="!rowData.canWatchMembers" class="fa fa-times"></i>
+              <i *ngIf="rowData.canWatchMembers" class="fa fa-check"></i>
+            </span>
+          </td>
+          <td style="width: 11rem; max-width: 11rem;">
+            <button
+              pButton
+              type="button"
+              icon="pi pi-pencil"
+              class="alg-button-icon small no-bg primary-color"
+              (click)="openPermissionsEditDialog(rowData)"
+              *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'"
+            ></button>
+          </td>
+        </tr>
+      </ng-template>
+
+      <ng-template #footerTemplate>
+        <tr *ngIf="datapager.canLoadMore$ | async">
+          <td [colSpan]="6">
+            <div class="text-center">
               <button
                 pButton
-                type="button"
-                icon="pi pi-pencil"
-                class="p-button-text"
-                (click)="openPermissionsEditDialog(rowData)"
-                *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'"
+                class="p-button-rounded"
+                i18n-label label="Load more"
+                (click)="fetchMoreData()"
+                [disabled]="state.isFetching"
               ></button>
-            </td>
-          </tr>
-        </ng-template>
+            </div>
+          </td>
+        </tr>
+      </ng-template>
 
-        <ng-template #footerTemplate>
-          <tr *ngIf="datapager.canLoadMore$ | async">
-            <td [colSpan]="6">
-              <div class="text-center">
-                <button
-                  pButton
-                  class="p-button-rounded"
-                  i18n-label label="Load more"
-                  (click)="fetchMoreData()"
-                  [disabled]="state.isFetching"
-                ></button>
-              </div>
-            </td>
-          </tr>
-        </ng-template>
-
-        <ng-template *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'" #summaryTemplate>
-          <div class="summary">
-            <p-tableHeaderCheckbox></p-tableHeaderCheckbox>
-            <span class="select-all" (click)="onSelectAll(managers)" i18n>
+      <ng-template *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'" #summaryTemplate>
+        <div class="alg-table-summary">
+          <div class="alg-table-summary-left">
+            <p-tableHeaderCheckbox class="alg-table-summary-checkbox"></p-tableHeaderCheckbox>
+            <span class="alg-table-summary-select-all" (click)="onSelectAll(managers)" i18n>
               Select all
             </span>
-            <span class="filler"></span>
-            <div class="summary-actions">
-              <span (click)="onRemove($event)" [class.disabled]="removalInProgress || !state.isReady || selection.length === 0">
-              <span i18n>Remove</span>
-                <i class="fa fa-trash-alt"></i>
-              </span>
-            </div>
           </div>
-        </ng-template>
-      </alg-grid>
-
-      <ng-template #noManagers>
-        <div class="validation-text" i18n>
-          This group has no dedicated managers.
+          <button
+            class="alg-button-icon small no-bg primary-color"
+            pButton
+            type="button"
+            icon="fa fa-trash-alt"
+            (click)="onRemove($event)"
+            [disabled]="removalInProgress || !state.isReady || selection.length === 0"
+          ></button>
         </div>
       </ng-template>
-    </alg-section>
+    </alg-grid>
+
+    <ng-template #noManagers>
+      <div class="validation-text" i18n>
+        This group has no dedicated managers.
+      </div>
+    </ng-template>
+
     <alg-group-manager-add
       *ngIf="groupData?.group?.currentUserCanManage === 'memberships_and_group'"
       [groupData]="groupData"

--- a/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
+++ b/src/app/modules/group/components/group-manager-list/group-manager-list.component.scss
@@ -1,5 +1,10 @@
 @import 'src/variables';
 
+:host {
+  display: flex;
+  flex-direction: column;
+}
+
 .add-manager-button-wrapper {
   display: flex;
   align-items: center;
@@ -14,119 +19,6 @@
   }
 }
 
-:host .slanted-grid {
-  margin-left: -4.8rem;
-
-  .p-datatable-wrapper {
-    overflow: hidden;
-  }
-
-  .p-datatable-thead > tr {
-    height: 100%;
-  }
-
-  tr > th {
-    border-left: none;
-    border-right: none;
-    height: 13rem;
-    transform: skewX(-45deg);
-    transform-origin: 0 100%;
-    position: relative;
-    background-color: #f8f8f8;
-    min-width: 3.3333rem;
-    flex: auto;
-
-    .slanted-header {
-      position: absolute;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      transform: translate(50%, 50%) skewX(45deg) rotate(-45deg);
-      transform-origin: 0 50%;
-      text-align: left;
-      padding-left: 3rem;
-      color: #8c8c8c;
-      overflow: visible;
-      font-size: 1.2rem;
-
-      &-content {
-        width: 15rem;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        text-transform: initial;
-      }
-    }
-
-    &:nth-child(odd) {
-      background-color: white;
-    }
-
-    &:first-child {
-      background-color: white;
-    }
-  }
-
-  tr > td {
-    background-color: #f8f8f8;
-    padding: 0;
-    text-align: center;
-    font-size: 1.2rem;
-    justify-content: center;
-    height: auto;
-    max-height: none;
-
-    &:nth-child(odd) {
-      background-color: white;
-      text-align: center;
-    }
-
-    &:first-child {
-      background-color: white;
-    }
-
-    .table-icon {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      i {
-        font-size: 1.2rem;
-      }
-
-      &.edit {
-        color: var(--base-color);
-      }
-
-      &.locked {
-        color: #9acc68;
-      }
-
-      &.unlocked {
-        color: var(--notify-error-color);
-      }
-    }
-
-    .can-manage {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-
-      > span {
-        margin-bottom: 0.4167rem;
-      }
-    }
-  }
-
-  tr {
-    height: 5rem;
-  }
-
-  @media screen and (max-width: 599.98px) {
-    margin-left: -1.8rem;
-  }
-}
-
 .error {
   padding: 1rem;
 }
@@ -135,4 +27,18 @@
   color: var(--base-color);
   font-size: 1.6rem;
   text-align: center;
+}
+
+.table-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-locked {
+  color: var(--notify-error-color);
+}
+
+.icon-unlocked {
+  color: var(--alg-success-color);
 }

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.html
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.html
@@ -69,28 +69,32 @@
       </div>
     </div>
 
-    <div class="bg-white">
-      <alg-group-overview
-        *ngIf="overviewTab?.isActive || !overviewTab && group.currentUserManagership === 'none' && group.currentUserMembership === 'none'"
-        [group]="group"
-        (groupRefreshRequired)="onGroupRefreshRequired()"
-        (leftGroup)="refreshNav()"
-      ></alg-group-overview>
-      <alg-group-composition *ngIf="!!compositionTab?.isActive" [groupData]="state.data" (groupRefreshRequired)="onGroupRefreshRequired()" (addedGroup)="refreshNav()" (removedGroup)="refreshNav()"></alg-group-composition>
-      <alg-group-managers *ngIf="!!adminTab?.isActive" [groupData]="state.data"></alg-group-managers>
-      <alg-group-access *ngIf="!!accessTab?.isActive" [group]="group"></alg-group-access>
-      <alg-group-edit *ngIf="!!settingsTab?.isActive" #groupEdit></alg-group-edit>
-    </div>
-
+    <alg-group-overview
+      *ngIf="overviewTab?.isActive || !overviewTab && group.currentUserManagership === 'none' && group.currentUserMembership === 'none'"
+      class="alg-flex-1"
+      [group]="group"
+      (groupRefreshRequired)="onGroupRefreshRequired()"
+      (leftGroup)="refreshNav()"
+    ></alg-group-overview>
+    <alg-group-composition
+      *ngIf="!!compositionTab?.isActive"
+      class="alg-flex-1"
+      [groupData]="state.data"
+      (groupRefreshRequired)="onGroupRefreshRequired()"
+      (addedGroup)="refreshNav()"
+      (removedGroup)="refreshNav()"
+    ></alg-group-composition>
+    <alg-group-managers *ngIf="!!adminTab?.isActive" class="alg-flex-1" [groupData]="state.data"></alg-group-managers>
+    <alg-group-access *ngIf="!!accessTab?.isActive" class="alg-flex-1" [group]="group"></alg-group-access>
+    <alg-group-edit *ngIf="!!settingsTab?.isActive" class="alg-flex-1" #groupEdit></alg-group-edit>
   </ng-container>
 
-  <alg-loading *ngIf="state.isFetching && !state.data"></alg-loading>
+  <alg-loading class="alg-flex-1" *ngIf="state.isFetching && !state.data"></alg-loading>
 
   <alg-error
     *ngIf="state.isError"
-    class="dark"
+    class="alg-flex-1"
     [showRefreshButton]="$any(state.error).status !== 403"
-    refreshButtonType="refresh"
     (refresh)="onGroupRefreshRequired()"
   >
     <ng-container *ngIf="$any(state.error).status === 403; else otherError;" i18n>

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.html
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.html
@@ -15,9 +15,9 @@
     </alg-group-indicator>
     <!-- tabs -- if only the first tab is visible, do not show the tab bar -->
     <div [hidden]="!group.isCurrentUserManager && group.currentUserMembership === 'none' && !adminTab.isActive && !accessTab?.isActive && !compositionTab.isActive && !settingsTab.isActive">
-      <div class="nav-tab">
+      <div class="alg-nav-tab">
         <a
-          class="nav-tab-item"
+          class="alg-nav-tab-item"
           [routerLink]="'./'"
           routerLinkActive #overviewTab="routerLinkActive"
           [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
@@ -28,7 +28,7 @@
         </a>
         <a
           [hidden]="!group.isCurrentUserManager && !compositionTab?.isActive"
-          class="nav-tab-item"
+          class="alg-nav-tab-item"
           [routerLink]="'./members'"
           routerLinkActive #compositionTab="routerLinkActive"
           [class.active]="compositionTab.isActive"
@@ -38,7 +38,7 @@
         </a>
         <a
           [hidden]="!group.isCurrentUserManager && group.currentUserMembership === 'none' && !adminTab?.isActive"
-          class="nav-tab-item"
+          class="alg-nav-tab-item"
           [routerLink]="'./managers'"
           routerLinkActive #adminTab="routerLinkActive"
           [class.active]="adminTab.isActive"
@@ -47,18 +47,18 @@
           Managers
         </a>
         <a
-            [hidden]="(hideAccessTab || !group.currentUserCanGrantGroupAccess) && !accessTab?.isActive"
-            class="nav-tab-item"
-            [routerLink]="'./access'"
-            routerLinkActive #accessTab="routerLinkActive"
-            [class.active]="accessTab.isActive"
-            i18n
+          [hidden]="(hideAccessTab || !group.currentUserCanGrantGroupAccess) && !accessTab?.isActive"
+          class="alg-nav-tab-item"
+          [routerLink]="'./access'"
+          routerLinkActive #accessTab="routerLinkActive"
+          [class.active]="accessTab.isActive"
+          i18n
         >
           Access
         </a>
         <a
           [hidden]="!group.canCurrentUserManageGroup && !settingsTab?.isActive"
-          class="nav-tab-item"
+          class="alg-nav-tab-item"
           [routerLink]="'./settings'"
           routerLinkActive #settingsTab="routerLinkActive"
           [class.active]="settingsTab.isActive"

--- a/src/app/modules/group/pages/group-by-id/group-by-id.component.scss
+++ b/src/app/modules/group/pages/group-by-id/group-by-id.component.scss
@@ -1,6 +1,7 @@
 :host {
-  position: relative;
-  display: block;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .group-indicator {

--- a/src/app/modules/group/pages/group-composition/group-composition.component.html
+++ b/src/app/modules/group/pages/group-composition/group-composition.component.html
@@ -1,14 +1,15 @@
 <ng-container *ngIf="groupWithPermissions">
   <ng-container *ngIf="groupWithPermissions.isCurrentUserManager; else noPermission">
-    <alg-section icon="fa fa-users" i18n-label label="Current Composition">
-      <alg-member-list #memberList [groupData]="groupData" (removedGroup)="removedGroup.emit()"></alg-member-list>
-      <alg-add-sub-group
-          *ngIf="groupData?.group?.currentUserCanManage !== 'none'"
-          [loading]="state === 'addingGroup'"
-          (addGroup)="addGroup($event)"
-          #addSubGroupComponent
-      ></alg-add-sub-group>
-    </alg-section>
+    <h2 class="alg-h2" i18n>Current Composition</h2>
+<!--    <alg-section icon="fa fa-users" i18n-label label="Current Composition">-->
+    <alg-member-list #memberList [groupData]="groupData" (removedGroup)="removedGroup.emit()"></alg-member-list>
+    <alg-add-sub-group
+        *ngIf="groupData?.group?.currentUserCanManage !== 'none'"
+        [loading]="state === 'addingGroup'"
+        (addGroup)="addGroup($event)"
+        #addSubGroupComponent
+    ></alg-add-sub-group>
+<!--    </alg-section>-->
     <alg-group-join-by-code [group]="groupData?.group" (refreshRequired)="refreshGroupInfo()" *ngIf="groupWithPermissions.canCurrentUserManageMembers">
     </alg-group-join-by-code>
 

--- a/src/app/modules/group/pages/group-composition/group-composition.component.html
+++ b/src/app/modules/group/pages/group-composition/group-composition.component.html
@@ -1,7 +1,6 @@
 <ng-container *ngIf="groupWithPermissions">
   <ng-container *ngIf="groupWithPermissions.isCurrentUserManager; else noPermission">
     <h2 class="alg-h2" i18n>Current Composition</h2>
-<!--    <alg-section icon="fa fa-users" i18n-label label="Current Composition">-->
     <alg-member-list #memberList [groupData]="groupData" (removedGroup)="removedGroup.emit()"></alg-member-list>
     <alg-add-sub-group
         *ngIf="groupData?.group?.currentUserCanManage !== 'none'"
@@ -9,7 +8,6 @@
         (addGroup)="addGroup($event)"
         #addSubGroupComponent
     ></alg-add-sub-group>
-<!--    </alg-section>-->
     <alg-group-join-by-code [group]="groupData?.group" (refreshRequired)="refreshGroupInfo()" *ngIf="groupWithPermissions.canCurrentUserManageMembers">
     </alg-group-join-by-code>
 

--- a/src/app/modules/group/pages/group-overview/group-overview.component.html
+++ b/src/app/modules/group/pages/group-overview/group-overview.component.html
@@ -1,14 +1,15 @@
 <ng-container *ngIf="group">
-  <alg-section icon="fa fa-users" i18n-label label="Presentation">
-    <p *ngIf="group.description ; else noDesc">{{ group.description }}</p>
-    <ng-template #noDesc i18n>This group has no description</ng-template>
-  </alg-section>
+  <h2 class="alg-h2" i18n>Presentation</h2>
+  <p *ngIf="group.description ; else noDesc">{{ group.description }}</p>
+  <ng-template #noDesc><span i18n>This group has no description</span></ng-template>
 
-  <alg-section icon="fa fa-chart-line" i18n-label label="Progress" *ngIf="group.currentUserCanWatchMembers">
+  <ng-container *ngIf="group.currentUserCanWatchMembers">
+    <h2 class="alg-h2" i18n>Progress</h2>
     <alg-group-log-view [groupId]="group.id"></alg-group-log-view>
-  </alg-section>
+  </ng-container>
 
-  <alg-section icon="fa fa-sign-out-alt" i18n-label label="Leave the group?" *ngIf="group.currentUserMembership !== 'none'">
+  <ng-container *ngIf="group.currentUserMembership !== 'none'">
+    <h2 class="alg-h2" i18n>Leave the group?</h2>
     <alg-group-leave [group]="group" (leave)="onLeave()"></alg-group-leave>
-  </alg-section>
+  </ng-container>
 </ng-container>

--- a/src/app/modules/group/pages/group-overview/group-overview.component.html
+++ b/src/app/modules/group/pages/group-overview/group-overview.component.html
@@ -5,7 +5,7 @@
 
   <ng-container *ngIf="group.currentUserCanWatchMembers">
     <h2 class="alg-h2" i18n>Progress</h2>
-    <alg-group-log-view [groupId]="group.id"></alg-group-log-view>
+    <alg-group-log-view class="alg-flex-1" [groupId]="group.id"></alg-group-log-view>
   </ng-container>
 
   <ng-container *ngIf="group.currentUserMembership !== 'none'">

--- a/src/app/modules/item/components/chapter-children/chapter-children.component.scss
+++ b/src/app/modules/item/components/chapter-children/chapter-children.component.scss
@@ -4,7 +4,6 @@
 :host {
   display: flex;
   flex-direction: column;
-  padding: var(--alg-space-size-4) 0;
 }
 
 .validation-text {

--- a/src/app/modules/item/components/item-children-list/item-children-list.component.scss
+++ b/src/app/modules/item/components/item-children-list/item-children-list.component.scss
@@ -3,11 +3,6 @@
 :host {
   display: block;
   margin: 0 toRem(-16);
-  padding: var(--alg-space-size-4) 0;
-
-  &.no-padding {
-    padding: 0;
-  }
 }
 
 .data-list-container {
@@ -74,7 +69,7 @@
 }
 
 .item-title {
-  color: #000;
+  color: var(--dark-text-color);
   font-size: toRem(20);
   font-weight: 400;
 }

--- a/src/app/modules/item/components/parent-skills/parent-skills.component.html
+++ b/src/app/modules/item/components/parent-skills/parent-skills.component.html
@@ -15,7 +15,6 @@
 
   <ng-container *ngIf="state.isReady && state.data as parents">
     <alg-item-children-list
-      class="no-padding"
       type="skill"
       i18n-emptyMessage emptyMessage="This skill does not have parent skills."
       [children]="parents"

--- a/src/app/modules/item/components/sub-skills/sub-skills.component.html
+++ b/src/app/modules/item/components/sub-skills/sub-skills.component.html
@@ -15,7 +15,6 @@
     </div>
 
     <alg-item-children-list
-      class="no-padding"
       type="skill"
       i18n-emptyMessage emptyMessage="This skill does not have subskills."
       [children]="data.skills"
@@ -28,7 +27,6 @@
     </div>
 
     <alg-item-children-list
-      class="no-padding"
       i18n-emptyMessage emptyMessage="This skill does not have related activities."
       [children]="data.activities"
       [routeParams]="{ parentAttemptId: attemptId, path: itemData.route.path.concat([ itemData.item.id ]) }"

--- a/src/app/modules/shared-components/components/add-content/add-content.component.html
+++ b/src/app/modules/shared-components/components/add-content/add-content.component.html
@@ -1,5 +1,6 @@
 <div class="add-content-wrapper">
   <alg-input
+    class="alg-flex-1"
     [parentForm]="addContentForm"
     [hasClearButton]="true"
     (focus)="onNewFocus()"
@@ -10,12 +11,14 @@
     i18n-pTooltip pTooltip="Enter at least 3 characters"
     tooltipEvent="focus"
     tooltipPosition="bottom"
+    inputIcon="ph-duotone ph-pen"
     [tooltipDisabled]="trimmedInputsValue.title.length >= minInputLength"
     *ngIf="showCreateUI"
   >
   </alg-input>
-  <span class="label" i18n *ngIf="showCreateUI && showSearchUI">or</span>
+  <p class="label" i18n *ngIf="showCreateUI && showSearchUI">or</p>
   <alg-input
+    class="alg-flex-1"
     [parentForm]="addContentForm"
     [hasClearButton]="true"
     (focus)="onExistingFocus()"
@@ -26,66 +29,68 @@
     i18n-pTooltip pTooltip="Enter at least 3 characters"
     tooltipEvent="focus"
     tooltipPosition="bottom"
+    inputIcon="ph-duotone ph-magnifying-glass"
     [tooltipDisabled]="trimmedInputsValue.searchExisting.length >= minInputLength"
     *ngIf="showSearchUI"
   >
   </alg-input>
 </div>
 
-<ng-container *ngIf="loading; else ready" style="text-align: center;">
-  <alg-loading size="medium"></alg-loading>
-</ng-container>
+<alg-loading class="loading" size="medium" *ngIf="loading; else ready"></alg-loading>
 <ng-template #ready>
-  <div *ngIf="trimmedInputsValue.title.length >= minInputLength" class="new-content-type">
-    <div class="new-content-container">
-      <div
-        *ngFor="let newContent of allowedTypesForNewContent"
-        class="content-type-item-container"
-        [ngClass]="{'selected': newContent === selected}"
-        (click)="onSelect(newContent)"
-      >
-        <div class="item-image-wrapper">
-          <span><i class="{{newContent.icon}}"></i></span>
+  <ng-container *ngIf="trimmedInputsValue.title.length >= minInputLength">
+    <p class="select-caption" i18n>Select the type of group to create</p>
+    <div class="new-content-type">
+      <div class="new-content-container">
+        <div
+          *ngFor="let newContent of allowedTypesForNewContent"
+          class="content-type-item-container alg-flex-1"
+          [ngClass]="{'selected': newContent === selected}"
+          (click)="onSelect(newContent)"
+        >
+          <div class="item-image-wrapper">
+            <i class="{{ newContent.icon }}"></i>
+          </div>
+          <div class="item-title">{{ newContent.title }}</div>
+          <div class="item-description">{{ newContent.description }}</div>
         </div>
-        <div class="item-title">{{newContent.title}}</div>
-        <div class="item-description">{{newContent.description}}</div>
+      </div>
+      <div class="input-group" *ngIf="selected">
+        <alg-input class="input-group-control" i18n-placeholder placeholder="Task URL" name="url" [parentForm]="addContentForm"></alg-input>
+        <p-button styleClass="alg-button primary" (onClick)="addNew(selected.type)">Add Task</p-button>
       </div>
     </div>
-    <div class="input-group" *ngIf="selected">
-      <alg-input class="input-group-control" i18n-placeholder placeholder="Task URL" name="url" [parentForm]="addContentForm"></alg-input>
-      <p-button styleClass="alg-button p-button-rounded" (onClick)="addNew(selected.type)">Add Task</p-button>
-    </div>
-  </div>
+  </ng-container>
 
   <ng-container *ngIf="state">
-    <div *ngIf="state.isError">
-      <div class="text-center" i18n>An error occurred while searching. If the problem persists, please contact us.</div>
+    <alg-loading class="alg-flex-1" *ngIf="state.isFetching"></alg-loading>
+
+    <div class="text-center" *ngIf="state.isError" i18n>
+      An error occurred while searching. If the problem persists, please contact us.
     </div>
 
-    <div *ngIf="trimmedInputsValue.searchExisting.length >= minInputLength && !state.isError">
-      <h3 i18n>Select a Content</h3>
-      <p-table class="alg-table --add-content" [value]="(state.data || []) | slice : 0 : 10" [loading]="state.isFetching">
-        <ng-template pTemplate="body" let-item>
-          <tr style="background-color: #dfe7f4">
-            <td><span class="type">{{ item.type }}</span></td>
-            <td class="main">{{ item.title }}</td>
-            <td>
-              <p-button
-                styleClass="alg-button p-small-button p-button-rounded"
-                [icon]="addedIds.includes(item.id) ? 'fa fa-check' : selectExistingText === 'Add' ? 'fa fa-plus' : ''"
-                [label]="addedIds.includes(item.id) ? addedText : selectExistingText"
-                [disabled]="addedIds.includes(item.id)"
-                (onClick)="addExisting(item)"
-              ></p-button>
-            </td>
-          </tr>
-        </ng-template>
-        <ng-template pTemplate="emptymessage">
-          <tr>
-            <td [attr.colspan]="1" i18n>No records found</td>
-          </tr>
-        </ng-template>
-      </p-table>
+    <div *ngIf="trimmedInputsValue.searchExisting.length >= minInputLength && state.isReady">
+      <p class="select-caption" i18n>Select a content among those wiches already exist</p>
+      <ul class="add-content-list" *ngIf="(state.data || []).length > 0; else emptyMessage">
+        <li class="add-content-list-item" *ngFor="let item of (state.data || []) | slice : 0 : 10">
+          <div class="add-content-list-left">
+            <span class="add-content-type">{{ item.type }}</span>
+            <span class="add-content-title">{{ item.title }}</span>
+          </div>
+          <div class="add-content-list-right">
+            <button
+              pButton
+              class="add-content-button alg-button primary small"
+              [label]="addedIds.includes(item.id || '') ? addedText : selectExistingText"
+              [disabled]="addedIds.includes(item.id || '')"
+              (click)="addExisting(item)"
+            ></button>
+          </div>
+        </li>
+      </ul>
+      <ng-template #emptyMessage>
+        <span i18n>No records found</span>
+      </ng-template>
       <p class="more-items text-center" *ngIf="(state.data || []).length > 10" i18n>
         More than 10 results match your search terms. If you have not found what you are looking for, make your search more specific.
       </p>

--- a/src/app/modules/shared-components/components/add-content/add-content.component.scss
+++ b/src/app/modules/shared-components/components/add-content/add-content.component.scss
@@ -1,47 +1,36 @@
 @import 'src/variables';
 @import 'src/geometry.scss';
+@import 'src/assets/scss/functions';
 
 :host {
-  display: block;
+  display: flex;
+  flex-direction: column;
 }
 
 .add-content-wrapper {
   display: flex;
   align-items: center;
-  margin-bottom: 1.5rem;
+}
 
-  span.label {
-    font-style: italic;
-    margin-left: 1.6667rem;
-    margin-right: 2rem;
-  }
-
-  alg-input {
-    flex: 1;
-  }
+.label {
+  margin: 0 toRem(20);
+  font-size: toRem(16);
 }
 
 .input-light {
   opacity: 0.5;
 }
 
-.main {
-  flex: 1;
-}
-
-.type {
-  color: var(--base-color);
-}
-
 .new-content-container {
   display: flex;
   flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+}
 
-  .new-content-type {
-    display: block;
-    margin: 1rem;
-    flex: 1 0 calc(25% - 1.6667rem);
-  }
+.new-content-type {
+  display: block;
+  flex: 1 0 calc(25% - 1.6667rem);
 }
 
 .content-type-item-container {
@@ -51,65 +40,49 @@
   padding: 1rem;
   background-color: transparent;
   cursor: pointer;
-  max-width: 12.5rem;
-  margin: 0 auto;
+  min-width: toRem(128);
+  min-height: toRem(128);
+  margin: 0 toRem(20);
+  border: toRem(2) solid var(--alg-border-color);
+  border-radius: var(--border-radius);
 
-  .item-image-wrapper {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    span {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 7.0833rem;
-      height: 7.0833rem;
-      background-color: var(--base-color);
-      color: white;
-      border-radius: 7.0833rem;
-      font-size: 3.3333rem;
-    }
+  &:first-child {
+    margin-left: 0;
   }
 
-  .item-title {
-    font-size: 1.1667rem;
-    font-weight: bold;
-    color: var(--dark-text-color);
-    margin-bottom: 1rem;
-    margin-top: 1rem;
-  }
-
-  .item-description {
-    font-size: 1.2rem;
-    color: var(--base-text-color);
-    text-align: center;
-    flex: 1;
-    overflow: hidden;
+  &:last-child {
+    margin-right: 0;
   }
 
   &:hover, &.selected {
-    background-color: var(--base-color);
-    .item-image-wrapper {
-      span {
-        background-color: white;
-        color: var(--base-color);
-      }
-    }
-
-    .item-title {
-      color: white;
-    }
-
-    .item-description {
-      color: white;
-    }
+    border: toRem(2) solid var(--alg-primary-color) ;
   }
 }
 
+.item-image-wrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: toRem(60);
+  color: var(--alg-primary-color);
+}
+
+.item-title {
+  margin-top: toRem(10);
+  color: var(--alg-secondary-color);
+}
+
+.item-description {
+  margin-top: toRem(10);
+  font-size: toRem(14);
+  text-align: center;
+  flex: 1;
+  overflow: hidden;
+}
+
 .more-items {
-  color: var(--base-text-color);
-  font-size: 1.2rem;
+  color: var(--alg-secondary-color);
+  font-size: toRem(12);
 }
 
 .input-group {
@@ -122,37 +95,38 @@
   flex: 1;
 }
 
-@media screen and (min-width: 1220px) {
-  .new-content-container {
-    .new-content-type {
-      max-width: calc(25% - 1.6667rem);
-    }
-  }
+.add-content-list {
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
 }
 
-@media screen and (min-width: 1040px) and (max-width: 1220px) {
-  .new-content-container {
-    .new-content-type {
-      flex: 1 0 calc(33.33% - 1.6667rem);
-      max-width: calc(33.33% - 1.6667rem);
-    }
-  }
+.add-content-list-item {
+  padding: toRem(8) 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: toRem(1) solid var(--alg-border-color);
 }
 
-@media screen and (min-width: 860px) and (max-width: 1040px) {
-  .new-content-container {
-    .new-content-type {
-      flex: 1 0 calc(50% - 1.6667rem);
-      max-width: calc(50% - 1.6667rem);
-    }
-  }
+.add-content-type {
+  margin-right: toRem(32);
+  color: #545454;
+  opacity: .5;
 }
 
-@media screen and (max-width: 860px) {
-  .new-content-container {
-    .new-content-type {
-      flex: 1 0 calc(100% - 1.6667rem);
-      max-width: calc(100% - 1.6667rem);
-    }
-  }
+.add-content-title {
+  color: #545454;
+  font-weight: 700;
+}
+
+.select-caption {
+  margin: toRem(30) 0 toRem(16) 0;
+  color: var(--alg-secondary-color);
+  font-size: toRem(12);
+}
+
+.loading {
+  margin-top: toRem(16);
 }

--- a/src/app/modules/shared-components/components/grid/grid.component.html
+++ b/src/app/modules/shared-components/components/grid/grid.component.html
@@ -1,6 +1,6 @@
 <p-table
   #table
-  class="alg-table --grid"
+  class="alg-table"
   [ngClass]="tableStyle"
   [columns]="selectedColumns!"
   [value]="data!"

--- a/src/app/modules/shared-components/components/input/input.component.html
+++ b/src/app/modules/shared-components/components/input/input.component.html
@@ -1,5 +1,6 @@
 <div class="input-wrapper" [ngClass]="{ large: size === 'large', light: !isDark }" *ngIf="parentForm" [formGroup]="parentForm">
   <input
+    class="input-element"
     #input
     [type]="inputType"
     [placeholder]="placeholder"
@@ -12,16 +13,20 @@
     [tooltipPosition]="tooltipPosition"
     [tooltipDisabled]="tooltipDisabled"
   >
-  <span *ngIf="hasClearButton && input.value" class="clear-button">
-    <button type="button" (click)="clearInput(); input.focus()" tabindex="-1">
-      <i class="pi pi-times"></i>
-    </button>
-  </span>
-  <span class="icon">
-    <i class="fa fa-{{inputIcon}}"></i>
+  <button
+    class="icon-wrapper clear-button"
+    type="button"
+    (click)="clearInput(); input.focus()"
+    tabindex="-1"
+    *ngIf="hasClearButton && input.value"
+  >
+    <i class="icon ph ph-x"></i>
+  </button>
+  <span class="icon-wrapper">
+    <i class="icon {{ inputIcon }}"></i>
   </span>
   <span *ngIf="buttonIcon" class="input-button" (click)="onButtonClick()">
-    <i class="fa fa-{{buttonIcon}}"></i>
+    <i class="{{ buttonIcon }}"></i>
   </span>
 </div>
 

--- a/src/app/modules/shared-components/components/input/input.component.scss
+++ b/src/app/modules/shared-components/components/input/input.component.scss
@@ -1,11 +1,9 @@
-@import 'src/variables';
-@import 'src/geometry.scss';
+@import 'src/assets/scss/functions';
 
 .input-wrapper {
   display: flex;
-  border-radius: $border-radius;
-  height: 3rem;
   position: relative;
+  border-radius: var(--border-radius);
 
   &.large {
     height: 3.75rem;
@@ -28,61 +26,21 @@
     }
   }
 
-  .icon {
-    position: absolute;
-    left: 1rem;
-    top: 50%;
-    margin-top: -.5em;
-    font-size: 1.2rem;
-    height: 1rem;
-    line-height: 1rem;
-    color: var(--base-text-color);
-  }
-
   input {
-    font-family: var(--font-family);
-    width: 100%;
-    display: flex;
-    background-color: rgba(0, 0, 0, 0.05);
-    border: none;
-    box-shadow: 0 .1rem #00000019 inset;
-    border-radius: $border-radius;
-    padding-left: 2.5rem;
-    font-size: 1.2rem;
-    line-height: 3rem;
-    color: var(--base-text-color);
-
     &.has-button {
       border-top-right-radius: unset;
       border-bottom-right-radius: unset;
     }
-
-    &:focus {
-      outline: none;
-    }
-
-    &::placeholder {
-      font-style: italic;
-      color: rgb(118, 118, 121);
-      font-size: 1.2rem;
-    }
-
-
   }
 
   .clear-button {
-    margin-left: -3rem;
-    margin-top: .6rem;
-
-    button {
-      cursor: pointer;
-      border: none;
-      outline: none;
-      position: relative;
-      width: 0;
-      color: #787878;
-      background-color: transparent;
-    }
+    right: toRem(4);
+    left: auto;
+    cursor: pointer;
+    border: none;
+    outline: none;
+    background-color: transparent;
+    font-size: toRem(24);
   }
 
   input::-webkit-outer-spin-button,
@@ -99,9 +57,44 @@
     width: 3rem;
     color: white;
     background-color: var(--base-color);
-    border-top-right-radius: $border-radius;
-    border-bottom-right-radius: $border-radius;
+    border-top-right-radius: var(--border-radius);
+    border-bottom-right-radius: var(--border-radius);
     cursor: pointer;
   }
+}
 
+.icon-wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: toRem(24);
+  width: toRem(40);
+  height: toRem(40);
+  color: var(--alg-primary-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.input-element {
+  width: 100%;
+  height: toRem(40);
+  display: flex;
+  background-color: #fff;
+  border: none;
+  border-radius: var(--border-radius);
+  padding-left: toRem(40);
+  font-size: toRem(16);
+  color: var(--alg-secondary-color);
+
+  &:focus {
+    outline: toRem(2) solid var(--alg-primary-color);
+  }
+
+  &::placeholder {
+    color: var(--alg-secondary-color);
+    font-size: toRem(16);
+    font-style: italic;
+    opacity: .5;
+  }
 }

--- a/src/app/modules/shared-components/components/input/input.component.ts
+++ b/src/app/modules/shared-components/components/input/input.component.ts
@@ -19,7 +19,7 @@ export class InputComponent {
   @Input() isDark = true;
   @Input() size: 'small' | 'large' = 'small';
   @Input() inputType = 'text';
-  @Input() inputIcon = 'font'; // a font-awesome icon identifier
+  @Input() inputIcon = 'fa fa-font';
   @Input() buttonIcon?: string; // a font-awesome icon identifier for the input button
   @Input() hasClearButton = false;
 

--- a/src/app/modules/shared-components/components/sub-section/sub-section.component.html
+++ b/src/app/modules/shared-components/components/sub-section/sub-section.component.html
@@ -1,10 +1,7 @@
 <div class="section-container">
   <div class="section-header">
-    <span class="section-handler">
-      <i class="fa fa-{{icon}}"></i>
-    </span>
-    <span class="section-title">{{label}}</span>
-    <span class="section-help" *ngIf="tooltip" title="{{tooltip}}">
+    <span class="section-title">{{ label }}</span>
+    <span class="section-help" *ngIf="tooltip" title="{{ tooltip }}">
       <i class="fa fa-question"></i>
     </span>
     <span class="section-close" *ngIf="canClose" (click)="onCloseEvent($event)">

--- a/src/app/modules/shared-components/components/sub-section/sub-section.component.html
+++ b/src/app/modules/shared-components/components/sub-section/sub-section.component.html
@@ -1,7 +1,7 @@
 <div class="section-container">
-  <div class="section-header">
+  <div>
     <span class="section-title">{{ label }}</span>
-    <span class="section-help" *ngIf="tooltip" title="{{ tooltip }}">
+    <span class="section-help" *ngIf="tooltip" [title]="tooltip">
       <i class="fa fa-question"></i>
     </span>
     <span class="section-close" *ngIf="canClose" (click)="onCloseEvent($event)">

--- a/src/app/modules/shared-components/components/sub-section/sub-section.component.scss
+++ b/src/app/modules/shared-components/components/sub-section/sub-section.component.scss
@@ -9,46 +9,43 @@
 }
 
 .section-container {
-  padding: var(--alg-space-size-3) var(--alg-space-size-2);
-  border-bottom: .1rem solid rgba(46, 94, 149, .2);
+  padding: var(--alg-space-size-4) var(--alg-space-size-2) var(--alg-space-size-1);
   background-color: rgba(0, 0, 0, .06);
 
   &.no-border {
     border-bottom: none;
   }
+}
 
-  .section-header {
-    .section-title {
-      color: var(--alg-secondary-color);
-      font-size: toRem(24);
-      font-weight: 400;
-      flex: 1;
-    }
+.section-title {
+  color: var(--alg-secondary-color);
+  font-size: toRem(24);
+  font-weight: 400;
+  flex: 1;
+}
 
-    .section-help {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 2.5rem;
-      height: 2.5rem;
-      font-size: 1.2rem;
-      border-radius: 1.25rem;
-      border: .1rem solid var(--nav-bk-color);
-      cursor: pointer;
-    }
+.section-help {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  font-size: 1.2rem;
+  border-radius: 1.25rem;
+  border: .1rem solid var(--nav-bk-color);
+  cursor: pointer;
+}
 
-    .section-close {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 2.5rem;
-      height: 2.5rem;
-      cursor: pointer;
-      color: var(--base-color);
-    }
-  }
+.section-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+  color: var(--base-color);
+}
 
-  .section-content {
-    margin-top: toRem(20);
-  }
+.section-content {
+  margin-top: toRem(20);
 }

--- a/src/app/modules/shared-components/components/sub-section/sub-section.component.scss
+++ b/src/app/modules/shared-components/components/sub-section/sub-section.component.scss
@@ -4,36 +4,24 @@
 
 :host {
   display: block;
-  margin-left: -5.8333rem;
-  margin-right: -1.6667rem;
+  margin-left: calc(-1 * var(--alg-space-size-2));
+  margin-right: calc(-1 * var(--alg-space-size-2));
 }
 
 .section-container {
-  padding: 2rem 2rem 2rem;
+  padding: var(--alg-space-size-3) var(--alg-space-size-2);
   border-bottom: .1rem solid rgba(46, 94, 149, .2);
-  background-color: var(--light-color);
+  background-color: rgba(0, 0, 0, .06);
 
   &.no-border {
     border-bottom: none;
   }
 
   .section-header {
-    @include section-header;
-
-      .section-handler {
-        @include section-handler(var(--base-color),var(--dark-color));
-        width: 3rem;
-        border-radius: 50%;
-        border: none;
-        padding-right: 0;
-        justify-content: center;
-      }
-
-
-
     .section-title {
-      @include h2-title;
-      color: var(--nav-bk-color);
+      color: var(--alg-secondary-color);
+      font-size: toRem(24);
+      font-weight: 400;
       flex: 1;
     }
 
@@ -61,8 +49,6 @@
   }
 
   .section-content {
-    // padding: .5rem 0 5rem 4.2rem;
-    padding: 2rem 0 0 4.2rem;
-    color: var(--base-text-color);
+    margin-top: toRem(20);
   }
 }

--- a/src/app/modules/shared-components/components/sub-section/sub-section.component.ts
+++ b/src/app/modules/shared-components/components/sub-section/sub-section.component.ts
@@ -6,7 +6,6 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
   styleUrls: [ './sub-section.component.scss' ],
 })
 export class SubSectionComponent {
-  @Input() icon?: string; // font awesome identifier
   @Input() label?: string;
   @Input() tooltip?: string;
   @Input() canClose = false;

--- a/src/assets/scss/components/button-icon.scss
+++ b/src/assets/scss/components/button-icon.scss
@@ -78,6 +78,12 @@
       background-color: #dbe1f3;
     }
   }
+
+  &.small {
+    .p-button-icon {
+      font-size: .8rem;
+    }
+  }
 }
 
 .alg-round-button-icon {

--- a/src/assets/scss/components/button.scss
+++ b/src/assets/scss/components/button.scss
@@ -44,4 +44,12 @@
       height: toRem(40);
     }
   }
+
+  &.small {
+    &.p-button {
+      height: toRem(32);
+      font-size: toRem(12);
+      font-weight: 500;
+    }
+  }
 }

--- a/src/assets/scss/components/table.scss
+++ b/src/assets/scss/components/table.scss
@@ -4,10 +4,31 @@
   display: block;
   margin: 0 toRem(-18);
 
+  &:not(.slanted) {
+    .p-datatable-thead > tr > th {
+      opacity: .5;
+    }
+
+    .p-datatable-tbody > tr {
+      &:nth-child(odd) {
+        background-color: rgba(0, 0, 0, .04);
+      }
+
+      td {
+        &:first-child {
+          border-radius: toRem(10) 0 0 toRem(10);
+        }
+
+        &:last-child {
+          border-radius: 0 toRem(10) toRem(10) 0;
+        }
+      }
+    }
+  }
+
   .p-datatable-thead > tr > th {
     padding: toRem(13) toRem(19);
     color: var(--alg-secondary-color);
-    opacity: .5;
     font-size: toRem(12);
     font-weight: 400;
     border: none;
@@ -15,24 +36,128 @@
   }
 
   .p-datatable-tbody > tr {
-    &:nth-child(odd) {
-      background-color: rgba(0, 0, 0, .04);
-    }
-
     td {
       padding: 0 toRem(19);
       color: var(--alg-secondary-color);
       font-size: toRem(12);
       border: none;
       height: toRem(56);
-
-      &:first-child {
-        border-radius: toRem(10) 0 0 toRem(10);
-      }
-
-      &:last-child {
-        border-radius: 0 toRem(10) toRem(10) 0;
-      }
     }
   }
+
+  .p-datatable .p-datatable-tbody > tr.p-highlight {
+    background: none;
+  }
+
+  &.slanted {
+    .p-datatable-wrapper {
+      overflow: hidden;
+    }
+
+    .p-datatable-thead > tr {
+      height: 100%;
+    }
+
+    .p-datatable-thead > tr > th {
+      border-left: none;
+      border-right: none;
+      height: 13rem;
+      transform: skewX(-45deg);
+      transform-origin: 0 100%;
+      position: relative;
+      background-color: rgba(0, 0, 0, .04);
+      min-width: 3.3333rem;
+      flex: auto;
+
+      .alg-table-slanted-header {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        transform: translate(50%, 50%) skewX(45deg) rotate(-45deg);
+        transform-origin: 0 50%;
+        text-align: left;
+        padding-left: 3rem;
+        overflow: visible;
+      }
+
+      .alg-table-slanted-header-content {
+        width: 15rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        text-transform: initial;
+      }
+
+      &:nth-child(odd) {
+        background-color: white;
+      }
+
+      &:first-child {
+        background-color: white;
+      }
+    }
+
+    .p-datatable-tbody > tr > td {
+      background-color: rgba(0, 0, 0, .04);
+      padding: 0;
+      text-align: center;
+      justify-content: center;
+
+      &:nth-child(odd) {
+        background-color: white;
+        text-align: center;
+      }
+
+      &:first-child {
+        background-color: white;
+      }
+    }
+
+    .p-datatable-tbody > tr {
+      &:active, &:focus {
+        outline: none;
+        box-shadow: none;
+      }
+    }
+
+    @media screen and (max-width: 479px) {
+      margin-left: -1.8rem;
+    }
+  }
+
+  .p-datatable .p-datatable-footer {
+    padding: 0 toRem(16);
+    border: none;
+  }
+}
+
+.alg-table-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: toRem(56);
+}
+
+.alg-table-summary-left {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+}
+
+.alg-table-summary-checkbox {
+  margin-left: toRem(14);
+}
+
+.alg-table-summary-select-all {
+  margin-left: toRem(16);
+  font-size: toRem(14);
+}
+
+.alg-table-selection-col {
+  width: auto;
+  min-width: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -5,29 +5,23 @@
       <trans-unit id="auth-error-modal-title" datatype="html">
         <source>Error</source><target state="translated">Erreur</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="7364788018890982994" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="7364788018890982994" datatype="html">
         <source> The application has been updated since you opened it, it needs to be reloaded. </source><target state="new"> The application has been updated since you opened it, it needs to be reloaded. </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/app.component.html</context>
-          <context context-type="linenumber">40,41</context>
-        </context-group>
-      </trans-unit><trans-unit id="auth-error-modal-context" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="auth-error-modal-context" datatype="html">
         <source> Oops, we are unable to make the site work properly. Are you connected to the Internet? </source><target state="translated">Impossible de démarrer une session. Êtes-vous bien connecté à Internet ?</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">44</context></context-group></trans-unit><trans-unit id="1337415050811257869" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="1337415050811257869" datatype="html">
         <source>Reload the application.</source><target state="new">Reload the application.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/app.component.html</context>
-          <context context-type="linenumber">52,53</context>
-        </context-group>
-      </trans-unit><trans-unit id="contactUs" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="contactUs" datatype="html">
         <source> If the problem persists, please contact us. </source><target state="translated">Si le problème persiste, contactez-nous.</target>
 
 
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">58</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">345</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">197</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">57</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">341</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">202</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
         <source>Language mismatch</source><target state="translated">Mauvaise langue?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/language-mismatch/language-mismatch.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="6895619751331935307" datatype="html">
@@ -51,22 +45,22 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/language-mismatch/language-mismatch.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="8675432263399119284" datatype="html">
         <source>My groups</source><target state="translated">Mes groupes</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.ts</context><context context-type="linenumber">23</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.ts</context><context context-type="linenumber">25</context></context-group></trans-unit>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.ts</context><context context-type="linenumber">18</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.ts</context><context context-type="linenumber">20</context></context-group></trans-unit>
       <trans-unit id="1939752001297092762" datatype="html">
         <source>There is no content to display</source><target state="translated">Il n'y a rien à afficher</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="1679971178283595016" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="1679971178283595016" datatype="html">
         <source>Your current access rights do not allow you to list the content of this skill.</source><target state="translated">Vos permissions actuelles ne vous permettent pas d'afficher le contenu de cette compétence.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">169</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">164</context></context-group></trans-unit><trans-unit id="187187500641108332" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="lter.type === 'users' ? 'Remove': 'Remove from group' }}"/></source><target state="translated"><x id="INTERPOLATION" equiv-text="{{ node.data.element.currentUserManagership === 'descendant' ? 'Vous êtes gestionnaire d'un des descendants de ce groupe' : 'Vous êtes gestionnaire de ce groupe' }}"/></target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">121</context></context-group></trans-unit><trans-unit id="3691777843862279458" datatype="html">
         <source>Your current access rights do not allow you to start the activity.</source><target state="translated">Vos permissions actuelles ne vous permettent pas de commencer l'activité.</target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">272</context></context-group></trans-unit><trans-unit id="4342625008558026850" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">267</context></context-group></trans-unit><trans-unit id="4342625008558026850" datatype="html">
         <source>Skills</source><target state="translated">Compétences</target>
 
         <note priority="1" from="description">Tab name</note>
@@ -74,13 +68,13 @@
         <source>Groups</source><target state="translated">Groupes</target>
 
         <note priority="1" from="description">Tab name</note>
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">38</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.ts</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="2192178401851161061" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">38</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="2192178401851161061" datatype="html">
         <source>Unable to load the list.</source><target state="translated">Erreur lors du chargement de la liste.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="6206098913491165963" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="6206098913491165963" datatype="html">
         <source> This menu is filtered by the observation mode. </source><target state="new"> This menu is filtered by the observation mode. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="4219108310098283044" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="4219108310098283044" datatype="html">
         <source>Observation Mode</source><target state="translated">Mode observation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/observation-bar/observation-bar.component.html</context>
@@ -104,7 +98,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">4</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">237</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">4</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">234</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
         <source>home page</source><target state="translated">accueil</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="9167217071684260011" datatype="html">
@@ -131,7 +125,7 @@
       </trans-unit><trans-unit id="7463044993322326313" datatype="html">
         <source> This content does not exist or you are not allowed to view it. </source><target state="translated"> Ce contenu n'existe pas ou vous n'êtes pas autorisé à le voir. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">233</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">230</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">48</context></context-group></trans-unit><trans-unit id="7296226328505512523" datatype="html">
@@ -442,31 +436,40 @@
         <source>Enter at least 3 characters</source><target state="translated">Entrez au moins 3 caractères</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">10</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="6627551976444260400" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">29</context></context-group></trans-unit><trans-unit id="6627551976444260400" datatype="html">
         <source>or</source><target state="translated">ou</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">17</context></context-group></trans-unit><trans-unit id="7032654202544735620" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="7032654202544735620" datatype="html">
         <source>Search for existing content</source><target state="translated">Chercher parmi les contenus existants</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">25</context></context-group></trans-unit><trans-unit id="4256736616422966530" datatype="html">
-        <source>Task URL</source><target state="new">Task URL</target>
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="6598737181359979919" datatype="html">
+        <source>Select the type of group to create</source><target state="new">Select the type of group to create</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context>
-          <context context-type="linenumber">55</context>
+          <context context-type="linenumber">42</context>
         </context-group>
-      </trans-unit><trans-unit id="8352464941141619256" datatype="html">
-        <source>An error occurred while searching. If the problem persists, please contact us.</source><target state="new">An error occurred while searching. If the problem persists, please contact us.</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">62</context></context-group></trans-unit><trans-unit id="311477701555546678" datatype="html">
-        <source>Select a Content</source><target state="translated">Sélectionnez un contenu</target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="3781733569549468335" datatype="html">
+      </trans-unit><trans-unit id="4256736616422966530" datatype="html">
+        <source>Task URL</source><target state="new">Task URL</target>
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">59</context></context-group></trans-unit><trans-unit id="4337023717719639106" datatype="html">
+        <source> An error occurred while searching. If the problem persists, please contact us. </source><target state="new"> An error occurred while searching. If the problem persists, please contact us. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context>
+          <context context-type="linenumber">68,70</context>
+        </context-group>
+      </trans-unit><trans-unit id="7282443917104900296" datatype="html">
+        <source>Select a content among those wiches already exist</source><target state="new">Select a content among those wiches already exist</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context>
+          <context context-type="linenumber">73</context>
+        </context-group>
+      </trans-unit><trans-unit id="3781733569549468335" datatype="html">
         <source>No records found</source><target state="translated">Aucun résultat</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="4834436992204469960" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="4834436992204469960" datatype="html">
         <source> More than 10 results match your search terms. If you have not found what you are looking for, make your search more specific. </source><target state="new"> More than 10 results match your search terms. If you have not found what you are looking for, make your search more specific. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="5928181193903168495" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="5928181193903168495" datatype="html">
         <source> Content </source><target state="translated"> Contenu </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">34</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit><trans-unit id="7585826646011739428" datatype="html">
@@ -485,20 +488,20 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">122</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
         <source>Leave unsaved task</source><target state="translated">Ne pas sauvegarder la réponse</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">257</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">254</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
         <source>You do not appear to be connected to the Internet, if you leave this task you may loose your progress. Are you sure you want to continue?</source><target state="translated">Vous ne semblez pas être connecté à Internet, si vous quittez cette tâche, vous perdrez vos changements. Êtes-vous sûr de vouloir continuer ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">259</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">256</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
         <source>Loose progress and leave the task</source><target state="translated">Perdre les changement et quitter la tâche</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">264</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">261</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
         <source>Retry</source><target state="translated">Réessayer</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">270</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">267</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
         <source>An unknown error occurred. </source><target state="translated">Une erreur est survenue. </target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">196</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">201</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="8679237608788920660" datatype="html">
@@ -519,14 +522,11 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">135</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="new">Saving answer...</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
         <source>Skip</source><target state="new">Skip</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">177</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">68</context></context-group></trans-unit><trans-unit id="1013373256961511434" datatype="html">
-        <source> This tab gives details about the date, time and number of attempts for each item in this chapter. </source><target state="new"> This tab gives details about the date, time and number of attempts for each item in this chapter. </target>
-        
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">193</context></context-group></trans-unit><trans-unit id="7344184843585356819" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">179</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="7344184843585356819" datatype="html">
         <source> You are not allowed to view the progress of other users on this content. </source><target state="new"> You are not allowed to view the progress of other users on this content. </target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">204</context></context-group></trans-unit><trans-unit id="6836185474382261556" datatype="html">
@@ -535,68 +535,56 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">207</context></context-group></trans-unit><trans-unit id="2251952288611071461" datatype="html">
         <source>Loading the task</source><target state="new">Loading the task</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="8703959562849056209" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">81</context></context-group></trans-unit><trans-unit id="8703959562849056209" datatype="html">
         <source>The task is taking an unexpected long time to load... please wait...</source><target state="new">The task is taking an unexpected long time to load... please wait...</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">83</context></context-group></trans-unit><trans-unit id="7005243353550317116" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="7005243353550317116" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">127</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">132</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">132</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">137</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
         <source>You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.</source><target state="new">You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">144</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">149</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
         <source>An unknown error occurred while publishing your result</source><target state="new">An unknown error occurred while publishing your result</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">145</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
         <source>Hint request failed</source><target state="new">Hint request failed</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group></trans-unit><trans-unit id="7340307578242589055" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">155</context></context-group></trans-unit><trans-unit id="7340307578242589055" datatype="html">
         <source>You cannot access this page.</source><target state="new">You cannot access this page.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
-          <context context-type="linenumber">182</context>
-        </context-group>
-      </trans-unit><trans-unit id="2693653888075218067" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">187</context></context-group></trans-unit><trans-unit id="2693653888075218067" datatype="html">
         <source>Unable to get linked page information. If the problem persists, contact us.</source><target state="new">Unable to get linked page information. If the problem persists, contact us.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context>
-          <context context-type="linenumber">183</context>
-        </context-group>
-      </trans-unit><trans-unit id="8993911766369461044" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">188</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
         <source>Solve</source><target state="new">Solve</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">247</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">253</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="new">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">248</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">254</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">249</context></context-group></trans-unit><trans-unit id="3155976057239202388" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">86</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">255</context></context-group></trans-unit><trans-unit id="3155976057239202388" datatype="html">
         <source># Subm.</source><target state="new"># Subm.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context>
-          <context context-type="linenumber">92</context>
-        </context-group>
+        
         <note priority="1" from="description">Truncated title (little space available) for 'number of submissions'</note>
-      </trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">124</context></context-group></trans-unit><trans-unit id="2738733136413289671" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">118</context></context-group></trans-unit><trans-unit id="2738733136413289671" datatype="html">
         <source>Leave the group?</source><target state="new">Leave the group?</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context>
-          <context context-type="linenumber">11</context>
-        </context-group>
-      </trans-unit><trans-unit id="3797570084942068182" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="3797570084942068182" datatype="html">
         <source>Select</source><target state="translated">Sélectionner</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/associated-item/associated-item.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="4814285799071780083" datatype="html">
         <source>Remove</source><target state="translated">Supprimer</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/associated-item/associated-item.component.html</context><context context-type="linenumber">43</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/associated-item/associated-item.component.html</context><context context-type="linenumber">56</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">142</context></context-group></trans-unit><trans-unit id="3307474071394609167" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/associated-item/associated-item.component.html</context><context context-type="linenumber">43</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/associated-item/associated-item.component.html</context><context context-type="linenumber">56</context></context-group></trans-unit><trans-unit id="3307474071394609167" datatype="html">
         <source>You don't have access to this </source><target state="new">You don't have access to this </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/associated-item/associated-item.component.ts</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="8488818580261010572" datatype="html">
@@ -752,10 +740,10 @@
       </trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">251</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">257</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
         <source>Statement</source><target state="new">Statement</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">252</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">258</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -782,7 +770,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="5711976490580430557" datatype="html">
         <source>Saving answer before loading submission...</source><target state="new">Saving answer before loading submission...</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">175</context></context-group></trans-unit><trans-unit id="1125515177419706232" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">177</context></context-group></trans-unit><trans-unit id="1125515177419706232" datatype="html">
         <source>Maformed url: "<x id="PH" equiv-text="url"/>"</source><target state="new">Maformed url: "<x id="PH" equiv-text="url"/>"</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">145</context></context-group></trans-unit><trans-unit id="1648546115727864611" datatype="html">
@@ -833,7 +821,7 @@
       </trans-unit><trans-unit id="8307140841776883735" datatype="html">
         <source>Join</source><target state="translated">Rejoindre</target>
 
-      <note from="description" priority="1">Button label for joining a group</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">18</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="2032942917532130545" datatype="html">
+      <note from="description" priority="1">Button label for joining a group</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="2032942917532130545" datatype="html">
         <source>Platform settings</source><target state="new">Platform settings</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/pages/platform-settings/platform-settings.component.html</context>
@@ -861,7 +849,7 @@
 
         <source>Error</source><target state="translated">Erreur</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">65</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">64</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/services/action-feedback.service.ts</context><context context-type="linenumber">28</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ item.type | i18nSelect : {
           Chapter: 'Only empty chapters can be deleted.',
           other: 'Only empty skills can be deleted.'
@@ -869,13 +857,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-remove-button/item-remove-button.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="8286483904887493596" datatype="html">
         <source>You are not allowed to watch the group for which you have requested watching.</source><target state="new">You are not allowed to watch the group for which you have requested watching.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">68</context></context-group></trans-unit><trans-unit id="1223537461642312433" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="1223537461642312433" datatype="html">
         <source>Something went wrong while enabling group watching. If the problem persists, please contact us.</source><target state="new">Something went wrong while enabling group watching. If the problem persists, please contact us.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="7819314041543176992" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">69</context></context-group></trans-unit><trans-unit id="7819314041543176992" datatype="html">
         <source>Close</source><target state="new">Close</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">75</context></context-group></trans-unit><trans-unit id="7708270344948043036" datatype="html">
         <source> <x id="INTERPOLATION" equiv-text="{{ item.type | i18nSelect : {
           Chapter: 'Only empty chapters can be deleted.',
           other: 'Only empty skills can be deleted.'
@@ -985,7 +973,7 @@
       <note from="description" priority="1">Button label for joining an item by (group) code</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
         <source>Edit content</source><target state="new">Edit content</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
@@ -994,19 +982,19 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit-form/item-children-edit-form.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
         <source> This activity has not been correctly configured. </source><target state="new"> This activity has not been correctly configured. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">69</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
         <source> You need to set a url in editing mode. </source><target state="new"> You need to set a url in editing mode. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="9152383970834327178" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="9152383970834327178" datatype="html">
         <source> Your current access rights do not allow you to list the content of this chapter. </source><target state="new"> Your current access rights do not allow you to list the content of this chapter. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="6557565374286675560" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">81</context></context-group></trans-unit><trans-unit id="6557565374286675560" datatype="html">
         <source> Your current access rights do not allow you to list the content of this skill. </source><target state="new"> Your current access rights do not allow you to list the content of this skill. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="8944765970586595001" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="8944765970586595001" datatype="html">
         <source> Your current access rights do not allow you to start the activity. </source><target state="new"> Your current access rights do not allow you to start the activity. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">88</context></context-group></trans-unit><trans-unit id="6198202441206570236" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="6198202441206570236" datatype="html">
         <source>This activity requires explicit entry</source><target state="new">This activity requires explicit entry</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
@@ -1020,13 +1008,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">107</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">105</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">126</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">206</context></context-group></trans-unit><trans-unit id="8227500063765912187" datatype="html">
         <source>Starting the activity</source><target state="new">Starting the activity</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">245</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">242</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -1041,7 +1029,7 @@
       </trans-unit><trans-unit id="9041444757418829014" datatype="html">
         <source>Error while loading the item.</source><target state="translated">Erreur lors du chargement du contenu.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">235</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">232</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
         <source>Add</source><target state="translated">Ajouter</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.html</context><context context-type="linenumber">14</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="9165363087268857396" datatype="html">
@@ -1075,7 +1063,7 @@
       <source> Select all </source>
       <target state="translated"> Tout sélectionner </target>
 
-    <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">137</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">116</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-request/pending-request.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="8905995985388209337" datatype="html">
+    <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">139</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">116</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-request/pending-request.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="8905995985388209337" datatype="html">
        <source>Accept</source><target state="translated">Accepter</target>
 
      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/pending-request/pending-request.component.html</context><context context-type="linenumber">102</context></context-group></trans-unit><trans-unit id="7378878529334768232" datatype="html">
@@ -1415,7 +1403,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-dependencies/item-dependencies.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-unlock-access/item-unlock-access.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="7731242626827304298" datatype="html">
         <source>Unable to load the dependencies</source><target state="new">Unable to load the dependencies</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-dependencies/item-dependencies.component.html</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-unlock-access/item-unlock-access.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="9045659846963395136" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-dependencies/item-dependencies.component.html</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-unlock-access/item-unlock-access.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="9045659846963395136" datatype="html">
         <source> Users will unlock access to this content if they solve <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>at least one<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> of the content below. </source><target state="new"> Users will unlock access to this content if they solve <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong>"/>at least one<x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong>"/> of the content below. </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-dependencies/item-dependencies.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="4862743093134382333" datatype="html">
@@ -1531,7 +1519,7 @@
       </trans-unit><trans-unit id="7855013435783502943" datatype="html">
         <source>This skill does not have parent skills.</source><target state="translated">Cette compétence n'a pas de compétence parente.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/parent-skills/parent-skills.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="7599176768250828782" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/parent-skills/parent-skills.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="7599176768250828782" datatype="html">
         <source>Error while loading path suggestion</source><target state="new">Error while loading path suggestion</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="7182192298964223312" datatype="html">
@@ -1555,25 +1543,22 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="5233338047905293197" datatype="html">
         <source>This skill does not have subskills.</source><target state="new">This skill does not have subskills.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="8724318010499103074" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="8724318010499103074" datatype="html">
         <source> Activities to learn or reinforce this skill </source><target state="new"> Activities to learn or reinforce this skill </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context>
-          <context context-type="linenumber">27,28</context>
-        </context-group>
-      </trans-unit><trans-unit id="3298563984742351101" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="3298563984742351101" datatype="html">
         <source>Activities to learn or reinforce this skill</source><target state="new">Activities to learn or reinforce this skill</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="4292111728885991868" datatype="html">
         <source>This skill does not have related activities.</source><target state="new">This skill does not have related activities.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="3303008548461857588" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">30</context></context-group></trans-unit><trans-unit id="3303008548461857588" datatype="html">
         <source><x id="INTERPOLATION" equiv-text="{{targetTypeString}}"/> own this item, and get the maximum access in all categories above, and may also delete this item</source><target state="translated"><x id="INTERPOLATION" equiv-text="{{targetTypeString}}"/> est propriétaire de cet
  et a donc toutes les permissions ci-dessus maximales. Il peut également l'effacer.</target>
       </trans-unit><trans-unit id="4178036374836569451" datatype="html">
         <source>Error while loading content</source><target state="translated">Erreur lors du chargement du contenu</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="7555865016486494326" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/sub-skills/sub-skills.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="7555865016486494326" datatype="html">
         <source> You </source><target state="new"> You </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.html</context><context context-type="linenumber">23</context></context-group></trans-unit><trans-unit id="3033931349682055221" datatype="html">
@@ -1600,7 +1585,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/thread-message/thread-message.component.ts</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">
         <source>Error while loading this chapter's children</source><target state="translated">Erreur lors du chargement des enfants de ce chapitre</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="7143643956716496978" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="7143643956716496978" datatype="html">
         <source> To validate this chapter, solve at least all tasks with Validation type </source><target state="translated"> Pour valider ce chapitre, résolvez toutes les tâches de type Validation </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="4085853929655384104" datatype="html">
@@ -1628,7 +1613,7 @@
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">13</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">95</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group><note from="description" priority="1">Tab name</note></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <note from="description" priority="1">Tab name</note><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">13</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">78</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">95</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -1641,7 +1626,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">65</context></context-group></trans-unit><trans-unit id="2577694282301310795" datatype="html">
         <source>Solution</source><target state="translated">Solution</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">19</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">250</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">19</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">256</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
@@ -1892,7 +1877,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="33149636091572968" datatype="html">
         <source>Load more</source><target state="new">Load more</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">124</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">96</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="5077586677126527379" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">125</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">96</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/group-progress-grid/group-progress-grid.component.html</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="5077586677126527379" datatype="html">
         <source>This list is empty. Check below the different ways to add members or sub-groups.</source><target state="translated">La liste est vide. Voyez ci-dessous comment vous pouvez ajouter des membres et sous-groupes.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/member-list/member-list.component.html</context><context context-type="linenumber">108</context></context-group></trans-unit><trans-unit id="1916930465370171483" datatype="html">
@@ -1962,25 +1947,25 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.ts</context><context context-type="linenumber">111</context></context-group></trans-unit><trans-unit id="2665063333072587702" datatype="html">
         <source>Error while loading the group managers</source><target state="translated">Erreur lors du chargement des gestionnaires de groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="2978634377936697829" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="2978634377936697829" datatype="html">
         <source>Managers of this group</source><target state="translated">Gestionnaires de ce groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="8778616811237742446" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="8778616811237742446" datatype="html">
         <source> Name </source><target state="translated"> Nom </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="8025474616450337243" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">32</context></context-group></trans-unit><trans-unit id="8025474616450337243" datatype="html">
         <source> Can Manage </source><target state="translated"> Peut gérer </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="6353731772561998688" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">39</context></context-group></trans-unit><trans-unit id="6353731772561998688" datatype="html">
         <source> Can grant group access </source><target state="translated"> Peut donner des droits </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit><trans-unit id="6649597312451406461" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">46</context></context-group></trans-unit><trans-unit id="6649597312451406461" datatype="html">
         <source> Can watch members </source><target state="translated"> Peut observer les membres </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">52</context></context-group></trans-unit><trans-unit id="514854065791709811" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="514854065791709811" datatype="html">
         <source> This group has no dedicated managers. </source><target state="new"> This group has no dedicated managers. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">152</context></context-group></trans-unit><trans-unit id="4902080776299806811" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-list/group-manager-list.component.html</context><context context-type="linenumber">156</context></context-group></trans-unit><trans-unit id="4902080776299806811" datatype="html">
         <source><x id="PH" equiv-text="successInvites.length"/> user(s) invited successfully: </source><target state="translated"><x id="PH" equiv-text="successInvites.length"/> utilisateur(s) invité(s) avec succès : </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-invite-users/group-invite-users.component.ts</context><context context-type="linenumber">79</context></context-group></trans-unit><trans-unit id="9209870712097047643" datatype="html">
@@ -2183,7 +2168,7 @@
       </trans-unit><trans-unit id="1734171097636944073" datatype="html">
         <source>There is no progress to report for this item.</source><target state="new">There is no progress to report for this item.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">98</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
         <source>You do not have the permissions to edit this content.</source><target state="translated">Vous n'avez pas les permissions d'éditer ce contenu.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">49</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5676044567873886390" datatype="html">
@@ -2202,10 +2187,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">26</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-content/item-edit-content.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="5521027790445234919" datatype="html">
         <source>Unable to load the recent activity</source><target state="translated">Erreur lors du chargement les activités récentes</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">15</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="8115085152478832979" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">15</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="8115085152478832979" datatype="html">
         <source>There is no progress to report for this group/user.</source><target state="new">There is no progress to report for this group/user.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">98</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">120</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">120</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
         <source>Action</source><target state="translated">Opération</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
@@ -2229,10 +2214,10 @@
       <note from="description" priority="1">Placeholder of field for searching for user by login</note></trans-unit><trans-unit id="1848556306631120071" datatype="html">
         <source>Time spent</source><target state="translated">Temps écoulé</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">8</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">88</context></context-group></trans-unit><trans-unit id="2827276519893025325" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">8</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="2827276519893025325" datatype="html">
         <source>Not started</source><target state="new">Not started</target>
         
-      <note from="description" priority="1">In progress matrix, explanation when cell is empty</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="7894478830808730680" datatype="html">
+      <note from="description" priority="1">In progress matrix, explanation when cell is empty</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="7894478830808730680" datatype="html">
         <source>You cannot view answers for this content.</source><target state="new">You cannot view answers for this content.</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="3935757628740535532" datatype="html">
@@ -2256,16 +2241,16 @@
       </trans-unit><trans-unit id="6746605846893800788" datatype="html">
         <source>Error while loading the group progress</source><target state="new">Error while loading the group progress</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-group-progress/chapter-group-progress.component.html</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="8897571869263582585" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-group-progress/chapter-group-progress.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="8897571869263582585" datatype="html">
         <source>Error while loading the user progress</source><target state="new">Error while loading the user progress</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">8</context></context-group></trans-unit><trans-unit id="5338231862998220113" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="5338231862998220113" datatype="html">
         <source>Latest activity</source><target state="new">Latest activity</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="7123653594948067002" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="7123653594948067002" datatype="html">
         <source>Score</source><target state="new">Score</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="8604389299042909377" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">98</context></context-group></trans-unit><trans-unit id="8604389299042909377" datatype="html">
         <source>All the groups you have joined and you manage</source><target state="new">All the groups you have joined and you manage</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">3</context></context-group></trans-unit><trans-unit id="6774795715471269377" datatype="html">
@@ -2295,13 +2280,13 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.html</context><context context-type="linenumber">67</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">55</context></context-group></trans-unit><trans-unit id="4710139977652705392" datatype="html">
         <source> You are not allowed to view this group page. </source><target state="new"> You are not allowed to view this group page. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.html</context><context context-type="linenumber">97</context></context-group></trans-unit><trans-unit id="7288998356732151629" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.html</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="7288998356732151629" datatype="html">
         <source> Access </source><target state="new"> Access </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="80384927579662477" datatype="html">
         <source>Error while loading the group info</source><target state="translated">Error lors du chargement du groupe</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">20</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="3835604152936342866" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">20</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-by-id/group-by-id.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit><trans-unit id="3835604152936342866" datatype="html">
         <source>Delete this group</source><target state="new">Delete this group</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-remove-button/group-remove-button.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="8675432263399119284" datatype="html">
@@ -2319,7 +2304,7 @@
       </trans-unit><trans-unit id="4930506384627295710" datatype="html">
         <source>Settings</source><target state="translated">Paramètres</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">126</context></context-group></trans-unit><trans-unit id="955425775818627867" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">120</context></context-group></trans-unit><trans-unit id="955425775818627867" datatype="html">
         <source>Add a new prerequisite</source><target state="new">Add a new prerequisite</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/add-dependency/add-dependency.component.html</context>
@@ -2340,7 +2325,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="4555457172864212828" datatype="html">
         <source>Users</source><target state="new">Users</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">16</context></context-group></trans-unit><trans-unit id="4139147089479340367" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="4139147089479340367" datatype="html">
         <source>Enter a title to create a new dependency</source><target state="new">Enter a title to create a new dependency</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/components/add-dependency/add-dependency.component.html</context>
@@ -2349,7 +2334,7 @@
       </trans-unit><trans-unit id="2618743771935093938" datatype="html">
         <source>Personal info</source><target state="new">Personal info</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">125</context></context-group></trans-unit><trans-unit id="1758440051293769579" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">119</context></context-group></trans-unit><trans-unit id="1758440051293769579" datatype="html">
         <source>Presentation</source><target state="translated">Présentation</target>
         
         

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -52,6 +52,7 @@
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   --left-panel-size: 18.5rem;
   --left-menu-animation: .5s;
+  --alg-success-color: #9acc68;
 
   // Re-Design colors
   --alg-primary-color: #0F61FF;


### PR DESCRIPTION
## Description

Fixes #...

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

From bugs list:

- children list (and other places): there is a padding under the list which adds to the 64px page padding... it should be 64px all included
- children list: display title in dark-text-color 

Note: new design for add content - including selection mode for fill url

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/group-page-1/en/a/home;pa=0)
  3. Then I see list without extra paddings
  4. And title is dark-text-color

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/group-page-1/en/a/home;pa=0)
  3. Then I see new tabs design

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/group-page-1/en/groups/by-id/2713577096475953687;p=)
  3. Then I see new titles "Presentation", "Progress" design

- [ ] Case 4:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/group-page-1/en/groups/by-id/5121055722873780306;p=)
  3. Then I see new logs table design

- [ ] Case 5:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/group-page-1/en/groups/by-id/5121055722873780306;p=/managers)
  3. Then I see new managers list table design

- [ ] Case 6:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/group-page-1/en/groups/by-id/5121055722873780306;p=/members)
  3. Then I see new "Add subgroups" design
