### PR TITLE
convert get-item-children service to zod

### DIFF
--- a/src/app/data-access/get-item-by-id.service.ts
+++ b/src/app/data-access/get-item-by-id.service.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import { decodeSnakeCaseZod } from 'src/app/utils/operators/decode';
 import { durationSchema } from 'src/app/utils/decoders';
 import { itemCanRequestHelpSchema, itemCorePermSchema } from 'src/app/models/item-permissions';
-import { itemStringSchema } from '../models/item-string';
+import { itemStringSchema, withDescription } from '../models/item-string';
 import { itemTypeSchema } from '../models/item-type';
 import {
   itemChildrenLayoutSchema,
@@ -19,7 +19,7 @@ import { participantTypeSchema } from '../models/group-types';
 const itemSchema = z.object({
   id: z.string(),
   requiresExplicitEntry: z.boolean(),
-  string: itemStringSchema,
+  string: withDescription(itemStringSchema),
   bestScore: z.number(),
   permissions: itemCorePermSchema.and(itemCanRequestHelpSchema),
   type: itemTypeSchema,

--- a/src/app/items/containers/chapter-children/chapter-children.component.ts
+++ b/src/app/items/containers/chapter-children/chapter-children.component.ts
@@ -1,6 +1,6 @@
 import { combineLatest, ReplaySubject, Subject } from 'rxjs';
 import { Component, Input, OnChanges, OnDestroy, SimpleChanges } from '@angular/core';
-import { GetItemChildrenService, ItemChild } from '../../../data-access/get-item-children.service';
+import { GetItemChildrenService, ItemChildren } from '../../../data-access/get-item-children.service';
 import { ItemData } from '../../services/item-datasource.service';
 import { bestAttemptFromResults } from 'src/app/models/attempts';
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
@@ -48,7 +48,7 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
   ]).pipe(
     switchMap(([{ id, attemptId }, observedGroupId ]) =>
       this.getItemChildrenService.get(id, attemptId, { watchedGroupId: observedGroupId ?? undefined })),
-    map<ItemChild[], ItemChildWithAdditions[]>(itemChildren => itemChildren.map(child => {
+    map<ItemChildren, ItemChildWithAdditions[]>(itemChildren => itemChildren.map(child => {
       const res = bestAttemptFromResults(child.results);
       return {
         ...child,

--- a/src/app/items/containers/group-progress-grid/group-progress-grid.component.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid.component.ts
@@ -9,11 +9,11 @@ import { GetGroupDescendantsService } from 'src/app/data-access/get-group-descen
 import { GetGroupProgressService, ParticipantProgresses } from 'src/app/data-access/get-group-progress.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { TypeFilter } from '../../models/composition-filter';
-import { GetItemChildrenService, ItemChildType } from '../../../data-access/get-item-children.service';
+import { GetItemChildrenService } from '../../../data-access/get-item-children.service';
 import { ItemData } from '../../services/item-datasource.service';
 import { ProgressCSVService } from 'src/app/data-access/progress-csv.service';
 import { downloadFile } from 'src/app/utils/download-file';
-import { typeCategoryOfItem } from 'src/app/models/item-type';
+import { ItemType, typeCategoryOfItem } from 'src/app/models/item-type';
 import { RawGroupRoute, rawGroupRoute } from 'src/app/models/routing/group-route';
 import { ProgressData, UserProgressDetailsComponent } from '../../containers/user-progress-details/user-progress-details.component';
 import { DataPager } from 'src/app/utils/data-pager';
@@ -47,7 +47,7 @@ interface DataRow {
 interface DataColumn {
   id: string,
   title: string|null,
-  type: ItemChildType,
+  type: ItemType,
   permissions: ItemCorePerm,
 }
 interface DataFetching {

--- a/src/app/items/containers/item-children-edit/item-children-edit.component.ts
+++ b/src/app/items/containers/item-children-edit/item-children-edit.component.ts
@@ -14,17 +14,13 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
 import { ItemChildrenEditListComponent } from '../item-children-edit-list/item-children-edit-list.component';
 import { SectionComponent } from 'src/app/ui-components/section/section.component';
 import { NgIf, AsyncPipe } from '@angular/common';
+import { ItemPermPropagations } from 'src/app/models/item-perm-propagation';
 
-interface BaseChildData {
-  contentViewPropagation?: 'none' | 'as_info' | 'as_content',
-  editPropagation?: boolean,
-  grantViewPropagation?: boolean,
-  upperViewLevelsPropagation?: 'use_content_view_propagation' | 'as_content_with_descendants' | 'as_is',
+type BaseChildData = Partial<ItemPermPropagations> & {
   scoreWeight: number,
-  watchPropagation?: boolean,
   permissions?: ItemCorePerm,
   type: ItemType,
-}
+};
 interface InvisibleChildData extends BaseChildData {
   id: string,
   isVisible: false,

--- a/src/app/items/containers/item-children-list/item-children.ts
+++ b/src/app/items/containers/item-children-list/item-children.ts
@@ -1,4 +1,5 @@
-import { BaseItemChildCategory, ItemChildType } from '../../../data-access/get-item-children.service';
+import { ItemChildCategory } from 'src/app/models/item-properties';
+import { ItemType } from 'src/app/models/item-type';
 
 export interface ItemChildWithAdditions {
   id: string,
@@ -7,8 +8,8 @@ export interface ItemChildWithAdditions {
     subtitle?: string | null,
     imageUrl: string | null,
   },
-  category: BaseItemChildCategory,
-  type: ItemChildType,
+  category: ItemChildCategory,
+  type: ItemType,
   watchedGroup?: {
     allValidated?: boolean,
     avgScore?: number,

--- a/src/app/items/containers/item-remove-button/item-remove-button.component.ts
+++ b/src/app/items/containers/item-remove-button/item-remove-button.component.ts
@@ -2,7 +2,7 @@ import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output } from '@a
 import { ReplaySubject, Subject } from 'rxjs';
 import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
 import { mapToFetchState } from 'src/app/utils/operators/state';
-import { GetItemChildrenService, ItemChild } from '../../../data-access/get-item-children.service';
+import { GetItemChildrenService, ItemChildren } from '../../../data-access/get-item-children.service';
 import { Item } from 'src/app/data-access/get-item-by-id.service';
 import { ConfirmationService } from 'primeng/api';
 import { RemoveItemService } from '../../data-access/remove-item.service';
@@ -39,7 +39,7 @@ export class ItemRemoveButtonComponent implements OnChanges, OnDestroy {
     distinctUntilChanged((a, b) => a.id === b.id && a.attemptId === b.attemptId),
     switchMap(({ id, attemptId }) =>
       this.getItemChildrenService.get(id, attemptId).pipe(
-        map((itemChildren: ItemChild[]) => itemChildren.length > 0)
+        map((itemChildren: ItemChildren) => itemChildren.length > 0)
       )
     ),
     mapToFetchState({ resetter: this.refresh$ }),

--- a/src/app/items/containers/user-progress-details/user-progress-details.component.ts
+++ b/src/app/items/containers/user-progress-details/user-progress-details.component.ts
@@ -6,7 +6,6 @@ import { ParticipantProgresses } from 'src/app/data-access/get-group-progress.se
 import { FullItemRoute } from 'src/app/models/routing/item-route';
 import { ItemPermWithWatch } from 'src/app/models/item-watch-permission';
 import { UserSessionService } from 'src/app/services/user-session.service';
-import { ItemChildType } from '../../../data-access/get-item-children.service';
 import { TypeFilter } from '../../models/composition-filter';
 import { DurationToReadable } from 'src/app/pipes/duration';
 import { AllowsWatchingItemAnswersPipe } from 'src/app/models/item-watch-permission';
@@ -17,13 +16,14 @@ import { TooltipModule } from 'primeng/tooltip';
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
 import { NgIf, NgClass, AsyncPipe } from '@angular/common';
 import { SharedModule } from 'primeng/api';
+import { ItemType } from 'src/app/models/item-type';
 
 export interface ProgressData {
   progress: ParticipantProgresses[number],
   target: Element,
   currentFilter: TypeFilter,
   colItem: {
-    type: ItemChildType,
+    type: ItemType,
     fullRoute: FullItemRoute,
     permissions: ItemPermWithWatch,
   },

--- a/src/app/lti/lti.component.ts
+++ b/src/app/lti/lti.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { combineLatest, EMPTY, forkJoin, Observable } from 'rxjs';
 import { catchError, filter, map, retry, shareReplay, switchMap, withLatestFrom } from 'rxjs/operators';
 import { ActivityNavTreeService } from 'src/app/services/navigation/item-nav-tree.service';
-import { GetItemChildrenService, ItemChild } from 'src/app/data-access/get-item-children.service';
+import { GetItemChildrenService, ItemChildren } from 'src/app/data-access/get-item-children.service';
 import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
 import { errorIsHTTPForbidden } from 'src/app/utils/errors';
 import { isNotNull } from 'src/app/utils/null-undefined-predicates';
@@ -161,7 +161,7 @@ export class LTIComponent implements OnDestroy {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());
   }
 
-  private getNavigationData(itemId: string): Observable<{ firstChild: ItemChild, path: string[], attemptId: string }> {
+  private getNavigationData(itemId: string): Observable<{ firstChild: ItemChildren[number], path: string[], attemptId: string }> {
     const path$ = this.getItemPathService.getItemPath(itemId).pipe(map(path => [ ...path, itemId ]), shareReplay(1));
 
     const attemptId$ = path$.pipe(

--- a/src/app/models/item-perm-propagation.ts
+++ b/src/app/models/item-perm-propagation.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+const itemContentViewPermPropagationSchema = z.enum([ 'none', 'as_info', 'as_content' ]);
+const itemUpperViewLevelsPermPropagationSchema = z.enum([ 'use_content_view_propagation', 'as_content_with_descendants', 'as_is' ]);
+const itemEditPermPropagationSchema = z.boolean();
+const itemGrantViewPermPropagationSchema = z.boolean();
+const itemWatchPermPropagationSchema = z.boolean();
+
+export const itemPermPropagationsSchema = z.object({
+  contentViewPropagation: itemContentViewPermPropagationSchema,
+  upperViewLevelsPropagation: itemUpperViewLevelsPermPropagationSchema,
+  editPropagation: itemEditPermPropagationSchema,
+  grantViewPropagation: itemGrantViewPermPropagationSchema,
+  watchPropagation: itemWatchPermPropagationSchema,
+});
+
+export type ItemPermPropagations = Zod.infer<typeof itemPermPropagationsSchema>;

--- a/src/app/models/item-properties.ts
+++ b/src/app/models/item-properties.ts
@@ -7,3 +7,6 @@ export const itemFullScreenSchema = z.enum([ 'forceYes','forceNo','default' ]);
 export const itemChildrenLayoutSchema = z.enum([ 'List', 'Grid' ]);
 
 export const itemEntryMinAdmittedMembersRatioSchema = z.enum([ 'All', 'Half', 'One', 'None' ]);
+
+export const itemChildCategorySchema = z.enum([ 'Undefined', 'Discovery', 'Application', 'Validation', 'Challenge' ]);
+export type ItemChildCategory = z.infer<typeof itemChildCategorySchema>;

--- a/src/app/models/item-string.ts
+++ b/src/app/models/item-string.ts
@@ -5,5 +5,8 @@ export const itemStringSchema = z.object({
   languageTag: z.string(),
   imageUrl: z.string().nullable(),
   subtitle: z.string().nullable().optional(),
-  description: z.string().nullable().optional(),
 });
+
+/* eslint-disable @typescript-eslint/explicit-function-return-type */ // Let type inference guess the return type (would be very verbose)
+export const withDescription = <T extends typeof itemStringSchema>(s: T) => s.extend({ description: z.string().nullable().optional() });
+/* eslint-enable @typescript-eslint/explicit-function-return-type */


### PR DESCRIPTION
## Description

Convert the get-item-children service to zod

## Test cases

As the the usual user
- [a chapter](https://dev.algorea.org/branch/zob-get-item-children/en/a/home;pa=0)
- [a progress grid](https://dev.algorea.org/branch/zob-get-item-children/en/a/6707691810849260111;p=;pa=0/progress/chapter?watchedGroupId=672913018859223173)
- the [chapter edit page](https://dev.algorea.org/branch/zob-get-item-children/en/a/6707691810849260111;p=;pa=0/edit-children)
- [a chapter with non visible content](https://dev.algorea.org/branch/zob-get-item-children/en/a/561969155071897034;p=4702,1352246428241737349;pa=0/edit-children)
- [when displaying the item remove button](https://dev.algorea.org/branch/zob-get-item-children/en/a/561969155071897034;p=4702,1352246428241737349;pa=0/parameters)
- [subskills component](https://dev.algorea.org/branch/zob-get-item-children/en/s/3000;p=;a=0)
