### PR TITLE
Adds animation for the loading component

### DIFF
--- a/src/app/modules/shared-components/components/loading/loading.component.scss
+++ b/src/app/modules/shared-components/components/loading/loading.component.scss
@@ -1,5 +1,17 @@
 @import 'src/assets/scss/functions';
 
+@keyframes fade {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: .2;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
 :host {
   display: flex;
   justify-content: center;
@@ -24,4 +36,16 @@
   background-color: #d2dfff;
   border: toRem(3) solid var(--alg-primary-color);
   border-radius: 50%;
+  animation-duration: 1s;
+  animation-timing-function: ease-out;
+  animation-iteration-count: infinite;
+  animation-name: fade;
+
+  &:nth-child(2) {
+    animation-delay: .2s;
+  }
+
+  &:last-child {
+    animation-delay: .4s;
+  }
 }


### PR DESCRIPTION
## Description

Fixes #1429

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. With slow connection mode in browser
  3. When I go to [this page](https://dev.algorea.org/branch/feature/animate-the-loader/en/a/home;pa=0)
  4. Then I see the loading component is animated
