### PR TITLE
Changes design for messages component

### DIFF
--- a/purgecss.js
+++ b/purgecss.js
@@ -30,6 +30,13 @@ const safeList = [
     'p-tooltip-top',
     'p-tooltip-bottom',
     'tooltip-custom',
+    'p-message',
+    'p-message-wrapper',
+    'p-message-success',
+    'p-message-info',
+    'p-message-error',
+    'p-message-icon',
+    'p-message-close-icon',
 ];
 
 if (allCssFiles.length === 0) {

--- a/src/app/groups/containers/group-invite-users/group-invite-users.component.ts
+++ b/src/app/groups/containers/group-invite-users/group-invite-users.component.ts
@@ -16,6 +16,7 @@ interface Message
   type: 'success' | 'info' | 'error',
   summary?: string,
   detail: string,
+  icon?: string,
 }
 
 type GroupInviteState = 'empty'|'too_many'|'loading'|'ready';
@@ -106,6 +107,7 @@ export class GroupInviteUsersComponent implements OnInit, OnDestroy {
         type: 'error',
         summary: $localize`${notFoundUsers.length} user login(s) not found: `,
         detail: `${notFoundUsers.join(', ')}`,
+        icon: 'ph-duotone ph-x-circle',
       });
 
     if (invalidInvites.length > 0)

--- a/src/app/ui-components/message/message.component.html
+++ b/src/app/ui-components/message/message.component.html
@@ -1,1 +1,1 @@
-<p-messages styleClass="alg-messages" [value]="msgs" [closable]="closable"></p-messages>
+<p-messages styleClass="alg-messages" [value]="messages" [closable]="closable"></p-messages>

--- a/src/app/ui-components/message/message.component.ts
+++ b/src/app/ui-components/message/message.component.ts
@@ -2,12 +2,18 @@ import { Component, OnChanges, Input, SimpleChanges } from '@angular/core';
 import { Message } from 'primeng/api';
 import { MessagesModule } from 'primeng/messages';
 
+const ICONS = {
+  'success': 'ph-bold ph-check',
+  'info': 'ph-duotone ph-info',
+  'error': 'ph-duotone ph-x-circle',
+};
+
 @Component({
   selector: 'alg-message',
   templateUrl: './message.component.html',
   styleUrls: [ './message.component.scss' ],
   standalone: true,
-  imports: [ MessagesModule ]
+  imports: [ MessagesModule ],
 })
 export class MessageComponent implements OnChanges {
 
@@ -16,15 +22,16 @@ export class MessageComponent implements OnChanges {
   @Input() detail = '';
   @Input() closable = true;
 
-  msgs : Message[] = [];
+  messages : Message[] = [];
 
   constructor() { }
 
   ngOnChanges(_changes: SimpleChanges): void {
-    this.msgs = [{
+    this.messages = [{
       severity: this.type,
       summary: this.summary,
-      detail: this.detail
+      detail: this.detail,
+      icon: ICONS[this.type],
     }];
   }
 }

--- a/src/assets/scss/components/messages.scss
+++ b/src/assets/scss/components/messages.scss
@@ -1,8 +1,39 @@
-@import '../../../variables';
+@import 'src/assets/scss/functions';
 
 .alg-messages {
-  border-radius: 9rem;
-  padding: 0.4167rem;
-  color: var(--base-color);
-  margin: 0.4167rem 0;
+  .p-message {
+    border-radius: toRem(10);
+    color: var(--alg-white-color);
+
+    .p-message-wrapper {
+      padding: toRem(8) toRem(16);
+    }
+
+    &.p-message-success  {
+      color: var(--alg-message-success-color);
+      background-color: var(--alg-message-success-bg-color);
+
+      .p-message-icon, .p-message-close-icon {
+        color: var(--alg-message-success-color);
+      }
+    }
+
+    &.p-message-info {
+      color: var(--alg-message-info-color);
+      background-color: var(--alg-message-info-bg-color);
+
+      .p-message-icon, .p-message-close-icon {
+        color: var(--alg-message-info-color);
+      }
+    }
+
+    &.p-message-error  {
+      color: var(--alg-message-error-color);
+      background-color: var(--alg-message-error-bg-color);
+
+      .p-message-icon, .p-message-close-icon {
+        color: var(--alg-message-error-color);
+      }
+    }
+  }
 }

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -82,6 +82,12 @@
   --alg-search-result-highlight: #0F61FF33;
   --alg-observation-button-bg-color: #ffdfcb;
   --alg-form-item-label: #545454;
+  --alg-message-success-color: #1ea97c;
+  --alg-message-success-bg-color: rgba(228, 248, 240, 0.7);
+  --alg-message-info-color: #3b82f6;
+  --alg-message-info-bg-color: rgba(219, 234, 254, 0.7);
+  --alg-message-error-color: #ff5757;
+  --alg-message-error-bg-color: rgba(255, 231, 230, 0.7);
 
   // Spacers
   --alg-space-size-1: 4rem;


### PR DESCRIPTION
## Description

Fixes #1624 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/message-component/en/groups/by-id/8791610698648252339;p=/members)
  3. And I do scroll to "Invite users" section
  4. Then I type "notfound" as login
  5. And I click on "Invite" button
  6. Then I see new design for failed message

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/message-component/en/groups/by-id/1069803384095693918;p=/members)
  3. And I do scroll to "Invite users" section
  4. Then I type "notfound, usr_5p020x2thuyu" as logins
  5. And I click on "Invite" button
  6. Then I see new design for info and failed messages

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/message-component/en/groups/by-id/7618436449137122738;p=/members)
  3. And I do scroll to "Invite users" section
  4. Then I type "usr_5p020x2thuyu" as login
  5. And I click on "Invite" button
  6. Then I see new design for success message
