### PR TITLE
Adds message color scheme for observing participant

### DIFF
--- a/src/app/core/components/thread-message/thread-message.component.html
+++ b/src/app/core/components/thread-message/thread-message.component.html
@@ -4,7 +4,8 @@
     'left': !userInfo?.isCurrentUser && event.label === 'message',
     'right': userInfo?.isCurrentUser && event.label === 'message',
     'full-width transparent': ['result_started', 'submission'].includes(event.label),
-    'started': event.label === 'result_started'
+    'started': event.label === 'result_started',
+    'participant': !userInfo?.isCurrentUser && userInfo?.isThreadParticipant && event.label === 'message'
   }"
 >
   <div class="message">

--- a/src/app/core/components/thread-message/thread-message.component.scss
+++ b/src/app/core/components/thread-message/thread-message.component.scss
@@ -92,6 +92,12 @@
       opacity: 1;
     }
   }
+
+  &.participant {
+    .bubble {
+      background-color: var(--alg-observation-button-bg-color);
+    }
+  }
 }
 
 .message {


### PR DESCRIPTION
## Description

Fixes #1499

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the demouser
  2. When I go to [this page](https://dev.algorea.org/branch/feature/colour-schemes-for-thread-bubbles/en/a/6379723280369399253;p=4702,1625159049301502151,5207993233955027100;pa=0/forum/others)
  3. And I click on open the thread
  4. Then I see the colours are correct

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/colour-schemes-for-thread-bubbles/en/a/6379723280369399253;p=7528142386663912287,7523720120450464843;a=0/forum/others?watchedGroupId=752024252804317630&watchUser=1)
  3. And I click on open the thread
  4. Then I see the participant has observation mode color