### PR TITLE
User-related reorganization

### DIFF
--- a/src/app/containers/observation-bar/observation-bar.component.html
+++ b/src/app/containers/observation-bar/observation-bar.component.html
@@ -8,7 +8,7 @@
       tooltipStyleClass="alg-tooltip observation-mode"
     ></i>
     <ng-template #observationModeTooltip>
-      <span *ngIf="observedGroup.route.isUser; else groupName" i18n>
+      <span *ngIf="(observedGroup.route | isUser); else groupName" i18n>
         Only the content visible by the user you are observing ({{ observedGroup.name }}) is shown.
       </span>
       <ng-template #groupName>

--- a/src/app/containers/observation-bar/observation-bar.component.ts
+++ b/src/app/containers/observation-bar/observation-bar.component.ts
@@ -6,13 +6,14 @@ import { TooltipModule } from 'primeng/tooltip';
 import { NgIf, NgClass, AsyncPipe } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store';
+import { GroupIsUserPipe } from 'src/app/pipes/groupIsUser';
 
 @Component({
   selector: 'alg-observation-bar',
   templateUrl: './observation-bar.component.html',
   styleUrls: [ './observation-bar.component.scss' ],
   standalone: true,
-  imports: [ NgIf, NgClass, TooltipModule, RouterLink, ButtonModule, AsyncPipe, GroupLinkPipe ]
+  imports: [ NgIf, NgClass, TooltipModule, RouterLink, ButtonModule, AsyncPipe, GroupLinkPipe, GroupIsUserPipe ]
 })
 export class ObservationBarComponent {
   @Output() cancel = new EventEmitter<void>();

--- a/src/app/containers/suggestion-of-activities/suggestion-of-activities.component.html
+++ b/src/app/containers/suggestion-of-activities/suggestion-of-activities.component.html
@@ -15,7 +15,7 @@
   <div class="empty-list" *ngIf="state.isReady && state.data.length === 0" i18n>
     There are no activities linked to this
     <ng-container *ngIf="observedGroupRoute$ | async as observedGroupRoute">
-      {{ observedGroupRoute.isUser.toString() | i18nSelect: { true: 'user', other: 'group' } }}.
+      {{ (observedGroupRoute | isUser).toString() | i18nSelect: { true: 'user', other: 'group' } }}.
     </ng-container>
   </div>
   <ul class="list" *ngIf="state.isReady && state.data.length > 0">

--- a/src/app/containers/suggestion-of-activities/suggestion-of-activities.component.ts
+++ b/src/app/containers/suggestion-of-activities/suggestion-of-activities.component.ts
@@ -13,6 +13,7 @@ import { LoadingComponent } from '../../ui-components/loading/loading.component'
 import { NgIf, AsyncPipe, NgFor, I18nSelectPipe } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store';
+import { GroupIsUserPipe } from 'src/app/pipes/groupIsUser';
 
 @Component({
   selector: 'alg-suggestion-of-activities',
@@ -30,6 +31,7 @@ import { fromObservation } from 'src/app/store';
     RouteUrlPipe,
     NgFor,
     I18nSelectPipe,
+    GroupIsUserPipe,
   ],
 })
 export class SuggestionOfActivitiesComponent implements OnDestroy {

--- a/src/app/data-access/get-user-by-login.service.ts
+++ b/src/app/data-access/get-user-by-login.service.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs';
 import { appConfig } from '../utils/config';
 import { decodeSnakeCase } from '../utils/operators/decode';
 import { HttpClient } from '@angular/common/http';
-import { User, userDecoder } from '../groups/data-access/get-user.service';
+import { User, userDecoder } from '../groups/models/user';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/groups/containers/user-header/user-header.component.ts
+++ b/src/app/groups/containers/user-header/user-header.component.ts
@@ -1,5 +1,5 @@
 import { Input, Component } from '@angular/core';
-import { User } from '../../data-access/get-user.service';
+import { User } from '../../models/user';
 import { map } from 'rxjs/operators';
 import { RawGroupRoute } from 'src/app/models/routing/group-route';
 import { UserCaptionPipe } from 'src/app/pipes/userCaption';

--- a/src/app/groups/containers/user-indicator/user-indicator.component.ts
+++ b/src/app/groups/containers/user-indicator/user-indicator.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { User } from '../../data-access/get-user.service';
+import { User } from '../../models/user';
 import { GroupLinksComponent } from '../group-links/group-links.component';
 import { NgIf } from '@angular/common';
 

--- a/src/app/groups/data-access/get-user.service.ts
+++ b/src/app/groups/data-access/get-user.service.ts
@@ -2,34 +2,8 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { appConfig } from '../../utils/config';
-import { pipe } from 'fp-ts/function';
-import * as D from 'io-ts/Decoder';
 import { decodeSnakeCase } from '../../utils/operators/decode';
-
-export const userDecoder = pipe(
-  D.struct({
-    groupId: D.string,
-    login: D.string,
-    tempUser: D.boolean,
-    webSite: D.nullable(D.string),
-    freeText: D.nullable(D.string),
-    isCurrentUser: D.boolean,
-    ancestorsCurrentUserIsManagerOf: D.array(D.struct({
-      id: D.string,
-      name: D.string,
-    })),
-  }),
-  D.intersect(
-    D.partial({
-      firstName: D.nullable(D.string),
-      lastName: D.nullable(D.string),
-      currentUserCanWatchUser: D.boolean,
-      currentUserCanGrantUserAccess: D.boolean,
-    }),
-  ),
-);
-
-export type User = D.TypeOf<typeof userDecoder>;
+import { User, userDecoder } from '../models/user';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/groups/models/user.ts
+++ b/src/app/groups/models/user.ts
@@ -1,0 +1,27 @@
+import { pipe } from 'fp-ts/function';
+import * as D from 'io-ts/Decoder';
+
+export const userDecoder = pipe(
+  D.struct({
+    groupId: D.string,
+    login: D.string,
+    tempUser: D.boolean,
+    webSite: D.nullable(D.string),
+    freeText: D.nullable(D.string),
+    isCurrentUser: D.boolean,
+    ancestorsCurrentUserIsManagerOf: D.array(D.struct({
+      id: D.string,
+      name: D.string,
+    })),
+  }),
+  D.intersect(
+    D.partial({
+      firstName: D.nullable(D.string),
+      lastName: D.nullable(D.string),
+      currentUserCanWatchUser: D.boolean,
+      currentUserCanGrantUserAccess: D.boolean,
+    }),
+  ),
+);
+
+export type User = D.TypeOf<typeof userDecoder>;

--- a/src/app/items/containers/item-log-view/item-log-view.component.ts
+++ b/src/app/items/containers/item-log-view/item-log-view.component.ts
@@ -26,7 +26,7 @@ import { NgIf, NgFor, NgSwitch, NgSwitchCase, NgClass, NgSwitchDefault, AsyncPip
 import { RelativeTimeComponent } from '../../../ui-components/relative-time/relative-time.component';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store';
-import { RawGroupRoute } from 'src/app/models/routing/group-route';
+import { RawGroupRoute, isUser } from 'src/app/models/routing/group-route';
 interface Column {
   field: string,
   header: string,
@@ -182,7 +182,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
       {
         field: 'item.user',
         header: $localize`User`,
-        enabled: observedGroupRoute && !observedGroupRoute.isUser,
+        enabled: observedGroupRoute && !isUser(observedGroupRoute),
       },
       {
         field: 'at',

--- a/src/app/items/containers/item-permissions/item-permissions.component.html
+++ b/src/app/items/containers/item-permissions/item-permissions.component.html
@@ -30,14 +30,14 @@
       <div class="content">
         <ng-container *ngIf="watchedGroupPermissions; else noPermissionToWatchContent">
           <div class="no-access" *ngIf="!(watchedGroupPermissions | allowsViewingInfo)" i18n>
-            The {{ observedGroup.route.isUser.toString() | i18nSelect : {
+            The {{ (observedGroup.route | isUser).toString() | i18nSelect : {
               true: 'user',
               other: 'group'
             } }} cannot currently view this content.
           </div>
 
           <div class="no-access" *ngIf="(watchedGroupPermissions | allowsViewingInfo) && !(watchedGroupPermissions | allowsViewingContent)" i18n>
-            The {{ observedGroup.route.isUser.toString() | i18nSelect : {
+            The {{ (observedGroup.route | isUser).toString() | i18nSelect : {
               true: 'user',
               other: 'group'
             } }}
@@ -80,7 +80,7 @@
         </ng-container>
       </div>
       <div class="footer">
-        <div class="footer-caption" *ngIf="!observedGroup.route.isUser" i18n>
+        <div class="footer-caption" *ngIf="!(observedGroup.route | isUser)" i18n>
           Note that some subgroups or users of the groups may have higher permissions.
         </div>
         <ng-container *ngIf="itemData?.item?.permissions">

--- a/src/app/items/containers/item-permissions/item-permissions.component.ts
+++ b/src/app/items/containers/item-permissions/item-permissions.component.ts
@@ -15,6 +15,7 @@ import { SectionHeaderComponent } from 'src/app/ui-components/section-header/sec
 import { SectionParagraphComponent } from 'src/app/ui-components/section-paragraph/section-paragraph.component';
 import { NgIf, I18nSelectPipe, NgClass } from '@angular/common';
 import { RawGroupRoute } from 'src/app/models/routing/group-route';
+import { GroupIsUserPipe } from 'src/app/pipes/groupIsUser';
 
 @Component({
   selector: 'alg-item-permissions',
@@ -34,6 +35,7 @@ import { RawGroupRoute } from 'src/app/models/routing/group-route';
     AllowsViewingItemContentPipe,
     AllowsViewingItemInfoPipe,
     NgClass,
+    GroupIsUserPipe,
   ],
 })
 export class ItemPermissionsComponent implements OnChanges {

--- a/src/app/items/containers/permissions-edit-dialog/permissions-edit-dialog.component.html
+++ b/src/app/items/containers/permissions-edit-dialog/permissions-edit-dialog.component.html
@@ -19,7 +19,7 @@
 
   <alg-error
     i18n-message message="User permissions cannot be changed via this page for the moment"
-    *ngIf="group.isUser && !sourceGroup; else stateBlock"
+    *ngIf="(group | isUser) && !sourceGroup; else stateBlock"
   ></alg-error>
 
   <ng-template #stateBlock>
@@ -36,7 +36,7 @@
           <ng-container *ngIf="item.string.title">
             <p class="dialog-description" i18n>
               These are the permissions given by "{{ permReceiverName }}" to "{{ item.string.title }}"
-              <ng-container *ngIf="group.isUser && permGiverName">on "{{ permGiverName }}"</ng-container>
+              <ng-container *ngIf="(group | isUser) && permGiverName">on "{{ permGiverName }}"</ng-container>
             </p>
           </ng-container>
 

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -67,6 +67,7 @@ import { fromForum } from '../forum/store';
 import { isNotNull } from '../utils/null-undefined-predicates';
 import { LocaleService } from '../services/localeService';
 import { fromObservation } from '../store';
+import { isUser } from '../models/routing/group-route';
 
 const itemBreadcrumbCat = $localize`Items`;
 
@@ -328,7 +329,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       map(([ state, userProfile, observedGroupRoute ]) => {
         if (userProfile.tempUser) return null;
         if (!state.data || !isATask(state.data.item)) return null;
-        if (observedGroupRoute && (!allowsWatchingAnswers(state.data.item.permissions) || !observedGroupRoute.isUser)) return null;
+        if (observedGroupRoute && (!allowsWatchingAnswers(state.data.item.permissions) || !isUser(observedGroupRoute))) return null;
         if (!observedGroupRoute && !state.data.item.permissions.canRequestHelp) return null;
         return { participantId: observedGroupRoute ? observedGroupRoute.id : userProfile.groupId, itemId: state.data.item.id };
       }),

--- a/src/app/models/group-types.ts
+++ b/src/app/models/group-types.ts
@@ -1,4 +1,6 @@
 
+export type GroupTypeCategory = 'group'|'user';
+
 export function isGroupTypeVisible(type: string): boolean {
   return type !== 'Base' && type !== 'ContestParticipants';
 }

--- a/src/app/models/routing/group-route.ts
+++ b/src/app/models/routing/group-route.ts
@@ -30,7 +30,7 @@ export function isUser(group: GroupLike): boolean {
 }
 
 function contentType(group: GroupLike): GroupTypeCategory {
-  return isUser(group) ? 'group' : 'user';
+  return isUser(group) ? 'user' : 'group';
 }
 
 export function rawGroupRoute(group: GroupLike): RawGroupRoute {

--- a/src/app/models/routing/group-route.ts
+++ b/src/app/models/routing/group-route.ts
@@ -3,10 +3,10 @@ import { Group } from 'src/app/groups/data-access/get-group-by-id.service';
 import { User } from 'src/app/groups/models/user';
 import { UrlCommand } from '../../utils/url';
 import { ContentRoute, pathAsParameter, pathFromRouterParameters } from './content-route';
+import { GroupTypeCategory } from '../group-types';
 
 export interface GroupRoute extends ContentRoute {
-  contentType: 'group',
-  isUser: boolean,
+  contentType: GroupTypeCategory,
 }
 export type RawGroupRoute = Omit<GroupRoute, 'path'> & Partial<Pick<ContentRoute, 'path'>>;
 
@@ -16,19 +16,26 @@ export interface GroupRouteError {
   id?: string,
 }
 
-
 export type GroupLike =
+  | { id: Group['id'], contentType: GroupTypeCategory }
   | { id: Group['id'], isUser: boolean }
   | { id: Group['id'], type: string }
   | Pick<User, 'groupId' | 'login'>;
 
-function isUser(group: GroupLike): boolean {
-  return ('isUser' in group && group.isUser) || ('login' in group && !!group.login) || ('type' in group && group.type === 'User');
+export function isUser(group: GroupLike): boolean {
+  return ('contentType' in group && group.contentType === 'user') ||
+    ('isUser' in group && group.isUser) ||
+    ('login' in group && !!group.login) ||
+    ('type' in group && group.type === 'User');
+}
+
+function contentType(group: GroupLike): GroupTypeCategory {
+  return isUser(group) ? 'group' : 'user';
 }
 
 export function rawGroupRoute(group: GroupLike): RawGroupRoute {
   const groupId = 'id' in group ? group.id : group.groupId;
-  return { contentType: 'group', id: groupId, isUser: isUser(group) };
+  return { contentType: contentType(group), id: groupId };
 }
 
 export function groupRoute(group: GroupLike, path: string[]): GroupRoute {
@@ -36,11 +43,13 @@ export function groupRoute(group: GroupLike, path: string[]): GroupRoute {
 }
 
 export function isGroupRoute(route: ContentRoute | RawGroupRoute): route is GroupRoute {
-  return route.contentType === 'group' && route.path !== undefined;
+  return (route.contentType === 'group' || route.contentType === 'user') && route.path !== undefined;
 }
 
 export function isRawGroupRoute(route?: unknown): route is RawGroupRoute {
-  return typeof route === 'object' && (route as Record<string, unknown> | null)?.contentType === 'group';
+  if (typeof route !== 'object') return false;
+  const contentType = (route as Record<string, unknown> | null)?.contentType;
+  return contentType === 'group' || contentType === 'user';
 }
 
 /**
@@ -51,8 +60,8 @@ export function urlArrayForGroupRoute(
   page?: string[],
 ): UrlCommand {
   const path = route.path ? pathAsParameter(route.path) : {};
-  const actualPage = page && ((route.isUser && isUserPage(page)) || (!route.isUser && isGroupPage(page))) ? page : [];
-  return [ '/', 'groups', route.isUser ? 'users' : 'by-id', route.id, path, ...actualPage ];
+  const actualPage = page && ((isUser(route) && isUserPage(page)) || (!isUser(route) && isGroupPage(page))) ? page : [];
+  return [ '/', 'groups', isUser(route) ? 'users' : 'by-id', route.id, path, ...actualPage ];
 }
 
 function isUserPage(page: string[]): boolean {

--- a/src/app/models/routing/group-route.ts
+++ b/src/app/models/routing/group-route.ts
@@ -1,6 +1,6 @@
 import { ParamMap } from '@angular/router';
 import { Group } from 'src/app/groups/data-access/get-group-by-id.service';
-import { User } from 'src/app/groups/data-access/get-user.service';
+import { User } from 'src/app/groups/models/user';
 import { UrlCommand } from '../../utils/url';
 import { ContentRoute, pathAsParameter, pathFromRouterParameters } from './content-route';
 

--- a/src/app/pipes/groupIsUser.ts
+++ b/src/app/pipes/groupIsUser.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { GroupLike, isUser } from '../models/routing/group-route';
+
+@Pipe({
+  name: 'isUser', pure: true,
+  standalone: true
+})
+export class GroupIsUserPipe implements PipeTransform {
+
+  transform(groupOrRoute: GroupLike): boolean {
+    return isUser(groupOrRoute);
+  }
+}

--- a/src/app/services/navigation/group-nav-tree.service.ts
+++ b/src/app/services/navigation/group-nav-tree.service.ts
@@ -4,7 +4,7 @@ import { map } from 'rxjs/operators';
 import { ContentInfo } from 'src/app/models/content/content-info';
 import { groupInfo, GroupInfo, isGroupInfo } from 'src/app/models/content/group-info';
 import { ContentRoute } from 'src/app/models/routing/content-route';
-import { groupRoute, isGroupRoute } from 'src/app/models/routing/group-route';
+import { groupRoute, isGroupRoute, isUser } from 'src/app/models/routing/group-route';
 import { GroupRouter } from 'src/app/models/routing/group-router';
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { GroupNavigationService, GroupNavigationChild, GroupNavigationData } from '../../data-access/group-navigation.service';
@@ -30,7 +30,7 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
   }
 
   canFetchChildren(content: GroupInfo): boolean {
-    return !content.route.isUser;
+    return !isUser(content.route);
   }
 
   fetchNavData(route: ContentRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {

--- a/src/app/store/observation/observation.effects.ts
+++ b/src/app/store/observation/observation.effects.ts
@@ -10,6 +10,7 @@ import { GetUserService } from 'src/app/groups/data-access/get-user.service';
 import { GetGroupByIdService } from 'src/app/groups/data-access/get-group-by-id.service';
 import { mapToFetchState } from 'src/app/utils/operators/state';
 import { cannotWatchError } from './utils/errors';
+import { isUser } from 'src/app/models/routing/group-route';
 
 /**
  * If the router has a observed group set (possibly 'none') AND it is different from the current one in the store, emit an
@@ -34,7 +35,7 @@ export const observationGroupFetching = createEffect(
     groupService = inject(GetGroupByIdService),
   ) => actions$.pipe(
     ofType(routerActions.enableObservation),
-    switchMap(({ route }) => (route.isUser ? fetchUser(userService, route.id) : fetchGroup(groupService, route.id)).pipe(
+    switchMap(({ route }) => (isUser(route) ? fetchUser(userService, route.id) : fetchGroup(groupService, route.id)).pipe(
       mapToFetchState(),
       map(fetchState => groupInfoFetchedActions.fetchStateChanged({ route, fetchState }))
     )),


### PR DESCRIPTION
## Description
 
Reorganization of the code around users (in preparation for other PRs):
- move user model to a proper file
- move user/non-user distinction in group content type as it is done for activity/skill distinction for items (no change to routes so far)

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [my user page](https://dev.algorea.org/branch/user-reorg/en/groups/users/670968966872011405;p=117532200658920233)
  4. Then I see it works as usual
  5. And I can select a group in the left menu (which navigates to a group page)

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [a group page](https://dev.algorea.org/branch/user-reorg/en/groups/by-id/672913018859223173;p=52767158366271444)
  4. Then I see it works as usual
  6. And if I start observation
  7. It works as expected

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [another user  page](https://dev.algorea.org/branch/user-reorg/en/groups/users/752024252804317630;p=5121055722873780306,6710944276987033666)
  4. Then I see it works as usual
  5. And if I start observation
  6. It works as expected
