### PR TITLE
Adds message for thread without messages

### DIFF
--- a/src/app/containers/thread/thread.component.html
+++ b/src/app/containers/thread/thread.component.html
@@ -1,25 +1,38 @@
-<div class="widget" *ngrxLet="{ state: state$, isWsOpen: isWsOpen$ } as thread">
+<div class="widget" *ngrxLet="{
+    state: state$,
+    isWsOpen: isWsOpen$,
+    threadStatus: threadStatus$,
+    messagesCount: messagesCount$,
+    isCurrentUserThreadParticipant: isCurrentUserThreadParticipant$,
+  } as thread"
+>
   <div class="widget-loading" *ngIf="thread.isWsOpen && thread.state.isFetching">Loading...</div>
   <div class="widget-error" *ngIf="thread.isWsOpen && thread.state.isError">Error!</div>
   <div class="ws-error" *ngIf="!thread.isWsOpen" i18n>The connection with the forum has been lost, try to refresh the current page.</div>
-  <div class="no-events" *ngIf="thread.state.isReady && thread.state.data.length === 0; else eventsBlock">
+  <div class="no-events" *ngIf="thread.state.isReady && thread.state.data.length === 0; else eventsBlock" i18n>
     There are currently no events
   </div>
   <ng-template #eventsBlock>
     <div class="widget-body" *ngIf="thread.isWsOpen">
       <div class="widget-scroll" #messagesScroll>
-        <ng-container *ngIf="{ userCache: userCache$ | async, canCurrentUserLoadAnswers: canCurrentUserLoadAnswers$ | async, itemRoute: itemRoute$ | async } as threadMetadata">
-          <alg-thread-message
-            class="thread-message"
-            [event]="event"
-            [userCache]="threadMetadata.userCache ?? []"
-            [canCurrentUserLoadAnswers]="threadMetadata.canCurrentUserLoadAnswers ?? false"
-            [itemRoute]="threadMetadata.itemRoute ?? undefined"
-            *ngFor="let event of thread.state.data"
-          ></alg-thread-message>
-        </ng-container>
+        <div class="no-messages" *ngIf="thread.isCurrentUserThreadParticipant && thread.threadStatus?.isReady && !thread.threadStatus?.data?.open && thread.messagesCount === 0; else messagesBlock" i18n>
+          In this panel, you can request help from other users about the content you are on.
+          People who have already validated this item will see your request and be able to answer.
+        </div>
+        <ng-template #messagesBlock>
+          <ng-container *ngIf="{ userCache: userCache$ | async, canCurrentUserLoadAnswers: canCurrentUserLoadAnswers$ | async, itemRoute: itemRoute$ | async } as threadMetadata">
+            <alg-thread-message
+              class="thread-message"
+              [event]="event"
+              [userCache]="threadMetadata.userCache ?? []"
+              [canCurrentUserLoadAnswers]="threadMetadata.canCurrentUserLoadAnswers ?? false"
+              [itemRoute]="threadMetadata.itemRoute ?? undefined"
+              *ngFor="let event of thread.state.data"
+            ></alg-thread-message>
+          </ng-container>
+        </ng-template>
         <ng-container *ngIf="threadId$ | async as threadId">
-          <div class="footer-panel" *ngrxLet="threadStatus$ as threadStatus">
+          <div class="footer-panel">
             <form class="send-form" [formGroup]="form" (ngSubmit)="sendMessage(threadId)">
               <textarea
                 class="textarea"
@@ -36,29 +49,29 @@
                 type="submit"
                 icon="pi pi-send"
                 pButton
-                [disabled]="!form.get('messageToSend')?.value?.trim() || !threadStatus?.data?.open"
+                [disabled]="!form.get('messageToSend')?.value?.trim() || !thread.threadStatus?.data?.open"
               ></button>
             </form>
             <div class="thread-status">
               <div class="thread-status-caption" >
-                <ng-container *ngIf="threadStatus?.data?.open">
+                <ng-container *ngIf="thread.threadStatus?.data?.open">
                   <span i18n>This thread is open</span>
                 </ng-container>
-                <ng-container *ngIf="threadStatus?.data?.open === false">
+                <ng-container *ngIf="thread.threadStatus?.data?.open === false">
                   <span i18n>This thread is closed</span>
                 </ng-container>
-                <ng-container *ngIf="threadStatus?.isFetching">
+                <ng-container *ngIf="thread.threadStatus?.isFetching">
                   <span i18n>Loading thread status...</span>
                 </ng-container>
-                <ng-container *ngIf="threadStatus?.isError">
+                <ng-container *ngIf="thread.threadStatus?.isError">
                   <span i18n>Error while loading thread info</span>
                 </ng-container>
