### PR TITLE
Removes unused scss-bundle package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "primeicons": "^6.0.1",
         "primeng": "^16.3.1",
         "rxjs": "~7.8.1",
-        "scss-bundle": "^3.1.1",
         "tslib": "^2.3.1",
         "zone.js": "~0.13.1"
       },
@@ -5583,10 +5582,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@types/archy": {
-      "version": "0.0.31",
-      "license": "MIT"
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
       "dev": true,
@@ -5607,6 +5602,7 @@
     },
     "node_modules/@types/color-name": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/connect": {
@@ -5639,10 +5635,6 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
-    "node_modules/@types/debug": {
-      "version": "4.1.5",
-      "license": "MIT"
-    },
     "node_modules/@types/eslint": {
       "version": "8.4.5",
       "dev": true,
@@ -5667,10 +5659,6 @@
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
-    "node_modules/@types/events": {
-      "version": "3.0.0",
-      "license": "MIT"
-    },
     "node_modules/@types/express": {
       "version": "4.17.13",
       "dev": true,
@@ -5690,22 +5678,6 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "node_modules/@types/fs-extra": {
-      "version": "8.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/glob": {
-      "version": "7.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
       }
     },
     "node_modules/@types/http-cache-semantics": {
@@ -5746,30 +5718,16 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.14.155",
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash.debounce": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/minimatch": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "14.18.36",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ=="
+      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+      "dev": true
     },
     "node_modules/@types/q": {
       "version": "0.0.32",
@@ -5799,13 +5757,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "node_modules/@types/sass": {
-      "version": "1.16.0",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/selenium-webdriver": {
       "version": "3.0.17",
@@ -7158,6 +7109,7 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -7192,10 +7144,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/archy": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/are-we-there-yet": {
       "version": "3.0.1",
@@ -7697,6 +7645,7 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -7767,6 +7716,7 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8049,6 +7999,7 @@
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8057,6 +8008,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -8388,6 +8340,7 @@
     },
     "node_modules/chokidar": {
       "version": "3.5.3",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -8691,6 +8644,7 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concurrently": {
@@ -11838,6 +11792,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -12151,12 +12106,14 @@
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -12409,6 +12366,7 @@
     },
     "node_modules/glob": {
       "version": "7.2.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -12427,6 +12385,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -12516,13 +12475,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/globs": {
-      "version": "0.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^7.1.1"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -12562,6 +12514,7 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/grapheme-splitter": {
@@ -13146,6 +13099,7 @@
     },
     "node_modules/immutable": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/import-fresh": {
@@ -13199,6 +13153,7 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -13207,6 +13162,7 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -13640,6 +13596,7 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -13745,6 +13702,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -13760,6 +13718,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -13839,6 +13798,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -14747,6 +14707,7 @@
     },
     "node_modules/jsonfile": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -15394,6 +15355,7 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -15568,21 +15530,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/loglevel": {
-      "version": "1.6.8",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      },
-      "funding": {
-        "type": "tidelift",
-        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
-      }
-    },
-    "node_modules/loglevel-plugin-prefix": {
-      "version": "0.8.4",
-      "license": "MIT"
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
@@ -15882,6 +15829,7 @@
     },
     "node_modules/minimatch": {
       "version": "3.0.5",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -16641,6 +16589,7 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17320,6 +17269,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -17859,6 +17809,7 @@
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -17942,6 +17893,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -18205,6 +18157,7 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
@@ -18975,6 +18928,7 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -19935,6 +19889,7 @@
       "version": "1.64.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
       "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -20066,112 +20021,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
-    },
-    "node_modules/scss-bundle": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "@types/archy": "^0.0.31",
-        "@types/debug": "^4.1.5",
-        "@types/fs-extra": "^8.0.1",
-        "@types/glob": "^7.1.1",
-        "@types/lodash.debounce": "^4.0.6",
-        "@types/sass": "^1.16.0",
-        "archy": "^1.0.0",
-        "chalk": "^3.0.0",
-        "chokidar": "^3.3.1",
-        "commander": "^4.0.1",
-        "fs-extra": "^8.1.0",
-        "globs": "^0.1.4",
-        "lodash.debounce": "^4.0.8",
-        "loglevel": "^1.6.6",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "pretty-bytes": "^5.3.0",
-        "sass": "^1.23.7",
-        "tslib": "^1.10.0"
-      },
-      "bin": {
-        "scss-bundle": "dist/cli/main.js"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/ansi-styles": {
-      "version": "4.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/color-name": "^1.1.1",
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/chalk": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/color-convert": {
-      "version": "2.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/color-name": {
-      "version": "1.1.4",
-      "license": "MIT"
-    },
-    "node_modules/scss-bundle/node_modules/commander": {
-      "version": "4.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/has-flag": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/supports-color": {
-      "version": "7.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/scss-bundle/node_modules/tslib": {
-      "version": "1.13.0",
-      "license": "0BSD"
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -20718,6 +20567,7 @@
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -21356,6 +21206,7 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -21733,6 +21584,7 @@
     },
     "node_modules/universalify": {
       "version": "0.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
@@ -23104,6 +22956,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -26970,9 +26823,6 @@
         }
       }
     },
-    "@types/archy": {
-      "version": "0.0.31"
-    },
     "@types/body-parser": {
       "version": "1.19.2",
       "dev": true,
@@ -26991,7 +26841,8 @@
       }
     },
     "@types/color-name": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "@types/connect": {
       "version": "3.4.35",
@@ -27022,9 +26873,6 @@
       "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==",
       "dev": true
     },
-    "@types/debug": {
-      "version": "4.1.5"
-    },
     "@types/eslint": {
       "version": "8.4.5",
       "dev": true,
@@ -27047,9 +26895,6 @@
       "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==",
       "dev": true
     },
-    "@types/events": {
-      "version": "3.0.0"
-    },
     "@types/express": {
       "version": "4.17.13",
       "dev": true,
@@ -27067,20 +26912,6 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
-      }
-    },
-    "@types/fs-extra": {
-      "version": "8.1.1",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/glob": {
-      "version": "7.1.1",
-      "requires": {
-        "@types/events": "*",
-        "@types/minimatch": "*",
-        "@types/node": "*"
       }
     },
     "@types/http-cache-semantics": {
@@ -27117,26 +26948,15 @@
       "version": "7.0.9",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.155"
-    },
-    "@types/lodash.debounce": {
-      "version": "4.0.6",
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/mime": {
       "version": "1.3.2",
       "dev": true
     },
