### PR TITLE
Adds relative time format into forum messages

### DIFF
--- a/src/app/forum/containers/thread-message/thread-message.component.html
+++ b/src/app/forum/containers/thread-message/thread-message.component.html
@@ -67,5 +67,5 @@
 </div>
 
 <ng-template #sentAt>
-  <span i18n>{{ event.time | date : 'short' }}</span>
+  <span i18n>{{ event.time | relativeTime }}</span>
 </ng-template>

--- a/src/app/forum/containers/thread-message/thread-message.component.ts
+++ b/src/app/forum/containers/thread-message/thread-message.component.ts
@@ -11,6 +11,7 @@ import { NgClass, NgIf, NgTemplateOutlet, DatePipe } from '@angular/common';
 import { BreakLinesPipe } from '../../../pipes/breakLines';
 import { ThreadId } from '../../models/threads';
 import { isAttemptStartedEvent, isSubmissionEvent } from '../../models/thread-events';
+import { RelativeTimePipe } from '../../../pipes/relativeTime';
 
 @Component({
   selector: 'alg-thread-message',
@@ -28,6 +29,7 @@ import { isAttemptStartedEvent, isSubmissionEvent } from '../../models/thread-ev
     RouteUrlPipe,
     AllowDisplayCodeSnippet,
     BreakLinesPipe,
+    RelativeTimePipe,
   ],
 })
 export class ThreadMessageComponent implements OnChanges {

--- a/src/app/pipes/relativeTime.ts
+++ b/src/app/pipes/relativeTime.ts
@@ -38,7 +38,7 @@ const formatTime = (locale?: string) => (value: string | Date): string => {
   return formatter.format(Math.trunc(diffInMS / MONTHS), 'months');
 };
 
-@Pipe({ name: 'relativeTime', standalone: true })
+@Pipe({ name: 'relativeTime', standalone: true, pure: false })
 export class RelativeTimePipe implements PipeTransform {
 
   constructor(private localeService: LocaleService) {


### PR DESCRIPTION
## Description

Fixes #1548

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

For my point as non pure pipe - it makes actual time without any additional timers very well.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/forum-use-relative-time/en/a/6379723280369399253;p=7523720120450464843;a=0)
  3. And I click on open the thread button
  4. Then I type message and click on send button
  5. Then I see new message with "Just now" caption
  6. Then I wait ~1 min
  7. Then I see the caption: "1 minute ago"
