### PR TITLE
Fix resubscribe on ws open

### DIFF
--- a/src/app/forum/store/current-thread/event-sync.effects.ts
+++ b/src/app/forum/store/current-thread/event-sync.effects.ts
@@ -1,28 +1,27 @@
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { inject } from '@angular/core';
-import { distinctUntilChanged, map, switchMap, tap } from 'rxjs';
-import { areSameThreads } from '../../models/threads';
+import { EMPTY, OperatorFunction, distinctUntilChanged, map, of, pipe, switchMap, take, tap } from 'rxjs';
 import { WebsocketClient } from 'src/app/data-access/websocket-client.service';
-import { fetchThreadInfoActions } from './fetchThreadInfo.actions';
 import { readyData } from 'src/app/utils/operators/state';
 import { ActivityLogService } from 'src/app/data-access/activity-log.service';
 import { isNotNull } from 'src/app/utils/null-undefined-predicates';
 import { publishEventsAction } from '../../data-access/websocket-messages/threads-outbound-actions';
+import { itemPageEventSyncActions } from './event-sync.actions';
+import { Store } from '@ngrx/store';
+import forumFeature from '..';
+import { Thread, areSameThreads } from '../../models/threads';
+import { fetchThreadInfoActions } from './fetchThreadInfo.actions';
 
 /**
- * Synchronization of the events in the forum thread with the events from the backend
+ * Synchronization of the events from the backend with the forum
  */
