### PR TITLE
Adds focus on message field when open the thread

### DIFF
--- a/src/app/core/components/thread/thread.component.html
+++ b/src/app/core/components/thread/thread.component.html
@@ -28,6 +28,7 @@
                 [rows]="1"
                 [autoResize]="true"
                 (keydown.enter)="$event.preventDefault(); sendMessage(threadId)"
+                #messageToSendEl
               ></textarea>
               <button
                 class="alg-button-icon primary-color rounded send-button"

--- a/src/app/core/components/thread/thread.component.ts
+++ b/src/app/core/components/thread/thread.component.ts
@@ -44,6 +44,7 @@ import { NgIf, NgFor, AsyncPipe } from '@angular/common';
 })
 export class ThreadComponent implements AfterViewInit, OnDestroy {
   @ViewChild('messagesScroll') messagesScroll?: ElementRef<HTMLDivElement>;
+  @ViewChild('messageToSendEl') messageToSendEl?: ElementRef<HTMLTextAreaElement>;
 
   form = this.fb.nonNullable.group({
     messageToSend: [ '' ],
@@ -162,6 +163,7 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
           return;
         }
         this.form.get('messageToSend')?.enable();
+        this.messageToSendEl?.nativeElement.focus();
       })
     );
   }


### PR DESCRIPTION
## Description

Fixes #1514 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/forum-focus-on-the-text-field-after-opening-thread/en/a/6379723280369399253;p=4702,1625159049301502151,5207993233955027100;pa=0)
  3. And I click on open the thread button
  4. And I click on "Open this thread" button
  5. Then I see focus on message field
