### PR TITLE
Bug fix: prevent WS unsubscription followed immediately by a subscription 

### DIFF
--- a/src/app/modules/item/services/threads.service.ts
+++ b/src/app/modules/item/services/threads.service.ts
@@ -65,6 +65,7 @@ export class ThreadService implements OnDestroy {
   );
   private threadSubscriptionSub = this.threadInfo$.pipe(
     readyData(),
+    distinctUntilChanged((prev, next) => prev?.participantId === next?.participantId && prev?.itemId === next?.itemId),
     map(t => t?.token),
     pairwise(),
     switchMap(([ prevToken, newToken ]) => concat(...[


### PR DESCRIPTION
Bug fix: prevent WS unsubscription followed immediately by a subscription on the same thread id as race conditions may (and it does) cause the unsubscribe to apply after the new subscription, resulting in no subscription at the end (bug: messages sent but not displayed)
