### PR TITLE
Move user content fetching into store

### DIFF
--- a/src/app/groups/containers/user/user.component.html
+++ b/src/app/groups/containers/user/user.component.html
@@ -14,15 +14,15 @@
 
   <ng-container *ngIf="state.isReady">
 
-    <alg-user-header [user]="state.data.user" [route]="state.data.route"></alg-user-header>
+    <alg-user-header *ngIf="userRoute$ | async as route" [user]="state.data" [route]="route" ></alg-user-header>
 
     <alg-user-indicator
       class="user-indicator"
-      [user]="state.data.user"
-      *ngIf="!state.data.user.isCurrentUser && state.data.user.ancestorsCurrentUserIsManagerOf.length > 0"
+      [user]="state.data"
+      *ngIf="!state.data.isCurrentUser && state.data.ancestorsCurrentUserIsManagerOf.length > 0"
     ></alg-user-indicator>
 
-    <nav class="alg-nav-tab" *ngIf="(currentUserGroupId$ | async) === state.data.user.groupId || (activeRoute$ | async) === 'personal-data' || (activeRoute$ | async) === 'settings'">
+    <nav class="alg-nav-tab" *ngIf="(currentUserGroupId$ | async) === state.data.groupId || (activeRoute$ | async) === 'personal-data' || (activeRoute$ | async) === 'settings'">
       <a
           class="alg-nav-tab-item"
           [routerLink]="'./'"
