### PR TITLE
Use user's locale for tasks

### DIFF
--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -66,6 +66,7 @@ import { NgIf, AsyncPipe, NgClass } from '@angular/common';
 import { Store } from '@ngrx/store';
 import forum from '../forum/store';
 import { isNotNull } from '../utils/null-undefined-predicates';
+import { LocaleService } from '../services/localeService';
 
 const itemBreadcrumbCat = $localize`Items`;
 
@@ -173,12 +174,14 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
   readonly taskConfig$: Observable<TaskConfig|null> = this.state$.pipe(readyData()).pipe(
     switchMap(data => {
       if (!isTask(data.item)) return of(null); // config for non-task's is null
+      const userLocale = this.localeService.currentLang?.tag;
+      if (!userLocale) throw new Error('unexpected: locale not defined');
       return this.initialAnswerDataSource.answer$.pipe(
         catchError(() => EMPTY), // error is handled by initialAnswerDataSource.error$
         map(initialAnswer => ({
           readOnly: !!data.route.answer && !data.route.answer.loadAsCurrent,
           initialAnswer,
-          locale: data.item.string.languageTag
+          locale: userLocale, // should use task locale if there is a way for the user to select it
         }))
       );
     })
@@ -356,6 +359,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     private layoutService: LayoutService,
     private currentContentService: CurrentContentService,
     private tabService: TabService,
+    private localeService: LocaleService,
   ) {}
 
   ngOnDestroy(): void {


### PR DESCRIPTION
## Description

Use user's locale for task instead of task locale. Otherwise, we are stuck with the task locale that users cannot currently change.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this task with English platform](https://dev.algorea.org/branch/fix-use-user-local-for-tasks/en/a/3371890559947583477;p=7528142386663912287,7523720120450464843;pa=0/edit-children)
  3. (and I possibly validate the change of language)
  4. Then I see the controls of the task are in English
 
- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this task with French platform](https://dev.algorea.org/branch/fix-use-user-local-for-tasks/fr/a/3371890559947583477;p=7528142386663912287,7523720120450464843;pa=0/edit-children)
  3. (and I possibly validate the change of language)
  4. Then I see the controls of the task are in French

