### PR TITLE
use isCurrentUser which is returned in the get-user service instead of user-session service

### DIFF
--- a/src/app/groups/containers/user/user.component.html
+++ b/src/app/groups/containers/user/user.component.html
@@ -22,7 +22,7 @@
       *ngIf="!state.data.isCurrentUser && state.data.ancestorsCurrentUserIsManagerOf.length > 0"
     ></alg-user-indicator>
 
-    <nav class="alg-nav-tab" *ngIf="(currentUserGroupId$ | async) === state.data.groupId || (activeRoute$ | async) === 'personal-data' || (activeRoute$ | async) === 'settings'">
+    <nav class="alg-nav-tab" *ngIf="state.data.isCurrentUser || (activeRoute$ | async) === 'personal-data' || (activeRoute$ | async) === 'settings'">
       <a
           class="alg-nav-tab-item"
           [routerLink]="'./'"
@@ -40,7 +40,7 @@
           [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
           [class.active]="personalData.isActive"
           i18n
-          [hidden]="(currentUserGroupId$ | async) !== state.data.groupId && (activeRoute$ | async) !== 'personal-data'"
+          [hidden]="!state.data.isCurrentUser && (activeRoute$ | async) !== 'personal-data'"
       >
         Personal data
       </a>
@@ -51,7 +51,7 @@
           [routerLinkActiveOptions]="{ matrixParams: 'ignored', queryParams: 'ignored', paths: 'exact', fragment: 'ignored'}"
           [class.active]="settings.isActive"
           i18n
-          [hidden]="(currentUserGroupId$ | async) !== state.data.groupId && (activeRoute$ | async) !== 'settings'"
+          [hidden]="!state.data.isCurrentUser && (activeRoute$ | async) !== 'settings'"
       >
         Settings
       </a>
@@ -59,22 +59,20 @@
 
     <ng-container *ngIf="activeRoute$ | async as activeRoute">
       <ng-container *ngIf="activeRoute === 'progress'">
-        <ng-container *ngIf="currentUserGroupId$ | async as currentUserGroupId">
-          <alg-group-log-view
-            [groupId]="currentUserGroupId !== state.data.groupId ? state.data.groupId : undefined"
-            [showUserColumn]="false"
-          ></alg-group-log-view>
-        </ng-container>
+        <alg-group-log-view
+          [groupId]="!state.data.isCurrentUser ? state.data.groupId : undefined"
+          [showUserColumn]="false"
+        ></alg-group-log-view>
       </ng-container>
 
       <ng-container *ngIf="activeRoute === 'personal-data'">
-        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.groupId; else forbidden">
+        <ng-container *ngIf="state.data.isCurrentUser; else forbidden">
           <alg-current-user></alg-current-user>
         </ng-container>
       </ng-container>
 
       <ng-container *ngIf="activeRoute === 'settings'">
-        <ng-container *ngIf="(currentUserGroupId$ | async) === state.data.groupId; else forbidden">
+        <ng-container *ngIf="state.data.isCurrentUser; else forbidden">
           <alg-platform-settings></alg-platform-settings>
         </ng-container>
       </ng-container>

--- a/src/app/groups/containers/user/user.component.ts
+++ b/src/app/groups/containers/user/user.component.ts
@@ -1,10 +1,9 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest, Observable, Subscription } from 'rxjs';
 import { NavigationEnd, Router, RouterLinkActive, RouterLink } from '@angular/router';
-import { delay, map, startWith, filter, distinctUntilChanged } from 'rxjs/operators';
+import { map, startWith, filter, distinctUntilChanged } from 'rxjs/operators';
 import { contentInfo } from 'src/app/models/content/content-info';
 import { CurrentContentService } from 'src/app/services/current-content.service';
-import { UserSessionService } from 'src/app/services/user-session.service';
 import { formatUser } from 'src/app/models/user';
 import { isGroupRoute } from 'src/app/models/routing/group-route';
 import { GroupRouter } from 'src/app/models/routing/group-router';
@@ -47,11 +46,6 @@ export class UserComponent implements OnInit, OnDestroy {
   userRoute$ = this.store.select(fromUserContent.selectActiveContentUserRoute).pipe(filter(isNotNull));
   state$ = this.store.select(fromUserContent.selectUser);
 
-  readonly currentUserGroupId$ = this.userSessionService.userProfile$.pipe(
-    delay(0),
-    map(userProfile => userProfile.groupId),
-  );
-
   private url$ = this.router.events.pipe(
     filter(event => event instanceof NavigationEnd),
     map(() => this.router.url),
@@ -67,7 +61,6 @@ export class UserComponent implements OnInit, OnDestroy {
   constructor(
     private store: Store,
     private router: Router,
-    private userSessionService: UserSessionService,
     private currentContent: CurrentContentService,
     private groupRouter: GroupRouter,
   ) {}


### PR DESCRIPTION
Minor improvement: use `isCurrentUser` which is returned in the get-user service instead of user-session service

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/user-current-user-info-from-request/en/groups/users/670968966872011405/personal-data)
  4. Then I see all tabs

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go [to another user page](https://dev.algorea.org/branch/user-current-user-info-from-request/en/groups/users/752024252804317630)
  3. Then I see no tabs

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go [to the personal page of another user](https://dev.algorea.org/branch/user-current-user-info-from-request/en/groups/users/752024252804317630/personal-data)
  3. Then I get an error message



