### PR TITLE
Replace io-ts by zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "primeng": "^17.1.0",
         "rxjs": "~7.8.1",
         "tslib": "^2.3.1",
+        "zod": "^3.22.4",
         "zone.js": "~0.14.2"
       },
       "devDependencies": {
@@ -22182,6 +22183,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/zone.js": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.14.2.tgz",
@@ -37997,6 +38006,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg=="
     },
     "zone.js": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "primeng": "^17.1.0",
     "rxjs": "~7.8.1",
     "tslib": "^2.3.1",
+    "zod": "^3.22.4",
     "zone.js": "~0.14.2"
   },
   "devDependencies": {

--- a/src/app/data-access/activity-log.service.ts
+++ b/src/app/data-access/activity-log.service.ts
@@ -8,7 +8,7 @@ import { SECONDS } from '../utils/duration';
 import { requestTimeout } from '../interceptors/interceptor_common';
 import { itemTypeSchema } from '../models/item-type';
 import { participantTypeSchema } from '../models/group-types';
-import { userSchema } from '../groups/models/user';
+import { userBaseSchema, withId } from '../groups/models/user';
 
 const activityLogsSchema = z.array(
   z.object({
@@ -29,7 +29,7 @@ const activityLogsSchema = z.array(
     }),
     answerId: z.string().optional(),
     score: z.number().optional(),
-    user: userSchema.optional(),
+    user: withId(userBaseSchema).optional(),
   })
 );
 

--- a/src/app/data-access/check-login.service.ts
+++ b/src/app/data-access/check-login.service.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { appConfig } from '../utils/config';
-import * as D from 'io-ts/Decoder';
-import { decodeSnakeCase } from 'src/app/utils/operators/decode';
+import { z } from 'zod';
+import { decodeSnakeCaseZod } from 'src/app/utils/operators/decode';
 import { map } from 'rxjs/operators';
 
