### PR TITLE
Changes design for common confirm dialog

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -37,7 +37,7 @@
   </div>
 </div>
 <p-toast position="bottom-left"></p-toast>
-<p-confirmDialog></p-confirmDialog>
+<p-confirmDialog styleClass="alg-common-confirm-dialog"></p-confirmDialog>
 <p-confirmPopup key="commonPopup" styleClass="alg-common-confirm-popup"></p-confirmPopup>
 <p-dialog
   *ngrxLet="fatalError$; let fatalError"

--- a/src/app/containers/access-code-view/access-code-view.component.ts
+++ b/src/app/containers/access-code-view/access-code-view.component.ts
@@ -67,8 +67,9 @@ export class AccessCodeViewComponent {
           header: $localize`Join the group "${response.group.name}"`,
           message: message,
           acceptLabel: $localize`Join`,
-          acceptIcon: 'fa fa-check',
+          acceptIcon: 'ph-bold ph-check',
           rejectLabel: $localize`Cancel`,
+          rejectIcon: 'ph-bold ph-x',
           accept: () => {
             this.joinGroup(this.code);
           }

--- a/src/app/groups/containers/group-remove-button/group-remove-button.component.ts
+++ b/src/app/groups/containers/group-remove-button/group-remove-button.component.ts
@@ -68,12 +68,14 @@ export class GroupRemoveButtonComponent implements OnChanges, OnDestroy {
     this.confirmationService.confirm({
       message: $localize`Are you sure you want to delete the group "${ this.group.name }"`,
       header: $localize`Confirm Action`,
-      icon: 'pi pi-exclamation-triangle',
+      icon: 'ph-duotone ph-warning-circle',
       acceptLabel: $localize`Delete it`,
+      acceptIcon: 'ph-bold ph-check',
       accept: () => {
         this.deleteGroup();
       },
       rejectLabel: $localize`No`,
+      rejectIcon: 'ph-bold ph-x',
     });
   }
 

--- a/src/app/groups/containers/manager-permission-dialog/manager-permission-dialog.component.ts
+++ b/src/app/groups/containers/manager-permission-dialog/manager-permission-dialog.component.ts
@@ -121,11 +121,13 @@ export class ManagerPermissionDialogComponent implements OnChanges {
       header: $localize`Confirm Action`,
       icon: 'pi pi-exclamation-triangle',
       acceptLabel: $localize`Yes, save these changes.`,
-      acceptButtonStyleClass: 'p-button-danger',
+      acceptButtonStyleClass: 'danger',
+      acceptIcon: 'ph-bold ph-check',
       accept: () => {
         this.update();
       },
       rejectLabel: $localize`No`,
+      rejectIcon: 'ph-bold ph-x',
     });
   }
 

--- a/src/app/guards/pending-changes-guard.ts
+++ b/src/app/guards/pending-changes-guard.ts
@@ -47,12 +47,14 @@ export class PendingChangesGuard implements OnDestroy {
     this.confirmationService.confirm({
       message: $localize`This page has unsaved changes. Do you want to leave this page and lose its changes?`,
       header: $localize`Confirm Navigation`,
-      icon: 'pi pi-exclamation-triangle',
+      icon: 'ph-duotone ph-warning-circle',
       acceptLabel: $localize`Yes, leave page`,
+      acceptIcon: 'ph-bold ph-check',
       accept: () => {
         this.dialogResponse.next(true);
       },
       rejectLabel: $localize`No`,
+      rejectIcon: 'ph-bold ph-x',
       reject: () => {
         this.dialogResponse.next(false);
       },

--- a/src/app/items/containers/item-remove-button/item-remove-button.component.ts
+++ b/src/app/items/containers/item-remove-button/item-remove-button.component.ts
@@ -77,14 +77,16 @@ export class ItemRemoveButtonComponent implements OnChanges, OnDestroy {
     this.confirmationService.confirm({
       message: $localize`Deleting it will also remove permanently all answers and results related with this content.`,
       header: $localize`Are you sure you want to delete this content?`,
-      icon: 'pi pi-exclamation-triangle',
+      icon: 'ph-duotone ph-warning-circle',
       acceptLabel: $localize`Yes`,
-      acceptButtonStyleClass: 'p-button-danger',
+      acceptButtonStyleClass: 'danger',
+      acceptIcon: 'ph-bold ph-check',
       accept: () => {
         this.confirmRemoval.emit();
         this.deleteItem();
       },
       rejectLabel: $localize`No`,
+      rejectIcon: 'ph-bold ph-x',
     });
   }
 

--- a/src/assets/scss/components/common-confirm-dialog.scss
+++ b/src/assets/scss/components/common-confirm-dialog.scss
@@ -10,8 +10,12 @@
     color: var(--alg-secondary-color);
     background: none;
     border-radius: toRem(32);
-    border: toRem(1) solid var(--alg-light-color);
+    border: none;
     font-size: toRem(14);
+
+    &.p-confirm-dialog-reject {
+      border: toRem(1) solid var(--alg-light-color);
+    }
 
     &:focus, &:active {
       outline: none;

--- a/src/assets/scss/components/common-confirm-dialog.scss
+++ b/src/assets/scss/components/common-confirm-dialog.scss
@@ -1,0 +1,34 @@
+@import 'src/assets/scss/functions';
+
+.alg-common-confirm-dialog {
+  .p-confirm-dialog-message, .p-confirm-dialog-icon {
+    color: var(--alg-secondary-color);
+  }
+
+  .p-confirm-dialog-accept, .p-confirm-dialog-reject {
+    height: toRem(32);
+    color: var(--alg-secondary-color);
+    background: none;
+    border-radius: toRem(32);
+    border: toRem(1) solid var(--alg-light-color);
+    font-size: toRem(14);
+
+    &:focus, &:active {
+      outline: none;
+      box-shadow: none;
+    }
+
+    &.danger {
+      background: var(--danger-color);
+    }
+
+    i {
+      margin-right: toRem(4);
+    }
+  }
+
+  .p-confirm-dialog-accept {
+    background: var(--alg-primary-color);
+    color: var(--alg-white-color);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -32,6 +32,7 @@
 @import 'assets/scss/components/input';
 @import 'assets/scss/components/top-bar-scrollbar';
 @import 'assets/scss/components/common-confirm-popup';
+@import 'assets/scss/components/common-confirm-dialog';
 
 // New Design
 @import 'assets/fonts/roboto/stylesheet';


### PR DESCRIPTION
## Description

Fixes #1561

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/confirmation-message/en/a/4925914885021677676;p=54644880678791414;a=0/parameters)
  3. And I click on "Delete this item" button
  4. Then I see changed design for confirmation modal

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/confirmation-message/en/a/54644880678791414;p=;a=0/edit-children)
  3. And I do changes in list
  4. Then I click on next tab
  5. Then I see changed design for confirmation modal

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/confirmation-message/en/groups/by-id/2132623576446659559;p=/settings)
  3. And I click on "Delete this group" button
  4. Then I see changed design for confirmation modal

- [ ] Case 4:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/confirmation-message/en/groups/by-id/2516747935037112838;p=/managers)
  3. And I click on "Edit manager" button
  4. Then I do downgrade permissions
  5. And I click on "Proceed" button
  6. Then I see changed design for confirmation modal