### PR TITLE
Improves design of load more button in table

### DIFF
--- a/src/app/groups/containers/group-log-view/group-log-view.component.html
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.html
@@ -94,7 +94,8 @@
             <div class="text-center">
               <button
                 pButton
-                class="p-button-rounded"
+                class="alg-button basic"
+                icon="ph-duotone ph-arrow-circle-down"
                 i18n-label label="Load more"
                 (click)="fetchMoreRows()"
                 [disabled]="state.isFetching || state.isError"

--- a/src/app/groups/containers/group-manager-list/group-manager-list.component.html
+++ b/src/app/groups/containers/group-manager-list/group-manager-list.component.html
@@ -120,7 +120,8 @@
             <div class="text-center">
               <button
                 pButton
-                class="p-button-rounded"
+                class="alg-button basic"
+                icon="ph-duotone ph-arrow-circle-down"
                 i18n-label label="Load more"
                 (click)="fetchMoreData()"
                 [disabled]="state.isFetching"

--- a/src/app/groups/containers/member-list/member-list.component.html
+++ b/src/app/groups/containers/member-list/member-list.component.html
@@ -99,7 +99,8 @@
             <div class="text-center">
               <button
                 pButton
-                class="p-button-rounded"
+                class="alg-button basic"
+                icon="ph-duotone ph-arrow-circle-down"
                 i18n-label label="Load more"
                 (click)="fetchMoreRows()"
                 [disabled]="state.isFetching"

--- a/src/app/items/containers/group-progress-grid/group-progress-grid.component.html
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid.component.html
@@ -115,7 +115,8 @@
                 <div class="text-center">
                   <button
                     pButton
-                    class="p-button-rounded"
+                    class="alg-button basic"
+                    icon="ph-duotone ph-arrow-circle-down"
                     i18n-label label="Load more"
                     (click)="fetchMoreRows()"
                     [disabled]="rowsState.isFetching"

--- a/src/assets/scss/components/table.scss
+++ b/src/assets/scss/components/table.scss
@@ -148,6 +148,11 @@
     padding: 0 toRem(16);
     border: none;
   }
+
+  .p-datatable .p-datatable-tfoot > tr > td {
+    border: none;
+    background: none;
+  }
 }
 
 .alg-table-summary {


### PR DESCRIPTION
## Description

Fixes #1589

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Haven't found test case for this [table](https://dev.algorea.org/branch/new-design/table-load-more-button/en/groups/by-id/5121055722873780306;p=/managers)

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/table-load-more-button/en/groups/users/670968966872011405)
  3. And I scroll down to end of the table
  4. Then I see new design for "Load more" button

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/table-load-more-button/en/groups/by-id/947670356997220543;p=/members)
  3. And I scroll down to end of the table
  4. Then I see new design for "Load more" button

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/table-load-more-button/en/groups/by-id/5121055722873780306;p=)
  3. And I scroll down to end of the table
  4. Then I see new design for "Load more" button