### PR TITLE
Make tabs global

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.html
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.html
@@ -26,7 +26,7 @@
         [@threadOpenClose]="(threadOpened$ | async) ? 'opened' : 'closed'"
         *ngrxLet="currentTab$ as currentTab"
       >
-        <ng-container *ngIf="itemData.item.type === 'Task' || currentTab?.tag ==='alg-content' || currentTab?.tag ==='alg-children-edit'">
+        <ng-container *ngIf="(itemContentComponent?.isTaskLoaded$ | async) || currentTab?.tag ==='alg-content' || currentTab?.tag ==='alg-children-edit'">
           <alg-error *ngIf="answerLoadingError$ | async as error; else noAnswerLoadingError">
             <ng-container *ngIf="!error.fallbackLink; else fallback" i18n>Unable to load the answer</ng-container>
             <ng-template #fallback>

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.html
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.html
@@ -1,269 +1,159 @@
-<ng-container *ngIf="userProfile$ | async as userProfile">
-  <ng-container *ngIf="state$ | async as state">
-    <ng-container *ngIf="state.isReady && state.data as itemData">
+<ng-container *ngIf="state$ | async as state">
+  <ng-container *ngIf="state.isReady && state.data as itemData">
 
-      <ng-container *ngIf="taskTabs$ | async as taskTabs">
-        <alg-item-header [itemData]="itemData" *ngIf="!(fullFrameContent$ | async)"></alg-item-header>
+    <ng-container>
+      <alg-item-header [itemData]="itemData" *ngIf="!(fullFrameContent$ | async)"></alg-item-header>
 
-        <alg-access-code-view
-          *ngIf="showAccessCodeField$ | async"
-          i18n-sectionLabel sectionLabel="Access to activity"
-          i18n-buttonLabel="Button label for joining an item by (group) code" buttonLabel="Access"
-          [itemData]="itemData"
-          (groupJoined)="reloadItem()"
-        ></alg-access-code-view>
+      <alg-access-code-view
+        *ngIf="showAccessCodeField$ | async"
+        i18n-sectionLabel sectionLabel="Access to activity"
+        i18n-buttonLabel="Button label for joining an item by (group) code" buttonLabel="Access"
+        [itemData]="itemData"
+        (groupJoined)="reloadItem()"
+      ></alg-access-code-view>
 
-        <alg-item-permissions
-          *ngIf="watchedGroup$ | async as watchedGroup"
-          [itemData]="itemData"
-          [watchedGroup]="watchedGroup"
-          (changed)="reloadItem()"
-        ></alg-item-permissions>
+      <alg-item-permissions
+        *ngIf="watchedGroup$ | async as watchedGroup"
+        [itemData]="itemData"
+        [watchedGroup]="watchedGroup"
+        (changed)="reloadItem()"
+      ></alg-item-permissions>
 
