### PR TITLE
fix: avoid a race condition when the task was destroyed just before b…

### DIFF
--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -25,7 +25,7 @@
         #contentContainer
         *ngrxLet="currentTab$ as currentTab"
       >
-        <ng-container *ngIf="(itemContentComponent?.isTaskLoaded$ | async) || currentTab?.tag === 'alg-content' || currentTab?.tag === 'alg-children-edit'">
+        <ng-container *ngIf="currentTab?.isTaskTab || (itemContentComponent?.isTaskLoaded$ | async) || currentTab?.tag === 'alg-content' || currentTab?.tag === 'alg-children-edit'">
           <alg-error *ngIf="answerLoadingError$ | async as error; else noAnswerLoadingError">
             <ng-container *ngIf="!error.fallbackLink; else fallback" i18n>Unable to load the answer</ng-container>
             <ng-template #fallback>


### PR DESCRIPTION
## Description

Avoid a race condition when the task was destroyed just before being loaded.  Was happening mainly on Chrome. 

The ngIf condition goal:
- show the block when we are on the "content" tab
- show the block when we are on a task-provided tab
- do not use the block when arriving on another tab (for instance "forum"), to prevent loading the task in this case
- keep the block up (hidden by another condition) when the task has been loaded, so that it is not unloaded when going to the history tab for instance

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. When I go to [the content tab of a task](https://dev.algorea.org/branch/fix-empty-tasks/en/a/5280599138983174;p=4702,458602124916982205,7261489280300959902,200517755928090034,1723784257226654901;a=0)
  3. Then I see the task load correctly to the end
  4. Then I switch to the history tab
  5. Then I go back to the "statement" tab,
  6. And the task displays immediately without reload

- [ ] Case 2:
  1. Given I am any user
  2. I open the network dev tools
  3. When I go to [the history tab of a task directly](https://dev.algorea.org/branch/fix-empty-tasks/en/a/5280599138983174;p=4702,458602124916982205,7261489280300959902,200517755928090034,1723784257226654901;a=0/progress/history)
  7. Then I see the task does NOT load in background
  8. Then I click on the "content" tab and it loads correctly


