### PR TITLE
Improves stats and history pages

### DIFF
--- a/src/app/core/components/left-search-result/left-search-result.component.html
+++ b/src/app/core/components/left-search-result/left-search-result.component.html
@@ -1,10 +1,9 @@
 <div class="container" *ngIf="data !== undefined">
   <alg-left-menu-back-button (close)="close.emit()">
-    {{ data.length }}
     {{ data.length | i18nPlural: {
-      '=0': 'activities found',
-      '=1': 'activity found',
-      'other': 'activities found'
+      '=0': '# activities found',
+      '=1': '# activity found',
+      'other': '# activities found'
     } }}
   </alg-left-menu-back-button>
 </div>

--- a/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html
+++ b/src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html
@@ -14,113 +14,97 @@
         Refresh
       </button>
     </div>
-    <p-table
-      class="alg-table"
-      [columns]="columns"
-      [value]="state.data"
-      [loading]="state.isFetching"
-      [tableStyle]="{'min-width': '599.98px'}"
-      responsiveLayout="scroll"
-      *ngrxLet="watchedGroup$; let watchedGroup"
-    >
-      <ng-template pTemplate="header" let-rowData let-columns>
-        <tr *ngIf="rowData.length > 0">
-          <ng-container *ngFor="let col of columns">
-            <th [class.text-center]="[ 'hintsRequested', 'timeSpent', 'submissions' ].includes(col.field)">
-              {{ col.header }}
-            </th>
-          </ng-container>
-        </tr>
-      </ng-template>
-
-      <ng-template
-        pTemplate="body"
-        let-rowData
-        let-columns="columns"
+    <ng-container *ngIf="columns$ | async as columns">
+      <p-table
+        class="alg-table"
+        [columns]="columns"
+        [value]="state.data"
+        [loading]="state.isFetching"
+        [tableStyle]="{'min-width': '599.98px'}"
+        responsiveLayout="scroll"
       >
-        <tr>
-          <td *ngFor="let col of columns" [class.text-center]="[ 'hintsRequested', 'timeSpent', 'submissions' ].includes(col.field)">
-            <ng-container [ngSwitch]="col.field">
-              <ng-container *ngSwitchCase="'title'">
-                <ng-container *ngIf="itemData && itemData.currentResult?.attemptId as parentAttemptId">
-                  <div>
-                    <a
-                      class="alg-link"
-                      [ngClass]="{ 'disabled font-bold text-black': rowData.id === itemData.item.id }"
-                      [routerLink]="{
-                        id: rowData.id,
-                        contentType: rowData | contentTypeFromItem,
-                        path: itemData.route.path.concat([ itemData.item.id ]),
-                        parentAttemptId: parentAttemptId
-                      } | url : [ 'progress', 'chapter-user-progress' ]"
-                    >
-                      {{ rowData.title }}
-                    </a>
-                  </div>
-                  <ng-container *ngIf="rowData.type === 'Task'">
-                    <a
-                      class="alg-link item-title-link"
-                      [routerLink]="{
-                        id: rowData.id,
-                        contentType: rowData | contentTypeFromItem,
-                        path: itemData.item.id === rowData.id ? itemData.route.path : itemData.route.path.concat([ itemData.item.id ]),
-                        parentAttemptId: parentAttemptId,
-                        answer: {
-                          best: true, participantId: watchedGroup ? watchedGroup.route.id : undefined
-                        }
-                      } | url"
-                      *ngIf="rowData.submissions > 0 && (!watchedGroup || (watchedGroup.route.isUser && (rowData.currentUserPermissions | allowsWatchingAnswers)))"
-                    >
-                      {{ (!!watchedGroup ? 'watchingGroup' : '') | i18nSelect : {
-                        watchingGroup: 'View the best answer',
-                        other: 'Reload the best answer'
-                      } }}
-                    </a>
+        <ng-template pTemplate="header" let-rowData let-columns>
+          <tr *ngIf="rowData.length > 0">
+            <ng-container *ngFor="let col of columns">
+              <th [class.text-center]="[ 'timeSpent', 'submissions' ].includes(col.field)">
+                {{ col.header }}
+              </th>
+            </ng-container>
+          </tr>
+        </ng-template>
+
+        <ng-template
+          pTemplate="body"
+          let-rowData
+          let-columns="columns"
+        >
+          <tr>
+            <td *ngFor="let col of columns" [class.text-center]="[ 'timeSpent', 'submissions' ].includes(col.field)">
+              <ng-container [ngSwitch]="col.field">
+                <ng-container *ngSwitchCase="'title'">
+                  <ng-container *ngIf="itemData && itemData.currentResult?.attemptId as parentAttemptId">
+                    <div>
+                      <a
+                        class="alg-link"
+                        [ngClass]="{ 'disabled font-bold text-black': rowData.id === itemData.item.id }"
+                        [routerLink]="{
+                          id: rowData.id,
+                          contentType: rowData | contentTypeFromItem,
+                          path: itemData.route.path.concat([ itemData.item.id ]),
+                          parentAttemptId: parentAttemptId
+                        } | url : [ 'progress', 'chapter-user-progress' ]"
+                      >
+                        {{ rowData.title }}
+                      </a>
+                    </div>
                   </ng-container>
                 </ng-container>
