### PR TITLE
never show the discussion button in the top bar for temp users

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -45,7 +45,7 @@
       <alg-observation-bar-with-button></alg-observation-bar-with-button>
       <ng-container *ngrxLet="{ canBeShown: canDiscussionBeShown$, isVisible: isDiscussionVisible$ } as discussion">
         <button
-          *ngIf="discussion.canBeShown"
+          *ngIf="discussion.canBeShown && !(isTempUser$ | async)"
           class="alg-button-icon no-bg primary-color margin-left"
           pButton
           type="button"

--- a/src/app/core/components/content-top-bar/content-top-bar.component.ts
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { ContentInfo } from '../../../shared/models/content/content-info';
 import { Observable, of } from 'rxjs';
 import { CurrentContentService } from '../../../shared/services/current-content.service';
-import { delay, switchMap, filter } from 'rxjs/operators';
+import { delay, switchMap, filter, map } from 'rxjs/operators';
 import { ActivityNavTreeService, SkillNavTreeService } from '../../services/navigation/item-nav-tree.service';
 import { isItemInfo } from '../../../shared/models/content/item-info';
 import { LayoutService } from 'src/app/shared/services/layout.service';
@@ -10,6 +10,7 @@ import { GroupWatchingService } from '../../services/group-watching.service';
 import { DiscussionService } from 'src/app/modules/item/services/discussion.service';
 import { GroupNavTreeService } from '../../services/navigation/group-nav-tree.service';
 import { isGroupInfo } from '../../../shared/models/content/group-info';
+import { UserSessionService } from 'src/app/shared/services/user-session.service';
 
 @Component({
   selector: 'alg-content-top-bar',
@@ -23,6 +24,7 @@ export class ContentTopBarComponent {
   canDiscussionBeShown$ = this.discussionService.canShowInCurrentPage$;
   isDiscussionVisible$ = this.discussionService.visible$;
   watchedGroup$ = this.groupWatchingService.watchedGroup$;
+  isTempUser$ = this.userSessionService.userProfile$.pipe(map(user => user.tempUser));
 
   currentContent$: Observable<ContentInfo | null> = this.currentContentService.content$.pipe(
     delay(0),
@@ -54,6 +56,7 @@ export class ContentTopBarComponent {
     private groupNavTreeService: GroupNavTreeService,
     private discussionService: DiscussionService,
     private layoutService: LayoutService,
+    private userSessionService: UserSessionService,
   ) {}
 
   toggleDiscussionPanelVisibility(visible: boolean): void {


### PR DESCRIPTION
## Description

never show the discussion button in the top bar for temp users

## Test cases

- [ ] Case 1: BEFORE 
  1. Given I am a TEMP user
  2. When I go to [a task](https://dev.algorea.org/en/a/1135065237661691731;p=4702,1471479157476024035;a=0)
  4. Then I see discussion button in the top bar

- [ ] Case 2: FIX
  1. Given I am a TEMP user
  2. When I go to [a task](https://dev.algorea.org/branch/no-discussion-button-in-top-bar-for-temp-users/en/a/1135065237661691731;p=4702,1471479157476024035;a=0)
  4. Then I don't see discussion button in the top bar anymore

- [ ] Case 3: normal user
  1. Given I am the usual user
  2. When I go to [a task](https://dev.algorea.org/branch/no-discussion-button-in-top-bar-for-temp-users/en/a/1135065237661691731;p=4702,1471479157476024035;a=0)
  4. Then I still see the discussion button
