### PR TITLE
Quick-fix: make sure the breadcrumb is not shown in the top when using LTI

### DIFF
--- a/src/app/core/app.component.html
+++ b/src/app/core/app.component.html
@@ -6,7 +6,7 @@
     <div class="right-container" [ngClass]="{ collapsed: !leftMenu.shown, animated: leftMenu.animated, 'thread-opened': (threadState$ | async)?.visible }">
       <alg-top-bar
         *ngrxLet="fullFrameContentDisplayed$ as fullFrameContentDisplayed"
-        [showBreadcrumbs]="!scrolled && !fullFrameContentDisplayed && !(isNarrowScreen$ | async)"
+        [showBreadcrumbs]="!scrolled && !fullFrameContentDisplayed && !(isNarrowScreen$ | async) && !!(canShowBreadcrumbs$ | async)"
         [modeBarDisplayed]="isWatching"
         [showLeftMenuOpener]="!!(canShowLeftMenu$ | async) && !leftMenu.shown"
         [showTopRightControls]="!!(showTopRightControls$ | async) && !(isNarrowScreen$ | async)"

--- a/src/app/core/app.component.ts
+++ b/src/app/core/app.component.ts
@@ -38,6 +38,7 @@ export class AppComponent implements OnInit, OnDestroy {
   leftMenu$ = this.layoutService.leftMenu$;
   fullFrameContentDisplayed$ = this.layoutService.fullFrameContentDisplayed$;
   canShowLeftMenu$ = this.layoutService.canShowLeftMenu$;
+  canShowBreadcrumbs$ = this.layoutService.canShowBreadcrumbs$;
   showTopRightControls$ = this.layoutService.showTopRightControls$.pipe(delay(0));
   isNarrowScreen$ = this.layoutService.isNarrowScreen$;
   threadState$ = this.discussionService.state$;

--- a/src/app/modules/lti/pages/lti/lti.component.ts
+++ b/src/app/modules/lti/pages/lti/lti.component.ts
@@ -144,7 +144,7 @@ export class LTIComponent implements OnDestroy {
     private getItemChildrenService: GetItemChildrenService,
     private ltiDataSource: LTIDataSource,
   ) {
-    this.layoutService.configure({ showTopRightControls: false, canShowLeftMenu: false });
+    this.layoutService.configure({ showTopRightControls: false, canShowLeftMenu: false, canShowBreadcrumbs: false });
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -24,6 +24,7 @@ export class LayoutService implements OnDestroy {
   /* independant variables */
   private showTopRightControls = new BehaviorSubject(true);
   private canShowLeftMenu = new BehaviorSubject<boolean>(true);
+  private canShowBreadcrumbs = new BehaviorSubject<boolean>(false);
 
   /* variables to be used by other services and components */
   isNarrowScreen$ = this.breakpointObserver.observe(Breakpoints.XSmall).pipe(
@@ -33,6 +34,7 @@ export class LayoutService implements OnDestroy {
   fullFrameContentDisplayed$ = this.contentDisplayType$.pipe(map(t => t === ContentDisplayType.ShowFullFrame));
   showTopRightControls$ = this.showTopRightControls.asObservable();
   canShowLeftMenu$ = this.canShowLeftMenu.asObservable();
+  canShowBreadcrumbs$ = this.canShowBreadcrumbs.asObservable();
   /**
    * Left menu: expected behavior
    * (note that in the following, a narrow window as the same behavior as mobile)
@@ -89,19 +91,22 @@ export class LayoutService implements OnDestroy {
     this.manualMenuToggle$.complete();
     this.showTopRightControls.complete();
     this.canShowLeftMenu.complete();
+    this.canShowBreadcrumbs.complete();
   }
 
   /**
    * Configure layout.
    * The layout is considered not initialized (so not using animation) only until the first call.
    */
-  configure({ contentDisplayType, canShowLeftMenu, showTopRightControls }: {
+  configure({ contentDisplayType, canShowLeftMenu, canShowBreadcrumbs, showTopRightControls }: {
     contentDisplayType?: ContentDisplayType,
     canShowLeftMenu?: boolean,
+    canShowBreadcrumbs?: boolean,
     showTopRightControls?: boolean,
   }): void {
     if (contentDisplayType !== undefined) this.contentDisplayType$.next(contentDisplayType);
     if (canShowLeftMenu !== undefined) this.canShowLeftMenu.next(canShowLeftMenu);
+    if (canShowBreadcrumbs !== undefined) this.canShowBreadcrumbs.next(canShowBreadcrumbs);
     if (showTopRightControls !== undefined) this.showTopRightControls.next(showTopRightControls);
   }
 


### PR DESCRIPTION
## Description

We got the complain that, when using LTI, users were seeing the breadcrumb while they were not supposed to. Fix that.

## Test cases

- [x] Case 1: BEFORE 
  2. When I go to [the moodle test platform](http://moodletest.algorea.org/course/view.php?id=3#section-1)
  3. And I click on "Test dev.algorea.org (new platform)"
  4. Then I see that the breadcrumbs are shown during the loading

- [x] Case 2: FIX 
  2. When I go to [the moodle test platform](http://moodletest.algorea.org/course/view.php?id=3#section-1)
  3. And I click on "Test dev.algorea.org (new platform) (quick-fix-disable-breadcrumbs-on-lti)"
  4. Then I see that the breadcrumbs are now shown during the loading

