### PR TITLE
Allow to navigate other item without closing the thread

### DIFF
--- a/src/app/core/components/content-top-bar/content-top-bar.component.html
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.html
@@ -43,14 +43,14 @@
     </div>
     <div class="right-pane">
       <alg-observation-bar-with-button></alg-observation-bar-with-button>
-      <ng-container *ngrxLet="{ canBeShown: canDiscussionBeShown$, isVisible: isDiscussionVisible$ } as discussion">
+      <ng-container *ngrxLet="{ configuredThread: configuredThread$, isVisible: isDiscussionVisible$ } as discussion">
         <button
-          *ngIf="discussion.canBeShown"
+          *ngIf="discussion.configuredThread"
           class="alg-button-icon no-bg primary-color margin-left"
           pButton
           type="button"
           icon="ph-duotone ph-chats-circle"
-          (click)="toggleDiscussionPanelVisibility(!discussion.isVisible)"
+          (click)="toggleDiscussionPanelVisibility(!discussion.isVisible, discussion.configuredThread)"
         ></button>
       </ng-container>
       <alg-neighbor-widget

--- a/src/app/core/components/content-top-bar/content-top-bar.component.ts
+++ b/src/app/core/components/content-top-bar/content-top-bar.component.ts
@@ -10,6 +10,7 @@ import { GroupWatchingService } from '../../services/group-watching.service';
 import { DiscussionService } from 'src/app/modules/item/services/discussion.service';
 import { GroupNavTreeService } from '../../services/navigation/group-nav-tree.service';
 import { isGroupInfo } from '../../../shared/models/content/group-info';
+import { ThreadId } from '../../../modules/item/services/threads.service';
 
 @Component({
   selector: 'alg-content-top-bar',
@@ -20,7 +21,7 @@ export class ContentTopBarComponent {
   @Input() showBreadcrumbs = true;
   @Input() showLeftMenuOpener = false;
 
-  canDiscussionBeShown$ = this.discussionService.canShowInCurrentPage$;
+  configuredThread$ = this.discussionService.configuredThread$;
   isDiscussionVisible$ = this.discussionService.visible$;
   watchedGroup$ = this.groupWatchingService.watchedGroup$;
 
@@ -56,8 +57,8 @@ export class ContentTopBarComponent {
     private layoutService: LayoutService,
   ) {}
 
-  toggleDiscussionPanelVisibility(visible: boolean): void {
-    this.discussionService.toggleVisibility(visible);
+  toggleDiscussionPanelVisibility(visible: boolean, thread: ThreadId): void {
+    this.discussionService.toggleVisibility(visible, visible ? thread : undefined);
   }
 
   showLeftMenu(): void {

--- a/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
+++ b/src/app/modules/item/pages/item-by-id/item-by-id.component.ts
@@ -166,7 +166,6 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
   private subscriptions: Subscription[] = [
 
     this.itemChanged$.subscribe(() => {
-      this.discussionService.toggleVisibility(false);
       this.fullFrameContent$.next(false);
       this.editorUrl = undefined;
       this.itemTabs.itemChanged();
@@ -311,7 +310,6 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
 
   ngOnDestroy(): void {
     this.tabService.setTabs([]);
-    this.discussionService.configureThread(null);
     this.currentContent.clear();
     this.subscriptions.forEach(s => s.unsubscribe());
     this.layoutService.configure({ contentDisplayType: ContentDisplayType.Default });
@@ -320,7 +318,6 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     this.beforeUnload$.complete();
     this.destroyed$.next();
     this.destroyed$.complete();
-    this.discussionService.toggleVisibility(false);
   }
 
 

--- a/src/app/modules/item/services/discussion.service.ts
+++ b/src/app/modules/item/services/discussion.service.ts
@@ -80,7 +80,7 @@ export class DiscussionService implements OnDestroy {
   toggleVisibility(visible: boolean, thread?: ThreadId): void {
     if (!this.threadService) return;
     this.visible.next(visible);
-    this.threadService.setThread(thread ? thread : this.configuredThreadSubject.value);
+    this.threadService.setThread(thread ?? this.configuredThreadSubject.value);
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #1501

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/forum-dont-close-the-panel-when-navigating/en/a/6379723280369399253;p=7523720120450464843;a=0/forum/my-threads)
  3. And I click on "Thread" button
  4. Then I see the thread panel is opened
  5. And click on "Task with solution tab" item in left menu
  6. Then I see the thread container is not closed and content is not changed

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/forum-dont-close-the-panel-when-navigating/en/a/6379723280369399253;p=7523720120450464843;a=0/forum/my-threads)
  3. And I click on "Thread" button
  4. Then I see the thread panel is opened
  5. And click on "Groups" tab in left menu
  6. Then I click on "!634" group
  7. Then I see the thread container is not closed and content is not changed

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/forum-dont-close-the-panel-when-navigating/en/a/6379723280369399253;p=7523720120450464843;a=0/forum/others)
  3. And I click on "Thread" button
  4. Then I see the thread panel is opened
  5. And click on "Task with localization" item in left menu
  6. Then I see the thread container is not closed and content is not changed
  7. Then I click on "Thread" button in top menu
  8. Then I see the thread is closed
  9. And I click again on "Thread" button
  10. Then I see the thread is opened and content is changed