### PR TITLE
Moves neighbor and thread button into top bar from item and group hea…

### DIFF
--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -7,7 +7,6 @@
       <alg-top-bar
         *ngrxLet="fullFrameContentDisplayed$ as fullFrameContentDisplayed"
         [showBreadcrumbs]="!scrolled && !fullFrameContentDisplayed && !(isNarrowScreen$ | async)"
-        [showHeaderControls]="scrolled || fullFrameContentDisplayed"
         [modeBarDisplayed]="isWatching"
         [showLeftMenuOpener]="!!(canShowLeftMenu$ | async) && !leftMenu.shown"
         [showTopRightControls]="!!(showTopRightControls$ | async) && !(isNarrowScreen$ | async)"

--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -32,32 +32,30 @@
         ></alg-breadcrumb>
       </ng-template>
     </div>
-    <ng-container *ngIf="showHeaderControls">
-      <button
-        *ngIf="discussionState$ | async as discussion"
-        class="alg-button-icon no-bg primary-color margin-left"
-        [ngClass]="{ 'active': discussion.visible }"
-        pButton
-        type="button"
-        icon="ph-duotone ph-chats-circle"
-        (click)="toggleThreadVisibility(!discussion.visible)"
-      ></button>
-      <alg-watch-button
-        class="margin-left"
-        *ngIf="currentContent.type === 'group' && !!$any(currentContent).details?.currentUserCanWatchMembers"
-      ></alg-watch-button>
-      <alg-neighbor-widget
-        *ngIf="navigationNeighbors$ | async as navigationNeighbors"
-        class="neighbor-widget margin-left"
-        [navigationMode]="{
-          parent: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.parent,
-          left: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.previous,
-          right: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.next
-        }"
-        (parent)="navigationNeighbors?.data?.parent?.navigateTo()"
-        (left)="navigationNeighbors?.data?.previous?.navigateTo()"
-        (right)="navigationNeighbors?.data?.next?.navigateTo()"
-      ></alg-neighbor-widget>
-    </ng-container>
+    <button
+      *ngIf="discussionState$ | async as discussion"
+      class="alg-button-icon no-bg primary-color margin-left"
+      [ngClass]="{ 'active': discussion.visible }"
+      pButton
+      type="button"
+      icon="ph-duotone ph-chats-circle"
+      (click)="toggleThreadVisibility(!discussion.visible)"
+    ></button>
+    <alg-watch-button
+      class="margin-left"
+      *ngIf="currentContent.type === 'group' && !!$any(currentContent).details?.currentUserCanWatchMembers"
+    ></alg-watch-button>
+    <alg-neighbor-widget
+      *ngIf="navigationNeighbors$ | async as navigationNeighbors"
+      class="neighbor-widget margin-left"
+      [navigationMode]="{
+        parent: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.parent,
+        left: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.previous,
+        right: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.next
+      }"
+      (parent)="navigationNeighbors?.data?.parent?.navigateTo()"
+      (left)="navigationNeighbors?.data?.previous?.navigateTo()"
+      (right)="navigationNeighbors?.data?.next?.navigateTo()"
+    ></alg-neighbor-widget>
   </div>
 </ng-container>

--- a/src/app/core/components/content-top-bar/content-top-bar.component.ts
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.ts
@@ -18,7 +18,6 @@ import { isGroupInfo } from '../../../shared/models/content/group-info';
 })
 export class ContentTopBarComponent {
   @Input() showBreadcrumbs = true;
-  @Input() showHeaderControls = false;
   @Input() showLeftMenuOpener = false;
 
   discussionState$ = this.discussionService.state$;

--- a/src/app/core/components/top-bar/top-bar.component.html
+++ b/src/app/core/components/top-bar/top-bar.component.html
@@ -1,7 +1,6 @@
 <alg-left-header *ngIf="showLeftMenuOpener" [compactMode]="true"></alg-left-header>
 <alg-content-top-bar
   [showBreadcrumbs]="showBreadcrumbs"
-  [showHeaderControls]="showHeaderControls"
   [showLeftMenuOpener]="showLeftMenuOpener"
 ></alg-content-top-bar>
 <alg-top-right-controls *ngIf="showTopRightControls" [drawLeftBorder]="!modeBarDisplayed"></alg-top-right-controls>

--- a/src/app/core/components/top-bar/top-bar.component.ts
+++ b/src/app/core/components/top-bar/top-bar.component.ts
@@ -7,7 +7,6 @@ import { Component, ElementRef, Input } from '@angular/core';
 })
 export class TopBarComponent {
   @Input() showBreadcrumbs = true;
-  @Input() showHeaderControls = false;
   @Input() modeBarDisplayed = false;
   @Input() showTopRightControls = true;
   @Input() showLeftMenuOpener = true;

--- a/src/app/modules/group/components/group-header/group-header.component.html
+++ b/src/app/modules/group/components/group-header/group-header.component.html
@@ -3,21 +3,5 @@
     <div class="group-title-container">
       <h1 class="group-title">{{ groupData.group.name }}</h1>
     </div>
-    <ng-container *ngIf="navigationNeighbors$ | async as navigationNeighbors">
-      <alg-page-navigator
-        *ngIf="groupWithManagement"
-        [allowWatching]="!!groupWithManagement.currentUserCanWatchMembers"
-        [showNewStartWatchButton]="true"
-        [allowFullScreen]="false"
-        [navigationMode]="{
-          parent: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.parent,
-          left: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.previous,
-          right: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.next
-        }"
-        (parent)="navigationNeighbors?.data?.parent?.navigateTo()"
-        (left)="navigationNeighbors?.data?.previous?.navigateTo()"
-        (right)="navigationNeighbors?.data?.next?.navigateTo()"
-      ></alg-page-navigator>
-    </ng-container>
   </div>
 </div>

