### PR TITLE
Removes unused space when no tabs, fixes disabled skills feature

### DIFF
--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="activeTab$ | async as activeTab;">
   <ng-container *ngIf="currentUser$ | async as currentUser">
-    <div class="tab-view-container">
-      <div class="main-menu" *ngIf="!skillsDisabled || activeTab.index === 2 || !currentUser.tempUser">
+    <div class="tab-view-container" *ngIf="!skillsDisabled || activeTab.index === 2 || !currentUser.tempUser">
+      <div class="main-menu">
         <button
           class="main-menu-button active"
           [ngClass]="{ 'active': activeTab.index === 0 }"
@@ -16,7 +16,7 @@
         <button
           class="main-menu-button"
           [ngClass]="{ 'active': activeTab.index === 1 }"
-          [hidden]="skillsDisabled"
+          *ngIf="!skillsDisabled"
           (click)="onSelectionChangedByIdx(1)"
         >
           <div class="main-menu-icon-wrapper">


### PR DESCRIPTION
## Description

Fixes #1391 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

From todo: "left menu: no empty space on top of the menu when there is no activities/skills/groups selector"

## Test cases

