### PR TITLE
Prevent score from flashing in the menu when selecting a node

### DIFF
--- a/src/app/core/services/navigation/item-nav-tree.service.ts
+++ b/src/app/core/services/navigation/item-nav-tree.service.ts
@@ -97,7 +97,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
         bestScore: details.bestScore,
         currentScore: details.bestScore,
         validated: details.validated,
-      } : undefined,
+      } : treeElement.score,
     };
   }
 


### PR DESCRIPTION
## Description

Prevent score from flashing when changing selection

https://github.com/France-ioi/AlgoreaFrontend/assets/1053150/23dc2a13-1131-4f10-b2a1-49a62e5c1410



## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix-left-menu-score-flashing/en/a/algorea--adventure;p=4702;a=0)
  3. And I select "ALGOREA SERIOUS GAME"
  4. And I select "ALGOREA ADVENTURE"
  5. Then I see there is no score flashing anymore