### PR TITLE
Fixes 'Throttle non-visible cross-origin iframes' chrome feature for …

### DIFF
--- a/src/app/modules/item/pages/item-content/item-content.component.html
+++ b/src/app/modules/item/pages/item-content/item-content.component.html
@@ -48,6 +48,7 @@
       <ng-container *ngIf="itemData.item.url; else noUrl">
         <alg-item-display
           class="alg-flex-1"
+          [ngClass]="{ 'alg-opacity-0': !(isTaskLoaded$ | async) }"
           [route]="itemData.route"
           [editingPermission]="itemData.item.permissions"
           [url]="itemData.item.url"
@@ -55,7 +56,6 @@
           [view]="taskView"
           [taskConfig]="taskConfig"
           [savingAnswer]="savingAnswer"
-          [style.display]="(isTaskLoaded$ | async) ? 'flex' : 'none'"
           (viewChange)="taskViewChange.emit($event)"
           (tabsChange)="taskTabsChange.emit($event)"
           (scoreChange)="onScoreChange($event)"
@@ -98,7 +98,7 @@
   </ng-container>
 
   <alg-task-loader
-    class="alg-flex-1"
+    class="alg-flex-1 task-loader"
     *ngIf="(itemData.item.permissions | allowsViewingContent) && !itemData.item.requiresExplicitEntry && (!itemData.currentResult || (itemData.item.type === 'Task' && itemData.item.url && !(isTaskLoaded$ | async)))"
     i18n-label label="Loading the content"
     i18n-delayedLabel delayedLabel="The content is taking an unexpected long time to load... please wait..."

--- a/src/app/modules/item/pages/item-content/item-content.component.scss
+++ b/src/app/modules/item/pages/item-content/item-content.component.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   padding: 0;
+  position: relative;
 }
 
 .validation-text {
@@ -39,4 +40,13 @@
   font-weight: 300;
   line-height: toRem(24);
   max-width: toRem(920);
+}
+
+.task-loader {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: var(--alg-white-color);
 }

--- a/src/app/modules/item/pages/item-display/item-display.component.html
+++ b/src/app/modules/item/pages/item-display/item-display.component.html
@@ -1,7 +1,6 @@
 <div
   class="item-display alg-flex-1"
   [ngClass]="{ 'full-frame': fullFrame$ | async }"
-  [style.display]="!state.isFetching ? 'flex' : 'none'"
   *ngIf="state$ | async as state"
 >
   <div class="error-container alg-flex-1" *ngIf="(state.isError || (metadataError$ | async)) && !showTaskAnyway" [algFullHeightContent]="true">
@@ -62,7 +61,6 @@
   </div>
   <div
     class="iframe-container alg-flex-1"
-    [style.display]="(state.isError || (metadataError$ | async)) && !showTaskAnyway ? 'none' : 'flex'"
   >
     <div class="saving-answer" *ngIf="savingAnswer">
       <p class="saving-answer-message">

--- a/src/assets/scss/helpers.scss
+++ b/src/assets/scss/helpers.scss
@@ -83,3 +83,7 @@
   justify-content: center;
   align-items: center;
 }
+
+.alg-opacity-0 {
+  opacity: 0 !important;
+}


### PR DESCRIPTION
## Description

Fixes loading task affected by feature of Chrome: "Throttle non-visible cross-origin iframes".

Feature description:

When enabled, all cross-origin iframes with zero visibility (either display:none or zero viewport intersection with non-zero area) will be throttled, regardless of whether they are same-process or cross-process. When disabled, throttling for cross-process iframes is the same, but for same-process iframes throttling only occurs when the frame has zero viewport intersection, a non-zero area, and is not display:none. – Mac, Windows, Linux, ChromeOS, Android, Fuchsia, Lacros

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/loading-tasks-on-last-chrome/en/a/8760146602351467826;p=7528142386663912287,7523720120450464843;a=0)
  3. And I see loading of task adjusted correct
  4. Then I see the task is loaded