### PR TITLE
Fix forum+obs buttons always shown in top bar

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -39,7 +39,7 @@
         [ngClass]="{ 'active': discussion.visible }"
         pButton
         type="button"
-        icon="ph-duotone ph-chat-circle-dots"
+        icon="ph-duotone ph-chats-circle"
         (click)="toggleThreadVisibility(!discussion.visible)"
       ></button>
       <alg-watch-button

--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -32,20 +32,20 @@
         ></alg-breadcrumb>
       </ng-template>
     </div>
-    <button
-      *ngIf="discussionState$ | async as discussion"
-      class="alg-button-icon no-bg primary-color margin-left"
-      [ngClass]="{ 'active': discussion.visible }"
-      pButton
-      type="button"
-      icon="ph-duotone ph-chat-circle-dots"
-      (click)="toggleThreadVisibility(!discussion.visible)"
-    ></button>
-    <alg-watch-button
-      class="margin-left"
-      *ngIf="currentContent.type === 'group' && !!$any(currentContent).details?.currentUserCanWatchMembers"
-    ></alg-watch-button>
     <ng-container *ngIf="showHeaderControls">
+      <button
+        *ngIf="discussionState$ | async as discussion"
+        class="alg-button-icon no-bg primary-color margin-left"
+        [ngClass]="{ 'active': discussion.visible }"
+        pButton
+        type="button"
+        icon="ph-duotone ph-chat-circle-dots"
+        (click)="toggleThreadVisibility(!discussion.visible)"
+      ></button>
+      <alg-watch-button
+        class="margin-left"
+        *ngIf="currentContent.type === 'group' && !!$any(currentContent).details?.currentUserCanWatchMembers"
+      ></alg-watch-button>
       <alg-neighbor-widget
         *ngIf="navigationNeighbors$ | async as navigationNeighbors"
         class="neighbor-widget margin-left"


### PR DESCRIPTION
## Description

The forum and observation buttons were always shown in the top bar (when forum / obervation makes sense for the content) instead of showing them on scroll.

Also change the forum icon so that the icon is the same as the one in the item header 


## Test cases

BEFORE 

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/en/a/2004936693550411739;p=7528142386663912287,7523720120450464843;pa=0)
  4. Then I see the forum icon in both the top bar and the task header
  5. I see icons are different

AFTER:

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix-forum-obs-buttons-always-shown/en/a/2004936693550411739;p=7528142386663912287,7523720120450464843;pa=0)
  4. Then I see the forum icon only in the task header
  6. Then if I scroll, I see it in the top bar
  7. I see icons are the same