-export const syncEventsEffect = createEffect(
-  (
-    actions$ = inject(Actions),
-    activityLogService = inject(ActivityLogService),
-    websocketClient = inject(WebsocketClient),
-  ) => actions$.pipe(
-    ofType(fetchThreadInfoActions.fetchStateChanged),
-    map(({ fetchState }) => fetchState),
-    readyData(),
-    distinctUntilChanged(areSameThreads),
-    map(({ itemId, participantId, isMine, token }) => ({ itemId, token, watchedGroupId: isMine ? undefined : participantId })),
+
+function syncThread(activityLogService: ActivityLogService, websocketClient: WebsocketClient): OperatorFunction<Thread, unknown> {
+  return pipe(
+    switchMap(({ itemId, participantId, isMine, token, canWatch }) => {
+      if (!isMine && !canWatch) return EMPTY; // will not be allowed to get the activity log, so do not sync
+      return of({ itemId, token, watchedGroupId: isMine ? undefined : participantId });
+    }),
     switchMap(({ itemId, token, watchedGroupId }) => activityLogService.getActivityLog(itemId, { watchedGroupId, limit: 100 }).pipe(
       map(log => log.map(e => {
         switch (e.activityType) {
@@ -40,6 +39,35 @@ export const syncEventsEffect = createEffect(
     tap(({ log, token }) => {
       websocketClient.send(publishEventsAction(token, log));
     }),
+  );
+}
+
+export const syncOnThreadChangeEffect = createEffect(
+  (
+    actions$ = inject(Actions),
+    activityLogService = inject(ActivityLogService),
+    websocketClient = inject(WebsocketClient),
+  ) => actions$.pipe(
+    ofType(fetchThreadInfoActions.fetchStateChanged),
+    map(({ fetchState }) => fetchState),
+    readyData(),
+    distinctUntilChanged(areSameThreads),
+    syncThread(activityLogService, websocketClient),
+  ),
+  { functional: true, dispatch: false }
+);
+
+export const forceSyncEffect = createEffect(
+  (
+    actions$ = inject(Actions),
+    store$ = inject(Store),
+    activityLogService = inject(ActivityLogService),
+    websocketClient = inject(WebsocketClient),
+  ) => actions$.pipe(
+    ofType(itemPageEventSyncActions.forceSyncCurrentThreadEvents),
+    switchMap(() => store$.select(forumFeature.selectInfo).pipe(take(1))), // take the current info
+    readyData(), // only if current info is ready
+    syncThread(activityLogService, websocketClient),
   ),
   { functional: true, dispatch: false }
 );

--- a/src/app/forum/store/current-thread/threadSubscription.effects.spec.ts
+++ b/src/app/forum/store/current-thread/threadSubscription.effects.spec.ts
@@ -1,0 +1,90 @@
+import { shareReplay } from 'rxjs';
+import { WebsocketClient } from 'src/app/data-access/websocket-client.service';
+import { fetchThreadInfoActions } from './fetchThreadInfo.actions';
+import { fetchingState, readyState } from 'src/app/utils/state';
+import { Thread } from '../../models/threads';
+import { threadSubscriptionEffect } from './threadSubscription.effects';
+import { Store } from '@ngrx/store';
+import { TestScheduler } from 'rxjs/testing';
+
+describe('threadSubscriptionEffect', () => {
+
+  const mockThread1 = { itemId: '1', participantId: '2' } as Thread;
+  const mockThread2 = { itemId: '1', participantId: '3' } as Thread;
+  const wsClientMock = {
+    send: (): void => {}
+  } as unknown as WebsocketClient;
+
+  // actions for marble testing
+  const a = fetchThreadInfoActions.fetchStateChanged({ fetchState: readyState(mockThread1) });
+  const b = fetchThreadInfoActions.fetchStateChanged({ fetchState: readyState(mockThread2) });
+  const c = fetchThreadInfoActions.fetchStateChanged({ fetchState: fetchingState(mockThread1) });
+
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+
+  beforeEach(() => {
+    spyOn(wsClientMock, 'send');
+  });
+
+  it('subscribes to each new thread (only once) while the ws is open', done => {
+    testScheduler.run(({ hot }) => {
+      const actionsMock$ = hot('       -a-b-a-a-b-c-|', { a, b, c });
+      const selectWebsocketOpen = hot('1------------|', { 1: true }).pipe(shareReplay(1));
+      selectWebsocketOpen.subscribe(); // to ensure the observable starts immediately
+
+      const storeMock$ = {
+        select: () => selectWebsocketOpen
+      } as unknown as Store;
+
+      threadSubscriptionEffect(actionsMock$, storeMock$, wsClientMock).subscribe({
+        complete: () => {
+          expect(wsClientMock.send).toHaveBeenCalledTimes(4);
+          done();
+        }
+      });
+    });
+
+  });
+
+  it('resubscribes to thread each time the ws reconnects', done => {
+    testScheduler.run(({ hot }) => {
+      const actionsMock$ = hot('       -------a-------|', { a });
+      const selectWebsocketOpen = hot('0-1-0-1-0-1-0-1|', { 1: true , 0: false }).pipe(shareReplay(1));
+      selectWebsocketOpen.subscribe();// to ensure the observable starts immediately
+
+      const storeMock$ = {
+        select: () => selectWebsocketOpen
+      } as unknown as Store;
+
+      threadSubscriptionEffect(actionsMock$, storeMock$, wsClientMock).subscribe({
+        complete: () => {
+          expect(wsClientMock.send).toHaveBeenCalledTimes(3);
+          done();
+        }
+      });
+    });
+
+  });
+
+  it('wait for the ws to connect to subscribe', done => {
+    testScheduler.run(({ hot, cold }) => {
+      const actionsMock$ = hot('        -a-------|', { a });
+      const selectWebsocketOpen = cold('0---1-0-1|', { 1: true , 0: false }).pipe(shareReplay(1));
+
+      const storeMock$ = {
+        select: () => selectWebsocketOpen
+      } as unknown as Store;
+
+      threadSubscriptionEffect(actionsMock$, storeMock$, wsClientMock).subscribe({
+        complete: () => {
+          expect(wsClientMock.send).toHaveBeenCalledTimes(2);
+          done();
+        }
+      });
+    });
+
+  });
+
+});

--- a/src/app/forum/store/index.ts
+++ b/src/app/forum/store/index.ts
@@ -9,14 +9,15 @@ import { getCurrentThreadSelectors } from './current-thread/current-thread.selec
 import { topBarActions, forumThreadListActions, threadPanelActions, itemPageActions } from './current-thread/current-thread.actions';
 import { itemPageEventSyncActions } from './current-thread/event-sync.actions';
 import { getWebsocketSelectors } from './websocket/websocket.selectors';
+import { FunctionalEffect } from '@ngrx/effects';
 
-export const forumEffects = {
+export const forumEffects = (): Record<string, FunctionalEffect> => ({
   ...websocketEffects,
   ...fetchThreadInfoEffects,
   ...syncEffects,
   ...threadSubscriptionEffects,
   ...currentThreadEffects,
-};
+});
 
 const forumFeature = {
   ...createFeature({

--- a/src/main.ts
+++ b/src/main.ts
@@ -128,7 +128,7 @@ bootstrapApplication(AppComponent, {
     },
     provideStore(),
     provideState(forum),
-    provideEffects(forumEffects),
+    provideEffects(forumEffects()),
     provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() }),
     provideAnimations(),
     provideHttpClient(withInterceptorsFromDi()),


### PR DESCRIPTION
## Description

Make sure the app re-subscribe to forum thread when the WS reconnects after a disconnection (computer put to sleep for instance)

## Test cases

Not really/easily testable by scenarios but unit tests have been written.