-const dataDecoder = D.struct({
-  loginIdMatched: D.boolean,
+const responseSchema = z.object({
+  loginIdMatched: z.boolean()
 });
 
 @Injectable({
@@ -23,7 +23,7 @@ export class CheckLoginService {
     return this.http
       .get<unknown>(`${appConfig.apiUrl}/current-user/check-login-id`, { params })
       .pipe(
-        decodeSnakeCase(dataDecoder),
+        decodeSnakeCaseZod(responseSchema),
         map(data => data.loginIdMatched),
       );
   }

--- a/src/app/data-access/current-user.service.ts
+++ b/src/app/data-access/current-user.service.ts
@@ -2,37 +2,34 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { appConfig } from '../utils/config';
-import * as D from 'io-ts/Decoder';
-import { pipe } from 'fp-ts/function';
-import { decodeSnakeCase } from 'src/app/utils/operators/decode';
+import { z } from 'zod';
+import { decodeSnakeCaseZod } from 'src/app/utils/operators/decode';
 import { assertSuccess, SimpleActionResponse } from './action-response';
 import { map } from 'rxjs/operators';
 
-export const currentUserDecoder = pipe(
-  D.struct({
-    groupId: D.string,
-    login: D.string,
-    firstName: D.nullable(D.string),
-    lastName: D.nullable(D.string),
-    birthDate: D.nullable(D.string),
-    studentId: D.nullable(D.string),
-    sex: D.nullable(D.string),
-    countryCode: D.string,
-    webSite: D.nullable(D.string),
-    grade: D.nullable(D.number),
-    graduationYear: D.number,
-    email: D.nullable(D.string),
-    defaultLanguage: D.string,
-    address: D.nullable(D.string),
-    city: D.nullable(D.string),
-    zipCode: D.nullable(D.string),
-    cellPhoneNumber: D.nullable(D.string),
-    timeZone: D.nullable(D.string),
-    tempUser: D.boolean
-  })
-);
+const currentUserSchema = z.object({
+  groupId: z.string(),
+  login: z.string(),
+  firstName: z.string().nullable(),
+  lastName: z.string().nullable(),
+  birthDate: z.string().nullable(),
+  studentId: z.string().nullable(),
+  sex: z.string().nullable(),
+  countryCode: z.string(),
+  webSite: z.string().nullable(),
+  grade: z.number().nullable(),
+  graduationYear: z.number(),
+  email: z.string().nullable(),
+  defaultLanguage: z.string(),
+  address: z.string().nullable(),
+  city: z.string().nullable(),
+  zipCode: z.string().nullable(),
+  cellPhoneNumber: z.string().nullable(),
+  timeZone: z.string().nullable(),
+  tempUser: z.boolean()
+});
 
-export type UserProfile = D.TypeOf<typeof currentUserDecoder>;
+export type CurrentUserProfile = z.infer<typeof currentUserSchema>;
 
 export interface UpdateUserBody {
   default_language: string,
@@ -45,11 +42,11 @@ export class CurrentUserHttpService {
 
   constructor(private http: HttpClient) {}
 
-  getProfileInfo(): Observable<UserProfile> {
+  getProfileInfo(): Observable<CurrentUserProfile> {
     return this.http
       .get<unknown>(`${appConfig.apiUrl}/current-user`)
       .pipe(
-        decodeSnakeCase(currentUserDecoder)
+        decodeSnakeCaseZod(currentUserSchema)
       );
   }
 

--- a/src/app/data-access/get-group-descendants.service.ts
+++ b/src/app/data-access/get-group-descendants.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { appConfig } from 'src/app/utils/config';
 import { z } from 'zod';
 import { decodeSnakeCaseZod } from 'src/app/utils/operators/decode';
-import { userSchema, withGrade } from '../groups/models/user';
+import { withGrade, withGroupId, userBaseSchema } from '../groups/models/user';
 
 const parentsSchema = z.array(
   z.object({
@@ -17,7 +17,7 @@ const teamDescendantsSchema = z.array(
   z.object({
     grade: z.number(),
     id: z.string(),
-    members: z.array(withGrade(userSchema)),
+    members: z.array(withGrade(withGroupId(userBaseSchema))),
     name: z.string(),
     parents: parentsSchema,
   })
@@ -30,7 +30,7 @@ const userDescendantsSchema = z.array(
     id: z.string(),
     name: z.string(),
     parents: parentsSchema,
-    user: withGrade(userSchema),
+    user: withGrade(userBaseSchema),
   })
 );
 

--- a/src/app/data-access/get-group-descendants.service.ts
+++ b/src/app/data-access/get-group-descendants.service.ts
@@ -2,51 +2,39 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { appConfig } from 'src/app/utils/config';
-import * as D from 'io-ts/Decoder';
-import { pipe } from 'fp-ts/function';
-import { decodeSnakeCase } from 'src/app/utils/operators/decode';
-import { userDecoder as memberDecoder } from 'src/app/groups/data-access/get-group-members.service';
+import { z } from 'zod';
+import { decodeSnakeCaseZod } from 'src/app/utils/operators/decode';
+import { userSchema, withGrade } from '../groups/models/user';
 
-const descendantParentDecoder = D.struct({
-  id: D.string,
-  name: D.string,
-});
-
-const teamDescendantDecoder = pipe(
-  D.struct({
-    grade: D.number,
-    id: D.string,
-    members: D.array(memberDecoder),
-    name: D.string,
-    parents: D.array(descendantParentDecoder),
-  }),
+const parentsSchema = z.array(
+  z.object({
+    id: z.string(),
+    name: z.string()
+  })
 );
 
-export type TeamDescendants = D.TypeOf<typeof teamDescendantDecoder>;
-
-const userDecoder = pipe(
-  D.struct({
-    grade: D.nullable(D.number),
-    login: D.string,
-  }),
-  D.intersect(
-    D.partial({
-      firstName: D.nullable(D.string),
-      lastName: D.nullable(D.string),
-    })
-  )
+const teamDescendantsSchema = z.array(
+  z.object({
+    grade: z.number(),
+    id: z.string(),
+    members: z.array(withGrade(userSchema)),
+    name: z.string(),
+    parents: parentsSchema,
+  })
 );
 
-const userDescendantDecoder = pipe(
-  D.struct({
-    id: D.string,
-    name: D.string,
-    parents: D.array(descendantParentDecoder),
-    user: userDecoder,
-  }),
+type TeamDescendants = z.infer<typeof teamDescendantsSchema>;
+
+const userDescendantsSchema = z.array(
+  z.object({
+    id: z.string(),
+    name: z.string(),
+    parents: parentsSchema,
+    user: withGrade(userSchema),
+  })
 );
 
-export type UserDescendant = D.TypeOf<typeof userDescendantDecoder>;
+type UserDescendants = z.infer<typeof userDescendantsSchema>;
 
 @Injectable({
   providedIn: 'root'
@@ -55,7 +43,7 @@ export class GetGroupDescendantsService {
 
   constructor(private http: HttpClient) { }
 
-  getUserDescendants(groupId: string, options: { sort?: string[], limit?: number, fromId?: string }): Observable<UserDescendant[]> {
+  getUserDescendants(groupId: string, options: { sort?: string[], limit?: number, fromId?: string }): Observable<UserDescendants> {
     let params = new HttpParams();
     if (options.sort && options.sort.length > 0) params = params.set('sort', options.sort.join(','));
     if (options.limit !== undefined) params = params.set('limit', options.limit);
@@ -63,20 +51,20 @@ export class GetGroupDescendantsService {
     return this.http
       .get<unknown>(`${appConfig.apiUrl}/groups/${groupId}/user-descendants`, { params: params })
       .pipe(
-        decodeSnakeCase(D.array(userDescendantDecoder)),
+        decodeSnakeCaseZod(userDescendantsSchema),
       );
   }
 
   getTeamDescendants(
     groupId: string,
     sort: string[] = [],
-  ): Observable<TeamDescendants[]> {
+  ): Observable<TeamDescendants> {
     let params = new HttpParams();
     if (sort.length > 0) params = params.set('sort', sort.join(','));
     return this.http
       .get<unknown>(`${appConfig.apiUrl}/groups/${groupId}/team-descendants`, { params: params })
       .pipe(
-        decodeSnakeCase(D.array(teamDescendantDecoder)),
+        decodeSnakeCaseZod(teamDescendantsSchema),
       );
   }
 }

--- a/src/app/data-access/get-group-descendants.service.ts
+++ b/src/app/data-access/get-group-descendants.service.ts
@@ -43,11 +43,11 @@ export class GetGroupDescendantsService {
 
   constructor(private http: HttpClient) { }
 
-  getUserDescendants(groupId: string, options: { sort?: string[], limit?: number, fromId?: string }): Observable<UserDescendants> {
+  getUserDescendants(groupId: string, options?: { sort?: string[], limit?: number, fromId?: string }): Observable<UserDescendants> {
     let params = new HttpParams();
-    if (options.sort && options.sort.length > 0) params = params.set('sort', options.sort.join(','));
-    if (options.limit !== undefined) params = params.set('limit', options.limit);
-    if (options.fromId !== undefined) params = params.set('from.id', options.fromId);
+    if (options?.sort && options.sort.length > 0) params = params.set('sort', options.sort.join(','));
+    if (options?.limit !== undefined) params = params.set('limit', options.limit);
+    if (options?.fromId !== undefined) params = params.set('from.id', options.fromId);
     return this.http
       .get<unknown>(`${appConfig.apiUrl}/groups/${groupId}/user-descendants`, { params: params })
       .pipe(
@@ -55,12 +55,9 @@ export class GetGroupDescendantsService {
       );
   }
 
-  getTeamDescendants(
-    groupId: string,
-    sort: string[] = [],
-  ): Observable<TeamDescendants> {
+  getTeamDescendants(groupId: string, options?: { sort: string[] }): Observable<TeamDescendants> {
     let params = new HttpParams();
-    if (sort.length > 0) params = params.set('sort', sort.join(','));
+    if (options?.sort && options.sort.length > 0) params = params.set('sort', options.sort.join(','));
     return this.http
       .get<unknown>(`${appConfig.apiUrl}/groups/${groupId}/team-descendants`, { params: params })
       .pipe(

--- a/src/app/groups/containers/group-log-view/group-log-view.component.ts
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.ts
@@ -1,7 +1,7 @@
 import { Component, ElementRef, Input, OnChanges, OnDestroy, QueryList, SimpleChanges, ViewChild, ViewChildren } from '@angular/core';
 import { BehaviorSubject, debounceTime, merge, Observable } from 'rxjs';
 import { distinctUntilChanged, filter, shareReplay } from 'rxjs/operators';
-import { ActivityLog, ActivityLogService } from 'src/app/data-access/activity-log.service';
+import { ActivityLogs, ActivityLogService } from 'src/app/data-access/activity-log.service';
 import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
 import { DataPager } from 'src/app/utils/data-pager';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
@@ -68,7 +68,7 @@ export class GroupLogViewComponent implements OnChanges, OnDestroy {
   });
 
   datapager = new DataPager({
-    fetch: (pageSize, latestRow?: ActivityLog): Observable<ActivityLog[]> => this.getRows(pageSize, latestRow),
+    fetch: (pageSize, latestRow?: ActivityLogs[number]): Observable<ActivityLogs> => this.getRows(pageSize, latestRow),
     pageSize: logsLimit,
     onLoadMoreError: (): void => {
       this.actionFeedbackService.error($localize`Could not load more logs, are you connected to the internet?`);
@@ -101,7 +101,7 @@ export class GroupLogViewComponent implements OnChanges, OnDestroy {
     this.resetRows();
   }
 
-  getRows(pageSize: number, latestRow?: ActivityLog): Observable<ActivityLog[]> {
+  getRows(pageSize: number, latestRow?: ActivityLogs[number]): Observable<ActivityLogs> {
     const paginationParams = latestRow === undefined ? undefined : {
       fromItemId: latestRow.item.id,
       fromParticipantId: latestRow.participant.id,
@@ -110,12 +110,11 @@ export class GroupLogViewComponent implements OnChanges, OnDestroy {
       fromActivityType: latestRow.activityType,
     };
 
-    return this.activityLogService.getAllActivityLog(
-      this.groupId, {
-        limit: pageSize,
-        pagination: paginationParams,
-      }
-    );
+    return this.activityLogService.getAllActivityLog({
+      watchedGroupId: this.groupId,
+      limit: pageSize,
+      pagination: paginationParams,
+    });
   }
 
   resetRows(): void {

--- a/src/app/groups/containers/member-list/member-list.component.ts
+++ b/src/app/groups/containers/member-list/member-list.component.ts
@@ -175,7 +175,7 @@ export class MemberListComponent implements OnChanges, OnDestroy {
           }))));
       case TypeFilter.Teams:
         if (!this.currentFilter.directChildren) {
-          return this.getGroupDescendantsService.getTeamDescendants(route.id, this.currentSort)
+          return this.getGroupDescendantsService.getTeamDescendants(route.id, { sort: this.currentSort })
             .pipe(map(descendantTeams => descendantTeams.map(descendantTeam => ({
               id: descendantTeam.id,
               name: descendantTeam.name,

--- a/src/app/groups/containers/member-list/member-list.component.ts
+++ b/src/app/groups/containers/member-list/member-list.component.ts
@@ -7,7 +7,7 @@ import { GetGroupDescendantsService } from 'src/app/data-access/get-group-descen
 import { groupRoute, rawGroupRoute, RawGroupRoute } from 'src/app/models/routing/group-route';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { GetGroupChildrenService, GroupChild } from '../../data-access/get-group-children.service';
-import { GetGroupMembersService, Member } from '../../data-access/get-group-members.service';
+import { GetGroupMembersService, GroupMembers } from '../../data-access/get-group-members.service';
 import { GroupUsersService, parseResults } from '../../data-access/group-users.service';
 import { GroupData } from '../../services/group-datasource.service';
 import { Filter, GroupCompositionFilterComponent, TypeFilter } from '../group-composition-filter/group-composition-filter.component';
@@ -24,6 +24,8 @@ import { ButtonModule } from 'primeng/button';
 import { RouterLink } from '@angular/router';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { NgIf, NgFor, NgSwitch, NgSwitchCase, NgSwitchDefault, AsyncPipe, DatePipe, I18nSelectPipe, NgClass } from '@angular/common';
+
+type Member = GroupMembers[number];
 
 function getSelectedGroupChildCaptions(selection: GroupChild[]): string {
   return selection.map(selected => selected.name).join(', ');

--- a/src/app/groups/data-access/get-group-members.service.ts
+++ b/src/app/groups/data-access/get-group-members.service.ts
@@ -4,12 +4,12 @@ import { Observable } from 'rxjs';
 import { appConfig } from 'src/app/utils/config';
 import { z } from 'zod';
 import { decodeSnakeCaseZod } from 'src/app/utils/operators/decode';
-import { userSchema, withGrade } from '../models/user';
+import { userBaseSchema, withGrade, withGroupId } from '../models/user';
 
 const groupMembersSchema = z.array(
   z.object({
     id: z.string(),
-    user: withGrade(userSchema),
+    user: withGrade(withGroupId(userBaseSchema)),
     action: z.enum([ 'invitation_accepted', 'join_request_accepted', 'joined_by_code', 'joined_by_badge', 'added_directly' ]).optional(),
     memberSince: z.coerce.date().optional(),
   })

--- a/src/app/groups/models/user.ts
+++ b/src/app/groups/models/user.ts
@@ -1,5 +1,23 @@
 import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
+import { z } from 'zod';
+
+export const userSchema = z.object({
+  groupId: z.string(),
+  login: z.string(),
+  firstName: z.string().nullable().optional(),
+  lastName: z.string().nullable().optional(),
+});
+
+// Let type inference guess the return type (would be very long to type)
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const withGrade = <T extends typeof userSchema>(user: T) => user.and(
+  z.object({
+    grade: z.number().nullable(),
+  })
+);
+
+/** former version (to be removed/transformed soon) */
 
 export const userDecoder = pipe(
   D.struct({

--- a/src/app/groups/models/user.ts
+++ b/src/app/groups/models/user.ts
@@ -2,20 +2,17 @@ import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
 import { z } from 'zod';
 
-export const userSchema = z.object({
-  groupId: z.string(),
+export const userBaseSchema = z.object({
   login: z.string(),
   firstName: z.string().nullable().optional(),
   lastName: z.string().nullable().optional(),
 });
 
-// Let type inference guess the return type (would be very long to type)
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export const withGrade = <T extends typeof userSchema>(user: T) => user.and(
-  z.object({
-    grade: z.number().nullable(),
-  })
-);
+/* eslint-disable @typescript-eslint/explicit-function-return-type */ // Let type inference guess the return type (would be very verbose)
+export const withGroupId = <T extends typeof userBaseSchema>(user: T) => user.extend({ groupId: z.string() });
+export const withId = <T extends typeof userBaseSchema>(user: T) => user.extend({ id: z.string() });
+export const withGrade = <T extends typeof userBaseSchema>(user: T) => user.extend({ grade: z.number().nullable() });
+/* eslint-enable @typescript-eslint/explicit-function-return-type */
 
 /** former version (to be removed/transformed soon) */
 

--- a/src/app/items/containers/group-progress-grid/group-progress-grid.component.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid.component.ts
@@ -6,7 +6,7 @@ import { Group } from 'src/app/groups/data-access/get-group-by-id.service';
 import { GetGroupChildrenService } from 'src/app/groups/data-access/get-group-children.service';
 import { formatUser } from 'src/app/models/user';
 import { GetGroupDescendantsService } from 'src/app/data-access/get-group-descendants.service';
-import { GetGroupProgressService, TeamUserProgress } from 'src/app/data-access/get-group-progress.service';
+import { GetGroupProgressService, ParticipantProgresses } from 'src/app/data-access/get-group-progress.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { TypeFilter } from '../../models/composition-filter';
 import { GetItemChildrenService, ItemChildType } from '../../../data-access/get-item-children.service';
@@ -42,7 +42,7 @@ const progressListLimit = 25;
 interface DataRow {
   header: string,
   id: string,
-  data: (TeamUserProgress|undefined)[],
+  data: (ParticipantProgresses[number]|undefined)[],
 }
 interface DataColumn {
   id: string,
@@ -172,7 +172,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
     return row.id;
   }
 
-  showProgressDetail(target: HTMLElement, userProgress: TeamUserProgress, row: DataRow, col: DataColumn): void {
+  showProgressDetail(target: HTMLElement, userProgress: ParticipantProgresses[number], row: DataRow, col: DataColumn): void {
     if (!this.itemData) {
       throw new Error('Unexpected: Missed item data');
     }
@@ -223,7 +223,7 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
     this.fetchMoreRows();
   }
 
-  private getProgress({ itemId, groupId, filter, pageSize, fromId }: DataFetching): Observable<TeamUserProgress[]> {
+  private getProgress({ itemId, groupId, filter, pageSize, fromId }: DataFetching): Observable<ParticipantProgresses> {
     switch (filter) {
       case 'Users':
         return this.getGroupUsersProgressService.getUsersProgress(groupId, [ itemId ], { limit: pageSize, fromId });

--- a/src/app/items/containers/item-log-view/item-log-view.component.ts
+++ b/src/app/items/containers/item-log-view/item-log-view.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { ItemData } from '../../services/item-datasource.service';
-import { ActivityLog, ActivityLogService } from 'src/app/data-access/activity-log.service';
+import { ActivityLogs, ActivityLogService } from 'src/app/data-access/activity-log.service';
 import { combineLatest, Observable, ReplaySubject } from 'rxjs';
 import { distinctUntilChanged, switchMap, map } from 'rxjs/operators';
 import { ItemType } from 'src/app/models/item-type';
@@ -75,7 +75,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
   isObserving$ = this.store.select(fromObservation.selectIsObserving);
 
   datapager = new DataPager({
-    fetch: (pageSize, latestRow?: ActivityLog): Observable<ActivityLog[]> => this.getRows(pageSize, latestRow),
+    fetch: (pageSize, latestRow?: ActivityLogs[number]): Observable<ActivityLogs> => this.getRows(pageSize, latestRow),
     pageSize: logsLimit,
     onLoadMoreError: (): void => {
       this.actionFeedbackService.error($localize`Could not load more logs, are you connected to the internet?`);
@@ -131,7 +131,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
     this.resetRows();
   }
 
-  getRows(pageSize: number, latestRow?: ActivityLog): Observable<ActivityLog[]> {
+  getRows(pageSize: number, latestRow?: ActivityLogs[number]): Observable<ActivityLogs> {
     return this.store.select(fromObservation.selectObservedGroupId).pipe(
 
       switchMap(observedGroupId => {
@@ -163,7 +163,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
   }
 
 
-  private isSelfCurrentAnswer(log: ActivityLog, profileId: string): boolean {
+  private isSelfCurrentAnswer(log: ActivityLogs[number], profileId: string): boolean {
     return log.activityType === 'current_answer' && log.participant.id === profileId;
   }
 

--- a/src/app/items/containers/user-progress-details/user-progress-details.component.ts
+++ b/src/app/items/containers/user-progress-details/user-progress-details.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, SimpleChanges } from '@angular/core';
 import { Component, EventEmitter, Input, Output, ViewChild, OnChanges } from '@angular/core';
 import { OverlayPanel, OverlayPanelModule } from 'primeng/overlaypanel';
 import { delay, take } from 'rxjs';
-import { TeamUserProgress } from 'src/app/data-access/get-group-progress.service';
+import { ParticipantProgresses } from 'src/app/data-access/get-group-progress.service';
 import { FullItemRoute } from 'src/app/models/routing/item-route';
 import { ItemPermWithWatch } from 'src/app/models/item-watch-permission';
 import { UserSessionService } from 'src/app/services/user-session.service';
@@ -19,7 +19,7 @@ import { NgIf, NgClass, AsyncPipe } from '@angular/common';
 import { SharedModule } from 'primeng/api';
 
 export interface ProgressData {
-  progress: TeamUserProgress,
+  progress: ParticipantProgresses[number],
   target: Element,
   currentFilter: TypeFilter,
   colItem: {

--- a/src/app/items/containers/user-progress/user-progress.component.ts
+++ b/src/app/items/containers/user-progress/user-progress.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
 import { mustNotBeUndefined } from 'src/app/utils/assert';
-import { TeamUserProgress } from 'src/app/data-access/get-group-progress.service';
+import { ParticipantProgresses } from 'src/app/data-access/get-group-progress.service';
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
 import { NgClass, NgIf } from '@angular/common';
 
@@ -13,7 +13,7 @@ import { NgClass, NgIf } from '@angular/common';
 })
 export class UserProgressComponent implements OnInit, OnChanges {
 
-  @Input() userProgress!: TeamUserProgress;
+  @Input() userProgress!: ParticipantProgresses[number];
 
   state: 'success'|'in-progress'|'no-score'|'not-started' = 'no-score';
 

--- a/src/app/models/group-types.ts
+++ b/src/app/models/group-types.ts
@@ -1,6 +1,9 @@
+import { z } from 'zod';
 
 export type GroupTypeCategory = 'group'|'user';
 
 export function isGroupTypeVisible(type: string): boolean {
   return type !== 'Base' && type !== 'ContestParticipants';
 }
+
+export const participantTypeSchema = z.enum([ 'Team', 'User' ]);

--- a/src/app/models/item-edit-permission.ts
+++ b/src/app/models/item-edit-permission.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import * as D from 'io-ts/Decoder';
+import { z } from 'zod';
 
 export enum ItemEditPerm {
   None = 'none',
@@ -11,6 +12,9 @@ export const itemEditPermMax = ItemEditPerm.AllWithGrant;
 const P = ItemEditPerm; // non-exported shorthand
 
 export const itemEditPermValues = [ P.None, P.Children, P.All, P.AllWithGrant ] as const;
+export const itemEditPermSchema = z.object({
+  canEdit: z.enum(itemEditPermValues)
+});
 export const itemEditPermDecoder = D.struct({
   canEdit: D.literal(...itemEditPermValues)
 });

--- a/src/app/models/item-grant-view-permission.ts
+++ b/src/app/models/item-grant-view-permission.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import * as D from 'io-ts/Decoder';
+import { z } from 'zod';
 
 export enum ItemGrantViewPerm {
   None = 'none',
@@ -14,6 +15,9 @@ export const itemGrantViewPermMax = ItemGrantViewPerm.SolutionWithGrant;
 const P = ItemGrantViewPerm; // non-exported shorthand
 
 export const itemGrantViewPermValues = [ P.None, P.Enter, P.Content, P.ContentWithDescendants, P.Solution, P.SolutionWithGrant ] as const;
+export const itemGrantViewPermSchema = z.object({
+  canGrantView: z.enum(itemGrantViewPermValues)
+});
 export const itemGrantViewPermDecoder = D.struct({
   canGrantView: D.literal(...itemGrantViewPermValues)
 });

--- a/src/app/models/item-permissions.ts
+++ b/src/app/models/item-permissions.ts
@@ -1,20 +1,35 @@
 import { pipe } from 'fp-ts/function';
 import * as D from 'io-ts/Decoder';
+import { z } from 'zod';
 import { dateDecoder } from '../utils/decoders';
-import { allowsGrantingEdition, ItemPermWithEdit, itemEditPermDecoder } from './item-edit-permission';
-import { allowsGrantingView, ItemPermWithGrantView, itemGrantViewPermDecoder } from './item-grant-view-permission';
-import { itemViewPermDecoder } from './item-view-permission';
-import { allowsGrantingWatch, ItemPermWithWatch, itemWatchPermDecoder } from './item-watch-permission';
+import { allowsGrantingEdition, ItemPermWithEdit, itemEditPermDecoder, itemEditPermSchema } from './item-edit-permission';
+import { allowsGrantingView, ItemPermWithGrantView, itemGrantViewPermDecoder, itemGrantViewPermSchema } from './item-grant-view-permission';
+import { itemViewPermDecoder, itemViewPermSchema } from './item-view-permission';
+import { allowsGrantingWatch, ItemPermWithWatch, itemWatchPermDecoder, itemWatchPermSchema } from './item-watch-permission';
+
+export const itemOwnerPermSchema = z.object({
+  isOwner: z.boolean()
+});
 
 export const itemOwnerPermDecoder = D.struct({
   isOwner: D.boolean
 });
 export type ItemOwnerPerm = D.TypeOf<typeof itemOwnerPermDecoder>;
 
+export const itemSessionPermSchema = z.object({
+  canMakeSessionOfficial: z.boolean()
+});
 export const itemSessionPermDecoder = D.struct({
   canMakeSessionOfficial: D.boolean
 });
 export type ItemSessionPerm = D.TypeOf<typeof itemSessionPermDecoder>;
+
+export const itemEntryFromPermSchema = z.object({
+  canEnterFrom: z.coerce.date(),
+});
+export const itemEntryUntilPermSchema = z.object({
+  canEnterUntil: z.coerce.date(),
+});
 
 export const itemEntryFromPermDecoder = D.struct({
   canEnterFrom: dateDecoder,
@@ -25,9 +40,19 @@ export const itemEntryUntilPermDecoder = D.struct({
 export const itemEntryTimePermDecoder = D.intersect(itemEntryFromPermDecoder)(itemEntryUntilPermDecoder);
 export type ItemEntryTimePerm = D.TypeOf<typeof itemEntryTimePermDecoder>;
 
+
+export const itemCanRequestHelpSchema = z.object({
+  canRequestHelp: z.boolean()
+});
 export const itemCanRequestHelpDecoder = D.struct({
   canRequestHelp: D.boolean,
 });
+
+export const itemCorePermSchema = itemViewPermSchema
+  .and(itemGrantViewPermSchema)
+  .and(itemEditPermSchema)
+  .and(itemWatchPermSchema)
+  .and(itemOwnerPermSchema);
 
 export const itemCorePermDecoder = pipe(
   itemViewPermDecoder,

--- a/src/app/models/item-properties.ts
+++ b/src/app/models/item-properties.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const itemValidationTypeSchema = z.enum([ 'None','All','AllButOne','Categories','One','Manual' ]);
+
+export const itemFullScreenSchema = z.enum([ 'forceYes','forceNo','default' ]);
+
+export const itemChildrenLayoutSchema = z.enum([ 'List', 'Grid' ]);
+
+export const itemEntryMinAdmittedMembersRatioSchema = z.enum([ 'All', 'Half', 'One', 'None' ]);

--- a/src/app/models/item-string.ts
+++ b/src/app/models/item-string.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const itemStringSchema = z.object({
+  title: z.string().nullable(),
+  languageTag: z.string(),
+  imageUrl: z.string().nullable(),
+  subtitle: z.string().nullable().optional(),
+  description: z.string().nullable().optional(),
+});

--- a/src/app/models/item-type.ts
+++ b/src/app/models/item-type.ts
@@ -1,8 +1,12 @@
+import { z } from 'zod';
+
+export const itemTypeSchema = z.enum([ 'Chapter', 'Task', 'Skill' ]);
 
 export type ActivityType = 'Chapter'|'Task';
-export type ItemType = ActivityType|'Skill';
+export type ItemType = z.infer<typeof itemTypeSchema>;
 export type ItemTypeCategory = 'activity'|'skill';
 interface ItemWithType { type: ItemType }
+
 
 /* Helpers in Item-like */
 export function isASkill(item: ItemWithType): boolean {

--- a/src/app/models/item-view-permission.ts
+++ b/src/app/models/item-view-permission.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import * as D from 'io-ts/Decoder';
+import { z } from 'zod';
 
 export enum ItemViewPerm {
   None = 'none',
@@ -12,6 +13,9 @@ export const itemViewPermMax = ItemViewPerm.Solution;
 const P = ItemViewPerm; // non-exported shorthand
 
 export const itemViewPermValues = [ P.None, P.Info, P.Content, P.ContentWithDescendants, P.Solution ] as const;
+export const itemViewPermSchema = z.object({
+  canView: z.enum(itemViewPermValues)
+});
 export const itemViewPermDecoder = D.struct({
   canView: D.literal(...itemViewPermValues)
 });

--- a/src/app/models/item-watch-permission.ts
+++ b/src/app/models/item-watch-permission.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import * as D from 'io-ts/Decoder';
+import { z } from 'zod';
 
 export enum ItemWatchPerm {
   None = 'none',
@@ -11,6 +12,9 @@ export const itemWatchPermMax = ItemWatchPerm.AnswerWithGrant;
 const P = ItemWatchPerm; // non-exported shorthand
 
 export const itemWatchPermValues = [ P.None, P.Result, P.Answer, P.AnswerWithGrant ] as const;
+export const itemWatchPermSchema = z.object({
+  canWatch: z.enum(itemWatchPermValues)
+});
 export const itemWatchPermDecoder = D.struct({
   canWatch: D.literal(...itemWatchPermValues)
 });

--- a/src/app/pipes/logActionDisplay.ts
+++ b/src/app/pipes/logActionDisplay.ts
@@ -1,7 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { ActivityLog } from '../data-access/activity-log.service';
+import { ActivityLogs } from '../data-access/activity-log.service';
 
-function formatLogAction (type: ActivityLog['activityType'], score?: number): string {
+function formatLogAction (type: ActivityLogs[number]['activityType'], score?: number): string {
   switch (type) {
     case 'submission': return score === undefined ? $localize`Submission` : $localize`Submission (score: ${ score })`;
     case 'result_started': return $localize`Activity started`;

--- a/src/app/services/user-session.service.ts
+++ b/src/app/services/user-session.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, Subscription, Observable, Subject, of } from 'rxjs';
 import { AuthService } from './auth/auth.service';
 import { switchMap, distinctUntilChanged, map, filter, skip, shareReplay, retry } from 'rxjs/operators';
-import { CurrentUserHttpService, UpdateUserBody, UserProfile } from '../data-access/current-user.service';
+import { CurrentUserHttpService, UpdateUserBody, CurrentUserProfile } from '../data-access/current-user.service';
 import { isNotUndefined } from '../utils/null-undefined-predicates';
 import { repeatLatestWhen } from '../utils/operators/repeatLatestWhen';
 
@@ -11,7 +11,7 @@ import { repeatLatestWhen } from '../utils/operators/repeatLatestWhen';
 })
 export class UserSessionService implements OnDestroy {
 
-  session$ = new BehaviorSubject<UserProfile|undefined>(undefined);
+  session$ = new BehaviorSubject<CurrentUserProfile|undefined>(undefined);
   userProfileError$ = new Subject<Error>();
 
   /** currently-connected user profile, temporary or not, excluding transient (undefined) states */
@@ -32,7 +32,7 @@ export class UserSessionService implements OnDestroy {
     this.subscription = this.authService.status$.pipe(
       repeatLatestWhen(this.userProfileUpdated$),
       switchMap(auth => {
-        if (!auth.authenticated) return of<UserProfile | undefined>(undefined);
+        if (!auth.authenticated) return of<CurrentUserProfile | undefined>(undefined);
         return this.currentUserService.getProfileInfo().pipe(retry(1));
       }),
       distinctUntilChanged(), // skip two undefined values in a row

--- a/src/app/utils/decoders.ts
+++ b/src/app/utils/decoders.ts
@@ -1,6 +1,7 @@
 import { pipe } from 'fp-ts/function';
 import { fold } from 'fp-ts/Either';
 import * as D from 'io-ts/Decoder';
+import { z } from 'zod';
 import { Duration } from './duration';
 
 class DecodingError extends Error {
@@ -51,3 +52,15 @@ export const durationDecoder: D.Decoder<unknown, Duration> = pipe(
     return duration.isValid() ? D.success(duration) : D.failure(s, 'DurationFromString');
   })
 );
+
+export const durationSchema = z.string().transform((val, ctx) => {
+  const duration = Duration.fromString(val);
+  if (!duration.isValid()) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'Not a duration',
+    });
+    return z.NEVER;
+  }
+  return duration;
+});

--- a/src/app/utils/operators/decode.ts
+++ b/src/app/utils/operators/decode.ts
@@ -1,5 +1,6 @@
 import { map } from 'rxjs/operators';
 import * as D from 'io-ts/Decoder';
+import { ZodType, ZodTypeDef } from 'zod';
 import { OperatorFunction, pipe as rxpipe } from 'rxjs';
 import { decode } from '../decoders';
 import { snakeToCamelKeys } from '../case_conversion';
@@ -13,6 +14,24 @@ export function decodeSnakeCase<T>(decoder: D.Decoder<unknown, T>): OperatorFunc
     map(input => {
       try {
         return decode(decoder)(input);
+      } catch (err) {
+        reportError(err);
+        throw err;
+      }
+    }),
+  );
+}
+
+export function decodeSnakeCaseZod<
+  Output,
+  Def extends ZodTypeDef,
+  Input
+>(schema: ZodType<Output,Def,Input>): OperatorFunction<unknown,Output> {
+  return rxpipe(
+    map(snakeToCamelKeys),
+    map(input => {
+      try {
+        return schema.parse(input);
       } catch (err) {
         reportError(err);
         throw err;


### PR DESCRIPTION
## Description

Introduce "Zod" to replace io-ts+fp-ts. 
Lighter and more readable (no need for the functional part, the pipe and intersections).

I've tried to make it using automatic conversion tool and testing the new decoder with the former type before deleting it.. but I cannot promise it has no error.

## Test cases

As the usual user, I go to:
- [an activity log](http://localhost:4200/groups/by-id/2713577096475953687;p=)
- [an activity page](http://localhost:4200/a/home;a=0)
- [a group composition page](http://localhost:4200/groups/by-id/947670356997220543;p=/members) -> and the "sub-groups" tab
- [a progress matrix](http://localhost:4200/a/6707691810849260111;p=;pa=0/progress/chapter?watchedGroupId=672913018859223173)
