### PR TITLE
Changes align for empty message

### DIFF
--- a/src/app/items/containers/item-children-list/item-children-list.component.html
+++ b/src/app/items/containers/item-children-list/item-children-list.component.html
@@ -66,5 +66,5 @@
 </ul>
 
 <ng-template #noChildrenSection>
-  <p *ngIf="emptyMessage">{{ emptyMessage }}</p>
+  <p class="empty-message" *ngIf="emptyMessage">{{ emptyMessage }}</p>
 </ng-template>

--- a/src/app/items/containers/item-children-list/item-children-list.component.scss
+++ b/src/app/items/containers/item-children-list/item-children-list.component.scss
@@ -93,3 +93,7 @@
   color: var(--alg-primary-color);
   font-size: toRem(24);
 }
+
+.empty-message {
+  text-align: center;
+}

--- a/src/app/items/containers/item-children-list/item-children-list.component.scss
+++ b/src/app/items/containers/item-children-list/item-children-list.component.scss
@@ -95,5 +95,6 @@
 }
 
 .empty-message {
-  text-align: center;
+  text-align: left;
+  margin-left: toRem(16);
 }


### PR DESCRIPTION
## Description

Fixes #1569

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/item-list-empty-message/en/s/3000;p=;a=0)
  3. Then I see empty message aligned by center