--- a/src/app/modules/group/components/group-header/group-header.component.ts
+++ b/src/app/modules/group/components/group-header/group-header.component.ts
@@ -1,31 +1,13 @@
-import { Component, Input, OnChanges, ViewChild } from '@angular/core';
-import { Group } from '../../http-services/get-group-by-id.service';
-import { withManagementAdditions, ManagementAdditions } from '../../helpers/group-management';
-import { OverlayPanel } from 'primeng/overlaypanel';
+import { Component, Input } from '@angular/core';
 import { GroupData } from '../../services/group-datasource.service';
-import { GroupNavTreeService } from '../../../../core/services/navigation/group-nav-tree.service';
-import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
 
 @Component({
   selector: 'alg-group-header',
   templateUrl: './group-header.component.html',
   styleUrls: [ './group-header.component.scss' ],
 })
-export class GroupHeaderComponent implements OnChanges {
+export class GroupHeaderComponent {
   @Input() groupData?: GroupData;
 
-  @ViewChild('op') op?: OverlayPanel;
-
-  groupWithManagement?: Group & ManagementAdditions;
-
-  navigationNeighbors$ = this.groupNavTreeService.navigationNeighbors$;
-
-  constructor(
-    private groupWatchingService: GroupWatchingService,
-    private groupNavTreeService: GroupNavTreeService,
-  ) {}
-
-  ngOnChanges(): void {
-    this.groupWithManagement = this.groupData?.group ? withManagementAdditions(this.groupData.group) : undefined;
-  }
+  constructor() {}
 }

--- a/src/app/modules/item/components/item-header/item-header.component.html
+++ b/src/app/modules/item/components/item-header/item-header.component.html
@@ -4,26 +4,5 @@
       <h1 class="item-title alg-h1" data-cy="item-title">{{ itemData.item.string.title }}</h1>
       <p class="item-subtitle" *ngIf="itemData.item.string.subtitle">{{ itemData.item.string.subtitle }}</p>
     </div>
-    <alg-page-navigator
-      *ngIf="navigationNeighbors$ | async as navigationNeighbors"
-      [allowFullScreen]="false"
-      [navigationMode]="{
-        parent: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.parent,
-        left: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.previous,
-        right: !!navigationNeighbors?.isReady && !!navigationNeighbors?.data?.next
-      }"
-      (parent)="navigationNeighbors?.data?.parent?.navigateTo()"
-      (left)="navigationNeighbors?.data?.previous?.navigateTo()"
-      (right)="navigationNeighbors?.data?.next?.navigateTo()"
-    ></alg-page-navigator>
-    <button
-      *ngIf="discussionState$ | async as discussion"
-      class="alg-button-icon no-bg primary-color margin-left"
-      [ngClass]="{'active': discussion.visible }"
-      pButton
-      type="button"
-      icon="ph-duotone ph-chats-circle"
-      (click)="toggleThreadVisibility(!discussion.visible)"
-    ></button>
   </div>
 </div>

--- a/src/app/modules/item/components/item-header/item-header.component.scss
+++ b/src/app/modules/item/components/item-header/item-header.component.scss
@@ -29,7 +29,3 @@
   font-weight: 300;
   line-height: toRem(24);
 }
-
-.margin-left {
-  margin-left: var(--alg-space-size-5);
-}

--- a/src/app/modules/item/components/item-header/item-header.component.ts
+++ b/src/app/modules/item/components/item-header/item-header.component.ts
@@ -1,7 +1,4 @@
-import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { ActivityNavTreeService, SkillNavTreeService } from 'src/app/core/services/navigation/item-nav-tree.service';
-import { isASkill } from 'src/app/shared/helpers/item-type';
-import { DiscussionService } from '../../services/discussion.service';
+import { Component, Input } from '@angular/core';
 import { ItemData } from '../../services/item-datasource.service';
 
 @Component({
@@ -9,27 +6,9 @@ import { ItemData } from '../../services/item-datasource.service';
   templateUrl: './item-header.component.html',
   styleUrls: [ './item-header.component.scss' ]
 })
-export class ItemHeaderComponent implements OnChanges {
+export class ItemHeaderComponent {
   @Input() itemData?: ItemData;
 
-  private activityNavigationNeighbors$ = this.activityNavTreeService.navigationNeighbors$;
-  private skillNavigationNeighbors$ = this.skillNavTreeService.navigationNeighbors$;
-  navigationNeighbors$ = this.activityNavigationNeighbors$;
-  discussionState$ = this.discussionService.state$;
-
-  constructor(
-    private activityNavTreeService: ActivityNavTreeService,
-    private skillNavTreeService: SkillNavTreeService,
-    private discussionService: DiscussionService
-  ) {}
-
-  ngOnChanges(_changes: SimpleChanges): void {
-    if (!this.itemData) return;
-    this.navigationNeighbors$ = isASkill(this.itemData.item) ? this.skillNavigationNeighbors$ : this.activityNavigationNeighbors$;
-  }
-
-  toggleThreadVisibility(visible: boolean): void {
-    this.discussionService.toggleVisibility(visible);
-  }
+  constructor() {}
 
 }


### PR DESCRIPTION
…ders

## Description

Fixes #1432

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/move-header-buttons-into-top-bar/en/a/2268458803184278714;p=;a=0/dependencies)
  3. Then I see neighbours and chat button in top bar
  4. And I see no neighbours and chat button in header of item page

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/move-header-buttons-into-top-bar/en/groups/by-id/4035378957038759250;p=)
  3. Then I see neighbours and chat button in top bar
  4. And I see no neighbours and chat button in header of group page
