### PR TITLE
Moves login, lang, profile buttons into left menu for mobile

### DIFF
--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -10,7 +10,7 @@
         [showHeaderControls]="scrolled || fullFrameContentDisplayed"
         [modeBarDisplayed]="isWatching"
         [showLeftMenuOpener]="!!(canShowLeftMenu$ | async) && !leftMenu.shown"
-        [showTopRightControls]="!!(showTopRightControls$ | async)"
+        [showTopRightControls]="!!(showTopRightControls$ | async) && !(isNarrowScreen$ | async)"
       ></alg-top-bar>
       <div
         class="main-content-wrapper alg-flex-1"

--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -1,11 +1,17 @@
 <div class="container" *ngIf="!compactMode">
-  <a class="platform-name" routerLink="/">{{ title }}</a>
-  <button
-    class="alg-button-icon no-bg primary-color left-menu"
-    pButton
-    type="button"
-    icon="ph ph-list"
-    data-cy="left-menu-btn"
-    (click)="hideLeftMenu()"
-  ></button>
+  <div class="left-section">
+    <button
+      class="alg-button-icon no-bg primary-color left-menu"
+      pButton
+      type="button"
+      icon="ph ph-list"
+      data-cy="left-menu-btn"
+      (click)="hideLeftMenu()"
+    ></button>
+    <a class="platform-name" routerLink="/">{{ title }}</a>
+  </div>
+  <alg-top-right-controls
+    languagePickerStyleClass="alg-language-picker-dropdown dark-gray-border"
+    *ngIf="!!(showTopRightControls$ | async) && !!(isNarrowScreen$ | async)"
+  ></alg-top-right-controls>
 </div>

--- a/src/app/core/components/left-header/left-header.component.html
+++ b/src/app/core/components/left-header/left-header.component.html
@@ -1,17 +1,20 @@
 <div class="container" *ngIf="!compactMode">
-  <div class="left-section">
-    <button
-      class="alg-button-icon no-bg primary-color left-menu"
-      pButton
-      type="button"
-      icon="ph ph-list"
-      data-cy="left-menu-btn"
-      (click)="hideLeftMenu()"
-    ></button>
-    <a class="platform-name" routerLink="/">{{ title }}</a>
-  </div>
-  <alg-top-right-controls
-    languagePickerStyleClass="alg-language-picker-dropdown dark-gray-border"
-    *ngIf="!!(showTopRightControls$ | async) && !!(isNarrowScreen$ | async)"
-  ></alg-top-right-controls>
+  <ng-container *ngrxLet="isNarrowScreen$; let isNarrowScreen">
+    <div class="left-section alg-flex-1" [ngClass]="{ 'for-mobile': isNarrowScreen }">
+      <a class="platform-name" routerLink="/">{{ title }}</a>
+      <button
+        class="alg-button-icon no-bg primary-color left-menu"
+        pButton
+        type="button"
+        icon="ph ph-list"
+        data-cy="left-menu-btn"
+        (click)="hideLeftMenu()"
+      ></button>
+    </div>
+    <alg-top-right-controls
+      topRightMenuStyleClass="alg-top-right-menu for-mobile"
+      languagePickerStyleClass="alg-language-picker-dropdown dark-gray-border"
+      *ngIf="!!(showTopRightControls$ | async) && isNarrowScreen"
+    ></alg-top-right-controls>
+  </ng-container>
 </div>

--- a/src/app/core/components/left-header/left-header.component.scss
+++ b/src/app/core/components/left-header/left-header.component.scss
@@ -12,10 +12,20 @@
 .left-section {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+
+  &.for-mobile {
+    justify-content: flex-end;
+    flex-direction: row-reverse;
+
+    .platform-name {
+      margin-left: toRem(14);
+    }
+  }
 }
 
 .platform-name {
-  margin-left: toRem(14);
+  margin-right: toRem(14);
   color: var(--alg-primary-color);
   text-transform: uppercase;
   text-decoration: none;

--- a/src/app/core/components/left-header/left-header.component.scss
+++ b/src/app/core/components/left-header/left-header.component.scss
@@ -9,7 +9,13 @@
   align-items: center;
 }
 
