### PR TITLE
Fixes margin for new tabs and mobile arrows

### DIFF
--- a/src/assets/scss/components/tab-menu.scss
+++ b/src/assets/scss/components/tab-menu.scss
@@ -1,6 +1,8 @@
 @import 'src/assets/scss/functions';
 
 .alg-tab-menu {
+  margin-bottom: var(--alg-space-size-4);
+
   .p-tabmenu-nav {
     &:after {
       content: '';
@@ -59,6 +61,13 @@
       font-weight: 300 !important;
       text-decoration: none;
       opacity: .5;
+    }
+  }
+
+  .p-tabmenu-nav-btn {
+    &.p-link {
+      background: var(--alg-white-color);
+      color: var(--alg-primary-color);
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #1451

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/tabs-design/en/a/784078458149384669;p=;a=0)
  3. Then I see the tabs displayed correct

- [ ] Case 2:
  1. Given I am the usual user
  2. From mobile mode or narrow width of window
  3. When I go to [this page](https://dev.algorea.org/branch/bugfix/tabs-design/en/a/899800937596940136;p=;a=0)
  4. Then I see designed arrow buttons
