### PR TITLE
Disable discussion for few cases

### DIFF
--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -276,6 +276,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     // TODO as soon as the backend service has implemented it: check that the current/observed user "can request help" on this item
     combineLatest([ this.itemDataSource.state$, this.userProfile$, this.watchedGroup$ ]).pipe(
       map(([ state, userProfile, watchedGroup ]) => {
+        if (userProfile.tempUser) return null;
         if (!state.data || !isATask(state.data.item)) return null;
         if (watchedGroup && (!allowsWatchingAnswers(state.data.item.permissions) || !watchedGroup.route.isUser)) return null;
         return { participantId: watchedGroup ? watchedGroup.route.id : userProfile.groupId, itemId: state.data.item.id };

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -273,12 +273,12 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     ).subscribe(display => this.layoutService.configure({ contentDisplayType: display })),
 
     // configuring the forum parameters (if the user can open it on this content for the potentially observed group)
-    // TODO as soon as the backend service has implemented it: check that the current/observed user "can request help" on this item
     combineLatest([ this.itemDataSource.state$, this.userProfile$, this.watchedGroup$ ]).pipe(
       map(([ state, userProfile, watchedGroup ]) => {
         if (userProfile.tempUser) return null;
         if (!state.data || !isATask(state.data.item)) return null;
         if (watchedGroup && (!allowsWatchingAnswers(state.data.item.permissions) || !watchedGroup.route.isUser)) return null;
+        if (!watchedGroup && !state.data.item.permissions.canRequestHelp) return null;
         return { participantId: watchedGroup ? watchedGroup.route.id : userProfile.groupId, itemId: state.data.item.id };
       }),
       distinctUntilChanged((x, y) => x?.itemId === y?.itemId && x?.participantId === y?.participantId),

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -277,7 +277,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     combineLatest([ this.itemDataSource.state$, this.userProfile$, this.watchedGroup$ ]).pipe(
       map(([ state, userProfile, watchedGroup ]) => {
         if (!state.data || !isATask(state.data.item)) return null;
-        if (watchedGroup && !allowsWatchingAnswers(state.data.item.permissions)) return null;
+        if (watchedGroup && (!allowsWatchingAnswers(state.data.item.permissions) || !watchedGroup.route.isUser)) return null;
         return { participantId: watchedGroup ? watchedGroup.route.id : userProfile.groupId, itemId: state.data.item.id };
       }),
       distinctUntilChanged((x, y) => x?.itemId === y?.itemId && x?.participantId === y?.participantId),


### PR DESCRIPTION
## Description

Disable discussion panel when:
- temp user
- observing a non-participant
- cannot request help

## Test cases

- [ ] Case 1:
  1. Given I am the TEMP user
  2. When I go to [a task](https://dev.algorea.org/branch/disable-discussion-for-few-cases/en/a/1414822370876733593;p=4702,100575556387408660,1788359139685642917;pa=0)
  4. Then I do not see the discussion button in the top bar

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [a task while observing a group](https://dev.algorea.org/branch/disable-discussion-for-few-cases/en/a/1293400563985240032;p=4702,1625159049301502151,5207993233955027100;pa=0?watchedGroupId=4462192261130512818&watchUser=0)
  4. Then I do not see the discussion button in the top bar

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [a task on which I cannot request help](https://dev.algorea.org/branch/disable-discussion-for-few-cases/en/a/126952315730161957;p=4702,4102,1980584647557587953,39530140456452546;a=0)
  4. Then I do not see the discussion button in the top bar

- [ ] Case 4:
  1. Given I am the usual user
  2. When I go to [a task while observing a user](https://dev.algorea.org/branch/disable-discussion-for-few-cases/en/a/1293400563985240032;p=7528142386663912287,7523720120450464843;a=0?watchedGroupId=752024252804317630&watchUser=1)
  4. Then I DO see the discussion button in the top bar

- [ ] Case 5:
  1. Given I am the usual user
  2. When I go to [a task while on which I can request help](https://dev.algorea.org/branch/disable-discussion-for-few-cases/en/a/6379723280369399253;p=7528142386663912287,7523720120450464843;a=0)
  4. Then I DO see the discussion button in the top bar
