### PR TITLE
fetch the thread info on loading, use the thread info token with the WS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "fp-ts": "^2.13.1",
         "io-ts": "^2.2.20",
         "jschannel": "^1.0.2",
+        "jwt-decode": "^3.1.2",
         "ngx-scrollbar": "^13.0.0",
         "primeicons": "^6.0.1",
         "primeng": "^16.0.2",
@@ -13626,6 +13627,11 @@
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/karma": {
       "version": "6.3.16",
@@ -30942,6 +30948,11 @@
         "readable-stream": "~2.3.6",
         "set-immediate-shim": "~1.0.1"
       }
+    },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "karma": {
       "version": "6.3.16",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "fp-ts": "^2.13.1",
     "io-ts": "^2.2.20",
     "jschannel": "^1.0.2",
+    "jwt-decode": "^3.1.2",
     "ngx-scrollbar": "^13.0.0",
     "primeicons": "^6.0.1",
     "primeng": "^16.0.2",

--- a/src/app/core/components/content-top-bar/content-top-bar.component.ts
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.ts
@@ -21,7 +21,6 @@ export class ContentTopBarComponent {
   @Input() showLeftMenuOpener = false;
 
   discussionState$ = this.discussionService.state$;
-
   watchedGroup$ = this.groupWatchingService.watchedGroup$;
 
   currentContent$: Observable<ContentInfo | null> = this.currentContentService.content$.pipe(

--- a/src/app/core/components/thread-container/thread-container.component.ts
+++ b/src/app/core/components/thread-container/thread-container.component.ts
@@ -1,7 +1,6 @@
-import { AfterViewInit, Component, OnDestroy, ViewChild } from '@angular/core';
-import { DiscussionService } from '../../../modules/item/services/discussion.service';
-import { filter, map, Subscription } from 'rxjs';
-import { isNotUndefined } from '../../../shared/helpers/null-undefined-predicates';
+import { AfterViewInit, Component, Input, OnDestroy, ViewChild } from '@angular/core';
+import { DiscussionService } from 'src/app/modules/item/services/discussion.service';
+import { filter, Subscription } from 'rxjs';
 import { ThreadComponent } from '../thread/thread.component';
 
 @Component({
@@ -12,7 +11,9 @@ import { ThreadComponent } from '../thread/thread.component';
 export class ThreadContainerComponent implements AfterViewInit, OnDestroy {
   @ViewChild(ThreadComponent) threadComponent?: ThreadComponent;
 
-  visible$ = this.discussionService.state$.pipe(filter(isNotUndefined), map(({ visible }) => visible));
+  @Input() topCompensation = 0;
+
+  visible$ = this.discussionService.visible$;
 
   private subscription?: Subscription;
 

--- a/src/app/modules/item/http-services/thread.service.ts
+++ b/src/app/modules/item/http-services/thread.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, map, of, switchMap } from 'rxjs';
+import { appConfig } from 'src/app/shared/helpers/config';
+import * as D from 'io-ts/Decoder';
+import { decodeSnakeCase } from 'src/app/shared/operators/decode';
+import jwtDecode from 'jwt-decode';
+
+const threadDecoder = D.struct({
+  // itemId: D.string, -> bug in backend
+  // participantId: D.string, -> bug in backend
+  status: D.literal('not_started', 'waiting_for_participant', 'waiting_for_trainer', 'closed'),
+  token: D.string,
+});
+
+type Thread = D.TypeOf<typeof threadDecoder>;
+
+const threadTokenDecoder = D.struct({
+  itemId: D.string,
+  participantId: D.string,
+  userId: D.string,
+  isMine: D.boolean,
+  canWatch: D.boolean,
+  canWrite: D.boolean,
+});
+type ThreadToken = D.TypeOf<typeof threadTokenDecoder>;
+
+export type ThreadInfo = Thread & ThreadToken;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ThreadService {
+
+  constructor(private http: HttpClient) {}
+
+  get(itemId: string, participantId: string): Observable<ThreadInfo> {
+    return this.http.get<unknown>(`${appConfig.apiUrl}/items/${itemId}/participant/${participantId}/thread`).pipe(
+      decodeSnakeCase(threadDecoder),
+      switchMap(thread => of(jwtDecode(thread.token, { header: false })).pipe(
+        decodeSnakeCase(threadTokenDecoder),
+        map(token => ({ ...thread, ...token }))
+      ))
+    );
+  }
+
+}

--- a/src/app/modules/item/services/threads-outbound-actions.ts
+++ b/src/app/modules/item/services/threads-outbound-actions.ts
@@ -1,25 +1,17 @@
 import { ThreadEvent } from './threads-events';
 
-export interface ThreadToken {
-  participantId: string,
-  itemId: string,
-  userId: string,
-  isMine: boolean,
-  canWatchParticipant: boolean,
-}
-
 export type ThreadAction = (
   | { action: 'unsubscribe' }
   | { action: 'subscribe' }
   | { action: 'publish', events: (ThreadEvent & { time?: number })[] }
-) & { token: ThreadToken };
+) & { token: string };
 
-export function unsubscribeAction(token: ThreadToken): ThreadAction {
+export function unsubscribeAction(token: string): ThreadAction {
   return { action: 'unsubscribe', token };
 }
-export function subscribeAction(token: ThreadToken): ThreadAction {
+export function subscribeAction(token: string): ThreadAction {
   return { action: 'subscribe', token };
 }
-export function publishEventsAction(token: ThreadToken, events: (ThreadEvent & { time?: number })[]): ThreadAction {
+export function publishEventsAction(token: string, events: (ThreadEvent & { time?: number })[]): ThreadAction {
   return { action: 'publish', events: events, token };
 }


### PR DESCRIPTION
## Description

Reorganize to way forum threads are loaded:
- Use the new thread info service to get perm information
- get the JWS (signed by the backend) as authentication with the forum backend
- change the way participant-item is provided to the service, so that we can open a thread which does not match the currently-shown item, in order to link (future) for the "my/other's threads" tables

In practice there is not really new functionalities in this PR but more a preparation for the next changes.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/forum-thread-open/en/a/2268458803184278714;p=;a=0)
  3. And I click on open thread button
  4. Then I see the forum loads correctly