-                <ng-container *ngIf="threadStatus === undefined">
+                <ng-container *ngIf="thread.threadStatus === undefined">
                   <span i18n>Could not load thread</span>
                 </ng-container>
               </div>
               <div
-                *ngrxLet="!!threadStatus && !!threadStatus.data && ((threadStatus.data.open && threadStatus.data.canClose) || (!threadStatus.data.open && threadStatus.data.canOpen)) as canSwitch"
+                *ngrxLet="!!thread.threadStatus && !!thread.threadStatus.data && ((thread.threadStatus.data.open && thread.threadStatus.data.canClose) || (!thread.threadStatus.data.open && thread.threadStatus.data.canOpen)) as canSwitch"
                 [pTooltip]="threadStatusTooltip"
                 [tooltipDisabled]="canSwitch"
                 tooltipPosition="top"
@@ -69,17 +82,17 @@
                   class="alg-button primary small"
                   [disabled]="!canSwitch"
                   pButton
-                  (click)="changeThreadStatus(!threadStatus.data.open, threadId)"
-                  *ngIf="threadStatus && threadStatus.data"
+                  (click)="changeThreadStatus(!thread.threadStatus.data.open, threadId)"
+                  *ngIf="thread.threadStatus && thread.threadStatus.data"
                 >
-                  <span *ngIf="threadStatus.data.open; else openThreadCaption" i18n>Close this thread</span>
+                  <span *ngIf="thread.threadStatus.data.open; else openThreadCaption" i18n>Close this thread</span>
                   <ng-template #openThreadCaption>
                     <span i18n>Open this thread</span>
                   </ng-template>
                 </button>
               </div>
               <ng-template #threadStatusTooltip>
-                <span *ngIf="threadStatus?.data?.open; else notOpenedTooltipCaption" i18n>
+                <span *ngIf="thread.threadStatus?.data?.open; else notOpenedTooltipCaption" i18n>
                   Only the user of the thread can close it.
                 </span>
                 <ng-template #notOpenedTooltipCaption>

--- a/src/app/containers/thread/thread.component.html
+++ b/src/app/containers/thread/thread.component.html
@@ -17,7 +17,7 @@
       <div class="widget-scroll" #messagesScroll>
         <div class="no-messages" *ngIf="thread.isCurrentUserThreadParticipant && thread.threadStatus?.isReady && !thread.threadStatus?.data?.open && thread.messagesCount === 0; else messagesBlock" i18n>
           In this panel, you can request help from other users about the content you are on.
-          People who have already validated this item will see your request and be able to answer.
+          People who have already validated this activity will see your request and be able to answer.
         </div>
         <ng-template #messagesBlock>
           <ng-container *ngIf="{ userCache: userCache$ | async, canCurrentUserLoadAnswers: canCurrentUserLoadAnswers$ | async, itemRoute: itemRoute$ | async } as threadMetadata">

--- a/src/app/containers/thread/thread.component.scss
+++ b/src/app/containers/thread/thread.component.scss
@@ -83,3 +83,10 @@
     box-shadow: none !important;
   }
 }
+
+.no-messages {
+  padding: 0 toRem(6);
+  color: var(--alg-secondary-color);
+  font-size: toRem(14);
+  text-align: center;
+}

--- a/src/app/containers/thread/thread.component.ts
+++ b/src/app/containers/thread/thread.component.ts
@@ -95,7 +95,7 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
   private readonly isThreadStatusOpened$ = this.threadService.threadInfo$.pipe( // may be true, false or undefined!
     map(t => (t.data ? [ 'waiting_for_participant', 'waiting_for_trainer' ].includes(t.data.status) : undefined)),
   );
