### PR TITLE
Unsafe assignment of an any value for $localize

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: './tsconfig.json'
+    project: './tsconfig.app.json'
   },
   extends: [
     'eslint:recommended',


### PR DESCRIPTION
## Description

Fixes: $localize is not handled properly by eslint and displays a systematic error in vscode: Unsafe assignment of an any value

## Test cases

- [ ] Case 1:
  1. Open a component.ts file in vscode
  2. Then no warning should be display on the $localize variable

