### PR TITLE
catch tasktoken error so that it does crash the app

### DIFF
--- a/src/app/items/services/item-task-init.service.ts
+++ b/src/app/items/services/item-task-init.service.ts
@@ -119,7 +119,7 @@ export class ItemTaskInitService implements OnDestroy {
   });
 
   // subscribe to the task token so that it is requested even before it is needed (so ready more quickly)
-  tokenSubscription = this.taskToken$.subscribe();
+  tokenSubscription = this.taskToken$.pipe(catchError(() => EMPTY)).subscribe();
 
   constructor(
     private taskTokenService: TaskTokenService,


### PR DESCRIPTION
## Description

Catch error on subscribe so that task-token fetch error does not appear as a crash to the user.  The error is handled by the task loading part anyway.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. I open the network dev tools
  3. When I go to [this taks](https://dev.algorea.org/branch/fix-catch-tasktoken-error/en/a/6319140447749005365;p=7528142386663912287,7523720120450464843;a=0)
  4. And I block the task token generation request
  5. And I go back to the task 
  6. Then I see there is not app crash reported, but the task loading fails properly with an error