-    "@types/minimatch": {
-      "version": "3.0.3"
-    },
     "@types/node": {
       "version": "14.18.36",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ=="
+      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
+      "dev": true
     },
     "@types/q": {
       "version": "0.0.32",
@@ -27163,12 +26983,6 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
       "dev": true
-    },
-    "@types/sass": {
-      "version": "1.16.0",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/selenium-webdriver": {
       "version": "3.0.17",
@@ -28084,6 +27898,7 @@
     },
     "anymatch": {
       "version": "3.1.2",
+      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -28100,9 +27915,6 @@
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
       "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
       "dev": true
-    },
-    "archy": {
-      "version": "1.0.0"
     },
     "are-we-there-yet": {
       "version": "3.0.1",
@@ -28451,7 +28263,8 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -28496,7 +28309,8 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0"
+      "version": "2.0.0",
+      "dev": true
     },
     "bl": {
       "version": "4.1.0",
@@ -28693,6 +28507,7 @@
     },
     "brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -28700,6 +28515,7 @@
     },
     "braces": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -28914,6 +28730,7 @@
     },
     "chokidar": {
       "version": "3.5.3",
+      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -29125,7 +28942,8 @@
       }
     },
     "concat-map": {
-      "version": "0.0.1"
+      "version": "0.0.1",
+      "dev": true
     },
     "concurrently": {
       "version": "6.5.1",
@@ -31360,6 +31178,7 @@
     },
     "fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -31572,12 +31391,14 @@
       "dev": true
     },
     "fs.realpath": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "optional": true
     },
     "ftp": {
@@ -31772,6 +31593,7 @@
     },
     "glob": {
       "version": "7.2.0",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -31783,6 +31605,7 @@
     },
     "glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -31843,12 +31666,6 @@
         }
       }
     },
-    "globs": {
-      "version": "0.1.4",
-      "requires": {
-        "glob": "^7.1.1"
-      }
-    },
     "gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -31878,7 +31695,8 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10"
+      "version": "4.2.10",
+      "dev": true
     },
     "grapheme-splitter": {
       "version": "1.0.4",
@@ -32284,7 +32102,8 @@
       "peer": true
     },
     "immutable": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -32318,13 +32137,15 @@
     },
     "inflight": {
       "version": "1.0.6",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
     "inherits": {
-      "version": "2.0.4"
+      "version": "2.0.4",
+      "dev": true
     },
     "ini": {
       "version": "1.3.8",
@@ -32613,6 +32434,7 @@
     },
     "is-binary-path": {
       "version": "2.1.0",
+      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -32672,7 +32494,8 @@
       "dev": true
     },
     "is-extglob": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -32680,6 +32503,7 @@
     },
     "is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -32729,7 +32553,8 @@
       "dev": true
     },
     "is-number": {
-      "version": "7.0.0"
+      "version": "7.0.0",
+      "dev": true
     },
     "is-number-object": {
       "version": "1.0.7",
@@ -33364,6 +33189,7 @@
     },
     "jsonfile": {
       "version": "4.0.0",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -33806,7 +33632,8 @@
       "dev": true
     },
     "lodash.debounce": {
-      "version": "4.0.8"
+      "version": "4.0.8",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -33924,12 +33751,6 @@
         "rfdc": "^1.3.0",
         "streamroller": "^3.0.2"
       }
