### PR TITLE
User content breadcrumbs

### DIFF
--- a/src/app/groups/containers/user/user.component.ts
+++ b/src/app/groups/containers/user/user.component.ts
@@ -45,7 +45,7 @@ const breadcrumbHeader = $localize`Users`;
 })
 export class UserComponent implements OnInit, OnDestroy {
   userRoute$ = this.store.select(fromUserContent.selectActiveContentUserRoute).pipe(filter(isNotNull));
-  state$ = this.store.select(fromUserContent.selectUser).pipe(filter(isNotNull));
+  state$ = this.store.select(fromUserContent.selectUser);
 
   readonly currentUserGroupId$ = this.userSessionService.userProfile$.pipe(
     delay(0),

--- a/src/app/groups/containers/user/user.component.ts
+++ b/src/app/groups/containers/user/user.component.ts
@@ -1,12 +1,11 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { combineLatest, Observable, of, Subscription } from 'rxjs';
+import { combineLatest, Observable, Subscription } from 'rxjs';
 import { NavigationEnd, Router, RouterLinkActive, RouterLink } from '@angular/router';
-import { catchError, delay, switchMap, map, startWith, filter, distinctUntilChanged } from 'rxjs/operators';
+import { delay, map, startWith, filter, distinctUntilChanged } from 'rxjs/operators';
 import { contentInfo } from 'src/app/models/content/content-info';
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { UserSessionService } from 'src/app/services/user-session.service';
 import { formatUser } from 'src/app/models/user';
-import { GetGroupBreadcrumbsService } from '../../data-access/get-group-breadcrumbs.service';
 import { isGroupRoute } from 'src/app/models/routing/group-route';
 import { GroupRouter } from 'src/app/models/routing/group-router';
 import { PlatformSettingsComponent } from '../platform-settings/platform-settings.component';
@@ -63,10 +62,6 @@ export class UserComponent implements OnInit, OnDestroy {
     map(url => this.getCurrentRoute(url)),
   );
 
-  private readonly breadcrumbs$ = this.userRoute$.pipe(
-    switchMap(route => (isGroupRoute(route) ? this.getGroupBreadcrumbsService.getBreadcrumbs(route) : of(undefined)))
-  );
-
   private subscription?: Subscription;
 
   constructor(
@@ -75,7 +70,6 @@ export class UserComponent implements OnInit, OnDestroy {
     private userSessionService: UserSessionService,
     private currentContent: CurrentContentService,
     private groupRouter: GroupRouter,
-    private getGroupBreadcrumbsService: GetGroupBreadcrumbsService,
   ) {}
 
   ngOnInit(): void {
@@ -83,7 +77,7 @@ export class UserComponent implements OnInit, OnDestroy {
       this.userRoute$,
       this.activeRoute$.pipe(map(p => this.pageTitle(p))),
       this.state$,
-      this.breadcrumbs$.pipe(catchError(() => of(undefined))), // error is handled elsewhere
+      this.store.select(fromUserContent.selectBreadcrumbs),
     ])
       .pipe(
         map(([ currentUserRoute, currentPageTitle, state, breadcrumbs ]) => contentInfo({
@@ -91,11 +85,11 @@ export class UserComponent implements OnInit, OnDestroy {
           breadcrumbs: {
             category: breadcrumbHeader,
             path: state.isReady ? [
-              ...(breadcrumbs?.slice(0,-1) ?? []).map(b => ({ title: b.name, navigateTo: this.groupRouter.url(b.route) })),
+              ...(breadcrumbs?.data?.slice(0,-1) ?? []).map(b => ({ title: b.name, navigateTo: this.groupRouter.url(b.route) })),
               { title: formatUser(state.data), navigateTo: this.groupRouter.url(currentUserRoute) },
               { title: currentPageTitle }
             ] : [],
-            currentPageIdx: breadcrumbs ? breadcrumbs.length : 1,
+            currentPageIdx: breadcrumbs !== null && breadcrumbs.isReady ? breadcrumbs.data.length : 1,
           },
           route: isGroupRoute(currentUserRoute) ? currentUserRoute : undefined,
         }))

--- a/src/app/groups/data-access/get-group-breadcrumbs.service.ts
+++ b/src/app/groups/data-access/get-group-breadcrumbs.service.ts
@@ -6,18 +6,7 @@ import { map } from 'rxjs/operators';
 import { appConfig } from 'src/app/utils/config';
 import { groupRoute, GroupRoute } from 'src/app/models/routing/group-route';
 import { decodeSnakeCase } from 'src/app/utils/operators/decode';
-
-const breadcrumbDecoder = D.struct({
-  id: D.string,
-  name: D.string,
-  type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base'),
-});
-
-type Breadcrumb = D.TypeOf<typeof breadcrumbDecoder>;
-
-export interface GroupBreadcrumb extends Breadcrumb {
-  route: GroupRoute,
-}
+import { breadcrumbDecoder, GroupBreadcrumbs } from '../models/group-breadcrumbs';
 
 @Injectable({
   providedIn: 'root'
@@ -26,7 +15,7 @@ export class GetGroupBreadcrumbsService {
 
   constructor(private http: HttpClient) {}
 
-  getBreadcrumbs(route: GroupRoute): Observable<GroupBreadcrumb[]> {
+  getBreadcrumbs(route: GroupRoute): Observable<GroupBreadcrumbs> {
     const groupIds = [ ...route.path, route.id ];
 
     return this.http.get<unknown>(`${appConfig.apiUrl}/groups/${groupIds.join('/')}/breadcrumbs`).pipe(

--- a/src/app/groups/models/group-breadcrumbs.ts
+++ b/src/app/groups/models/group-breadcrumbs.ts
@@ -1,0 +1,14 @@
+import * as D from 'io-ts/Decoder';
+import { GroupRoute } from 'src/app/models/routing/group-route';
+
+export const breadcrumbDecoder = D.struct({
+  id: D.string,
+  name: D.string,
+  type: D.literal('Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base'),
+});
+
+interface GroupBreadcrumb extends D.TypeOf<typeof breadcrumbDecoder> {
+  route: GroupRoute,
+}
+
+export type GroupBreadcrumbs = GroupBreadcrumb[];

--- a/src/app/groups/services/group-datasource.service.ts
+++ b/src/app/groups/services/group-datasource.service.ts
@@ -3,13 +3,14 @@ import { forkJoin, ReplaySubject, Subject } from 'rxjs';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { mapToFetchState } from 'src/app/utils/operators/state';
 import { GroupRoute } from 'src/app/models/routing/group-route';
-import { GetGroupBreadcrumbsService, GroupBreadcrumb } from '../data-access/get-group-breadcrumbs.service';
+import { GetGroupBreadcrumbsService } from '../data-access/get-group-breadcrumbs.service';
 import { GetGroupByIdService, Group } from '../data-access/get-group-by-id.service';
+import { GroupBreadcrumbs } from '../models/group-breadcrumbs';
 
 export interface GroupData {
   route: GroupRoute,
   group: Group,
-  breadcrumbs: GroupBreadcrumb[],
+  breadcrumbs: GroupBreadcrumbs,
 }
 
 /**

--- a/src/app/groups/store/user-content/user-content.actions.ts
+++ b/src/app/groups/store/user-content/user-content.actions.ts
@@ -1,11 +1,19 @@
 import { createActionGroup, emptyProps, props } from '@ngrx/store';
 import { User } from 'src/app/groups/models/user';
 import { FetchState } from 'src/app/utils/state';
+import { GroupBreadcrumbs } from '../../models/group-breadcrumbs';
 
 export const userInfoFetchedActions = createActionGroup({
   source: 'User API',
   events: {
     fetchStateChanged: props<{ fetchState: FetchState<User> }>(),
+  },
+});
+
+export const breadcrumbsFetchedActions = createActionGroup({
+  source: 'Group breadcrumbs API',
+  events: {
+    fetchStateChanged: props<{ fetchState: FetchState<GroupBreadcrumbs> }>(),
   },
 });
 

--- a/src/app/groups/store/user-content/user-content.effects.ts
+++ b/src/app/groups/store/user-content/user-content.effects.ts
@@ -2,21 +2,34 @@ import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { inject } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { filter, map, switchMap } from 'rxjs';
-import { selectActiveContentUserId } from './user-content.selectors';
 import { GetUserService } from '../../data-access/get-user.service';
 import { mapToFetchState } from 'src/app/utils/operators/state';
-import { userInfoFetchedActions, userPageActions } from './user-content.actions';
+import { breadcrumbsFetchedActions, userInfoFetchedActions, userPageActions } from './user-content.actions';
 import { isNotNull } from 'src/app/utils/null-undefined-predicates';
+import { GetGroupBreadcrumbsService } from '../../data-access/get-group-breadcrumbs.service';
+import { fromUserContent } from './user-content.store';
 
 export const fetchUserInfoEffect = createEffect(
   (
     store$ = inject(Store),
     actions$ = inject(Actions),
     userService = inject(GetUserService)
-  ) => store$.select(selectActiveContentUserId).pipe(
+  ) => store$.select(fromUserContent.selectActiveContentUserId).pipe(
     filter(isNotNull),
     switchMap(id => userService.getForId(id).pipe(mapToFetchState({ resetter: actions$.pipe(ofType(userPageActions.refresh)) }))),
     map(fetchState => userInfoFetchedActions.fetchStateChanged({ fetchState }))
+  ),
+  { functional: true }
+);
+
+export const fetchBreadcrumbsEffect = createEffect(
+  (
+    store$ = inject(Store),
+    breadcrumbsService = inject(GetGroupBreadcrumbsService),
+  ) => store$.select(fromUserContent.selectActiveContentUserFullRoute).pipe(
+    filter(isNotNull),
+    switchMap(route => breadcrumbsService.getBreadcrumbs(route).pipe(mapToFetchState())),
+    map(fetchState => breadcrumbsFetchedActions.fetchStateChanged({ fetchState }))
   ),
   { functional: true }
 );

--- a/src/app/groups/store/user-content/user-content.reducer.ts
+++ b/src/app/groups/store/user-content/user-content.reducer.ts
@@ -1,6 +1,6 @@
 import { createReducer, on } from '@ngrx/store';
 import { State, initialState } from './user-content.state';
-import { userInfoFetchedActions } from './user-content.actions';
+import { breadcrumbsFetchedActions, userInfoFetchedActions } from './user-content.actions';
 
 export const reducer = createReducer(
   initialState,
@@ -9,5 +9,10 @@ export const reducer = createReducer(
     userInfoFetchedActions.fetchStateChanged,
     (state, { fetchState }): State => ({ ...state, user: fetchState })
   ),
+
+  on(
+    breadcrumbsFetchedActions.fetchStateChanged,
+    (state, { fetchState }): State => ({ ...state, breadcrumbs: fetchState })
+  )
 
 );

--- a/src/app/groups/store/user-content/user-content.selectors.ts
+++ b/src/app/groups/store/user-content/user-content.selectors.ts
@@ -4,7 +4,8 @@ import { GroupRoute, RawGroupRoute, contentTypeOfPath, groupRoute, rawGroupRoute
 import { fromRouter } from 'src/app/store';
 import { State } from './user-content.state';
 import { GroupBreadcrumbs } from '../../models/group-breadcrumbs';
-import { FetchState } from 'src/app/utils/state';
+import { FetchState, fetchingState } from 'src/app/utils/state';
+import { User } from '../../models/user';
 
 type RootState = Record<string, any>;
 
@@ -13,6 +14,7 @@ interface UserContentSelectors<T extends RootState> {
   selectActiveContentUserId: MemoizedSelector<T, string|null>,
   selectActiveContentUserRoute: MemoizedSelector<T, RawGroupRoute|null>,
   selectActiveContentUserFullRoute: MemoizedSelector<T, GroupRoute|null>,
+  selectUser: MemoizedSelector<T, FetchState<User>>,
   selectBreadcrumbs: MemoizedSelector<T, FetchState<GroupBreadcrumbs>|null>,
 }
 
@@ -48,6 +50,12 @@ export function selectors<T extends RootState>(selectState: Selector<T, State>):
     (id, path) => (id && path ? groupRoute({ id, isUser: true }, path) : null)
   );
 
+  const selectUser = createSelector(
+    selectState,
+    selectIsUserContentActive,
+    (state, active) => (active ? state.user : fetchingState())
+  );
+
   const selectBreadcrumbs = createSelector(
     selectState,
     selectActiveContentUserPath,
@@ -59,6 +67,7 @@ export function selectors<T extends RootState>(selectState: Selector<T, State>):
     selectActiveContentUserId,
     selectActiveContentUserRoute,
     selectActiveContentUserFullRoute,
+    selectUser,
     selectBreadcrumbs,
   };
 }

--- a/src/app/groups/store/user-content/user-content.selectors.ts
+++ b/src/app/groups/store/user-content/user-content.selectors.ts
@@ -1,27 +1,64 @@
-import { createSelector } from '@ngrx/store';
-import { pathFromParamValue } from 'src/app/models/routing/content-route';
-import { contentTypeOfPath, groupRoute, rawGroupRoute } from 'src/app/models/routing/group-route';
+import { MemoizedSelector, Selector, createSelector } from '@ngrx/store';
+import { pathFromParamValue, pathParamName } from 'src/app/models/routing/content-route';
+import { GroupRoute, RawGroupRoute, contentTypeOfPath, groupRoute, rawGroupRoute } from 'src/app/models/routing/group-route';
 import { fromRouter } from 'src/app/store';
+import { State } from './user-content.state';
+import { GroupBreadcrumbs } from '../../models/group-breadcrumbs';
+import { FetchState } from 'src/app/utils/state';
 
-export const selectIsUserContentActive = createSelector(
-  fromRouter.selectPath,
-  path => !!path && contentTypeOfPath(path) === 'user'
-);
+type RootState = Record<string, any>;
 
-export const selectActiveContentUserId = createSelector(
-  selectIsUserContentActive,
-  fromRouter.selectParam('id'),
-  (isActive, id) => (isActive && id ? id : null)
-);
+interface UserContentSelectors<T extends RootState> {
+  selectIsUserContentActive: MemoizedSelector<T, boolean>,
+  selectActiveContentUserId: MemoizedSelector<T, string|null>,
+  selectActiveContentUserRoute: MemoizedSelector<T, RawGroupRoute|null>,
+  selectActiveContentUserFullRoute: MemoizedSelector<T, GroupRoute|null>,
+  selectBreadcrumbs: MemoizedSelector<T, FetchState<GroupBreadcrumbs>|null>,
+}
 
-const selectActiveContentUserPath = createSelector(
-  selectIsUserContentActive,
-  fromRouter.selectParam('path'),
-  (isActive, path) => (isActive && path ? pathFromParamValue(path) : null)
-);
+export function selectors<T extends RootState>(selectState: Selector<T, State>): UserContentSelectors<T> {
 
-export const selectActiveContentUserRoute = createSelector(
-  selectActiveContentUserId,
-  selectActiveContentUserPath,
-  (id, path) => (id ? (path ? groupRoute({ id, isUser: true }, path) : rawGroupRoute({ id, isUser: true })) : null)
-);
+  const selectIsUserContentActive = createSelector(
+    fromRouter.selectPath,
+    path => !!path && contentTypeOfPath(path) === 'user'
+  );
+
+  const selectActiveContentUserId = createSelector(
+    selectIsUserContentActive,
+    fromRouter.selectParam('id'),
+    (isActive, id) => (isActive && id ? id : null)
+  );
+
+  const selectActiveContentUserPath = createSelector(
+    selectIsUserContentActive,
+    fromRouter.selectParam(pathParamName),
+    (isActive, path) => (isActive && path ? pathFromParamValue(path) : null)
+  );
+
+  const selectActiveContentUserRoute = createSelector(
+    selectActiveContentUserId,
+    selectActiveContentUserPath,
+    (id, path) => (id ? (path ? groupRoute({ id, isUser: true }, path) : rawGroupRoute({ id, isUser: true })) : null)
+  );
+
+  /** select the full route only, so only if the path is defined */
+  const selectActiveContentUserFullRoute = createSelector(
+    selectActiveContentUserId,
+    selectActiveContentUserPath,
+    (id, path) => (id && path ? groupRoute({ id, isUser: true }, path) : null)
+  );
+
+  const selectBreadcrumbs = createSelector(
+    selectState,
+    selectActiveContentUserPath,
+    (state, path) => (path !== null ? state.breadcrumbs : null)
+  );
+
+  return {
+    selectIsUserContentActive,
+    selectActiveContentUserId,
+    selectActiveContentUserRoute,
+    selectActiveContentUserFullRoute,
+    selectBreadcrumbs,
+  };
+}

--- a/src/app/groups/store/user-content/user-content.state.ts
+++ b/src/app/groups/store/user-content/user-content.state.ts
@@ -1,12 +1,16 @@
 import { FetchState } from 'src/app/utils/state';
 import { User } from '../../models/user';
+import { GroupBreadcrumbs } from '../../models/group-breadcrumbs';
 
 export interface GroupInfo { name: string, currentUserCanGrantAccess: boolean }
 
 export interface State {
   user: FetchState<User> | null,
+  // if (and only if) the content is currently a user page AND the page has a path in url: the corresponding breadcrumbs
+  breadcrumbs: FetchState<GroupBreadcrumbs> | null,
 }
 
 export const initialState: State = {
   user: null,
+  breadcrumbs: null,
 };

--- a/src/app/groups/store/user-content/user-content.state.ts
+++ b/src/app/groups/store/user-content/user-content.state.ts
@@ -1,16 +1,17 @@
-import { FetchState } from 'src/app/utils/state';
+import { FetchState, fetchingState } from 'src/app/utils/state';
 import { User } from '../../models/user';
 import { GroupBreadcrumbs } from '../../models/group-breadcrumbs';
 
 export interface GroupInfo { name: string, currentUserCanGrantAccess: boolean }
 
 export interface State {
-  user: FetchState<User> | null,
+  // if the content is currently a user page: the corresponding user info
+  user: FetchState<User>,
   // if (and only if) the content is currently a user page AND the page has a path in url: the corresponding breadcrumbs
-  breadcrumbs: FetchState<GroupBreadcrumbs> | null,
+  breadcrumbs: FetchState<GroupBreadcrumbs>,
 }
 
 export const initialState: State = {
-  user: null,
-  breadcrumbs: null,
+  user: fetchingState(),
+  breadcrumbs: fetchingState(),
 };

--- a/src/app/groups/store/user-content/user-content.store.ts
+++ b/src/app/groups/store/user-content/user-content.store.ts
@@ -5,7 +5,7 @@ import * as selectors from './user-content.selectors';
 
 export const fromUserContent = {
   ...createFeature({
-    name: 'user-content',
+    name: 'userContent',
     reducer,
     extraSelectors: () => selectors
   }),

--- a/src/app/groups/store/user-content/user-content.store.ts
+++ b/src/app/groups/store/user-content/user-content.store.ts
@@ -1,13 +1,13 @@
 import { createFeature } from '@ngrx/store';
 import { reducer } from './user-content.reducer';
+import { selectors } from './user-content.selectors';
 import * as actions from './user-content.actions';
-import * as selectors from './user-content.selectors';
 
 export const fromUserContent = {
   ...createFeature({
     name: 'userContent',
     reducer,
-    extraSelectors: () => selectors
+    extraSelectors: ({ selectUserContentState }) => ({ ...selectors(selectUserContentState) })
   }),
   ...actions
 };

--- a/src/app/models/routing/content-route.ts
+++ b/src/app/models/routing/content-route.ts
@@ -2,7 +2,7 @@ import { ParamMap } from '@angular/router';
 import { UrlCommandParameters } from '../../utils/url';
 
 /* for url */
-const pathParamName = 'p';
+export const pathParamName = 'p';
 
 type Id = string;
 


### PR DESCRIPTION
## Description

Move user page breadcrumbs to the store.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [a user page with a path](https://dev.algorea.org/branch/user-content-breadcrumbs/en/groups/users/752024252804317630;p=52767158366271444,672913018859223173)
  4. Then I see the breadcrumbs

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [a user page without a path](https://dev.algorea.org/branch/user-content-breadcrumbs/en/groups/users/752024252804317630)
  4. Then I just see the name of the user and the page as breadcrumbs
