### PR TITLE
remove the 'sent at' in front of date/time in the forum

### DIFF
--- a/src/app/core/components/thread-message/thread-message.component.html
+++ b/src/app/core/components/thread-message/thread-message.component.html
@@ -66,5 +66,5 @@
 </div>
 
 <ng-template #sentAt>
-  <span i18n>Sent at {{ event.time | date : 'short' }}</span>
+  <span i18n>{{ event.time | date : 'short' }}</span>
 </ng-template>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1588,10 +1588,13 @@
           <context context-type="sourcefile">src/app/core/components/thread-message/thread-message.component.html</context>
           <context context-type="linenumber">54,56</context>
         </context-group>
-      </trans-unit><trans-unit id="5078919999921089039" datatype="html">
-        <source>Sent at <x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></source><target state="new">Sent at <x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread-message/thread-message.component.html</context><context context-type="linenumber">69</context></context-group></trans-unit><trans-unit id="4672292365306876208" datatype="html">
+      </trans-unit><trans-unit id="187187500641108332" datatype="html">
+        <source><x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></source><target state="new"><x id="INTERPOLATION" equiv-text="{{ event.time | date : 'short' }}"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/thread-message/thread-message.component.html</context>
+          <context context-type="linenumber">69</context>
+        </context-group>
+      </trans-unit><trans-unit id="4672292365306876208" datatype="html">
         <source>An unknown user</source><target state="new">An unknown user</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread-message/thread-message.component.ts</context><context context-type="linenumber">20</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">


### PR DESCRIPTION
## Description
remove the 'sent at' in front of date/time in the forum

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/forum-remove-sent-at/en/a/6379723280369399253;p=;pa=0?watchedGroupId=752024252804317630&watchUser=1)
  3. And I open the discussion panel 
  4. Then I see there is no "sent at" anymore in front of the dates and time