### PR TITLE
Left menu: toggle chapter children display

### DIFF
--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.html
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.html
@@ -22,7 +22,7 @@
     >
       <div class="tree-nav-left">
         <div class="tree-nav-icon" *ngIf="node.inL1; else dotsWithLine">
-          <i class="ph-duotone" [ngClass]="{
+          <i class="ph-duotone" (click)="toggleFolder(node)" [ngClass]="{
             'ph-caret-right': !node.expanded,
             'ph-caret-down': node.expanded
           }"></i>

--- a/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
+++ b/src/app/core/components/left-nav-tree/left-nav-tree.component.ts
@@ -42,6 +42,13 @@ export class LeftNavTreeComponent implements OnChanges {
     });
   }
 
+  toggleFolder(node: CustomTreeNode<NavTreeElement>): void {
+    // if this is the "selected" node of the menu, expand/collapse it... otherwise just select it
+    if (node.data.route.id === this.data?.selectedElementId) {
+      this.nodes = this.nodes.map(n => (n == node ? { ...n, expanded: !n.expanded } : n));
+    } else this.selectNode(node);
+  }
+
   navigateToParent(): void {
     if (!this.data) throw new Error('Unexpected: missing data for left nav tree (navigateToParent)');
     if (!this.data.parent) throw new Error('Unexpected: missing parent when navigating to parent');


### PR DESCRIPTION
## Description

Toggle the chapter children display in the menu when clicking on the chevron (as expected by users)

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [this page](https://dev.algorea.org/branch/menu-chapter-toggle/en/a/home;pa=0)
  3. And I click, in the left menu, on the chevron in front of the selected item
  5. Then I see the children are hidden
  6. And I reclick
  7. Then I see the children are shown
  8. And I click on the chevron of a non-selected item
  9. Then I see it navigates to this item