### PR TITLE
Improve forum action name consistency

### DIFF
--- a/src/app/forum/store/current-thread/current-thread.actions.ts
+++ b/src/app/forum/store/current-thread/current-thread.actions.ts
@@ -27,6 +27,6 @@ export const threadPanelActions = createActionGroup({
 export const itemPageActions = createActionGroup({
   source: 'Item Page',
   events: {
-    currentThreadIdChange: props<{ id: ThreadId }>(),
+    changeCurrentThreadId: props<{ id: ThreadId }>(),
   },
 });

--- a/src/app/forum/store/current-thread/current-thread.effects.ts
+++ b/src/app/forum/store/current-thread/current-thread.effects.ts
@@ -11,7 +11,7 @@ export const fetchStateChangeGuardEffect = createEffect(
     actions$ = inject(Actions),
     store$ = inject(Store),
   ) => actions$.pipe(
-    ofType(fetchThreadInfoActions.fetchStateChange),
+    ofType(fetchThreadInfoActions.fetchStateChanged),
     withLatestFrom(store$.select(forumFeature.selectThreadId)),
     tap(([{ fetchState } , id ]) => {
       if (id === null) throw new Error('unexpected: no state id while changing thread info');

--- a/src/app/forum/store/current-thread/current-thread.reducers.ts
+++ b/src/app/forum/store/current-thread/current-thread.reducers.ts
@@ -41,7 +41,7 @@ const reducer = createReducer(
     })
   ),
 
-  on(fetchThreadInfoActions.fetchStateChange, (state, { fetchState }): State => ({ ...state, info: fetchState })),
+  on(fetchThreadInfoActions.fetchStateChanged, (state, { fetchState }): State => ({ ...state, info: fetchState })),
 
 );
 

--- a/src/app/forum/store/current-thread/current-thread.reducers.ts
+++ b/src/app/forum/store/current-thread/current-thread.reducers.ts
@@ -31,7 +31,7 @@ const reducer = createReducer(
   on(threadPanelActions.close, (state): State => ({ ...state, visible: false })),
 
   on(
-    itemPageActions.currentThreadIdChange,
+    itemPageActions.changeCurrentThreadId,
     forumThreadListActions.showAsCurrentThread,
     (state, { id }): State => ({
       ...state,

--- a/src/app/forum/store/current-thread/event-sync.actions.ts
+++ b/src/app/forum/store/current-thread/event-sync.actions.ts
@@ -3,6 +3,6 @@ import { createActionGroup, emptyProps } from '@ngrx/store';
 export const itemPageEventSyncActions = createActionGroup({
   source: 'Item page',
   events: {
-    currentThreadEventsSync: emptyProps(),
+    forceSyncCurrentThreadEvents: emptyProps(),
   },
 });

--- a/src/app/forum/store/current-thread/event-sync.effects.ts
+++ b/src/app/forum/store/current-thread/event-sync.effects.ts
@@ -18,7 +18,7 @@ export const syncEventsEffect = createEffect(
     activityLogService = inject(ActivityLogService),
     websocketClient = inject(WebsocketClient),
   ) => actions$.pipe(
-    ofType(fetchThreadInfoActions.fetchStateChange),
+    ofType(fetchThreadInfoActions.fetchStateChanged),
     map(({ fetchState }) => fetchState),
     readyData(),
     distinctUntilChanged(areSameThreads),

--- a/src/app/forum/store/current-thread/fetchThreadInfo.actions.ts
+++ b/src/app/forum/store/current-thread/fetchThreadInfo.actions.ts
@@ -5,6 +5,6 @@ import { FetchState } from 'src/app/utils/state';
 export const fetchThreadInfoActions = createActionGroup({
   source: 'Forum API',
   events: {
-    fetchStateChange: props<{ fetchState: FetchState<ThreadInfo> }>(),
+    fetchStateChanged: props<{ fetchState: FetchState<ThreadInfo> }>(),
   },
 });

--- a/src/app/forum/store/current-thread/fetchThreadInfo.effects.ts
+++ b/src/app/forum/store/current-thread/fetchThreadInfo.effects.ts
@@ -21,7 +21,7 @@ export const fetchThreadInfoEffect = createEffect(
     switchMap(({ itemId, participantId }) => threadHttpService.get(itemId, participantId).pipe(
       mapToFetchState(),
     )),
-    map(fetchState => fetchThreadInfoActions.fetchStateChange({ fetchState }))
+    map(fetchState => fetchThreadInfoActions.fetchStateChanged({ fetchState }))
   ),
   { functional: true }
 );
@@ -39,7 +39,7 @@ export const refreshThreadInfoEffect = createEffect(
     switchMap(({ itemId, participantId }) => threadHttpService.get(itemId, participantId).pipe(
       mapToFetchState(),
     )),
-    map(fetchState => fetchThreadInfoActions.fetchStateChange({ fetchState }))
+    map(fetchState => fetchThreadInfoActions.fetchStateChanged({ fetchState }))
   ),
   { functional: true }
 );

--- a/src/app/forum/store/current-thread/fetchThreadInfo.effects.ts
+++ b/src/app/forum/store/current-thread/fetchThreadInfo.effects.ts
@@ -15,7 +15,7 @@ export const fetchThreadInfoEffect = createEffect(
     actions$ = inject(Actions),
     threadHttpService = inject(ThreadService),
   ) => actions$.pipe(
-    ofType(forumThreadListActions.showAsCurrentThread, itemPageActions.currentThreadIdChange),
+    ofType(forumThreadListActions.showAsCurrentThread, itemPageActions.changeCurrentThreadId),
     map(({ id }) => id),
     distinctUntilChanged(areSameThreads),
     switchMap(({ itemId, participantId }) => threadHttpService.get(itemId, participantId).pipe(

--- a/src/app/forum/store/current-thread/threadSubscription.effects.ts
+++ b/src/app/forum/store/current-thread/threadSubscription.effects.ts
@@ -25,7 +25,7 @@ export const threadUnsubscriptionEffect = createEffect(
     merge(
       fromEvent(window, 'beforeunload'),
       actions$.pipe(
-        ofType(forumThreadListActions.showAsCurrentThread, itemPageActions.currentThreadIdChange),
+        ofType(forumThreadListActions.showAsCurrentThread, itemPageActions.changeCurrentThreadId),
         map(({ id }) => id),
         distinctUntilChanged(areSameThreads), // only when the id really changes
       )

--- a/src/app/forum/store/current-thread/threadSubscription.effects.ts
+++ b/src/app/forum/store/current-thread/threadSubscription.effects.ts
@@ -49,7 +49,7 @@ export const threadSubscriptionEffect = createEffect(
     actions$ = inject(Actions),
     websocketClient = inject(WebsocketClient),
   ) => actions$.pipe(
-    ofType(fetchThreadInfoActions.fetchStateChange),
+    ofType(fetchThreadInfoActions.fetchStateChanged),
     map(({ fetchState }) => fetchState),
     readyData(),
     distinctUntilChanged(areSameThreads),

--- a/src/app/items/containers/item-content/item-content.component.ts
+++ b/src/app/items/containers/item-content/item-content.component.ts
@@ -89,7 +89,7 @@ export class ItemContentComponent implements PendingChangesComponent {
 
   onScoreChange(score: number): void {
     this.scoreChange.emit(score);
-    this.store.dispatch(forum.itemPageEventSyncActions.currentThreadEventsSync());
+    this.store.dispatch(forum.itemPageEventSyncActions.forceSyncCurrentThreadEvents());
   }
 
 }

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -330,7 +330,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       }),
       distinctUntilChanged((x, y) => x?.itemId === y?.itemId && x?.participantId === y?.participantId),
       filter(isNotNull), // leave the forum as it is if no new value
-    ).subscribe(threadId => this.store.dispatch(forum.itemPageActions.currentThreadIdChange({ id: threadId }))),
+    ).subscribe(threadId => this.store.dispatch(forum.itemPageActions.changeCurrentThreadId({ id: threadId }))),
 
   ];
 


### PR DESCRIPTION
Just improve action name for consistency.

Action names are either:
* doSomething (e.g., toggleCurrentThreadVisibility) to trigger a change
* somethingDone (e.g. threadStatusChanged) to notify a change happened