### PR TITLE
Improves on scroll content logic

### DIFF
--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, NgZone, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { Component, ElementRef, NgZone, OnDestroy, OnInit, Renderer2, ViewChild } from '@angular/core';
 import { UserSessionService } from '../shared/services/user-session.service';
 import { delay, switchMap, tap } from 'rxjs/operators';
 import { merge, Subscription } from 'rxjs';
@@ -14,6 +14,7 @@ import { version } from 'src/version';
 import { CrashReportingService } from './services/crash-reporting.service';
 import { Location } from '@angular/common';
 import { ChunkErrorService } from './services/chunk-error.service';
+import { TopBarComponent } from './components/top-bar/top-bar.component';
 
 @Component({
   selector: 'alg-root',
@@ -21,6 +22,7 @@ import { ChunkErrorService } from './services/chunk-error.service';
   styleUrls: [ './app.component.scss' ]
 })
 export class AppComponent implements OnInit, OnDestroy {
+  @ViewChild(TopBarComponent) topBarComponent?: TopBarComponent;
 
   fatalError$ = merge(
     this.authService.failure$,
@@ -94,11 +96,17 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   onScrollContent(): void {
-    if (window.scrollY > 65 && !this.scrolled) {
+    const topBarHeight = Number(this.topBarComponent?.elementRef.nativeElement.clientHeight || 0);
+    const pageNavigatorNeighborWidgetRect
+      = document.querySelector('#page-navigator-neighbor-widget')?.getBoundingClientRect();
+    const gap = pageNavigatorNeighborWidgetRect
+      ? ((pageNavigatorNeighborWidgetRect.top + pageNavigatorNeighborWidgetRect.height) + window.scrollY) - topBarHeight
+      : topBarHeight;
+    if (window.scrollY > gap && !this.scrolled) {
       this.ngZone.run(() => {
         this.scrolled = true;
       });
-    } else if (window.scrollY <= 65 && this.scrolled) {
+    } else if (window.scrollY <= gap && this.scrolled) {
       this.ngZone.run(() => {
         this.scrolled = false;
       });

--- a/src/app/core/components/top-bar/top-bar.component.ts
+++ b/src/app/core/components/top-bar/top-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, ElementRef, Input } from '@angular/core';
 
 @Component({
   selector: 'alg-top-bar',
@@ -11,4 +11,7 @@ export class TopBarComponent {
   @Input() modeBarDisplayed = false;
   @Input() showTopRightControls = true;
   @Input() showLeftMenuOpener = true;
+
+  constructor(public elementRef: ElementRef<HTMLElement>) {
+  }
 }

--- a/src/app/modules/shared-components/components/page-navigator/page-navigator.component.html
+++ b/src/app/modules/shared-components/components/page-navigator/page-navigator.component.html
@@ -13,11 +13,13 @@
     <i class="fa fa-expand-arrows-alt"></i>
   </span>
   <alg-neighbor-widget
+    id="page-navigator-neighbor-widget"
     class="navigator"
     [navigationMode]="navigationMode"
     (parent)="parent.emit()"
     (left)="left.emit()"
     (right)="right.emit()"
+    *ngIf="navigationMode"
   ></alg-neighbor-widget>
 </div>
 


### PR DESCRIPTION
## Description

Fixes #...

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Fixes bugs:

- increase the scroll threshold to switch the top bar from breadcrumb to "title only"... so that we cannot have twice the prev/next/top navigation displayed

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/new-design-2/en/a/458602124916982205;p=4702;a=0/progress/history)
  3. And I do scroll down
  4. Then I see neighbours widget in header appears after neighbours widget on page is scrolled 

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/new-design-2/en/s/3000;p=;a=0/progress/history)
  3. And I do scroll down
  4. Then I see neighbours widget in header appears after neighbours widget on page is scrolled 

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/new-design-2/en/groups/by-id/4035378957038759250;p=)
  3. And I do scroll down
  4. Then I see neighbours widget in header appears after neighbours widget on page is scrolled 

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/new-design-2/en/groups/users/670968966872011405/personal-data)
  3. And I do scroll down
  4. Then I see the title appears and breadcrumbs disappears 

