### PR TITLE
Fix web manifest file distribution

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,6 +39,11 @@
                 "glob": "**/*",
                 "input": "src/assets/images/",
                 "output": "/images/"
+              },
+              {
+                "glob": "site.webmanifest",
+                "input": "src/assets/",
+                "output": "/assets/"
               }
             ],
             "styles": [

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "extract-i18n": "ng extract-i18n --output-path src/locale && ./node_modules/.bin/xliffmerge",
     "copyColor": "xcopy \"projects\\core\\src\\lib\\colors.scss\" \"dist\\core\\\"",
     "copyGeo": "xcopy \"projects\\core\\src\\lib\\geometry.scss\" \"dist\\core\\\"",
-    "injectDeployUrlForAssets": "find src -regex \".*\\.html\" -exec sed -i -E 's@(href|src)=\"images/(.*)\"@\\1=\"'$npm_config_url'images/\\2\"@g' {} + && find src -regex \".*\\.scss\" -exec sed -i -E 's@url\\(\"/images/(.*)\"\\)@url\\(\"'$npm_config_url'images/\\1\")@g' {} + && find src/index.html -exec sed -i -E 's@href=\"((.*).(woff2|ttf))\"@href=\"'$npm_config_url'\\1\"@g' {} +",
+    "injectDeployUrlForAssets": "find src -regex \".*\\.html\" -exec sed -i -E 's@(href|src)=\"images/(.*)\"@\\1=\"'$npm_config_url'images/\\2\"@g' {} + && find src -regex \".*\\.scss\" -exec sed -i -E 's@url\\(\"/images/(.*)\"\\)@url\\(\"'$npm_config_url'images/\\1\")@g' {} + && find src/index.html -exec sed -i -E 's@href=\"((.*).(woff2|ttf|webmanifest))\"@href=\"'$npm_config_url'\\1\"@g' {} + && find src/assets/site.webmanifest -exec sed -i -E 's@\"src\":\"images/([^\"]*)\"@\"src\":\"'$npm_config_url'images/\\1\"@g' {} +",
     "test": "ng test",
     "lint": "./node_modules/.bin/eslint src/ --ext .ts",
     "e2e": "ng e2e",


### PR DESCRIPTION
## Description

Currently, the asset path was not put in front of the reference to the web manifest file. Fix this as well as the image reference it contains.

## Test cases

- [ ] Case 1:
  1. Given I use Chrome
  2. I open network debug panel and disable cache
  3. When I go to [the home page](https://dev.algorea.org/branch/fix-webmanifest-distribution/en)
  4. And I see the webmanifest file is received
  5. Then I see in the response that the image it references are reachable as well
