### PR TITLE
display an error on ws error to ease debugging

### DIFF
--- a/src/app/core/components/thread/thread.component.html
+++ b/src/app/core/components/thread/thread.component.html
@@ -1,11 +1,12 @@
-<div class="widget" *ngIf="state$ | async as state">
-  <div class="widget-loading" *ngIf="state.isFetching">Loading...</div>
-  <div class="widget-error" *ngIf="state.isError">Error!</div>
-  <div class="no-events" *ngIf="state.isReady && state.data.length === 0; else eventsBlock">
+<div class="widget" *ngrxLet="{ state: state$, isWsOpen: isWsOpen$ } as thread">
+  <div class="widget-loading" *ngIf="thread.isWsOpen && thread.state.isFetching">Loading...</div>
+  <div class="widget-error" *ngIf="thread.isWsOpen && thread.state.isError">Error!</div>
+  <div class="ws-error" *ngIf="!thread.isWsOpen" i18n>The connection with the forum has been lost, try to refresh the current page.</div>
+  <div class="no-events" *ngIf="thread.state.isReady && thread.state.data.length === 0; else eventsBlock">
     There are currently no events
   </div>
   <ng-template #eventsBlock>
-    <div class="widget-body">
+    <div class="widget-body" *ngIf="thread.isWsOpen">
       <div class="widget-scroll" #messagesScroll>
         <ng-container *ngIf="{ userCache: userCache$ | async, canCurrentUserLoadAnswers: canCurrentUserLoadAnswers$ | async, itemRoute: itemRoute$ | async } as threadMetadata">
           <alg-thread-message
@@ -14,7 +15,7 @@
             [userCache]="threadMetadata.userCache ?? []"
             [canCurrentUserLoadAnswers]="threadMetadata.canCurrentUserLoadAnswers ?? false"
             [itemRoute]="threadMetadata.itemRoute ?? undefined"
-            *ngFor="let event of state.data"
+            *ngFor="let event of thread.state.data"
           ></alg-thread-message>
         </ng-container>
         <ng-container *ngIf="threadId$ | async as threadId">

--- a/src/app/core/components/thread/thread.component.scss
+++ b/src/app/core/components/thread/thread.component.scss
@@ -7,7 +7,7 @@
   overflow: hidden;
 }
 
-.widget-loading, .widget-error, .no-events {
+.widget-loading, .widget-error, .no-events, .ws-error {
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/app/core/components/thread/thread.component.ts
+++ b/src/app/core/components/thread/thread.component.ts
@@ -53,6 +53,8 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
   readonly subscriptions = new Subscription();
   readonly state$ = this.threadService.eventsState$;
 
+  readonly isWsOpen$ = this.discussionService.isWsOpen$;
+
   private distinctUsersInThread = this.state$.pipe(
     map(state => state.data ?? []), // if there is no data, consider there is no events
     map(events => events.map(e => e.createdBy)),

--- a/src/app/modules/item/services/discussion.service.ts
+++ b/src/app/modules/item/services/discussion.service.ts
@@ -22,6 +22,7 @@ export class DiscussionService implements OnDestroy {
 
   private readonly threadService?: ThreadService; // only injected if forum is enabled
   threadId$: Observable<ThreadId|undefined> = EMPTY;
+  isWsOpen$: Observable<boolean> = EMPTY;
 
   private configuredThreadSubject = new BehaviorSubject<ThreadId|null>(null);
   readonly configuredThread$ = this.configuredThreadSubject.asObservable();
@@ -43,6 +44,7 @@ export class DiscussionService implements OnDestroy {
 
     this.threadService = this.injector.get<ThreadService>(ThreadService);
     this.threadId$ = this.threadService.threadId$;
+    this.isWsOpen$ = this.threadService.isWsOpen$;
 
     this.unreadCount$ = this.visible$.pipe(
       // when hidden (manually or because thread changes), store the current time as the last read time

--- a/src/app/modules/item/services/threads.service.ts
+++ b/src/app/modules/item/services/threads.service.ts
@@ -47,6 +47,8 @@ export class ThreadService implements OnDestroy {
   private configuredThreadId = new BehaviorSubject<ThreadId|null>(null);
   private clearEvents$ = new ReplaySubject<void>(1);
 
+  isWsOpen$ = this.forumService.isWsOpen$;
+
   private refresh$ = new Subject<void>();
   threadId$ = this.configuredThreadId.pipe(distinctUntilChanged((x,y) => x?.participantId === y?.participantId && x?.itemId === y?.itemId));
   threadInfo$ = combineLatest([

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1539,34 +1539,40 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread-message/thread-message.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="4672292365306876208" datatype="html">
         <source>An unknown user</source><target state="new">An unknown user</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread-message/thread-message.component.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="6814866706683747731" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread-message/thread-message.component.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="5431013772554598311" datatype="html">
+        <source>The connection with the forum has been lost, try to refresh the current page.</source><target state="new">The connection with the forum has been lost, try to refresh the current page.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context>
+          <context context-type="linenumber">4</context>
+        </context-group>
+      </trans-unit><trans-unit id="6814866706683747731" datatype="html">
         <source>This thread is open</source><target state="new">This thread is open</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">44</context></context-group></trans-unit><trans-unit id="7026225147837703446" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit><trans-unit id="7026225147837703446" datatype="html">
         <source>This thread is closed</source><target state="new">This thread is closed</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">47</context></context-group></trans-unit><trans-unit id="7081022654245598030" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">48</context></context-group></trans-unit><trans-unit id="7081022654245598030" datatype="html">
         <source>Loading thread status...</source><target state="new">Loading thread status...</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">50</context></context-group></trans-unit><trans-unit id="6336236085368327816" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="6336236085368327816" datatype="html">
         <source>Error while loading thread info</source><target state="new">Error while loading thread info</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">53</context></context-group></trans-unit><trans-unit id="622893788827542307" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="622893788827542307" datatype="html">
         <source>Could not load thread</source><target state="new">Could not load thread</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">56</context></context-group></trans-unit><trans-unit id="3179590434682638610" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="3179590434682638610" datatype="html">
         <source>Close this thread</source><target state="new">Close this thread</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">74</context></context-group></trans-unit><trans-unit id="2366438191404804817" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">75</context></context-group></trans-unit><trans-unit id="2366438191404804817" datatype="html">
         <source>Open this thread</source><target state="new">Open this thread</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">76</context></context-group></trans-unit><trans-unit id="1931675333210003976" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">77</context></context-group></trans-unit><trans-unit id="1931675333210003976" datatype="html">
         <source> Only the user of the thread can close it. </source><target state="new"> Only the user of the thread can close it. </target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">81</context></context-group></trans-unit><trans-unit id="6788707780009559106" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="6788707780009559106" datatype="html">
         <source>You are not allowed to open this thread.</source><target state="new">You are not allowed to open this thread.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">85</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/core/components/thread/thread.component.html</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">
         <source>Error while loading this chapter's children</source><target state="translated">Erreur lors du chargement des enfants de ce chapitre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/modules/item/components/chapter-children/chapter-children.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="7143643956716496978" datatype="html">


### PR DESCRIPTION
## Description

Just display an error if the websocket stays in error. It would help understanding cases where the whole forum is stalled on old data for instance after a os hibernation.

The only way to reproduce it easily (as I cannot close WS from the browser devtools) is to comment `forum.service.tsL21`.

The result is not really pretty but does the job: 
![Screenshot 2023-10-10 at 15 39 39](https://github.com/France-ioi/AlgoreaFrontend/assets/1053150/445d8bd2-c829-4d2e-9bda-a58883b53d5d)


