### PR TITLE
fix default breadcrumb display behavior

### DIFF
--- a/src/app/shared/services/layout.service.ts
+++ b/src/app/shared/services/layout.service.ts
@@ -24,7 +24,7 @@ export class LayoutService implements OnDestroy {
   /* independant variables */
   private showTopRightControls = new BehaviorSubject(true);
   private canShowLeftMenu = new BehaviorSubject<boolean>(true);
-  private canShowBreadcrumbs = new BehaviorSubject<boolean>(false);
+  private canShowBreadcrumbs = new BehaviorSubject<boolean>(true);
 
   /* variables to be used by other services and components */
   isNarrowScreen$ = this.breakpointObserver.observe(Breakpoints.XSmall).pipe(


### PR DESCRIPTION
## Description

Fix breadcrumb display behavior. Stupid bug, the default value was `false` while it was supposed to be true.

## Test cases

- [ ] Case 1: BUG
  1. Given I am any user
  2. When I go to [any page](https://dev.algorea.org/en/a/4102;p=4702;a=0)
  4. Then I see there is no breadcrumb displayed

- [ ] Case 2: FIX
  1. Given I am any user
  2. When I go to [any page](https://dev.algorea.org/en/a/4102;p=4702;a=0)
  4. Then I see there is no breadcrumb displayed

