### PR TITLE
fix a bug when a navigation happens immediately (case: an alias at the root)

### DIFF
--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -454,6 +454,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
           map(attemptId => ({ contentType, id, path, parentAttemptId: attemptId, answer }))
         );
       }),
+      delay(0), // for fixing a bug when a navigation happens immediately (case: an alias at the root)
       switchMap(itemRoute => {
         this.itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
         return EMPTY;


### PR DESCRIPTION
## Description

Fix a bug when a navigation happens immediately (case: an alias at the root)


## Test cases

BEFORE:
- [ ] Case 1:
  1. Given I am any user
  2. When I go to [the "home" alias which has no path](https://dev.algorea.org/en/a/home)
  4. Then I see it shows the loader forever

FIXED:
- [ ] Case 2:
  1. Given I am any user
  2. When I go to [the "home" alias which has no path](https://dev.algorea.org/branchen/a/home)
  4. Then I see it shows the loader forever