+.left-section {
+  display: flex;
+  align-items: center;
+}
+
 .platform-name {
+  margin-left: toRem(14);
   color: var(--alg-primary-color);
   text-transform: uppercase;
   text-decoration: none;

--- a/src/app/core/components/left-header/left-header.component.ts
+++ b/src/app/core/components/left-header/left-header.component.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { AuthService } from 'src/app/shared/auth/auth.service';
 import { LayoutService } from 'src/app/shared/services/layout.service';
+import { delay } from 'rxjs/operators';
 
 @Component({
   selector: 'alg-left-header',
@@ -13,6 +14,9 @@ export class LeftHeaderComponent {
   @Input() compactMode = false;
 
   title = this.titleService.getTitle();
+
+  showTopRightControls$ = this.layoutService.showTopRightControls$.pipe(delay(0));
+  isNarrowScreen$ = this.layoutService.isNarrowScreen$;
 
   constructor(
     private authService: AuthService,

--- a/src/app/core/components/top-right-controls/top-right-controls.component.html
+++ b/src/app/core/components/top-right-controls/top-right-controls.component.html
@@ -4,7 +4,7 @@
   ></ng-container>
 
   <ng-template #authenticated>
-    <alg-top-right-menu></alg-top-right-menu>
+    <alg-top-right-menu [styleClass]="topRightMenuStyleClass"></alg-top-right-menu>
   </ng-template>
 
   <ng-template #notAuthenticated>

--- a/src/app/core/components/top-right-controls/top-right-controls.component.html
+++ b/src/app/core/components/top-right-controls/top-right-controls.component.html
@@ -8,10 +8,14 @@
   </ng-template>
 
   <ng-template #notAuthenticated>
-    <alg-language-picker class="lang-button" *ngIf="languages.length > 1"></alg-language-picker>
+    <alg-language-picker
+      class="lang-button"
+      [styleClass]="languagePickerStyleClass"
+      *ngIf="languages.length > 1"
+    ></alg-language-picker>
     <button
-      class="alg-button-icon primary-color no-bg"
-      icon="ph ph-power"
+      class="alg-button-icon primary-color no-bg login"
+      icon="ph-bold ph-power"
       (click)="login()"
       pButton
     ></button>

--- a/src/app/core/components/top-right-controls/top-right-controls.component.ts
+++ b/src/app/core/components/top-right-controls/top-right-controls.component.ts
@@ -11,6 +11,7 @@ import { LocaleService } from '../../services/localeService';
 export class TopRightControlsComponent{
 
   @Input() drawLeftBorder = true;
+  @Input() topRightMenuStyleClass?: string;
   @Input() languagePickerStyleClass?: string;
   session$ = this.sessionService.session$.pipe(delay(0));
   readonly languages = this.localeService.languages;

--- a/src/app/core/components/top-right-controls/top-right-controls.component.ts
+++ b/src/app/core/components/top-right-controls/top-right-controls.component.ts
@@ -11,6 +11,7 @@ import { LocaleService } from '../../services/localeService';
 export class TopRightControlsComponent{
 
   @Input() drawLeftBorder = true;
+  @Input() languagePickerStyleClass?: string;
   session$ = this.sessionService.session$.pipe(delay(0));
   readonly languages = this.localeService.languages;
 

--- a/src/app/core/components/top-right-menu/top-right-menu.component.html
+++ b/src/app/core/components/top-right-menu/top-right-menu.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="menuItems$ | async as menuItems">
   <p-menu styleClass="alg-top-right-menu" #menu [popup]="true" [model]="menuItems" appendTo="body"></p-menu>
   <div class="user-container" *ngIf="userLogin$ | async as userLogin">
-    <span class="alg-secondary-color user-login">{{ userLogin }}</span>
+    <span class="alg-secondary-color user-login" *ngIf="!(isNarrowScreen$ | async)">{{ userLogin }}</span>
     <button
       class="alg-button-icon no-bg primary-color user-menu"
       icon="ph-duotone ph-user-circle"

--- a/src/app/core/components/top-right-menu/top-right-menu.component.html
+++ b/src/app/core/components/top-right-menu/top-right-menu.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="menuItems$ | async as menuItems">
-  <p-menu styleClass="alg-top-right-menu" #menu [popup]="true" [model]="menuItems" appendTo="body"></p-menu>
+  <p-menu [styleClass]="styleClass || 'alg-top-right-menu'" #menu [popup]="true" [model]="menuItems" appendTo="body"></p-menu>
   <div class="user-container" *ngIf="userLogin$ | async as userLogin">
     <span class="alg-secondary-color user-login" *ngIf="!(isNarrowScreen$ | async)">{{ userLogin }}</span>
     <button

--- a/src/app/core/components/top-right-menu/top-right-menu.component.ts
+++ b/src/app/core/components/top-right-menu/top-right-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { combineLatest } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
@@ -15,6 +15,8 @@ import { LayoutService } from '../../../shared/services/layout.service';
   styleUrls: [ './top-right-menu.component.scss' ],
 })
 export class TopRightMenuComponent {
+  @Input() styleClass?: string;
+
   isNarrowScreen$ = this.layoutService.isNarrowScreen$;
 
   readonly menuItems$ = combineLatest([

--- a/src/assets/scss/components/button-icon.scss
+++ b/src/assets/scss/components/button-icon.scss
@@ -67,6 +67,12 @@
     }
   }
 
+  &.login {
+    .p-button-icon {
+      font-size: toRem(24);
+    }
+  }
+
   &.back-button {
     .p-button-icon {
       color: var(--alg-primary-color);

--- a/src/assets/scss/components/language-picker-dropdown.scss
+++ b/src/assets/scss/components/language-picker-dropdown.scss
@@ -1,6 +1,9 @@
 @import "src/assets/scss/functions";
 
 .alg-language-picker-dropdown {
+  &.dark-gray-border {
+    border: toRem(1) solid #0000001a !important;
+  }
 
   &.p-focus {
     box-shadow: none !important;
@@ -22,7 +25,7 @@
   }
 
   &.p-dropdown {
-    border: toRem(1) solid var(--alg-light-color) !important;
+    border: toRem(1) solid var(--alg-light-color);
     border-radius: toRem(12);
     height: toRem(24);
     background-color: transparent;
@@ -34,6 +37,10 @@
     &:active, &:focus {
       outline: none;
       box-shadow: none;
+    }
+
+    &:not(.p-disabled) {
+      border: toRem(1) solid var(--alg-light-color);
     }
 
     .p-dropdown-panel {

--- a/src/assets/scss/components/top-right-menu.scss
+++ b/src/assets/scss/components/top-right-menu.scss
@@ -53,4 +53,12 @@
       }
     }
   }
+
+  .p-submenu-header {
+    background-color: var(--alg-primary-dark-color);
+    color: white;
+    font-size: toRem(12);
+    font-weight: 500;
+    text-align: right;
+  }
 }

--- a/src/assets/scss/components/top-right-menu.scss
+++ b/src/assets/scss/components/top-right-menu.scss
@@ -55,10 +55,24 @@
   }
 
   .p-submenu-header {
+    height: toRem(40);
     background-color: var(--alg-primary-dark-color);
     color: white;
     font-size: toRem(12);
     font-weight: 500;
-    text-align: right;
+    text-align: left;
+  }
+
+  &.for-mobile {
+    &.p-menu {
+      .p-menuitem-link {
+        margin: 0;
+        padding-top: 0;
+        padding-bottom: 0;
+        height: toRem(40);
+        border-radius: 0;
+        justify-content: space-between;
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

Fixes #1413

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the temp user
  2. And I turn on mobile mode or narrow width
  3. When I go to [this page](https://dev.algorea.org/branch/feature/move-login-and-lang-in-left-menu-in-mobile/en/a/home;pa=0)
  4. Then I see no login and lang buttons
  5. And I click on main menu button
  6. Then I see login and lang buttons

- [ ] Case 2:
  1. Given I am the usual user
  2. And I turn on mobile mode or narrow width
  3. When I go to [this page](https://dev.algorea.org/branch/feature/move-login-and-lang-in-left-menu-in-mobile/en/a/home;pa=0)
  4. Then I see no profile button
  5. And I click on main menu button
  6. Then I see profile button

- [ ] Case 2:
  1. Given I am the usual user
  2. And I turn on mobile mode or narrow width
  3. When I go to [this page](https://dev.algorea.org/branch/feature/move-login-and-lang-in-left-menu-in-mobile/en/a/home;pa=0)
  4. Then I see no profile button
  5. And I click on main menu button
  6. Then I see profile button without login
  7. Then I click on profile button
  8. Then I see login in header of the menu
