### PR TITLE
Fix "no score" items -> should not have no score in menu and top bar

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -272,10 +272,11 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
           type: data.item.type,
           permissions: data.item.permissions,
           attemptId: data.currentResult?.attemptId,
-          bestScore: data.item.watchedGroup ? data.item.watchedGroup.averageScore : data.item.bestScore,
-          currentScore: data.item.watchedGroup ? data.item.watchedGroup.averageScore : data.currentResult?.score,
-          validated: data.item.watchedGroup ?
-            data.item.watchedGroup.averageScore === 100 : data.currentResult?.validated,
+          bestScore: data.item.noScore ? undefined : (data.item.watchedGroup ? data.item.watchedGroup.averageScore : data.item.bestScore),
+          currentScore: data.item.noScore ? undefined :
+            (data.item.watchedGroup ? data.item.watchedGroup.averageScore : data.currentResult?.score),
+          validated: data.item.noScore ? undefined :
+            (data.item.watchedGroup ? data.item.watchedGroup.averageScore === 100 : data.currentResult?.validated),
         },
       }));
 


### PR DESCRIPTION
Bugfix: When an item is 'no-score', its score should not be shown in the left menu and top-bar.

## Test cases

BEFORE:

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/en/a/1426779562289969857;p=7528142386663912287,944619266928306927;a=0/edit-children)
  4. Then I see there is a score ring the current chapter in the menu and in the top bar

AFTER
- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix-no-score-in-menu-and-topbar/en/a/1426779562289969857;p=7528142386663912287,944619266928306927;a=0/edit-children)
  4. Then I see there is no score ring the current chapter in the menu and in the top bar
