### PR TITLE
Improves design for selection component

### DIFF
--- a/src/app/modules/shared-components/components/selection/selection.component.scss
+++ b/src/app/modules/shared-components/components/selection/selection.component.scss
@@ -25,14 +25,15 @@
   justify-content: center;
   align-items: center;
   height: toRem(40);
-  color: var(--alg-secondary-color);
   cursor: pointer;
 
   &.active {
-    color: var(--alg-light-color);
-    font-weight: 500;
     background-color: var(--alg-primary-color);
     border-radius: toRem(20);
+
+    .label {
+      color: var(--alg-light-color);
+    }
   }
 
   &:not(.active, .next, :first-child):before {
@@ -48,4 +49,11 @@
     background: linear-gradient(0, rgba(255, 255, 255, 0) 0%, rgba(209, 215, 230, 1) 50%, rgba(255, 255, 255, 0) 100%);
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr="#ffffff", endColorstr="#ffffff", GradientType=1);
   }
+}
+
+.label {
+  color: var(--alg-secondary-color);
+  text-align: center;
+  line-height: toRem(14);
+  font-size: toRem(16);
 }


### PR DESCRIPTION
## Description

Fixes #...

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Part of forms task #1406 

Improves selection when narrow screen:

<img width="400" alt="selection" src="https://github.com/France-ioi/AlgoreaFrontend/assets/7044736/38135a63-8d76-4021-9c04-04bf5b340c41">

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. On screen width about 1200px
  3. When I go to [this page](https://dev.algorea.org/branch/new-design/improve-selection/en/a/7528142386663912287;p=;a=0/parameters)
  4. Then I see the captions of selection aligned by center

