### PR TITLE
Handle errors caused by token generation errors to prevent unhandled crashes

### DIFF
--- a/src/app/items/services/item-task-answer.service.ts
+++ b/src/app/items/services/item-task-answer.service.ts
@@ -44,7 +44,11 @@ export class ItemTaskAnswerService implements OnDestroy {
   private saved$ = new ReplaySubject<{ answer: string, state: string }>();
   private saveError$ = new Subject<Error>();
 
-  private loadedTask$ = this.taskInitService.loadedTask$.pipe(takeUntil(this.error$));
+  private loadedTask$ = this.taskInitService.loadedTask$.pipe(
+    catchError(() => EMPTY), // error handled in subscriptions
+    takeUntil(this.error$)
+  );
+
   private config$ = this.taskInitService.config$.pipe(
     takeUntil(this.error$),
     filter((config): config is RunningItemTaskConfig => config.attemptId !== undefined)
@@ -127,6 +131,9 @@ export class ItemTaskAnswerService implements OnDestroy {
       error: err => this.errorSubject.next(err),
     }),
     this.initializedTaskState$.subscribe({
+      error: err => this.errorSubject.next(err),
+    }),
+    this.taskInitService.loadedTask$.subscribe({
       error: err => this.errorSubject.next(err),
     }),
     this.initialAnswer$

--- a/src/app/items/services/item-task-init.service.ts
+++ b/src/app/items/services/item-task-init.service.ts
@@ -56,6 +56,7 @@ export class ItemTaskInitService implements OnDestroy {
     shareReplay(1),
   );
 
+  // task token generation (possibly after some delay) (may fail!)
   readonly taskToken$: Observable<TaskToken> = this.config$.pipe(
     // build strategy separately from switchMap to prevent cancellation of the request
     map(({ readOnly, initialAnswer, attemptId, route }) => {
@@ -81,7 +82,7 @@ export class ItemTaskInitService implements OnDestroy {
     shareReplay(1),
   );
 
-  // the task (i.e., a client to the task in the iframe) which has been loaded
+  // the task (i.e., a client to the task in the iframe) which has been loaded (may fail!)
   readonly loadedTask$ = this.task$.pipe(
     switchMap(task => task.getMetaData().pipe(map(({ usesTokens }) => ({ usesTokens: usesTokens ?? true, task })))),
     switchMap(({ usesTokens, task }) => (usesTokens ? this.taskToken$.pipe(

--- a/src/app/items/services/item-task-views.service.ts
+++ b/src/app/items/services/item-task-views.service.ts
@@ -12,7 +12,7 @@ export class ItemTaskViewsService implements OnDestroy {
 
   private displaySubject = new ReplaySubject<UpdateDisplayParams>(1);
   readonly display$ = this.displaySubject.asObservable().pipe(takeUntil(this.error$));
-  private loadedTask$ = this.initService.loadedTask$.pipe(takeUntil(this.error$));
+  private loadedTask$ = this.initService.loadedTask$.pipe(catchError(() => EMPTY), takeUntil(this.error$));
 
   private readonly views = merge(
     this.loadedTask$.pipe(switchMap(task => task.getViews())),


### PR DESCRIPTION
## Description

Handle errors caused by token generation errors to prevent unhandled exceptions (so crashes).

I have many crashes reported in Sentry which are due to timeout error on the token generation request. However I am not able to reproduce this crash when I manually block this request... hum strange. 
Nevertheless, observable errors was not fully handled... so I fixed that.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [a task](https://dev.algorea.org/branch/fix-improve-generate-task-token-timeout-handling/en/a/1293400563985240032;p=7528142386663912287,7523720120450464843;a=0)
  4. Then I see the task loading

- [ ] Case 2:
  1. Given I am the usual user
  2. I block the `https://dev.algorea.org/api/items/*/attempts/0/generate-task-token` requests
  3. When I go to [a task](https://dev.algorea.org/branch/fix-improve-generate-task-token-timeout-handling/en/a/1293400563985240032;p=7528142386663912287,7523720120450464843;a=0)
  4. Then I see the task failing properly

