### PR TITLE
fix: the error and loader both displayed when url not configured

### DIFF
--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -98,7 +98,7 @@
 
   <alg-task-loader
     class="alg-flex-1"
-    *ngIf="(itemData.item.permissions | allowsViewingContent) && !itemData.item.requiresExplicitEntry && (!itemData.currentResult || (itemData.item.type === 'Task' && !(isTaskLoaded$ | async)))"
+    *ngIf="(itemData.item.permissions | allowsViewingContent) && !itemData.item.requiresExplicitEntry && (!itemData.currentResult || (itemData.item.type === 'Task' && itemData.item.url && !(isTaskLoaded$ | async)))"
     i18n-label label="Loading the content"
     i18n-delayedLabel delayedLabel="The content is taking an unexpected long time to load... please wait..."
   ></alg-task-loader>


### PR DESCRIPTION
## Description

Bug Fix: the error and loader both displayed when url not configured

Note: I am not very pleased with the organization of the code / conditions in this file, it should be reorganized in a near future.

## Test cases

BEFORE

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/en/a/1501663083087440078;p=7528142386663912287,3327328786400474746;a=0)
  4. Then I see both the error message and the loader displayed

AFTER 

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix-no-configured-url-case/en/a/1501663083087440078;p=7528142386663912287,3327328786400474746;a=0)
  4. Then I only see the error message

