### PR TITLE
Fixes cli warning of import fp-ts functions pipe

### DIFF
--- a/src/app/modules/item/http-services/get-item-children.service.ts
+++ b/src/app/modules/item/http-services/get-item-children.service.ts
@@ -7,7 +7,7 @@ import { decodeSnakeCase } from 'src/app/shared/operators/decode';
 import { dateDecoder } from 'src/app/shared/helpers/decoders';
 import { canCurrentUserViewInfo, itemViewPermDecoder, ItemWithViewPerm } from 'src/app/shared/models/domain/item-view-permission';
 import { itemCorePermDecoder } from 'src/app/shared/models/domain/item-permissions';
-import { pipe } from 'fp-ts/lib/function';
+import { pipe } from 'fp-ts/function';
 
 const baseItemChildCategory = D.literal('Undefined', 'Discovery', 'Application', 'Validation', 'Challenge');
 

--- a/src/app/shared/models/domain/item-permissions.ts
+++ b/src/app/shared/models/domain/item-permissions.ts
@@ -1,4 +1,4 @@
-import { pipe } from 'fp-ts/lib/function';
+import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
 import { dateDecoder } from '../../helpers/decoders';
 import { allowsGrantingEdition, ItemPermWithEdit, itemEditPermDecoder } from './item-edit-permission';


### PR DESCRIPTION
## Description

Fixes #...

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Fixes warning:

```
get-item-children.service.ts depends on 'fp-ts/lib/function'. 
CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
```

## Test cases

Branch for [test](https://dev.algorea.org/branch/feature/fix-cli-warning-fp-ts-lib/en/a/home;pa=0)
