### PR TITLE
Adds redirect to home on click on logo title

### DIFF
--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -1,5 +1,5 @@
 <div class="container" *ngIf="!compactMode">
-  <span class="platform-name">{{ title }}</span>
+  <a class="platform-name" routerLink="/">{{ title }}</a>
   <button
     class="alg-button-icon no-bg primary-color left-menu"
     pButton

--- a/src/app/core/components/left-header/left-header.component.scss
+++ b/src/app/core/components/left-header/left-header.component.scss
@@ -12,5 +12,6 @@
 .platform-name {
   color: var(--alg-primary-color);
   text-transform: uppercase;
+  text-decoration: none;
   font-size: toRem(16);
 }


### PR DESCRIPTION
## Description

Fixes #1399 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/clickable-logo-title/en/a/8123435593727593341;p=4702,458602124916982205,4769434107088212490;pa=0)
  3. And I click on logo title in top left corner
  4. Then I see the root "Parcours officiels" page