-  private readonly isCurrentUserThreadParticipant$ = combineLatest([
+  readonly isCurrentUserThreadParticipant$ = combineLatest([
     this.userSessionService.userProfile$,
     this.threadService.threadId$
   ]).pipe(
@@ -135,6 +135,10 @@ export class ThreadComponent implements AfterViewInit, OnDestroy {
       }),
     );
   threadId$ = this.threadService.threadId$;
+  messagesCount$ = this.threadService.eventsState$.pipe(
+    readyData(),
+    map(events => events.filter(event => event.label === 'message').length),
+  );
 
   constructor(
     private threadService: ThreadService,

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1353,8 +1353,8 @@
           <context context-type="sourcefile">src/app/containers/thread/thread.component.html</context>
           <context context-type="linenumber">12,14</context>
         </context-group>
-      </trans-unit><trans-unit id="2131010874213150430" datatype="html">
-        <source> In this panel, you can request help from other users about the content you are on. People who have already validated this item will see your request and be able to answer. </source><target state="new"> In this panel, you can request help from other users about the content you are on. People who have already validated this item will see your request and be able to answer. </target>
+      </trans-unit><trans-unit id="934631686934017933" datatype="html">
+        <source> In this panel, you can request help from other users about the content you are on. People who have already validated this activity will see your request and be able to answer. </source><target state="new"> In this panel, you can request help from other users about the content you are on. People who have already validated this activity will see your request and be able to answer. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/containers/thread/thread.component.html</context>
           <context context-type="linenumber">18,21</context>

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -1344,37 +1344,49 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread-message/thread-message.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="4672292365306876208" datatype="html">
         <source>An unknown user</source><target state="new">An unknown user</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread-message/thread-message.component.ts</context><context context-type="linenumber">38</context></context-group></trans-unit><trans-unit id="5431013772554598311" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread-message/thread-message.component.ts</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="5431013772554598311" datatype="html">
         <source>The connection with the forum has been lost, try to refresh the current page.</source><target state="new">The connection with the forum has been lost, try to refresh the current page.</target>
         
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">4</context></context-group></trans-unit><trans-unit id="6814866706683747731" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">11</context></context-group></trans-unit><trans-unit id="6113781660128924635" datatype="html">
+        <source> There are currently no events </source><target state="new"> There are currently no events </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/containers/thread/thread.component.html</context>
+          <context context-type="linenumber">12,14</context>
+        </context-group>
+      </trans-unit><trans-unit id="2131010874213150430" datatype="html">
+        <source> In this panel, you can request help from other users about the content you are on. People who have already validated this item will see your request and be able to answer. </source><target state="new"> In this panel, you can request help from other users about the content you are on. People who have already validated this item will see your request and be able to answer. </target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/containers/thread/thread.component.html</context>
+          <context context-type="linenumber">18,21</context>
+        </context-group>
+      </trans-unit><trans-unit id="6814866706683747731" datatype="html">
         <source>This thread is open</source><target state="new">This thread is open</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit><trans-unit id="7026225147837703446" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">58</context></context-group></trans-unit><trans-unit id="7026225147837703446" datatype="html">
         <source>This thread is closed</source><target state="new">This thread is closed</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">48</context></context-group></trans-unit><trans-unit id="7081022654245598030" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="7081022654245598030" datatype="html">
         <source>Loading thread status...</source><target state="new">Loading thread status...</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">51</context></context-group></trans-unit><trans-unit id="6336236085368327816" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">64</context></context-group></trans-unit><trans-unit id="6336236085368327816" datatype="html">
         <source>Error while loading thread info</source><target state="new">Error while loading thread info</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">54</context></context-group></trans-unit><trans-unit id="622893788827542307" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">67</context></context-group></trans-unit><trans-unit id="622893788827542307" datatype="html">
         <source>Could not load thread</source><target state="new">Could not load thread</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">57</context></context-group></trans-unit><trans-unit id="3179590434682638610" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">70</context></context-group></trans-unit><trans-unit id="3179590434682638610" datatype="html">
         <source>Close this thread</source><target state="new">Close this thread</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">75</context></context-group></trans-unit><trans-unit id="2366438191404804817" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">88</context></context-group></trans-unit><trans-unit id="2366438191404804817" datatype="html">
         <source>Open this thread</source><target state="new">Open this thread</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">77</context></context-group></trans-unit><trans-unit id="1931675333210003976" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">90</context></context-group></trans-unit><trans-unit id="1931675333210003976" datatype="html">
         <source> Only the user of the thread can close it. </source><target state="new"> Only the user of the thread can close it. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">82</context></context-group></trans-unit><trans-unit id="6788707780009559106" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">95</context></context-group></trans-unit><trans-unit id="6788707780009559106" datatype="html">
         <source>You are not allowed to open this thread.</source><target state="new">You are not allowed to open this thread.</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/containers/thread/thread.component.html</context><context context-type="linenumber">99</context></context-group></trans-unit><trans-unit id="4902361762285353004" datatype="html">
         <source>Error while loading this chapter's children</source><target state="translated">Erreur lors du chargement des enfants de ce chapitre</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/chapter-children/chapter-children.component.html</context><context context-type="linenumber">5</context></context-group></trans-unit><trans-unit id="7143643956716496978" datatype="html">


### PR DESCRIPTION
## Description

Fixes #1521

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/forum-message-for-empty-threads/en/a/773396873861865944;p=7523720120450464843;a=0)
  3. And I click on "Thread" button in top bar
  4. Then I see the new message for closed thread when no messages: "In this panel, you can request help from other users about the content you are on. People who have already validated this item will see your request and be able to answer."
  5. And I click on "Open this thread" button
  6. Then I see other events and "empty" message are disappeared
