### PR TITLE
Changes retry button caption in error component

### DIFF
--- a/src/app/modules/shared-components/components/error/error.component.ts
+++ b/src/app/modules/shared-components/components/error/error.component.ts
@@ -11,7 +11,7 @@ export class ErrorComponent {
   @Input() message?: string;
   @Input() icon?: string;
   @Input() showRefreshButton = false;
-  @Input() buttonCaption = 'Back home';
+  @Input() buttonCaption = 'Retry';
   @Input() buttonStyleClass?: string;
   @Input() link?: string;
 


### PR DESCRIPTION
## Description

Fixes #1448

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

As design are using common template the caption was wrong in some places. So I've changed the value by default to "Retry" for everywhere.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/wrong-message-for-retry-button/en/groups/by-id/917454091139548680;p=947670356997220543?watchedGroupId=917454091139548680&watchUser=0)
  3. And I wait for the timeout to happen
  4. Then I see the error message with "Retry" button