-              </ng-container>
-              <ng-container *ngSwitchCase="'latestActivityAt'">
-                <ng-container *ngIf="rowData.latestActivityAt; else notStarted">
-                  {{ rowData.latestActivityAt | date:'short' }}
+                <ng-container *ngSwitchCase="'latestActivityAt'">
+                  <ng-container *ngIf="rowData.latestActivityAt; else notStarted">
+                    {{ rowData.latestActivityAt | date:'short' }}
+                  </ng-container>
+                  <ng-template #notStarted>
+                    <span i18n>Not started</span>
+                  </ng-template>
                 </ng-container>
-                <ng-template #notStarted>
-                  <span i18n>Not started</span>
-                </ng-template>
-              </ng-container>
-              <ng-container *ngSwitchCase="'hintsRequested'">
-                {{ rowData.hintsRequested }}
-              </ng-container>
-              <ng-container *ngSwitchCase="'timeSpent'">
-                <ng-container *ngIf="rowData.latestActivityAt">
-                  {{ rowData.timeSpent | duration }}
+                <ng-container *ngSwitchCase="'timeSpent'">
+                  <ng-container *ngIf="rowData.latestActivityAt">
+                    {{ rowData.timeSpent | duration }}
+                  </ng-container>
+                </ng-container>
+                <ng-container *ngSwitchCase="'submissions'">
+                  <ng-container *ngIf="!['Chapter', 'Skill'].includes(rowData.type) && rowData.latestActivityAt">
+                    {{ rowData.submissions }}
+                    <span *ngIf="rowData.hintsRequested > 0" i18n>
+                      (using {{ rowData.hintsRequested | i18nPlural : {
+                        '=1': 'hint',
+                        'other': '# hints'
+                      } }})
+                    </span>
+                  </ng-container>
+                </ng-container>
+                <ng-container *ngSwitchCase="'score'">
+                  <alg-score-ring
+                    [currentScore]="rowData.score"
+                    [isValidated]="rowData.validated"
+                    *ngIf="!rowData.noScore && rowData.latestActivityAt"
+                  ></alg-score-ring>
+                </ng-container>
+                <ng-container *ngSwitchDefault>
+                  {{ rowData[col.field] }}
                 </ng-container>
               </ng-container>
-              <ng-container *ngSwitchCase="'submissions'">
-                <ng-container *ngIf="!['Chapter', 'Skill'].includes(rowData.type) && rowData.latestActivityAt">
-                  {{ rowData.submissions }}
-                </ng-container>
-              </ng-container>
-              <ng-container *ngSwitchCase="'score'">
-                <alg-score-ring
-                  [currentScore]="rowData.score"
-                  [isValidated]="rowData.validated"
-                  *ngIf="!rowData.noScore && rowData.latestActivityAt"
-                ></alg-score-ring>
-              </ng-container>
-              <ng-container *ngSwitchDefault>
-                {{ rowData[col.field] }}
-              </ng-container>
-            </ng-container>
-          </td>
-        </tr>
-      </ng-template>
-      <ng-template pTemplate="emptymessage" let-columns>
-        <tr>
-          <td [attr.colspan]="columns.length">
-            <span i18n>There is no progress to report for this group/user.</span>
-          </td>
-        </tr>
-      </ng-template>
-    </p-table>
+            </td>
+          </tr>
+        </ng-template>
+        <ng-template pTemplate="emptymessage" let-columns>
+          <tr>
+            <td [attr.colspan]="columns.length">
+              <span i18n>There is no progress to report for this group/user.</span>
+            </td>
+          </tr>
+        </ng-template>
+      </p-table>
+    </ng-container>
   </ng-container>
 </ng-container>

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.html
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.html
@@ -10,7 +10,30 @@
   ></alg-error>
 
   <ng-container *ngIf="state.data">