@@ -40,7 +40,7 @@
           [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
           [class.active]="personalData.isActive"
           i18n
-          [hidden]="(currentUserGroupId$ | async) !== state.data.user.groupId && (activeRoute$ | async) !== 'personal-data'"
+          [hidden]="(currentUserGroupId$ | async) !== state.data.groupId && (activeRoute$ | async) !== 'personal-data'"
       >
         Personal data
       </a>
@@ -51,7 +51,7 @@
           [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
           [class.active]="settings.isActive"
           i18n
-          [hidden]="(currentUserGroupId$ | async) !== state.data.user.groupId && (activeRoute$ | async) !== 'settings'"
+          [hidden]="(currentUserGroupId$ | async) !== state.data.groupId && (activeRoute$ | async) !== 'settings'"
       >
         Settings
       </a>
@@ -61,20 +61,20 @@
       <ng-container *ngIf="activeRoute === 'progress'">
         <ng-container *ngIf="currentUserGroupId$ | async as currentUserGroupId">
           <alg-group-log-view
-            [groupId]="currentUserGroupId !== state.data.user.groupId ? state.data.user.groupId : undefined"
+            [groupId]="currentUserGroupId !== state.data.groupId ? state.data.groupId : undefined"
             [showUserColumn]="false"
           ></alg-group-log-view>
         </ng-container>
       </ng-container>
 
       <ng-container *ngIf="activeRoute === 'personal-data'">
-        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.user.groupId; else forbidden">
+        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.groupId; else forbidden">
           <alg-current-user></alg-current-user>
         </ng-container>
       </ng-container>
 
       <ng-container *ngIf="activeRoute === 'settings'">
-        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.user.groupId; else forbidden">
+        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.groupId; else forbidden">
           <alg-platform-settings></alg-platform-settings>
         </ng-container>
       </ng-container>

--- a/src/app/groups/containers/user/user.component.ts
+++ b/src/app/groups/containers/user/user.component.ts
@@ -1,15 +1,13 @@
-import { Component, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { GetUserService } from '../../data-access/get-user.service';
-import { mapToFetchState } from 'src/app/utils/operators/state';
-import { combineLatest, Observable, of, Subject, Subscription } from 'rxjs';
-import { ActivatedRoute, NavigationEnd, Router, RouterLinkActive, RouterLink } from '@angular/router';
-import { catchError, delay, switchMap, map, startWith, filter, shareReplay, distinctUntilChanged, takeUntil } from 'rxjs/operators';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { combineLatest, Observable, of, Subscription } from 'rxjs';
+import { NavigationEnd, Router, RouterLinkActive, RouterLink } from '@angular/router';
+import { catchError, delay, switchMap, map, startWith, filter, distinctUntilChanged } from 'rxjs/operators';
 import { contentInfo } from 'src/app/models/content/content-info';
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { UserSessionService } from 'src/app/services/user-session.service';
 import { formatUser } from 'src/app/models/user';
 import { GetGroupBreadcrumbsService } from '../../data-access/get-group-breadcrumbs.service';
-import { groupRoute, groupRouteFromParams, isGroupRoute, rawGroupRoute } from 'src/app/models/routing/group-route';
+import { isGroupRoute } from 'src/app/models/routing/group-route';
 import { GroupRouter } from 'src/app/models/routing/group-router';
 import { PlatformSettingsComponent } from '../platform-settings/platform-settings.component';
 import { CurrentUserComponent } from '../current-user/current-user.component';
@@ -20,6 +18,9 @@ import { UserHeaderComponent } from '../user-header/user-header.component';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
 import { NgIf, AsyncPipe } from '@angular/common';
+import { Store } from '@ngrx/store';
+import { fromUserContent } from '../../store';
+import { isNotNull } from 'src/app/utils/null-undefined-predicates';
 
 const breadcrumbHeader = $localize`Users`;
 
@@ -44,26 +45,8 @@ const breadcrumbHeader = $localize`Users`;
   ],
 })
 export class UserComponent implements OnInit, OnDestroy {
-  @ViewChild('progress') progress?: RouterLinkActive;
-  @ViewChild('personalData') personalData?: RouterLinkActive;
-
-  private destroyed$ = new Subject<void>();
-  private refresh$ = new Subject<void>();
-  private readonly userRoute$ = this.route.paramMap.pipe(
-    map(params => {
-      const { id, path } = groupRouteFromParams(params);
-      if (!id) throw new Error('expected user id is user page path');
-      const group = { id, isUser: true };
-      return path ? groupRoute(group, path) : rawGroupRoute(group);
-    })
-  );
-
-  readonly state$ = this.userRoute$.pipe(
-    switchMap(route => this.getUserService.getForId(route.id).pipe(map(user => ({ route: route, user: user })))),
-    mapToFetchState({ resetter: this.refresh$ }),
-    takeUntil(this.destroyed$),
-    shareReplay(1),
-  );
+  userRoute$ = this.store.select(fromUserContent.selectActiveContentUserRoute).pipe(filter(isNotNull));
+  state$ = this.store.select(fromUserContent.selectUser).pipe(filter(isNotNull));
 
   readonly currentUserGroupId$ = this.userSessionService.userProfile$.pipe(
     delay(0),
@@ -87,9 +70,8 @@ export class UserComponent implements OnInit, OnDestroy {
   private subscription?: Subscription;
 
   constructor(
-    private route: ActivatedRoute,
+    private store: Store,
     private router: Router,
-    private getUserService: GetUserService,
     private userSessionService: UserSessionService,
     private currentContent: CurrentContentService,
     private groupRouter: GroupRouter,
@@ -105,12 +87,12 @@ export class UserComponent implements OnInit, OnDestroy {
     ])
       .pipe(
         map(([ currentUserRoute, currentPageTitle, state, breadcrumbs ]) => contentInfo({
-          title: state.isReady ? formatUser(state.data.user) : undefined,
+          title: state.isReady ? formatUser(state.data) : undefined,
           breadcrumbs: {
             category: breadcrumbHeader,
             path: state.isReady ? [
               ...(breadcrumbs?.slice(0,-1) ?? []).map(b => ({ title: b.name, navigateTo: this.groupRouter.url(b.route) })),
-              { title: formatUser(state.data.user), navigateTo: this.groupRouter.url(currentUserRoute) },
+              { title: formatUser(state.data), navigateTo: this.groupRouter.url(currentUserRoute) },
               { title: currentPageTitle }
             ] : [],
             currentPageIdx: breadcrumbs ? breadcrumbs.length : 1,
@@ -125,13 +107,10 @@ export class UserComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.currentContent.clear();
     this.subscription?.unsubscribe();
-    this.refresh$.complete();
-    this.destroyed$.next();
-    this.destroyed$.complete();
   }
 
   refresh(): void {
-    this.refresh$.next();
+    this.store.dispatch(fromUserContent.userPageActions.refresh());
   }
 
   /**

--- a/src/app/groups/store/index.ts
+++ b/src/app/groups/store/index.ts
@@ -1,0 +1,8 @@
+import { FunctionalEffect } from '@ngrx/effects';
+import * as userContentEffects from './user-content/user-content.effects';
+
+export const groupStoreEffects = (): Record<string, FunctionalEffect> => ({
+  ...userContentEffects,
+});
+
+export { fromUserContent } from './user-content/user-content.store';

--- a/src/app/groups/store/user-content/user-content.actions.ts
+++ b/src/app/groups/store/user-content/user-content.actions.ts
@@ -1,0 +1,17 @@
+import { createActionGroup, emptyProps, props } from '@ngrx/store';
+import { User } from 'src/app/groups/models/user';
+import { FetchState } from 'src/app/utils/state';
+
+export const userInfoFetchedActions = createActionGroup({
+  source: 'User API',
+  events: {
+    fetchStateChanged: props<{ fetchState: FetchState<User> }>(),
+  },
+});
+
+export const userPageActions = createActionGroup({
+  source: 'User Page',
+  events: {
+    refresh: emptyProps(),
+  },
+});

--- a/src/app/groups/store/user-content/user-content.effects.ts
+++ b/src/app/groups/store/user-content/user-content.effects.ts
@@ -1,0 +1,22 @@
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { inject } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { filter, map, switchMap } from 'rxjs';
+import { selectActiveContentUserId } from './user-content.selectors';
+import { GetUserService } from '../../data-access/get-user.service';
+import { mapToFetchState } from 'src/app/utils/operators/state';
+import { userInfoFetchedActions, userPageActions } from './user-content.actions';
+import { isNotNull } from 'src/app/utils/null-undefined-predicates';
+
+export const fetchUserInfoEffect = createEffect(
+  (
+    store$ = inject(Store),
+    actions$ = inject(Actions),
+    userService = inject(GetUserService)
+  ) => store$.select(selectActiveContentUserId).pipe(
+    filter(isNotNull),
+    switchMap(id => userService.getForId(id).pipe(mapToFetchState({ resetter: actions$.pipe(ofType(userPageActions.refresh)) }))),
+    map(fetchState => userInfoFetchedActions.fetchStateChanged({ fetchState }))
+  ),
+  { functional: true }
+);

--- a/src/app/groups/store/user-content/user-content.reducer.ts
+++ b/src/app/groups/store/user-content/user-content.reducer.ts
@@ -1,0 +1,13 @@
+import { createReducer, on } from '@ngrx/store';
+import { State, initialState } from './user-content.state';
+import { userInfoFetchedActions } from './user-content.actions';
+
+export const reducer = createReducer(
+  initialState,
+
+  on(
+    userInfoFetchedActions.fetchStateChanged,
+    (state, { fetchState }): State => ({ ...state, user: fetchState })
+  ),
+
+);

--- a/src/app/groups/store/user-content/user-content.selectors.ts
+++ b/src/app/groups/store/user-content/user-content.selectors.ts
@@ -1,0 +1,27 @@
+import { createSelector } from '@ngrx/store';
+import { pathFromParamValue } from 'src/app/models/routing/content-route';
+import { contentTypeOfPath, groupRoute, rawGroupRoute } from 'src/app/models/routing/group-route';
+import { fromRouter } from 'src/app/store';
+
+export const selectIsUserContentActive = createSelector(
+  fromRouter.selectPath,
+  path => !!path && contentTypeOfPath(path) === 'user'
+);
+
+export const selectActiveContentUserId = createSelector(
+  selectIsUserContentActive,
+  fromRouter.selectParam('id'),
+  (isActive, id) => (isActive && id ? id : null)
+);
+
+const selectActiveContentUserPath = createSelector(
+  selectIsUserContentActive,
+  fromRouter.selectParam('path'),
+  (isActive, path) => (isActive && path ? pathFromParamValue(path) : null)
+);
+
+export const selectActiveContentUserRoute = createSelector(
+  selectActiveContentUserId,
+  selectActiveContentUserPath,
+  (id, path) => (id ? (path ? groupRoute({ id, isUser: true }, path) : rawGroupRoute({ id, isUser: true })) : null)
+);

--- a/src/app/groups/store/user-content/user-content.state.ts
+++ b/src/app/groups/store/user-content/user-content.state.ts
@@ -1,0 +1,12 @@
+import { FetchState } from 'src/app/utils/state';
+import { User } from '../../models/user';
+
+export interface GroupInfo { name: string, currentUserCanGrantAccess: boolean }
+
+export interface State {
+  user: FetchState<User> | null,
+}
+
+export const initialState: State = {
+  user: null,
+};

--- a/src/app/groups/store/user-content/user-content.store.ts
+++ b/src/app/groups/store/user-content/user-content.store.ts
@@ -1,0 +1,13 @@
+import { createFeature } from '@ngrx/store';
+import { reducer } from './user-content.reducer';
+import * as actions from './user-content.actions';
+import * as selectors from './user-content.selectors';
+
+export const fromUserContent = {
+  ...createFeature({
+    name: 'user-content',
+    reducer,
+    extraSelectors: () => selectors
+  }),
+  ...actions
+};

--- a/src/app/models/routing/content-route.ts
+++ b/src/app/models/routing/content-route.ts
@@ -15,7 +15,11 @@ export interface ContentRoute {
 export function pathFromRouterParameters(params: ParamMap): string[]|null {
   const pathAsString = params.get(pathParamName);
   if (pathAsString === null) return null;
-  return pathAsString === '' ? [] : pathAsString.split(',');
+  return pathFromParamValue(pathAsString);
+}
+
+export function pathFromParamValue(path: string): string[] {
+  return path === '' ? [] : path.split(',');
 }
 
 export function pathAsParameter(value: string[]): UrlCommandParameters {

--- a/src/app/models/routing/group-route.ts
+++ b/src/app/models/routing/group-route.ts
@@ -33,6 +33,11 @@ function contentType(group: GroupLike): GroupTypeCategory {
   return isUser(group) ? 'user' : 'group';
 }
 
+export function contentTypeOfPath(path: string[]): GroupTypeCategory | undefined {
+  if (path[0] !== 'groups') return undefined;
+  return path[1] === 'users' ? 'user' : 'group';
+}
+
 export function rawGroupRoute(group: GroupLike): RawGroupRoute {
   const groupId = 'id' in group ? group.id : group.groupId;
   return { contentType: contentType(group), id: groupId };

--- a/src/app/store/router/router-serializer.ts
+++ b/src/app/store/router/router-serializer.ts
@@ -11,6 +11,18 @@ export class RouterSerializer implements RouterStateSerializer<State> {
       url,
       root: { queryParams },
     } = routerState;
-    return { url, queryParams };
+
+    // extract all params in the router state
+    let params = {};
+    let route = routerState.root;
+    while (route.firstChild) {
+      route = route.firstChild;
+      params = { ...params, ...route.params };
+    }
+
+    // extract path segments as string[]
+    const path = route.pathFromRoot.flatMap(({ url }) => url).map(({ path }) => path);
+
+    return { url, path, params, queryParams };
   }
 }

--- a/src/app/store/router/router.selectors.ts
+++ b/src/app/store/router/router.selectors.ts
@@ -9,6 +9,8 @@ interface Selectors<T> {
   selectState: MemoizedSelector<T, State | undefined>,
   selectNavigationId: MemoizedSelector<T, RouterReducerState['navigationId'] | undefined>,
   /** extra ones */
+  selectPath: MemoizedSelector<T, string[] | undefined>,
+  selectParam: (param: string) => MemoizedSelector<T, string | null>,
   selectQueryParam: (param: string) => MemoizedSelector<T, string | null>,
 }
 
@@ -27,7 +29,23 @@ export function selectors<T>(baseSelectRouterState: Selector<T, RouterReducerSta
     routerState => routerState?.navigationId
   );
 
+  const selectPath = createSelector(
+    selectState,
+    state => state?.path
+  );
+
   const emptyParams: Params = [];
+  const selectParams = createSelector(
+    selectState,
+    state => (state ? state.params : emptyParams)
+  );
+  const selectParamMap = createSelector(
+    selectParams,
+    params => convertToParamMap(params)
+  );
+  const selectParam = (param: string): MemoizedSelector<T, string | null> =>
+    createSelector(selectParamMap, paramMap => paramMap.get(param));
+
   const selectQueryParams = createSelector(
     selectState,
     state => (state ? state.queryParams : emptyParams)
@@ -39,5 +57,5 @@ export function selectors<T>(baseSelectRouterState: Selector<T, RouterReducerSta
   const selectQueryParam = (param: string): MemoizedSelector<T, string | null> =>
     createSelector(selectQueryParamMap, paramMap => paramMap.get(param));
 
-  return { selectRouterState, selectState, selectNavigationId, selectQueryParam };
+  return { selectRouterState, selectState, selectNavigationId, selectPath, selectParam, selectQueryParam };
 }

--- a/src/app/store/router/router.state.ts
+++ b/src/app/store/router/router.state.ts
@@ -2,5 +2,7 @@ import { Params } from '@angular/router';
 
 export interface State {
   url: string,
+  path: string[],
+  params: Params,
   queryParams: Params,
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,7 @@ import { provideStoreDevtools } from '@ngrx/store-devtools';
 import { provideEffects } from '@ngrx/effects';
 import { provideRouterStore, RouterState } from '@ngrx/router-store';
 import { fromObservation, fromRouter, rootStoreEffects, RouterSerializer } from './app/store';
+import { fromUserContent, groupStoreEffects } from './app/groups/store';
 
 const DEFAULT_SCROLLBAR_OPTIONS: NgScrollbarOptions = {
   visibility: 'hover',
@@ -134,7 +135,8 @@ bootstrapApplication(AppComponent, {
     provideState(fromRouter),
     provideState(fromObservation),
     provideState(fromForum),
-    provideEffects(rootStoreEffects(), forumEffects()),
+    provideState(fromUserContent),
+    provideEffects(rootStoreEffects(), forumEffects(), groupStoreEffects()),
     provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() , connectInZone: true }),
     provideAnimations(),
     provideHttpClient(withInterceptorsFromDi()),


### PR DESCRIPTION
## Description

Move user content fetching into store.
Tried to improve a bit the user component without rewriting everything. 

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [my personal page](https://dev.algorea.org/branch/user-current-content/en/groups/users/670968966872011405/personal-data)
  3. And I navigate to the other tabs
  4. Then everything looks ok
  5. and I dispatch a `[User Page] refresh` using the dev tooks
  6. And I see the get user request has been resent 

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [another user's page](https://dev.algorea.org/branch/user-current-content/en/groups/users/752024252804317630)
  4. Then everything looks ok
