### PR TITLE
Improves text styles for description of item

### DIFF
--- a/src/app/modules/item/components/item-header/item-header.component.scss
+++ b/src/app/modules/item/components/item-header/item-header.component.scss
@@ -1,4 +1,4 @@
-@import 'src/variables';
+@import 'src/assets/scss/functions';
 
 :host {
   display: block;

--- a/src/app/modules/item/pages/item-content/item-content.component.scss
+++ b/src/app/modules/item/pages/item-content/item-content.component.scss
@@ -35,5 +35,7 @@
 }
 
 .description, .html-container {
-  margin: toRem(30) 0 0 0;
+  margin: toRem(30) 0 2rem 0;
+  font-weight: 300;
+  line-height: toRem(24);
 }


### PR DESCRIPTION
## Description

Fixes #...

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Fixes: "description" in items: font-weight 300 + Line-height 1.5rem, 2 rem margin down

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/text-description/en/a/4769434107088212490;p=4702,458602124916982205;pa=0)
  3. Then I see new text styles for text description

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/text-description/en/a/5846722634000078615;p=;a=0)
  3. Then I see new text styles for html description

