### PR TITLE
Fix menu flashing on score change

### DIFF
--- a/src/app/core/components/left-nav/left-nav.component.html
+++ b/src/app/core/components/left-nav/left-nav.component.html
@@ -74,7 +74,7 @@
 
   <ng-template #navTree>
     <ng-container *ngIf="navTreeServices[activeTab.index]!.state$ | async as state">
-      <alg-loading class="alg-flex-1" *ngIf="state.isFetching"></alg-loading>
+      <alg-loading class="alg-flex-1" *ngIf="state.isFetching && !state.data"></alg-loading>
       <alg-error
         class="alg-flex-1"
         i18n-message message="Unable to load the list."
@@ -91,7 +91,7 @@
         </div>
       </div>
 
-      <div class="alg-flex-1 scroll-wrapper" *ngIf="state.isReady">
+      <div class="alg-flex-1 scroll-wrapper" *ngIf="state.data">
         <div class="scroll-container">
           <perfect-scrollbar>
             <alg-left-nav-tree

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -248,7 +248,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
       path: path,
       initial: fetch,
       shared: fetch.pipe(
-        mapToFetchState({}),
+        mapToFetchState({ resetter: this.reload$ }),
         // The fetches need to use a `shareReplay` which protect them from cancellation as long as they are retained by the `scan`.
         // The shareReplay's use `{ refCount: true, bufferSize: 1 }` options so that the service call is cancelled when there are no more
         // subscribers, and so that new subscribers get the latest results on subscription.

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -22,8 +22,7 @@ export interface NavigationNeighbors {
 
 interface FetchInfo {
   path: ContentRoute['path'], /* path to the fetched elements */
-  initial: Observable<NavTreeData>,
-  shared: Observable<FetchState<NavTreeData>>,
+  fetch: Observable<FetchState<NavTreeData>>,
 }
 
 export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
@@ -131,7 +130,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
      * - visit a chapter with children, visit a skill -> the children of the chapter are not shown anymore
     */
     switchMap(({ content, l1Fetch$, l2Fetch$ }) =>
-      combineLatest([ l1Fetch$.shared, l2Fetch$?.shared ?? of(undefined) ]).pipe(
+      combineLatest([ l1Fetch$.fetch, l2Fetch$?.fetch ?? of(undefined) ]).pipe(
         debounceTime(0),
         map(([ l1FetchState, l2FetchState ]) => {
           if (!l1FetchState.data) return l1FetchState; // l1 is fetching without data or in error -> just show the fetching or error
@@ -238,8 +237,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
   private fetch(path: ContentRoute['path'], fetch: Observable<NavTreeData>): FetchInfo {
     return {
       path: path,
-      initial: fetch,
-      shared: fetch.pipe(
+      fetch: fetch.pipe(
         mapToFetchState({ resetter: this.reload$ }),
         // The fetches need to use a `shareReplay` which protect them from cancellation as long as they are retained by the `scan`.
         // The shareReplay's use `{ refCount: true, bufferSize: 1 }` options so that the service call is cancelled when there are no more

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -1,5 +1,5 @@
 import { combineLatest, merge, Observable, of, Subject } from 'rxjs';
-import { delay, distinctUntilChanged, map, switchMap, shareReplay, scan } from 'rxjs/operators';
+import { delay, distinctUntilChanged, map, switchMap, shareReplay, scan, debounceTime } from 'rxjs/operators';
 import { arraysEqual } from 'src/app/shared/helpers/array';
 import { ensureDefined } from 'src/app/shared/helpers/assert';
 import { isDefined } from 'src/app/shared/helpers/null-undefined-predicates';
@@ -132,6 +132,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
     */
     switchMap(({ content, l1Fetch$, l2Fetch$ }) =>
       combineLatest([ l1Fetch$.shared, l2Fetch$?.shared ?? of(undefined) ]).pipe(
+        debounceTime(0),
         map(([ l1FetchState, l2FetchState ]) => {
           if (!l1FetchState.isReady) return l1FetchState; // l1 is fetching or in error -> just show the fetching or error
           let data = l1FetchState.data;

--- a/src/app/core/services/navigation/nav-tree.service.ts
+++ b/src/app/core/services/navigation/nav-tree.service.ts
@@ -134,10 +134,10 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
       combineLatest([ l1Fetch$.shared, l2Fetch$?.shared ?? of(undefined) ]).pipe(
         debounceTime(0),
         map(([ l1FetchState, l2FetchState ]) => {
-          if (!l1FetchState.isReady) return l1FetchState; // l1 is fetching or in error -> just show the fetching or error
+          if (!l1FetchState.data) return l1FetchState; // l1 is fetching without data or in error -> just show the fetching or error
           let data = l1FetchState.data;
           if (!content) return readyState(data.withNoSelection()); // no selected element -> only l1 shown
-          if (l2FetchState?.isReady) data = data.withChildren(content.route, l2FetchState.data.elements);
+          if (l2FetchState?.data) data = data.withChildren(content.route, l2FetchState.data.elements);
           data = data.withUpdatedElement(content.route, el => this.addDetailsToTreeElement(el, content));
           data = data.withSelection(content.route.id);
           return readyState(data);


### PR DESCRIPTION
## Description

Fix the menu flashing after a few seconds (actually when the score was pushed by the task):
https://github.com/France-ioi/AlgoreaFrontend/assets/1053150/e48b8e9c-52ce-4590-a921-ffbdcdee2100

As there were no change, it was useless to go through the "fetching" state.

It also simplifies code by removing the "reload" case handling from the menu processing.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. And I open network dev panel
  3. When I go to [this task](https://dev.algorea.org/branch/fix-menu-flashing-on-score-change/en/a/2004936693550411739;p=7528142386663912287,7523720120450464843;a=0)
  5. Then I immediately flush network request log
  6. And I wait a few seconds
  7. Then I see 1 request to nav + one cancelled as before
  8. And I didn't see any flashing in the left menu

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go its [parent](https://dev.algorea.org/branch/fix-menu-flashing-on-score-change/en/a/7523720120450464843;p=7528142386663912287;a=0) 
  3. And I click on "Long text task (opentezos-like)"
  4. And I wait a few seconds
  5. I see no flash in the left menu