-    <div class="refresh-button">
+    <div class="operation-buttons">
+      <div>
+        <ng-container *ngIf="itemData && itemData.currentResult?.attemptId as parentAttemptId">
+          <ng-container *ngIf="itemData && itemData.item.type === 'Task'">
+            <a class="alg-button basic" pButton icon="ph-duotone ph-arrows-clockwise"
+              [routerLink]="{
+                id: itemData.item.id,
+                contentType: itemData.item | contentTypeFromItem,
+                path: itemData.route.path,
+                parentAttemptId: parentAttemptId,
+                answer: {
+                  best: true, participantId: watchedGroup ? watchedGroup.route.id : undefined
+                }
+              } | url"
+              *ngrxLet="watchedGroup$; let watchedGroup"
+            >
+              {{ (!!watchedGroup ? 'watchingGroup' : '') | i18nSelect : {
+                watchingGroup: 'View the best answer',
+                other: 'Reload the best answer'
+              } }}
+            </a>
+          </ng-container>
+        </ng-container>
+      </div>
       <button class="alg-button basic" pButton icon="ph-duotone ph-arrows-clockwise" (click)="refresh()">
         Refresh
       </button>

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.scss
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.scss
@@ -6,9 +6,9 @@
   padding: var(--alg-space-size-4) 0;
 }
 