-    },
-    "loglevel": {
-      "version": "1.6.8"
-    },
-    "loglevel-plugin-prefix": {
-      "version": "0.8.4"
     },
     "lowercase-keys": {
       "version": "3.0.0",
@@ -34135,6 +33956,7 @@
     },
     "minimatch": {
       "version": "3.0.5",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -34677,7 +34499,8 @@
       }
     },
     "normalize-path": {
-      "version": "3.0.0"
+      "version": "3.0.0",
+      "dev": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -35173,6 +34996,7 @@
     },
     "once": {
       "version": "1.4.0",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -35545,7 +35369,8 @@
       "dev": true
     },
     "path-is-absolute": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -35604,7 +35429,8 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -35765,7 +35591,8 @@
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true
     },
     "primeicons": {
       "version": "6.0.1",
@@ -36334,6 +36161,7 @@
     },
     "readdirp": {
       "version": "3.6.0",
+      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -36984,6 +36812,7 @@
       "version": "1.64.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
       "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -37060,77 +36889,6 @@
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
           "dev": true
-        }
-      }
-    },
-    "scss-bundle": {
-      "version": "3.1.2",
-      "requires": {
-        "@types/archy": "^0.0.31",
-        "@types/debug": "^4.1.5",
-        "@types/fs-extra": "^8.0.1",
-        "@types/glob": "^7.1.1",
-        "@types/lodash.debounce": "^4.0.6",
-        "@types/sass": "^1.16.0",
-        "archy": "^1.0.0",
-        "chalk": "^3.0.0",
-        "chokidar": "^3.3.1",
-        "commander": "^4.0.1",
-        "fs-extra": "^8.1.0",
-        "globs": "^0.1.4",
-        "lodash.debounce": "^4.0.8",
-        "loglevel": "^1.6.6",
-        "loglevel-plugin-prefix": "^0.8.4",
-        "pretty-bytes": "^5.3.0",
-        "sass": "^1.23.7",
-        "tslib": "^1.10.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.2.1",
-          "requires": {
-            "@types/color-name": "^1.1.1",
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "3.0.0",
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4"
-        },
-        "commander": {
-          "version": "4.1.1"
-        },
-        "fs-extra": {
-          "version": "8.1.0",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0"
-        },
-        "supports-color": {
-          "version": "7.1.0",
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        },
-        "tslib": {
-          "version": "1.13.0"
         }
       }
     },
@@ -37552,7 +37310,8 @@
       "dev": true
     },
     "source-map-js": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "source-map-loader": {
       "version": "4.0.1",
@@ -38016,6 +37775,7 @@
     },
     "to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -38271,7 +38031,8 @@
       "dev": true
     },
     "universalify": {
-      "version": "0.1.2"
+      "version": "0.1.2",
+      "dev": true
     },
     "unpipe": {
       "version": "1.0.0",
@@ -39097,7 +38858,8 @@
       }
     },
     "wrappy": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "primeicons": "^6.0.1",
     "primeng": "^16.3.1",
     "rxjs": "~7.8.1",
-    "scss-bundle": "^3.1.1",
     "tslib": "^2.3.1",
     "zone.js": "~0.13.1"
   },

--- a/scss-bundle.config.json
+++ b/scss-bundle.config.json
@@ -1,7 +1,0 @@
-{
-  "bundlerOptions": {
-    "entryFile": "./projects/core/src/lib/index.scss",
-    "rootDir": "./",
-    "outFile": "dist/core/index.scss"
-  }
-}


### PR DESCRIPTION
## Description

Fixes #1410

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The package is not supported anymore https://github.com/reactway/scss-bundle

`Bundles all SCSS imports into a single file recursively.` - I guess it's already part of angular feature. I can see only 1 style css file (after build):

```styles.css | styles | 673.39 kB |```

After remove of lib nothing changed in build css file.

Here is [commit](https://github.com/France-ioi/AlgoreaFrontend/commit/394cacc5fc1aca1bdc5eab3c31a2ed723fba70bd) - it was added for old structure. Seems it wasn't used in our app for a long time

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/get-rid-scss-bundle/en/a/home;pa=0)
  3. Then I see the styles are correct
