### PR TITLE
Changes design for common popup

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -38,7 +38,7 @@
 </div>
 <p-toast position="bottom-left"></p-toast>
 <p-confirmDialog></p-confirmDialog>
-<p-confirmPopup key="commonPopup" styleClass="common-confirm-popup"></p-confirmPopup>
+<p-confirmPopup key="commonPopup" styleClass="alg-common-confirm-popup"></p-confirmPopup>
 <p-dialog
   *ngrxLet="fatalError$; let fatalError"
   i18n-header="@@auth-error-modal-title" header="Error"

--- a/src/app/groups/containers/group-manager-list/group-manager-list.component.ts
+++ b/src/app/groups/containers/group-manager-list/group-manager-list.component.ts
@@ -131,12 +131,12 @@ export class GroupManagerListComponent implements OnChanges {
       this.confirmationService.confirm({
         target: event.target || undefined,
         key: 'commonPopup',
-        icon: 'pi pi-exclamation-triangle',
+        icon: 'ph-duotone ph-warning-circle',
         message: $localize`Are you sure to remove yourself from the managers of this group? You may lose manager access and
           not be able to restore it.`,
         acceptLabel: $localize`Yes, remove me from the group managers`,
-        acceptButtonStyleClass: 'p-button-danger',
-        acceptIcon: 'fa fa-check',
+        acceptButtonStyleClass: 'danger',
+        acceptIcon: 'ph-bold ph-check',
         rejectLabel: $localize`No`,
         accept: () => this.remove(),
       });

--- a/src/app/groups/containers/joined-group-list/joined-group-list.component.ts
+++ b/src/app/groups/containers/joined-group-list/joined-group-list.component.ts
@@ -66,7 +66,7 @@ export class JoinedGroupListComponent implements OnDestroy {
       key: 'commonPopup',
       message: $localize`Are you sure you want to leave this group?`,
       header: $localize`Confirm Action`,
-      icon: 'pi pi-exclamation-triangle',
+      icon: 'ph-duotone ph-warning-circle',
       acceptLabel: $localize`Yes, leave group`,
       accept: () => {
         this.leaveGroup(membership);

--- a/src/app/groups/containers/member-list/member-list.component.ts
+++ b/src/app/groups/containers/member-list/member-list.component.ts
@@ -289,7 +289,7 @@ export class MemberListComponent implements OnChanges, OnDestroy {
     this.confirmationService.confirm({
       target: event.target || undefined,
       key: 'commonPopup',
-      icon: 'pi pi-exclamation-triangle',
+      icon: 'ph-duotone ph-warning-circle',
       message: $localize`Are you sure you want to permanently delete ${getSelectedGroupChildCaptions(this.selection as GroupChild[])}?
        This operation cannot be undone.`,
       acceptLabel: $localize`Yes`,
@@ -303,7 +303,7 @@ export class MemberListComponent implements OnChanges, OnDestroy {
     this.confirmationService.confirm({
       target: event.target || undefined,
       key: 'commonPopup',
-      icon: 'pi pi-exclamation-triangle',
+      icon: 'ph-duotone ph-warning-circle',
       message: $localize`By removing ${getSelectedGroupChildCaptions(this.selection as GroupChild[])} from the group, you may loose
        manager access to them (if no explicit permission or through other parent group). Are you sure you want to proceed?`,
       acceptLabel: $localize`Yes`,

--- a/src/assets/scss/components/common-confirm-popup.scss
+++ b/src/assets/scss/components/common-confirm-popup.scss
@@ -1,0 +1,42 @@
+@import 'src/assets/scss/functions';
+
+.alg-common-confirm-popup {
+  margin-left: var(--alg-space-size-3);
+  margin-right: var(--alg-space-size-3);
+  background-color: var(--alg-white-color);
+  border-radius: toRem(10);
+
+  &:before {
+    border-bottom-color: var(--alg-primary-color);
+  }
+
+  &:after {
+    border-bottom-color: var(--alg-primary-color);
+  }
+
+  .p-confirm-popup-message, .p-confirm-popup-icon {
+    color: var(--alg-secondary-color);
+  }
+
+  .p-confirm-popup-accept, .p-confirm-popup-reject {
+    height: toRem(32);
+    color: var(--alg-secondary-color);
+    background: none;
+    border-radius: toRem(32);
+    border: toRem(1) solid var(--alg-light-color);
+    font-size: toRem(14);
+
+    &.danger {
+      background: var(--danger-color);
+    }
+
+    i {
+      margin-right: toRem(4);
+    }
+  }
+
+  .p-confirm-popup-accept {
+    background: var(--alg-primary-color);
+    color: var(--alg-white-color);
+  }
+}

--- a/src/assets/scss/components/common-confirm-popup.scss
+++ b/src/assets/scss/components/common-confirm-popup.scss
@@ -26,6 +26,11 @@
     border: toRem(1) solid var(--alg-light-color);
     font-size: toRem(14);
 
+    &:focus, &:active {
+      outline: none;
+      box-shadow: none;
+    }
+
     &.danger {
       background: var(--danger-color);
     }

--- a/src/assets/scss/components/common-confirm-popup.scss
+++ b/src/assets/scss/components/common-confirm-popup.scss
@@ -5,13 +5,14 @@
   margin-right: var(--alg-space-size-3);
   background-color: var(--alg-white-color);
   border-radius: toRem(10);
+  border-color: var(--alg-border-color);
 
   &:before {
-    border-bottom-color: var(--alg-primary-color);
+    border-bottom-color: var(--alg-border-color);
   }
 
   &:after {
-    border-bottom-color: var(--alg-primary-color);
+    border-bottom-color: var(--alg-white-color);
   }
 
   .p-confirm-popup-message, .p-confirm-popup-icon {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -31,6 +31,7 @@
 @import 'assets/scss/components/rounded-icon-wrapper';
 @import 'assets/scss/components/input';
 @import 'assets/scss/components/top-bar-scrollbar';
+@import 'assets/scss/components/common-confirm-popup';
 
 // New Design
 @import 'assets/fonts/roboto/stylesheet';
@@ -127,11 +128,6 @@ body {
     }
   }
 
-}
-
-.common-confirm-popup {
-  margin-left: 2rem;
-  margin-right: 2rem;
 }
 
 .html-container {


### PR DESCRIPTION
## Description

Fixes #1580

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/confirmation-tooltip/en/groups/mine)
  3. And I click on leave group button
  4. Then I see changed design for popup

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/confirmation-tooltip/en/groups/by-id/1376052779483255449;p=/managers)
  3. And I select first row
  4. And I click on delete button
  5. Then I see changed design for popup

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/confirmation-tooltip/en/groups/by-id/1546088973873922141;p=/members)
  3. And I click on "Sub-groups" tab
  4. And I select first row
  5. Then I click on delete button
  6. Then I see changed design for popup