-.refresh-button {
+.operation-buttons {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
   align-items: center;
   margin-bottom: toRem(13);
 }

--- a/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
+++ b/src/app/modules/item/pages/item-log-view/item-log-view.component.ts
@@ -29,11 +29,12 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy {
 
   @Input() itemData?: ItemData;
 
+  watchedGroup$ = this.groupWatchingService.watchedGroup$;
   private readonly refresh$ = new Subject<void>();
   private readonly item$ = new ReplaySubject<Item>(1);
   readonly state$ = combineLatest([
     this.item$.pipe(distinctUntilChanged()),
-    this.groupWatchingService.watchedGroup$,
+    this.watchedGroup$,
   ]).pipe(
     switchMap(([ item, watchedGroup ]) => this.getData$(item, watchedGroup)),
     mapToFetchState({ resetter: this.refresh$ }),

--- a/src/assets/scss/components/button.scss
+++ b/src/assets/scss/components/button.scss
@@ -2,6 +2,7 @@
 
 .alg-button {
   border: none;
+  text-decoration: none;
 
   &.p-button {
     &:enabled:focus {

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -82,14 +82,11 @@
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="2419193533364061980" datatype="html">
         <source> Type at least 3 letters to search content </source><target state="new"> Type at least 3 letters to search content </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/components/left-search-result/left-search-result.component.html</context>
-          <context context-type="linenumber">13,15</context>
-        </context-group>
-      </trans-unit><trans-unit id="4213825410774196775" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-search-result/left-search-result.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="4213825410774196775" datatype="html">
         <source> No results </source><target state="new"> No results </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-search-result/left-search-result.component.html</context><context context-type="linenumber">19</context></context-group></trans-unit><trans-unit id="4219108310098283044" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-search-result/left-search-result.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="4219108310098283044" datatype="html">
         <source>Observation Mode</source><target state="translated">Mode observation</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/components/observation-bar/observation-bar.component.html</context>
@@ -583,11 +580,11 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">254</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">86</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">255</context></context-group></trans-unit><trans-unit id="3155976057239202388" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">255</context></context-group></trans-unit><trans-unit id="3155976057239202388" datatype="html">
         <source># Subm.</source><target state="new"># Subm.</target>
 
         <note priority="1" from="description">Truncated title (little space available) for 'number of submissions'</note>
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">88</context></context-group></trans-unit><trans-unit id="3419681791450150574" datatype="html">
         <source>Progress</source><target state="translated">Avancement</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-overview/group-overview.component.html</context><context context-type="linenumber">7</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.html</context><context context-type="linenumber">62</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/user/user.component.ts</context><context context-type="linenumber">118</context></context-group></trans-unit><trans-unit id="2738733136413289671" datatype="html">
@@ -1628,7 +1625,7 @@
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <note from="description" priority="1">Tab name</note><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">13</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">78</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">95</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <note from="description" priority="1">Tab name</note><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">13</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">76</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">96</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -2186,7 +2183,7 @@
       </trans-unit><trans-unit id="1734171097636944073" datatype="html">
         <source>There is no progress to report for this item.</source><target state="new">There is no progress to report for this item.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">116</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
         <source>You do not have the permissions to edit this content.</source><target state="translated">Vous n'avez pas les permissions d'éditer ce contenu.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.html</context><context context-type="linenumber">49</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">43</context></context-group></trans-unit><trans-unit id="5676044567873886390" datatype="html">
@@ -2208,16 +2205,16 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">15</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">7</context></context-group></trans-unit><trans-unit id="8115085152478832979" datatype="html">
         <source>There is no progress to report for this group/user.</source><target state="new">There is no progress to report for this group/user.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">120</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.html</context><context context-type="linenumber">101</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">122</context></context-group></trans-unit><trans-unit id="9216117865911519658" datatype="html">
         <source>Action</source><target state="translated">Opération</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
         <source>User</source><target state="new">User</target>
 
-      <note from="description" priority="1">User column label</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">88</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
+      <note from="description" priority="1">User column label</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">88</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
         <source>Time</source><target state="translated">Date/Heure</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">105</context></context-group></trans-unit><trans-unit id="2739370419840410792" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="2739370419840410792" datatype="html">
         <source>Add a manager</source><target state="new">Add a manager</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.html</context>
@@ -2232,10 +2229,10 @@
       <note from="description" priority="1">Placeholder of field for searching for user by login</note></trans-unit><trans-unit id="1848556306631120071" datatype="html">
         <source>Time spent</source><target state="translated">Temps écoulé</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">8</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="2827276519893025325" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">8</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="2827276519893025325" datatype="html">
         <source>Not started</source><target state="new">Not started</target>
         
-      <note from="description" priority="1">In progress matrix, explanation when cell is empty</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="7894478830808730680" datatype="html">
+      <note from="description" priority="1">In progress matrix, explanation when cell is empty</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">40</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="7894478830808730680" datatype="html">
         <source>You cannot view answers for this content.</source><target state="new">You cannot view answers for this content.</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/user-progress-details/user-progress-details.component.html</context><context context-type="linenumber">24</context></context-group></trans-unit><trans-unit id="3935757628740535532" datatype="html">
@@ -2262,13 +2259,31 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-group-progress/chapter-group-progress.component.html</context><context context-type="linenumber">12</context></context-group></trans-unit><trans-unit id="8897571869263582585" datatype="html">
         <source>Error while loading the user progress</source><target state="new">Error while loading the user progress</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="5338231862998220113" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="5806005315405881700" datatype="html">
+        <source> View the best answer </source><target state="new"> View the best answer </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context>
+          <context context-type="linenumber">76,77</context>
+        </context-group>
+      </trans-unit><trans-unit id="5015665626593413569" datatype="html">
+        <source> (using <x id="INTERPOLATION" equiv-text="{{ rowData.hintsRequested | i18nPlural : {
+                        '=1': 'hint',
+                        'other': '# hints'
+                      } }}"/>) </source><target state="new"> (using <x id="INTERPOLATION" equiv-text="{{ rowData.hintsRequested | i18nPlural : {
+                        '=1': 'hint',
+                        'other': '# hints'
+                      } }}"/>) </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.html</context>
+          <context context-type="linenumber">98,102</context>
+        </context-group>
+      </trans-unit><trans-unit id="5338231862998220113" datatype="html">
         <source>Latest activity</source><target state="new">Latest activity</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="7123653594948067002" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">80</context></context-group></trans-unit><trans-unit id="7123653594948067002" datatype="html">
         <source>Score</source><target state="new">Score</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">98</context></context-group></trans-unit><trans-unit id="8604389299042909377" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">93</context></context-group></trans-unit><trans-unit id="8604389299042909377" datatype="html">
         <source>All the groups you have joined and you manage</source><target state="new">All the groups you have joined and you manage</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/my-groups/my-groups.component.html</context><context context-type="linenumber">3</context></context-group></trans-unit><trans-unit id="6774795715471269377" datatype="html">


### PR DESCRIPTION
## Description

Fixes #1384

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-stats-history-pages/en/a/home;a=0/progress/chapter-user-progress)
  3. And I see no "hints" column

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-stats-history-pages/en/a/home;pa=0/progress/chapter-user-progress)
  3. And I see all rows are "Chapter" and no "# subm" column

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-stats-history-pages/en/a/39530140456452546;p=4702,4102,1980584647557587953;a=0/progress/chapter-user-progress)
  3. And I see  "# subm" with new format as "31 (using 3 hints)"
  4. And I see no "Reload the best answer" in rows

- [ ] Case 4:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/improve-stats-history-pages/en/a/1293400563985240032;p=7528142386663912287,7523720120450464843;a=0/progress/history)
  3. Then I see and click on "Reload the best answer" in top of table
  4. Then I see opened task with result