### PR TITLE
Fixes resize observer issue

### DIFF
--- a/src/app/containers/left-nav/left-nav.component.html
+++ b/src/app/containers/left-nav/left-nav.component.html
@@ -94,7 +94,7 @@
 
       <div class="alg-flex-1 scroll-wrapper" *ngIf="state.data">
         <div class="scroll-container">
-          <ng-scrollbar>
+          <ng-scrollbar [sensorDebounce]="1">
             <alg-left-nav-tree
               [data]="state.data"
               [elementType]="$any(['activity', 'skill', 'group'][activeTab.index])"


### PR DESCRIPTION
## Description

Fixes resize observer issue

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The problem with `ngx-scrollbar` lib - https://github.com/MurhafSousli/ngx-scrollbar/issues/275

## Test cases

From Safary in Developer tab -> Responsive Iphone 8 and User Agent IOS mode

BEFORE:
- [ ] Case 1:
  1. Given I am the temp user
  2. When I go to [this page](https://dev.algorea.org/en/a/4769434107088212490;p=4702,458602124916982205;pa=0)
  3. Then I see error in console - `ResizeObserver loop completed with undelivered notifications.`

AFTER: 
- [ ] Case 2:
  1. Given I am the temp user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/fix-resize-observer-issue/en/a/4769434107088212490;p=4702,458602124916982205;pa=0)
  3. Then I see no error in console
  4. And I click on open menu -> any item
  5. Then I see no error in console