-        <nav
-          class="alg-nav-tab"
-          [style.display]="!(showProgressTab$ | async) && taskTabs.length <= 1 && !(itemData.item.permissions | allowsEditingAll) && !chapterUserProgressTab?.isActive && !chapterGroupProgressTab?.isActive && !historyTab?.isActive && !dependenciesTab.isActive && !parametersTab.isActive && !taskEditTab.isActive ? 'none' : 'flex'">
-          <a
-            class="alg-nav-tab-item"
-            [routerLink]="'./'"
-            routerLinkActive #contentTab="routerLinkActive"
-            [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored' }"
-            [class.active]="contentTab.isActive"
-            [hidden]="taskTabs.length > 1 || editChildrenTab.isActive"
-            i18n
-          >
-            Content
-          </a>
-          <a
-            class="alg-nav-tab-item"
-            [routerLink]="'./edit-children'"
-            routerLinkActive #editChildrenTab="routerLinkActive"
-            [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored' }"
-            [class.active]="editChildrenTab.isActive"
-            [hidden]="taskTabs.length > 1 || !editChildrenTab.isActive"
-            i18n
-          >
-            Content
-          </a>
-          <ng-container *ngIf="taskTabs.length > 1">
-            <a
-              *ngFor="let tab of taskTabs"
-              class="alg-nav-tab-item cursor-pointer"
-              [routerLink]="'./'"
-              [class.active]="contentTab.isActive && tab.view === taskView"
-              (click)="setTaskTabActive(tab)"
-            >
-              {{ tab.name }}
-            </a>
-          </ng-container>
-          <a
-            [hidden]="(!editorUrl || !(itemData.item.permissions | allowsEditingAll)) && !taskEditTab.isActive"
-            class="alg-nav-tab-item"
-            [routerLink]="'./edit'"
-            routerLinkActive #taskEditTab="routerLinkActive"
-            [class.active]="taskEditTab?.isActive"
-          >
-            <span i18n>Edit</span>
-          </a>
-
-          <ng-container *ngIf="selectors$ | async as selectors">
-            <a
-              [hidden]="!(showProgressTab$ | async) && !chapterUserProgressTab.isActive"
-              class="alg-nav-tab-item"
-              [ngClass]="{'active': !!chapterGroupProgressTab.isActive, 'prev': !!chapterUserProgressTab?.isActive}"
-              [routerLink]="'./progress/chapter'"
-              routerLinkActive #chapterGroupProgressTab="routerLinkActive"
-              *ngIf="selectors === 'withGroupProgress'"
-              i18n
-            >
-              Stats
-            </a>
-
-            <a
-              class="alg-nav-tab-item"
-              [ngClass]="{'active': !!chapterUserProgressTab.isActive}"
-              [routerLink]="'./progress/chapter-user-progress'"
-              routerLinkActive #chapterUserProgressTab="routerLinkActive"
-              [style.display]="((showProgressTab$ | async) && selectors === 'withUserProgress' || !!chapterUserProgressTab.isActive) ? 'flex' : 'none'"
-              i18n
-            >
-              Stats
-            </a>
-
-            <a
-              [hidden]="!(showProgressTab$ | async) && !historyTab.isActive"
-              class="alg-nav-tab-item"
-              [ngClass]="{'active': !!historyTab.isActive}"
-              [routerLink]="'./progress/history'"
-              routerLinkActive #historyTab="routerLinkActive"
-              i18n
-            >
-              History
-            </a>
-          </ng-container>
-
-          <a
-            [hidden]="!(itemData.item.permissions | allowsEditingAll) && !dependenciesTab.isActive"
-            class="alg-nav-tab-item"
-            [routerLink]="'./dependencies'"
-            routerLinkActive #dependenciesTab="routerLinkActive"
-            [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored' }"
-            [class.active]="dependenciesTab.isActive"
-          >
-            <span i18n>Dependencies</span>
-          </a>
-          <a
-            [hidden]="!(itemData.item.permissions | allowsEditingAll) && !parametersTab.isActive"
-            class="alg-nav-tab-item"
-            [routerLink]="'./parameters'"
-            routerLinkActive #parametersTab="routerLinkActive"
-            [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
-            [class.active]="parametersTab.isActive"
-          >
-            <span i18n>Parameters</span>
-          </a>
-          <a
-            [hidden]="(userProfile.tempUser || !showItemThreadWidget) && !forumTab.isActive"
-            class="alg-nav-tab-item"
-            [routerLink]="'./forum'"
-            routerLinkActive #forumTab="routerLinkActive"
-            [class.active]="forumTab.isActive"
-          >
-            <span i18n>Forum</span>
-          </a>
-        </nav>
-        <div
-          class="content-container"
-          #contentContainer
-          [@threadOpenClose]="(threadOpened$ | async) ? 'opened' : 'closed'"
-        >
-          <ng-container *ngIf="contentTab.isActive || editChildrenTab.isActive || taskTabs.length > 0">
-            <alg-error *ngIf="answerLoadingError$ | async as error; else noAnswerLoadingError">
-              <ng-container *ngIf="!error.fallbackLink; else fallback" i18n>Unable to load the answer</ng-container>
-              <ng-template #fallback>
-                <ng-container i18n>
-                  Unable to load the answer, <a [routerLink]="error.fallbackLink" class="alg-link">back to the regular task page</a>.
-                </ng-container>
-              </ng-template>
-              <p *ngIf="!error.isForbidden">{{ errorMessageContactUs }}</p>
-            </alg-error>
-
-            <ng-template #noAnswerLoadingError>
-              <ng-container *ngrxLet="taskConfig$ as taskConfig">
-                <div *ngIf="taskConfig && taskConfig.readOnly && contentTab.isActive" class="indicator">
-                  <alg-answer-author-indicator *ngIf="taskConfig.initialAnswer" [answer]="taskConfig.initialAnswer"></alg-answer-author-indicator>
-                </div>
-                <alg-item-content
-                  class="alg-flex-1"
-                  [style.display]="contentTab.isActive || editChildrenTab.isActive ? 'flex' : 'none'"
-                  [itemData]="itemData"
-                  [taskConfig]="taskConfig"
-                  [savingAnswer]="(savingAnswer$ | async) ?? false"
-                  [(taskView)]="taskView"
-                  [editModeEnabled]="editChildrenTab.isActive"
-                  (taskTabsChange)="setTaskTabs($event)"
-                  (scoreChange)="onScoreChange($event)"
-                  (skipSave)="skipBeforeUnload()"
-                  (refresh)="reloadItem()"
-                  (editorUrl)="editorUrl = $event"
-                  (fullFrameTask)="fullFrameContent$.next($event)"
-                ></alg-item-content>
+      <alg-tab-bar *ngIf="shouldDisplayTabBar$ | async" />
+      <div
+        class="content-container"
+        #contentContainer
+        [@threadOpenClose]="(threadOpened$ | async) ? 'opened' : 'closed'"
+        *ngrxLet="currentTab$ as currentTab"
+      >
+        <ng-container *ngIf="itemData.item.type === 'Task' || currentTab?.tag ==='alg-content' || currentTab?.tag ==='alg-children-edit'">
+          <alg-error *ngIf="answerLoadingError$ | async as error; else noAnswerLoadingError">
+            <ng-container *ngIf="!error.fallbackLink; else fallback" i18n>Unable to load the answer</ng-container>
+            <ng-template #fallback>
+              <ng-container i18n>
+                Unable to load the answer, <a [routerLink]="error.fallbackLink" class="alg-link">back to the regular task page</a>.
               </ng-container>
             </ng-template>
+            <p *ngIf="!error.isForbidden">{{ errorMessageContactUs }}</p>
+          </alg-error>
 
-          </ng-container>
-
-          <alg-item-task-edit
-            *ngIf="taskEditTab?.isActive"
-            [editorUrl]="editorUrl"
-            (redirectToDefaultTab)="navigateToDefaultTab(itemData.route)"
-          ></alg-item-task-edit>
-
-          <ng-container *ngIf="!!historyTab?.isActive || !!chapterGroupProgressTab?.isActive || !!chapterUserProgressTab?.isActive">
-            <ng-container *ngrxLet="isWatching$ as isWatching">
-              <ng-container *ngIf="(!isWatching && (itemData.item.permissions | allowsViewingContent)) || (itemData.item.permissions | allowsWatchingResults) ; else unallowed">
-                <div *ngIf="(savingAnswer$ | async) ?? false" class="save-answer-loader">
-                  <p class="save-answer-loader-message">
-                    <span i18n>Saving answer before loading submission...</span>
-                    <alg-loading size="medium"></alg-loading>
-                    <p-button type="button" (click)="skipBeforeUnload()" i18n-label label="Skip"></p-button>
-                  </p>
-                </div>
-
-                <alg-item-log-view
-                  class="alg-flex-1"
-                  *ngIf="!!historyTab?.isActive"
-                  [itemData]="itemData"
-                ></alg-item-log-view>
-
-                <alg-chapter-group-progress
-                  class="alg-flex-1"
-                  *ngIf="!!chapterGroupProgressTab?.isActive"
-                  [itemData]="itemData"
-                ></alg-chapter-group-progress>
-
-                <alg-chapter-user-progress
-                  class="alg-flex-1"
-                  *ngIf="!!chapterUserProgressTab?.isActive"
-                  [itemData]="itemData"
-                ></alg-chapter-user-progress>
-
-              </ng-container>
-              <ng-template #unallowed>
-                <p class="not-allow-caption" *ngIf="isWatching" i18n>
-                  You are not allowed to view the progress of other users on this content.
-                </p>
-                <p class="not-allow-caption" *ngIf="!isWatching" i18n>
-                  You are not allowed to view this content.
-                </p>
-              </ng-template>
+          <ng-template #noAnswerLoadingError>
+            <ng-container *ngrxLet="taskConfig$ as taskConfig">
+              <div *ngIf="taskConfig && taskConfig.readOnly && currentTab?.tag ==='alg-content'" class="indicator">
+                <alg-answer-author-indicator *ngIf="taskConfig.initialAnswer" [answer]="taskConfig.initialAnswer"></alg-answer-author-indicator>
+              </div>
+              <alg-item-content
+                class="alg-flex-1"
+                [style.display]="currentTab?.tag ==='alg-content' || currentTab?.tag ==='alg-children-edit' || currentTab?.isTaskTab ? 'flex' : 'none'"
+                [itemData]="itemData"
+                [taskConfig]="taskConfig"
+                [savingAnswer]="(savingAnswer$ | async) ?? false"
+                [taskView]="(currentTaskView$ | async) ?? undefined"
+                [editModeEnabled]="currentTab?.tag ==='alg-children-edit'"
+                (taskViewChange)="setTaskView($event)"
+                (taskTabsChange)="setTaskTabs($event)"
+                (scoreChange)="onScoreChange($event)"
+                (skipSave)="skipBeforeUnload()"
+                (refresh)="reloadItem()"
+                (editorUrl)="editorUrlChanged($event)"
+                (disablePlatformProgress)="disablePlatformProgressChanged($event)"
+                (fullFrameTask)="fullFrameContent$.next($event)"
+              ></alg-item-content>
             </ng-container>
-          </ng-container>
+          </ng-template>
 
-          <ng-container *ngIf="dependenciesTab.isActive">
-            <alg-item-dependencies [itemData]="itemData"></alg-item-dependencies>
-          </ng-container>
+        </ng-container>
 
-          <ng-container *ngIf="parametersTab.isActive">
-            <alg-item-edit-wrapper [itemData]="itemData"></alg-item-edit-wrapper>
-          </ng-container>
+        <alg-item-task-edit
+          *ngIf="currentTab?.tag ==='alg-task-edit'"
+          [editorUrl]="editorUrl"
+          (redirectToDefaultTab)="navigateToDefaultTab(itemData.route)"
+        ></alg-item-task-edit>
 
-          <ng-container *ngIf="forumTab.isActive">
-            <alg-error
-              class="alg-flex-1"
-              i18n-message message="You are not allowed to view this content."
-              *ngIf="userProfile.tempUser || !showItemThreadWidget; else forumContent"
-            ></alg-error>
-            <ng-template #forumContent>
-              <alg-item-forum class="alg-flex-1" [itemData]="itemData"></alg-item-forum>
+        <ng-container *ngIf="currentTab && [ 'alg-log', 'alg-progress-matrix', 'alg-chapter-summary'].includes(currentTab.tag)">
+          <ng-container *ngrxLet="isWatching$ as isWatching">
+            <ng-container *ngIf="(!isWatching && (itemData.item.permissions | allowsViewingContent)) || (itemData.item.permissions | allowsWatchingResults) ; else unallowed">
+              <div *ngIf="(savingAnswer$ | async) ?? false" class="save-answer-loader">
+                <p class="save-answer-loader-message">
+                  <span i18n>Saving answer before loading submission...</span>
+                  <alg-loading size="medium"></alg-loading>
+                  <p-button type="button" (click)="skipBeforeUnload()" i18n-label label="Skip"></p-button>
+                </p>
+              </div>
+
+              <alg-item-log-view
+                class="alg-flex-1"
+                *ngIf="currentTab?.tag ==='alg-log'"
+                [itemData]="itemData"
+              ></alg-item-log-view>
+
+              <alg-chapter-group-progress
+                class="alg-flex-1"
+                *ngIf="currentTab?.tag === 'alg-progress-matrix'"
+                [itemData]="itemData"
+              ></alg-chapter-group-progress>
+
+              <alg-chapter-user-progress
+                class="alg-flex-1"
+                *ngIf="currentTab?.tag ==='alg-chapter-summary'"
+                [itemData]="itemData"
+              ></alg-chapter-user-progress>
+
+            </ng-container>
+            <ng-template #unallowed>
+              <p class="not-allow-caption" *ngIf="isWatching" i18n>
+                You are not allowed to view the progress of other users on this content.
+              </p>
+              <p class="not-allow-caption" *ngIf="!isWatching" i18n>
+                You are not allowed to view this content.
+              </p>
             </ng-template>
           </ng-container>
-        </div>
-        <alg-thread-container [topCompensation]="contentContainerTop" *ngIf="showItemThreadWidget"></alg-thread-container>
-      </ng-container>
+        </ng-container>
 
+        <ng-container *ngIf="currentTab?.tag ==='alg-dependencies'">
+          <alg-item-dependencies [itemData]="itemData"></alg-item-dependencies>
+        </ng-container>
+
+        <ng-container *ngIf="currentTab?.tag ==='alg-parameters'">
+          <alg-item-edit-wrapper [itemData]="itemData"></alg-item-edit-wrapper>
+        </ng-container>
+
+        <ng-container *ngIf="currentTab?.tag === 'alg-forum'">
+          <alg-error
+            class="alg-flex-1"
+            i18n-message message="You are not allowed to view this content."
+            *ngIf="(userProfile$ | async)?.tempUser || !showItemThreadWidget; else forumContent"
+          ></alg-error>
+          <ng-template #forumContent>
+            <alg-item-forum class="alg-flex-1" [itemData]="itemData"></alg-item-forum>
+          </ng-template>
+        </ng-container>
+      </div>
+      <alg-thread-container [topCompensation]="contentContainerTop" *ngIf="showItemThreadWidget"></alg-thread-container>
     </ng-container>
 
-    <alg-loading class="alg-flex-1" *ngIf="state.isFetching"></alg-loading>
+  </ng-container>
 
-    <ng-container *ngIf="state.isError">
-      <p class="alg-error-message" *ngIf="state.error && ($any(state.error).status === 403 || $any(state.error).status === 404); else unknownError" i18n>
-        This content does not exist or you are not allowed to view it.
-      </p>
-      <ng-template #unknownError><p class="alg-error-message" i18n>Error while loading the item.</p></ng-template>
-      <p class="alg-error-message" [style.visibility]="(backToHome.isActive)?'hidden':'visible'">
-        <span i18n>Go back to the </span>
-        <a
-          class="alg-link base-color"
-          routerLink="/"
-          [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
-          routerLinkActive #backToHome="routerLinkActive"
-          i18n
-        >
-          home page
-        </a>
-      </p>
-    </ng-container>
+  <alg-loading class="alg-flex-1" *ngIf="state.isFetching"></alg-loading>
+
+  <ng-container *ngIf="state.isError">
+    <p class="alg-error-message" *ngIf="state.error && ($any(state.error).status === 403 || $any(state.error).status === 404); else unknownError" i18n>
+      This content does not exist or you are not allowed to view it.
+    </p>
+    <ng-template #unknownError><p class="alg-error-message" i18n>Error while loading the item.</p></ng-template>
+    <p class="alg-error-message" [style.visibility]="(backToHome.isActive)?'hidden':'visible'">
+      <span i18n>Go back to the </span>
+      <a
+        class="alg-link base-color"
+        routerLink="/"
+        [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
+        routerLinkActive #backToHome="routerLinkActive"
+        i18n
+      >
+        home page
+      </a>
+    </p>
   </ng-container>
 </ng-container>
 

--- a/src/app/modules/item/pages/item-by-id/item-tabs.ts
+++ b/src/app/modules/item/pages/item-by-id/item-tabs.ts
@@ -1,6 +1,6 @@
 
 import { Injectable, OnDestroy } from '@angular/core';
-import { BehaviorSubject, Observable, combineLatest, debounceTime, distinctUntilChanged, filter, map } from 'rxjs';
+import { BehaviorSubject, Observable, combineLatest, debounceTime, distinctUntilChanged, filter, map, startWith } from 'rxjs';
 import { TabService } from 'src/app/shared/services/tab.service';
 import { TaskTab } from '../item-display/item-display.component';
 import { appConfig } from 'src/app/shared/helpers/config';
@@ -55,7 +55,8 @@ export class ItemTabs implements OnDestroy {
     this.disablePlatformProgressOnTasks$,
     this.editTabEnabled$,
     this.userSession.userProfile$,
-    this.router.events.pipe(filter(event => event instanceof NavigationEnd)), // so that displayed but forbidden tabs are hidden after nav
+    // so that displayed but forbidden tabs are hidden after nav:
+    this.router.events.pipe(filter(event => event instanceof NavigationEnd), map(() => {}), startWith()),
   ]).pipe(
     debounceTime(0),
     map(([ state, taskTabs, watchedGroup, disablePlatformProgressOnTasks, editTabEnabled, userProfile ]) => {

--- a/src/app/modules/item/pages/item-by-id/item-tabs.ts
+++ b/src/app/modules/item/pages/item-by-id/item-tabs.ts
@@ -1,0 +1,139 @@
+
+import { Injectable, OnDestroy } from '@angular/core';
+import { BehaviorSubject, Observable, combineLatest, debounceTime, distinctUntilChanged, filter, map } from 'rxjs';
+import { TabService } from 'src/app/shared/services/tab.service';
+import { TaskTab } from '../item-display/item-display.component';
+import { appConfig } from 'src/app/shared/helpers/config';
+import { isATask } from 'src/app/shared/helpers/item-type';
+import { allowsWatchingResults } from 'src/app/shared/models/domain/item-watch-permission';
+import { canCurrentUserViewContent, canCurrentUserViewSolution } from 'src/app/shared/models/domain/item-view-permission';
+import { allowsEditingAll } from 'src/app/shared/models/domain/item-edit-permission';
+import { GroupWatchingService } from 'src/app/core/services/group-watching.service';
+import { ItemDataSource } from '../../services/item-datasource.service';
+import { isNotNull, isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
+import { NavigationEnd, Router } from '@angular/router';
+import { ItemRouter } from 'src/app/shared/routing/item-router';
+import { arraysEqual } from 'src/app/shared/helpers/array';
+import { urlArrayForItemRoute } from 'src/app/shared/routing/item-route';
+import { UserSessionService } from 'src/app/shared/services/user-session.service';
+
+const contentTab = { title: $localize`Content`, routerLink: [], tag: 'alg-content', exactpathMatch: true };
+const childrenEditTab = { title: $localize`Content`, routerLink: [ 'edit-children' ], tag: 'alg-children-edit' };
+const editTab = { title: $localize`Edit`, routerLink: [ 'edit' ], tag: 'alg-task-edit' };
+const groupStatsTab = { title: $localize`Stats`, routerLink: [ 'progress', 'chapter' ], tag: 'alg-progress-matrix' };
+const userStatsTab = { title: $localize`Stats`, routerLink: [ 'progress', 'chapter-user-progress' ], tag: 'alg-chapter-summary' };
+const historyTab = { title: $localize`History`, routerLink: [ 'progress', 'history' ], tag: 'alg-log' };
+const dependenciesTab = { title: $localize`Dependencies`, routerLink: [ 'dependencies' ], tag: 'alg-dependencies' };
+const parametersTab = { title: $localize`Parameters`, routerLink: [ 'parameters' ], tag: 'alg-parameters' };
+const forumTab = { title: $localize`Forum`, routerLink: [ 'forum' ], tag: 'alg-forum' };
+
+const solutionTabView = 'solution'; // 'view' name used by tasks for the solution tab
+
+/**
+ * Service for letting item-by-id component know what tabs and active tab to be displayed
+ */
+@Injectable()
+export class ItemTabs implements OnDestroy {
+
+  private disablePlatformProgressOnTasks$ = new BehaviorSubject<boolean>(true); /* given by the task */
+  private editTabEnabled$ = new BehaviorSubject<boolean>(false);
+
+  private taskTabs$ = new BehaviorSubject<TaskTab[]>([]); // info coming from the task API, via item-display. resetted when item changes
+  currentTab$ = combineLatest([ this.taskTabs$, this.tabService.activeTab$ ]).pipe(
+    map(([ taskTabs, activeTab ]) => (activeTab ? { isTaskTab: taskTabs.some(t => t.view === activeTab), tag: activeTab } : undefined)),
+  );
+  currentTaskView$ = this.currentTab$.pipe( // track only task tab change to keep announcing existing views to task
+    filter(isNotUndefined),
+    filter(t => t?.isTaskTab),
+    map(t => t?.tag),
+  );
+
+  private tabs$: Observable<Parameters<TabService['setTabs']>[0]> = combineLatest([
+    this.itemDataSource.state$,
+    this.taskTabs$,
+    this.groupWatchingService.watchedGroup$,
+    this.disablePlatformProgressOnTasks$,
+    this.editTabEnabled$,
+    this.userSession.userProfile$,
+    this.router.events.pipe(filter(event => event instanceof NavigationEnd)), // so that displayed but forbidden tabs are hidden after nav
+  ]).pipe(
+    debounceTime(0),
+    map(([ state, taskTabs, watchedGroup, disablePlatformProgressOnTasks, editTabEnabled, userProfile ]) => {
+      if (!state.isReady) return [];
+
+      const hasEditionPerm = state.isReady ? allowsEditingAll(state.data.item.permissions) : false;
+      const canViewContent = state.isReady ? canCurrentUserViewContent(state.data.item) : false;
+      const canViewSolution = state.isReady ? canCurrentUserViewSolution(state.data.item, state.data.currentResult) : false;
+      const canWatchResults = state.isReady ? allowsWatchingResults(state.data.item.permissions) : false;
+      const isTask = state.isReady ? isATask(state.data.item) : undefined;
+      const canViewGroupStats = watchedGroup && !watchedGroup.route.isUser && canWatchResults;
+      const canViewUserStats = (watchedGroup && watchedGroup.route.isUser && canWatchResults) || (!watchedGroup && canViewContent);
+      const showProgress = (!isTask || !disablePlatformProgressOnTasks) && (canViewGroupStats || canViewUserStats);
+
+      const shouldHideTab = (v: string): boolean => appConfig.featureFlags.hideTaskTabs.includes(v);
+      const filteredTaskTabs = taskTabs.filter(({ view }) => !shouldHideTab(view) && (canViewSolution || view !== solutionTabView));
+
+      return [
+        filteredTaskTabs.length === 0 && !this.isCurrentTab(childrenEditTab) ? contentTab : null,
+        filteredTaskTabs.length === 0 && this.isCurrentTab(childrenEditTab) ? childrenEditTab : null,
+        ...taskTabs.map(t => ({ title: t.name, routerLink: [], tag: t.view })),
+        this.isCurrentTab(editTab) || (editTabEnabled && hasEditionPerm) ? editTab : null,
+        this.isCurrentTab(groupStatsTab) || (canViewGroupStats && !isTask) ? groupStatsTab : null,
+        this.isCurrentTab(userStatsTab) || (canViewUserStats && !isTask) ? userStatsTab : null,
+        this.isCurrentTab(historyTab) || showProgress ? historyTab : null,
+        this.isCurrentTab(dependenciesTab) || hasEditionPerm ? dependenciesTab : null,
+        this.isCurrentTab(parametersTab) || hasEditionPerm ? parametersTab : null,
+        this.isCurrentTab(forumTab) || (!userProfile.tempUser && !!appConfig.forumServerUrl) ? forumTab : null,
+      ]
+        .filter(isNotNull)
+        .filter(t => !shouldHideTab(t.tag))
+        .map(t => ({ ...t, command: urlArrayForItemRoute(state.data.route, t.routerLink) }))
+      ;
+    }),
+    distinctUntilChanged((x, y) => JSON.stringify(x) === JSON.stringify(y)),
+  );
+
+  private tabUpdateSubscription = this.tabs$.subscribe(tabs => this.tabService.setTabs(tabs));
+
+  constructor(
+    private router: Router,
+    private itemRouter: ItemRouter,
+    private itemDataSource: ItemDataSource,
+    private tabService: TabService,
+    private groupWatchingService: GroupWatchingService,
+    private userSession: UserSessionService,
+  ) {}
+
+  /**
+   * Called when a task defines the tabs to be displayed
+   */
+  setTaskTabs(tabs: TaskTab[]): void {
+    this.taskTabs$.next(tabs);
+  }
+
+  disablePlatformProgressChanged(value: boolean): void {
+    this.disablePlatformProgressOnTasks$.next(value);
+  }
+
+  editTabEnabledChange(value: boolean): void {
+    this.editTabEnabled$.next(value);
+  }
+
+  itemChanged(): void {
+    this.taskTabs$.next([]);
+    this.disablePlatformProgressOnTasks$.next(true);
+    this.editTabEnabled$.next(false);
+  }
+
+  ngOnDestroy(): void {
+    this.tabUpdateSubscription.unsubscribe();
+    this.taskTabs$.complete();
+    this.editTabEnabled$.complete();
+    this.disablePlatformProgressOnTasks$.complete();
+  }
+
+  private isCurrentTab(tab: { routerLink: string[] }): boolean {
+    return arraysEqual(this.itemRouter.currentItemPage() ?? [], tab.routerLink);
+  }
+
+}

--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -62,6 +62,7 @@
           (skipSave)="skipSave.emit()"
           (refresh)="refresh.emit()"
           (editorUrl)="editorUrl.emit($event)"
+          (disablePlatformProgress)="disablePlatformProgress.emit($event)"
           (fullFrame)="fullFrameTask.emit($event)"
           (loadingComplete)="isTaskLoaded$.next($event)"
         ></alg-item-display>

--- a/src/app/modules/item/pages/item-content/item-content.component.ts
+++ b/src/app/modules/item/pages/item-content/item-content.component.ts
@@ -33,6 +33,7 @@ export class ItemContentComponent implements PendingChangesComponent {
   @Output() skipSave = new EventEmitter<void>();
   @Output() refresh = new EventEmitter<void>();
   @Output() editorUrl = new EventEmitter<string|undefined>();
+  @Output() disablePlatformProgress = new EventEmitter<boolean>();
   @Output() fullFrameTask = new EventEmitter<boolean>();
 
   isTaskLoaded$ = new BehaviorSubject(false); // whether the task has finished loading, i.e. is ready or in error

--- a/src/app/modules/item/pages/item-display/item-display.component.ts
+++ b/src/app/modules/item/pages/item-display/item-display.component.ts
@@ -98,6 +98,7 @@ export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDest
   metadata$ = this.metadata.pipe(catchError(() => EMPTY)); /* never emit errors */
 
   @Output() editorUrl = this.metadata$.pipe(map(({ editorUrl }) => editorUrl));
+  @Output() disablePlatformProgress = this.metadata$.pipe(map(({ disablePlatformProgress }) => disablePlatformProgress ?? false));
 
   iframeHeight$ = this.metadata$.pipe(
     switchMap(({ autoHeight }) => {

--- a/src/app/modules/item/services/item-task-views.service.ts
+++ b/src/app/modules/item/services/item-task-views.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { combineLatest, EMPTY, merge, ReplaySubject, Subject } from 'rxjs';
-import { catchError, combineLatestWith, delayWhen, distinctUntilChanged, filter, map, switchMap, takeUntil } from 'rxjs/operators';
+import { catchError, delayWhen, distinctUntilChanged, filter, map, switchMap, takeUntil } from 'rxjs/operators';
 import { isNotUndefined } from 'src/app/shared/helpers/null-undefined-predicates';
 import { TaskViews, UpdateDisplayParams } from '../task-communication/types';
 import { ItemTaskInitService } from './item-task-init.service';
@@ -18,12 +18,8 @@ export class ItemTaskViewsService implements OnDestroy {
     this.task$.pipe(switchMap(task => task.getViews())),
     this.display$.pipe(map(({ views }) => views), filter(isNotUndefined)),
   ).pipe(
-    combineLatestWith(this.task$.pipe(switchMap(task => task.getMetaData()))),
-    map(([ views, { disablePlatformProgress }]) => {
-      const availableViews = this.getAvailableViews(views);
-      return disablePlatformProgress ? availableViews : [ ...availableViews, 'progress' ];
-    }),
-  ); // may error if `task.getViews()` or `.getMetaData()` fails (e.g., timeout)
+    map(views => this.getAvailableViews(views)),
+  ); // may error if `task.getViews()` fails (e.g., timeout)
   readonly views$ = this.views.pipe(catchError(() => EMPTY)); // never emit errors
 
   private activeViewSubject = new ReplaySubject<string>(1);

--- a/src/app/modules/shared-components/components/tab-bar/tab-bar.component.html
+++ b/src/app/modules/shared-components/components/tab-bar/tab-bar.component.html
@@ -1,0 +1,6 @@
+<p-tabMenu
+  *ngrxLet="tabs$ as tabs"
+  [model]="tabs"
+  [scrollable]="true"
+  (activeItemChange)="onChange($event)"
+/>

--- a/src/app/modules/shared-components/components/tab-bar/tab-bar.component.html
+++ b/src/app/modules/shared-components/components/tab-bar/tab-bar.component.html
@@ -1,5 +1,6 @@
 <p-tabMenu
   *ngrxLet="tabs$ as tabs"
+  styleClass="alg-tab-menu"
   [model]="tabs"
   [scrollable]="true"
   (activeItemChange)="onChange($event)"

--- a/src/app/modules/shared-components/components/tab-bar/tab-bar.component.ts
+++ b/src/app/modules/shared-components/components/tab-bar/tab-bar.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { MenuItem } from 'primeng/api';
+import { Observable, combineLatest, map } from 'rxjs';
+import { TabService } from 'src/app/shared/services/tab.service';
+
+@Component({
+  selector: 'alg-tab-bar',
+  templateUrl: './tab-bar.component.html',
+  styleUrls: [ './tab-bar.component.scss' ],
+})
+export class TabBarComponent {
+
+  tabs$: Observable<MenuItem[]> = combineLatest([ this.tabService.tabs$, this.tabService.activeTab$ ]).pipe(
+    map(([ tabs, active ]) => tabs.map(tab => ({
+      label: tab.title,
+      routerLink: tab.command,
+      id: tab.tag,
+      styleClass: tab.tag === active ? 'alg-tab-bar-active' : undefined,
+    }))),
+  );
+
+  constructor(
+    private tabService: TabService,
+  ) {}
+
+  onChange(tab: MenuItem): void {
+    if (!tab.id) throw new Error('unexpected: the tab should have an id!');
+    this.tabService.setActiveTab(tab.id);
+  }
+
+}

--- a/src/app/modules/shared-components/shared-components.module.ts
+++ b/src/app/modules/shared-components/shared-components.module.ts
@@ -82,8 +82,10 @@ import { SuggestionOfActivitiesComponent } from './components/suggestion-of-acti
 import { WatchButtonComponent } from './components/watch-button/watch-button.component';
 import { LetDirective } from '@ngrx/component';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
+import { TabMenuModule } from 'primeng/tabmenu';
 import { HtmlElLoadedDirective } from '../../shared/directives/html-el-loaded.directive';
 import { ThreadStatusDisplayPipe } from '../../shared/pipes/threadStatusDisplay';
+import { TabBarComponent } from './components/tab-bar/tab-bar.component';
 
 @NgModule({
   declarations: [
@@ -144,6 +146,7 @@ import { ThreadStatusDisplayPipe } from '../../shared/pipes/threadStatusDisplay'
     MessageInfoComponent,
     SuggestionOfActivitiesComponent,
     WatchButtonComponent,
+    TabBarComponent,
   ],
   imports: [
     CommonModule,
@@ -173,6 +176,7 @@ import { ThreadStatusDisplayPipe } from '../../shared/pipes/threadStatusDisplay'
     InputMaskModule,
     LetDirective,
     OverlayPanelModule,
+    TabMenuModule,
   ],
   exports: [
     SectionComponent,
@@ -235,6 +239,7 @@ import { ThreadStatusDisplayPipe } from '../../shared/pipes/threadStatusDisplay'
     AllowDisplayCodeSnippet,
     SuggestionOfActivitiesComponent,
     WatchButtonComponent,
+    TabBarComponent,
   ],
   providers: [],
 })

--- a/src/app/shared/routing/item-router.ts
+++ b/src/app/shared/routing/item-router.ts
@@ -43,7 +43,7 @@ export class ItemRouter {
    * Extract (bit hacky) the item page from what is currently displayed.
    * Return undefined if we are not on an "item" page
    */
-  private currentItemPage(): string[]|undefined {
+  currentItemPage(): string[]|undefined {
     const page = this.currentItemPagePath()?.slice(2);
     return page && page.length > 0 ? page : undefined;
   }

--- a/src/app/shared/services/tab.service.ts
+++ b/src/app/shared/services/tab.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, filter, map, withLatestFrom } from 'rxjs';
+import { BehaviorSubject, combineLatest, filter, map, startWith, withLatestFrom } from 'rxjs';
 import { UrlCommand } from '../helpers/url';
 
 interface Tab {
@@ -25,7 +25,7 @@ export class TabService implements OnDestroy {
 
   subscription = combineLatest([
     this.tabs$,
-    this.router.events.pipe(filter(event => event instanceof NavigationEnd), map(() => {})),
+    this.router.events.pipe(filter(event => event instanceof NavigationEnd), map(() => {}), startWith()),
   ]).pipe(
     withLatestFrom(this.activeTab$)
   ).subscribe(([ [ tabs ], activeTab ]) => {

--- a/src/app/shared/services/tab.service.ts
+++ b/src/app/shared/services/tab.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, OnDestroy } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { BehaviorSubject, combineLatest, filter, map, withLatestFrom } from 'rxjs';
+import { UrlCommand } from '../helpers/url';
+
+interface Tab {
+  title: string,
+  command: UrlCommand,
+  exactpathMatch?: boolean,
+  tag: string,
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TabService implements OnDestroy {
+
+  private tabs = new BehaviorSubject<Tab[]>([]);
+  tabs$ = this.tabs.asObservable();
+
+  shouldDisplayTabBar$ = this.tabs.pipe(map(tabs => tabs.length > 1));
+
+  private activeTab = new BehaviorSubject<string|undefined>(undefined);
+  activeTab$ = this.activeTab.asObservable();
+
+  subscription = combineLatest([
+    this.tabs$,
+    this.router.events.pipe(filter(event => event instanceof NavigationEnd), map(() => {})),
+  ]).pipe(
+    withLatestFrom(this.activeTab$)
+  ).subscribe(([ [ tabs ], activeTab ]) => {
+    // if the new url does not match the active tab, change tab
+    const currentTab = tabs.find(t => t.tag === activeTab);
+    if (!currentTab || !this.isTabLinkActive(currentTab)) {
+      // find the first tab matching the current route
+      const matchingTab = tabs.find(t => this.isTabLinkActive(t));
+      if (matchingTab) this.activeTab.next(matchingTab.tag);
+    }
+  });
+
+  constructor(
+    private router: Router,
+  ) {}
+
+  ngOnDestroy(): void {
+    this.tabs.complete();
+    this.activeTab.complete();
+    this.subscription.unsubscribe();
+  }
+
+  setTabs(tabs: Tab[]): void {
+    this.tabs.next(tabs);
+    const activeTab = this.activeTab.value;
+    // if the active tab is not among the tabs anymore OR if there was no active tab and tabs have changed: select the first tab as active
+    if ((activeTab !== undefined && !tagInTabs(activeTab, tabs)) || !activeTab) {
+      this.activeTab.next(tabs[0]?.tag); // set no active tab if there is no tabs
+    }
+  }
+
+  setActiveTab(tag: string|undefined): void {
+    this.activeTab.next(tag);
+  }
+
+  private isTabLinkActive(tab: Tab): boolean {
+    const urlTree = this.router.createUrlTree(tab.command);
+    return this.router.isActive(urlTree, {
+      paths: tab.exactpathMatch ? 'exact' : 'subset',
+      queryParams: 'ignored',
+      fragment: 'ignored',
+      matrixParams: 'ignored',
+    });
+  }
+
+}
+
+function tagInTabs(tag: string, tabs: Tab[]): boolean {
+  return tabs.some(tab => tab.tag === tag);
+}

--- a/src/assets/scss/components/tab-menu.scss
+++ b/src/assets/scss/components/tab-menu.scss
@@ -1,0 +1,75 @@
+@import 'src/assets/scss/functions';
+
+.alg-tab-menu {
+  .p-tabmenu-nav {
+    &:after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      display: block;
+      width: 100%;
+      height: toRem(1);
+      background: rgb(255,255,255);
+      background: -moz-linear-gradient(90deg, rgba(209,215,230,1) 50%, rgba(255,255,255,0) 100%);
+      background: -webkit-linear-gradient(90deg, rgba(209,215,230,1) 50%, rgba(255,255,255,0) 100%);
+      background: linear-gradient(90deg, rgba(209,215,230,1) 50%, rgba(255,255,255,0) 100%);
+      filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#ffffff",endColorstr="#ffffff",GradientType=1);
+    }
+  }
+
+  .p-tabmenuitem {
+    margin-right: 0 !important;
+
+    &:first-child {
+      .p-menuitem-link {
+        margin-left: 0 !important;
+      }
+    }
+
+    &:last-child {
+      .p-menuitem-link {
+        margin-right: 0 !important;
+      }
+    }
+  }
+
+  .p-menuitem-link {
+    margin: 0 toRem(16) !important;
+    padding-top: 0 !important;
+    padding-right: 0 !important;
+    padding-left: 0 !important;
+    padding-bottom: toRem(8);
+    border-top: none !important;
+    border-right: none !important;
+    border-left: none !important;
+    border-bottom: toRem(3) solid transparent !important;
+    position: relative;
+    z-index: 1;
+    background: transparent !important;
+    border-radius: 0 !important;
+
+    &:active, &:focus {
+      outline: none !important;
+      box-shadow: none !important;
+    }
+
+    .p-menuitem-text {
+      color: var(--alg-secondary-color) !important;
+      font-size: toRem(16);
+      font-weight: 300 !important;
+      text-decoration: none;
+      opacity: .5;
+    }
+  }
+
+  .alg-tab-bar-active {
+    .p-menuitem-link {
+      border-bottom: toRem(3) solid var(--alg-primary-color) !important;
+
+      .p-menuitem-text {
+        color: var(--alg-primary-color) !important;
+        opacity: 1 !important;
+      }
+    }
+  }
+}

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -21,7 +21,7 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">344</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">203</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/app.component.html</context><context context-type="linenumber">59</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/permissions-edit-dialog/permissions-edit-dialog.component.html</context><context context-type="linenumber">31</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">313</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">204</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/lti/pages/lti/lti.component.html</context><context context-type="linenumber">18</context></context-group></trans-unit><trans-unit id="727030606410719950" datatype="html">
         <source>Language mismatch</source><target state="translated">Mauvaise langue?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/language-mismatch/language-mismatch.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="6895619751331935307" datatype="html">
@@ -113,7 +113,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">2</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">4</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">255</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">4</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">146</context></context-group></trans-unit><trans-unit id="4465003478966998593" datatype="html">
         <source>home page</source><target state="translated">accueil</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/pages/redirect-to-id/redirect-to-id.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="9167217071684260011" datatype="html">
@@ -137,7 +137,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">15</context></context-group></trans-unit><trans-unit id="7463044993322326313" datatype="html">
         <source> This content does not exist or you are not allowed to view it. </source><target state="translated"> Ce contenu n'existe pas ou vous n'êtes pas autorisé à le voir. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">250</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">141</context></context-group></trans-unit><trans-unit id="5199111763891627410" datatype="html">
         <source>This page has unsaved changes. Do you want to leave this page and lose its changes?</source><target state="translated">Cette page comporte des changements non sauvegardés. Voulez-vous quitter cette page et perdre les changements ?</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/guards/pending-changes-guard.ts</context><context context-type="linenumber">48</context></context-group></trans-unit><trans-unit id="7296226328505512523" datatype="html">
@@ -281,29 +281,17 @@
         </context-group>
       </trans-unit><trans-unit id="8623978917681527907" datatype="html">
         <source>Group</source><target state="new">Group</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context>
-          <context context-type="linenumber">62</context>
-        </context-group>
-      </trans-unit><trans-unit id="5611592591303869712" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="5611592591303869712" datatype="html">
         <source>Status</source><target state="new">Status</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context>
-          <context context-type="linenumber">152</context>
-        </context-group>
-      </trans-unit><trans-unit id="989713090179506197" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">149</context></context-group></trans-unit><trans-unit id="989713090179506197" datatype="html">
         <source># msgs</source><target state="new"># msgs</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context>
-          <context context-type="linenumber">157</context>
-        </context-group>
-      </trans-unit><trans-unit id="4915667673980407083" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">154</context></context-group></trans-unit><trans-unit id="4915667673980407083" datatype="html">
         <source>Latest update</source><target state="new">Latest update</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context>
-          <context context-type="linenumber">162</context>
-        </context-group>
-      </trans-unit><trans-unit id="186460519743457757" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">159</context></context-group></trans-unit><trans-unit id="186460519743457757" datatype="html">
         <source>Global parameters</source><target>Paramètres globaux</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context>
@@ -532,39 +520,48 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="4834436992204469960" datatype="html">
         <source> More than 10 results match your search terms. If you have not found what you are looking for, make your search more specific. </source><target state="new"> More than 10 results match your search terms. If you have not found what you are looking for, make your search more specific. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="5928181193903168495" datatype="html">
-        <source> Content </source><target state="translated"> Contenu </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">34</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit><trans-unit id="7585826646011739428" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.html</context><context context-type="linenumber">94</context></context-group></trans-unit><trans-unit id="7585826646011739428" datatype="html">
         <source>Edit</source><target state="new">Edit</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">66</context></context-group></trans-unit><trans-unit id="6654200634583134581" datatype="html">
-        <source> Stats </source><target state="new"> Stats </target>
-        
-        
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">78</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">89</context></context-group></trans-unit><trans-unit id="4045087308145757242" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="4088311569349098646" datatype="html">
+        <source>Stats</source><target state="new">Stats</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context>
+          <context context-type="linenumber">23</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+      </trans-unit><trans-unit id="186236568870281953" datatype="html">
+        <source>History</source><target state="new">History</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit><trans-unit id="4045087308145757242" datatype="html">
         <source>Dependencies</source><target state="new">Dependencies</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">113</context></context-group></trans-unit><trans-unit id="2250922476634643797" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context><context context-type="linenumber">26</context></context-group></trans-unit><trans-unit id="2250922476634643797" datatype="html">
         <source>Parameters</source><target state="new">Parameters</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">123</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context><context context-type="linenumber">27</context></context-group></trans-unit><trans-unit id="887257604747944910" datatype="html">
         <source>Leave unsaved task</source><target state="translated">Ne pas sauvegarder la réponse</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">276</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">166</context></context-group></trans-unit><trans-unit id="6669833589802408443" datatype="html">
         <source>You do not appear to be connected to the Internet, if you leave this task you may loose your progress. Are you sure you want to continue?</source><target state="translated">Vous ne semblez pas être connecté à Internet, si vous quittez cette tâche, vous perdrez vos changements. Êtes-vous sûr de vouloir continuer ?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">278</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">168</context></context-group></trans-unit><trans-unit id="8127788667268693950" datatype="html">
         <source>Loose progress and leave the task</source><target state="translated">Perdre les changement et quitter la tâche</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">283</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">173</context></context-group></trans-unit><trans-unit id="7934833136974560675" datatype="html">
         <source>Retry</source><target state="translated">Réessayer</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">288</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">58</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.html</context><context context-type="linenumber">24</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">178</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">58</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.html</context><context context-type="linenumber">24</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/path-suggestion/path-suggestion.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="unknownError" datatype="html">
         <source>An unknown error occurred. </source><target state="translated">Une erreur est survenue. </target>
         
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">202</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">203</context></context-group></trans-unit><trans-unit id="6885936620581271929" datatype="html">
         <source>Unable to load the task</source><target state="new">Unable to load the task</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="8679237608788920660" datatype="html">
@@ -579,59 +576,56 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">52</context></context-group></trans-unit><trans-unit id="4586682462895822504" datatype="html">
         <source>Unable to load the answer</source><target state="new">Unable to load the answer</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">142</context></context-group></trans-unit><trans-unit id="2999758243399981972" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">31</context></context-group></trans-unit><trans-unit id="2999758243399981972" datatype="html">
         <source> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;error.fallbackLink&quot; class=&quot;alg-link&quot;>"/>back to the regular task page<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </source><target state="new"> Unable to load the answer, <x id="START_LINK" ctype="x-a" equiv-text="&lt;a [routerLink]=&quot;error.fallbackLink&quot; class=&quot;alg-link&quot;>"/>back to the regular task page<x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a>"/>. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">144</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">33</context></context-group></trans-unit><trans-unit id="3142808599136977164" datatype="html">
         <source>Saving answer...</source><target state="new">Saving answer...</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">69</context></context-group></trans-unit><trans-unit id="4563965495368336177" datatype="html">
         <source>Skip</source><target state="new">Skip</target>
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">189</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">71</context></context-group></trans-unit><trans-unit id="7344184843585356819" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.html</context><context context-type="linenumber">71</context></context-group></trans-unit><trans-unit id="7344184843585356819" datatype="html">
         <source> You are not allowed to view the progress of other users on this content. </source><target state="new"> You are not allowed to view the progress of other users on this content. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">213</context></context-group></trans-unit><trans-unit id="6836185474382261556" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit><trans-unit id="6836185474382261556" datatype="html">
         <source> You are not allowed to view this content. </source><target state="new"> You are not allowed to view this content. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">216</context></context-group></trans-unit><trans-unit id="4495565209134031333" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">107</context></context-group></trans-unit><trans-unit id="4495565209134031333" datatype="html">
         <source>You are not allowed to view this content.</source><target state="new">You are not allowed to view this content.</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
-          <context context-type="linenumber">234</context>
-        </context-group>
-      </trans-unit><trans-unit id="7005243353550317116" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">125</context></context-group></trans-unit><trans-unit id="7005243353550317116" datatype="html">
         <source>Your current progress could not have been saved. Are you connected to the internet?</source><target state="new">Your current progress could not have been saved. Are you connected to the internet?</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">133</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">134</context></context-group></trans-unit><trans-unit id="4373686826857756108" datatype="html">
         <source>Progress saved!</source><target state="new">Progress saved!</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">138</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">139</context></context-group></trans-unit><trans-unit id="1555021161449604077" datatype="html">
         <source>You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.</source><target state="new">You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">150</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">151</context></context-group></trans-unit><trans-unit id="2164874882400763735" datatype="html">
         <source>An unknown error occurred while publishing your result</source><target state="new">An unknown error occurred while publishing your result</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">151</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">152</context></context-group></trans-unit><trans-unit id="6790974458277153869" datatype="html">
         <source>Hint request failed</source><target state="new">Hint request failed</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">156</context></context-group></trans-unit><trans-unit id="7340307578242589055" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">157</context></context-group></trans-unit><trans-unit id="7340307578242589055" datatype="html">
         <source>You cannot access this page.</source><target state="new">You cannot access this page.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">188</context></context-group></trans-unit><trans-unit id="2693653888075218067" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">189</context></context-group></trans-unit><trans-unit id="2693653888075218067" datatype="html">
         <source>Unable to get linked page information. If the problem persists, contact us.</source><target state="new">Unable to get linked page information. If the problem persists, contact us.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">189</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">190</context></context-group></trans-unit><trans-unit id="8993911766369461044" datatype="html">
         <source>Solve</source><target state="new">Solve</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">254</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">255</context></context-group></trans-unit><trans-unit id="1961103453220395122" datatype="html">
         <source>Forum</source><target state="new">Forum</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">132</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">255</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context><context context-type="linenumber">28</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">256</context></context-group></trans-unit><trans-unit id="4579430119993221119" datatype="html">
         <source>Hints</source><target state="new">Hints</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">256</context></context-group></trans-unit><trans-unit id="3155976057239202388" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">257</context></context-group></trans-unit><trans-unit id="3155976057239202388" datatype="html">
         <source># Subm.</source><target state="new"># Subm.</target>
 
         <note priority="1" from="description">Truncated title (little space available) for 'number of submissions'</note>
@@ -809,10 +803,10 @@
       </trans-unit><trans-unit id="875621229969091247" datatype="html">
         <source>Submission</source><target state="translated">Soumission</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">258</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">259</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="331587195284992791" datatype="html">
         <source>Statement</source><target state="new">Statement</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">259</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">260</context></context-group></trans-unit><trans-unit id="2535576348998502417" datatype="html">
         <source>Submission (score: <x id="PH" equiv-text="score"/>)</source><target state="translated">Soumission (score: <x id="PH" equiv-text="score"/>)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/logActionDisplay.ts</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="4613238674011043082" datatype="html">
@@ -851,13 +845,10 @@
           <context context-type="sourcefile">src/app/shared/pipes/threadStatusDisplay.ts</context>
           <context context-type="linenumber">9</context>
         </context-group>
-      </trans-unit><trans-unit id="2919237623258423230" datatype="html">
-        <source> History </source><target state="new"> History </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="5711976490580430557" datatype="html">
+      </trans-unit><trans-unit id="5711976490580430557" datatype="html">
         <source>Saving answer before loading submission...</source><target state="new">Saving answer before loading submission...</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">187</context></context-group></trans-unit><trans-unit id="1125515177419706232" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">78</context></context-group></trans-unit><trans-unit id="1125515177419706232" datatype="html">
         <source>Maformed url: "<x id="PH" equiv-text="url"/>"</source><target state="new">Maformed url: "<x id="PH" equiv-text="url"/>"</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/services/item-task-init.service.ts</context><context context-type="linenumber">145</context></context-group></trans-unit><trans-unit id="1648546115727864611" datatype="html">
@@ -1038,7 +1029,7 @@
         <source>You are not allowed to manage permissions of this group.</source><target state="new">You are not allowed to manage permissions of this group.</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-access/group-access.component.html</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
-      <source>Access to activity</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
+      <source>Access to activity</source><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/pages/group-edit/group-edit.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit-wrapper.component.ts</context><context context-type="linenumber">279</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="6941980323724778673" datatype="html">
         <source>Access to activity</source><target state="translated">Accès à l'activité</target>
 
@@ -1057,10 +1048,10 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/access-code-view/access-code-view.component.ts</context><context context-type="linenumber">41</context></context-group></trans-unit><trans-unit id="5278627882107105833" datatype="html">
         <source>Access</source><target state="translated">Rejoindre</target>
 
-      <note from="description" priority="1">Button label for joining an item by (group) code</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
+      <note from="description" priority="1">Button label for joining an item by (group) code</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">10</context></context-group></trans-unit><trans-unit id="6162691442834560200" datatype="html">
         <source>Items</source><target state="translated">Élements</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.ts</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
         <source>Edit content</source><target state="new">Edit content</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">22</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
@@ -1069,34 +1060,28 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-children-edit-form/item-children-edit-form.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
         <source> This activity has not been correctly configured. </source><target state="new"> This activity has not been correctly configured. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">71</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">72</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
         <source> You need to set a url in editing mode. </source><target state="new"> You need to set a url in editing mode. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">74</context></context-group></trans-unit><trans-unit id="9152383970834327178" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">75</context></context-group></trans-unit><trans-unit id="9152383970834327178" datatype="html">
         <source> Your current access rights do not allow you to list the content of this chapter. </source><target state="new"> Your current access rights do not allow you to list the content of this chapter. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">83</context></context-group></trans-unit><trans-unit id="6557565374286675560" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">84</context></context-group></trans-unit><trans-unit id="6557565374286675560" datatype="html">
         <source> Your current access rights do not allow you to list the content of this skill. </source><target state="new"> Your current access rights do not allow you to list the content of this skill. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">87</context></context-group></trans-unit><trans-unit id="8944765970586595001" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">88</context></context-group></trans-unit><trans-unit id="8944765970586595001" datatype="html">
         <source> Your current access rights do not allow you to start the activity. </source><target state="new"> Your current access rights do not allow you to start the activity. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="701018348223992755" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">92</context></context-group></trans-unit><trans-unit id="701018348223992755" datatype="html">
         <source>Loading the content</source><target state="new">Loading the content</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
-          <context context-type="linenumber">102</context>
-        </context-group>
-      </trans-unit><trans-unit id="1105872825687577539" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">103</context></context-group></trans-unit><trans-unit id="1105872825687577539" datatype="html">
         <source>The content is taking an unexpected long time to load... please wait...</source><target state="new">The content is taking an unexpected long time to load... please wait...</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context>
-          <context context-type="linenumber">103</context>
-        </context-group>
-      </trans-unit><trans-unit id="6198202441206570236" datatype="html">
+        
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">104</context></context-group></trans-unit><trans-unit id="6198202441206570236" datatype="html">
         <source>This activity requires explicit entry</source><target state="new">This activity requires explicit entry</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">109</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">110</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
         <source>(not implemented)</source><target state="new">(not implemented)</target>
 
 
@@ -1104,13 +1089,13 @@
 
 
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">110</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">105</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">126</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">206</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-content/item-content.component.html</context><context context-type="linenumber">111</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">53</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">68</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">105</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">126</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-edit-advanced-parameters/item-edit-advanced-parameters.component.html</context><context context-type="linenumber">206</context></context-group></trans-unit><trans-unit id="7493155057912125679" datatype="html">
         <source>Your current access rights do not allow you to list the content of this chapter.</source><target state="new">Your current access rights do not allow you to list the content of this chapter.</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav-tree/left-nav-tree.component.html</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="6518315916537207134" datatype="html">
         <source> home page </source><target state="translated"> page d'accueil </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">262</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">153</context></context-group></trans-unit><trans-unit id="569741268651615075" datatype="html">
         <source>Go back to the </source><target state="translated">Retour à la </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context>
@@ -1125,7 +1110,7 @@
       </trans-unit><trans-unit id="9041444757418829014" datatype="html">
         <source>Error while loading the item.</source><target state="translated">Erreur lors du chargement du contenu.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">253</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-by-id.component.html</context><context context-type="linenumber">144</context></context-group></trans-unit><trans-unit id="3249513483374643425" datatype="html">
         <source>Add</source><target state="translated">Ajouter</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-manager-add/group-manager-add.component.html</context><context context-type="linenumber">14</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/shared-components/components/add-content/add-content.component.ts</context><context context-type="linenumber">37</context></context-group></trans-unit><trans-unit id="9165363087268857396" datatype="html">
@@ -1700,7 +1685,7 @@
         <source>Content</source><target state="translated">Contenu</target>
 
 
-      <note from="description" priority="1">Tab name</note><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">13</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">75</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">142</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">96</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
+      <note from="description" priority="1">Tab name</note><context-group purpose="location"><context context-type="sourcefile">src/app/core/components/left-nav/left-nav.component.html</context><context context-type="linenumber">13</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">84</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">9</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">17</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/chapter-user-progress/chapter-user-progress.component.ts</context><context context-type="linenumber">75</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context><context context-type="linenumber">20</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-by-id/item-tabs.ts</context><context context-type="linenumber">21</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">139</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">96</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">9</context></context-group></trans-unit><trans-unit id="1459057934865952132" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can see the content of this item</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut voir le contenu de cet élément</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">60</context></context-group></trans-unit><trans-unit id="240638056322492270" datatype="html">
@@ -1713,7 +1698,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">65</context></context-group></trans-unit><trans-unit id="2577694282301310795" datatype="html">
         <source>Solution</source><target state="translated">Solution</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">19</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">257</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">11</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-string.ts</context><context context-type="linenumber">19</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-display/item-display.component.ts</context><context context-type="linenumber">258</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/shared/pipes/groupPermissionCaption.ts</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="4838785989562241195" datatype="html">
         <source><x id="PH" equiv-text="targetTypeString"/> can also see the solution of this items and its descendants (when possible for this group)</source><target state="translated"><x id="PH" equiv-text="targetTypeString"/> peut également voir les solutions de cet élément et ses descendants (quand c'est possible pour ce groupe)</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/helpers/permissions-texts.ts</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="4704354403690851163" datatype="html">
@@ -2241,13 +2226,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">6</context></context-group></trans-unit><trans-unit id="4300451538108090648" datatype="html">
         <source>Item subtitle</source><target state="translated">Sous-titre</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="5928181193903168495" datatype="html">
-        <source> Content </source><target state="translated"> Contenu </target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/modules/item/pages/item-edit/item-edit.component.html</context>
-          <context context-type="linenumber">19,20</context>
-        </context-group>
-      </trans-unit><trans-unit id="1734171097636944073" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/item-edit-wrapper/item-edit-wrapper.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="1734171097636944073" datatype="html">
         <source>There is no progress to report for this item.</source><target state="new">There is no progress to report for this item.</target>
         
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.html</context><context context-type="linenumber">118</context></context-group></trans-unit><trans-unit id="3139978144476033891" datatype="html">
@@ -2278,7 +2257,7 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">80</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">91</context></context-group></trans-unit><trans-unit id="2392488717875840729" datatype="html">
         <source>User</source><target state="new">User</target>
 
-      <note from="description" priority="1">User column label</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">88</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">147</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
+      <note from="description" priority="1">User column label</note><context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">88</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-forum/item-forum.component.ts</context><context context-type="linenumber">144</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="8497528947328199741" datatype="html">
         <source>Time</source><target state="translated">Date/Heure</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/group/components/group-log-view/group-log-view.component.ts</context><context context-type="linenumber">93</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/pages/item-log-view/item-log-view.component.ts</context><context context-type="linenumber">106</context></context-group></trans-unit><trans-unit id="2739370419840410792" datatype="html">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -197,3 +197,10 @@ body {
     border-color: transparent transparent var(--alg-primary-color) transparent;
   }
 }
+
+.alg-tab-bar-active {
+
+  .p-element {
+    background: red !important;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,6 +30,7 @@
 @import 'assets/scss/components/tooltip';
 @import 'assets/scss/components/path-suggestion-overlay';
 @import 'assets/scss/components/rounded-icon-wrapper';
+@import 'assets/scss/components/tab-menu';
 
 // New Design
 @import 'assets/fonts/roboto/stylesheet';
@@ -195,12 +196,5 @@ body {
     border-style: solid;
     border-width: 0 toRem(8) toRem(8) toRem(8);
     border-color: transparent transparent var(--alg-primary-color) transparent;
-  }
-}
-
-.alg-tab-bar-active {
-
-  .p-element {
-    background: red !important;
   }
 }


### PR DESCRIPTION
## Description

Move the item tabs globally so that they can put (in a future issue) in the tab bar.

## Test cases

- [x] Case 1: Chapter basics
  1. Given I am the usual user
  2. When I go to [a chapter](https://dev.algorea.org/branch/make-tabs-global/en/a/7523720120450464843;p=7528142386663912287;a=0)
  3. And I land on the content of the "content" tab
  4. Then I see tabs "stats", "history", "dependencies" and "parameters" tabs with appropriate routing.
  5. The "stats" as the chapter view (for users)
  6. I see no other tabs

- [x] Case 2: Stat tab with observing a group
  1. Given I am the usual user
  2. When I go to [a content while observing a group](https://dev.algorea.org/branch/make-tabs-global/en/a/7528142386663912287;p=;pa=0?watchedGroupId=4462192261130512818&watchUser=0)
  3. I see one "stats" tab
  4. And it displays the matrix view

- [x] Case 3: Stat tab with observing a group
  1. Given I am the usual user
  2. When I go to [a content while observing a group](https://dev.algorea.org/branch/make-tabs-global/en/a/7528142386663912287;p=;pa=0?watchedGroupId=752024252804317630&watchUser=1)
  3. I see one "stats" tab
  4. And it displays the chapter view

- [x] Case 4: "Stat" tab hidden 
  1. Given I am the usual user
  2. When I go to a [task which hides the progress](https://dev.algorea.org/branch/make-tabs-global/en/a/6319140447749005365;p=7528142386663912287,7523720120450464843;a=0)
  3. I do not see any "stats" nor "history" tab
  4. I see the "content" tab has been replaced by the task tabs 
  5. I can switch freely among the task tab
  6. Switching the "dependencies" tab and switching back to the "Statement" does not reload the task

- [x] Case 5: Tab bar hidden if only one tab 
  1. Given I am the **demo** user
  2. And I test locally
  3. And I disable forum (`forumUrl` not set)
  4. When I go to a [task which hides the progress, have one tab and I do not have more perm on the content](http://localhost:4200/a/2004936693550411739;p=7528142386663912287,7523720120450464843;pa=0)
  5. I do not see tab bar
  6. I see the "content" of the only tab

-  [x] Case 6: Nav between item keep the same tab selected. Tab disappear when not supposed to be visible when leaving it.
  1. Given I am the usual user
  2. When I go to the [stats tab of a item](https://dev.algorea.org/branch/make-tabs-global/en/a/7523720120450464843;p=7528142386663912287;a=0/progress/chapter-user-progress)
  3. I select "Blockly Basic Task " 
  4. I am still on the "stats" even if this tab is not supposed to appear
  7. If I go to the "history" tab, the "stats" tab disappear

-  [x] Case 7: Visiting task with "edit-children" enabled
  1. Given I am the usual user
  2. When I go to [a chapter in edit-children mode](https://dev.algorea.org/branch/make-tabs-global/en/a/7523720120450464843;p=7528142386663912287;a=0/edit-children)
  3. I select "Blockly Basic Task " 
  4. The task loads normally

Unable to test for now: if on tab which disappear when resizing (task tabs can be created / removed on resize)... should fallback to a correct page.

Still a bug? Sometimes the content is empty (blank) ... had several times but cannot reproduce: 
- when switching user, on 7523720120450464843 for instance -> there is no current Tab so the ngrxlet does not run
