### PR TITLE
Improves view answer logic for logs

### DIFF
--- a/e2e/groups/view-answer.spec.ts
+++ b/e2e/groups/view-answer.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from '@playwright/test';
+import { initAsUsualUser } from '../helpers/e2e_auth';
+import { apiUrl } from '../helpers/e2e_http';
+
+const currentUserLogsJson = [
+  {
+    "at": "2024-02-26T13:20:05Z",
+    "activity_type": "submission",
+    "attempt_id": "0",
+    "answer_id": "6216264238928088073",
+    "from_answer_id": "6216264238928088073",
+    "score": 100,
+    "participant": {
+      "id": "670968966872011405",
+      "name": "arbonenfant",
+      "type": "User"
+    },
+    "user": {
+      "id": "670968966872011405",
+      "login": "arbonenfant",
+      "first_name": "Armelle",
+      "last_name": "Bonenfant"
+    },
+    "item": {
+      "id": "1907925541868462206",
+      "type": "Task",
+      "string": {
+        "title": "Task with edit tab"
+      }
+    },
+    "can_watch_item_answer": true
+  },
+];
+
+const otherUserJson = [
+  {
+    "at": "2024-02-06T14:25:29Z",
+    "activity_type": "saved_answer",
+    "attempt_id": "0",
+    "answer_id": "113722894726386992",
+    "from_answer_id": "113722894726386992",
+    "participant": {
+      "id": "752024252804317630",
+      "name": "usr_5p020x2thuyu",
+      "type": "User"
+    },
+    "user": {
+      "id": "752024252804317630",
+      "login": "usr_5p020x2thuyu"
+    },
+    "item": {
+      "id": "6379723280369399253",
+      "type": "Task",
+      "string": {
+        "title": "Blockly Basic Task"
+      }
+    },
+    "can_watch_item_answer": true
+  },
+];
+
+const groupLogsJson = [
+  {
+    "at": "2024-02-26T13:20:05Z",
+    "activity_type": "submission",
+    "attempt_id": "0",
+    "answer_id": "6216264238928088073",
+    "from_answer_id": "6216264238928088073",
+    "score": 100,
+    "participant": {
+      "id": "670968966872011405",
+      "name": "arbonenfant",
+      "type": "User"
+    },
+    "user": {
+      "id": "670968966872011405",
+      "login": "arbonenfant",
+      "first_name": "Armelle",
+      "last_name": "Bonenfant"
+    },
+    "item": {
+      "id": "1907925541868462206",
+      "type": "Task",
+      "string": {
+        "title": "Task with edit tab"
+      }
+    },
+    "can_watch_item_answer": true
+  },
+];
+
+const itemLogsJson = [
+  {
+    "at": "2024-02-26T13:20:02Z",
+    "activity_type": "submission",
+    "attempt_id": "0",
+    "answer_id": "5411327956377196984",
+    "from_answer_id": "5411327956377196984",
+    "score": 100,
+    "participant": {
+      "id": "670968966872011405",
+      "name": "arbonenfant",
+      "type": "User"
+    },
+    "user": {
+      "id": "670968966872011405",
+      "login": "arbonenfant",
+      "first_name": "Armelle",
+      "last_name": "Bonenfant"
+    },
+    "item": {
+      "id": "1907925541868462206",
+      "type": "Task",
+      "string": {
+        "title": "Task with edit tab"
+      }
+    },
+    "can_watch_item_answer": true
+  },
+];
+
+test('View answer in logs for current user', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/groups/users/670968966872011405');
+  await page.route(`${apiUrl}/items/log?limit=20`, async route => {
+    await route.fulfill({ json: currentUserLogsJson });
+  });
+  await expect.soft(page.locator('h1').getByText('Armelle Bonenfant (arbonenfant)')).toBeVisible();
+  await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
+  await page.getByRole('link', { name: 'View answer' }).click();
+  await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
+});
+
+test('View answer in logs for other user', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/groups/users/752024252804317630');
+  await page.route(`${apiUrl}/items/log?limit=20&watched_group_id=752024252804317630`, async route => {
+    await route.fulfill({ json: otherUserJson });
+  });
+  await expect.soft(page.locator('h1').getByText('usr_5p020x2thuyu')).toBeVisible();
+  await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
+  await page.getByRole('link', { name: 'View answer' }).click();
+  await expect.soft(page.locator('h1').getByText('Blockly Basic Task')).toBeVisible();
+});
+
+test('View answer in logs for a group', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/groups/by-id/672913018859223173;p=52767158366271444');
+  await page.route(`${apiUrl}/items/log?limit=20&watched_group_id=672913018859223173`, async route => {
+    await route.fulfill({ json: groupLogsJson });
+  });
+  await expect.soft(page.locator('h1').getByText('Pixal')).toBeVisible();
+  await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
+  await page.getByRole('link', { name: 'View answer' }).click();
+  await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
+});
+
+test('Reload answer in logs for a item', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/home;pa=0/progress/history');
+  await page.route(`${apiUrl}/items/4702/log?limit=20`, async route => {
+    await route.fulfill({ json: itemLogsJson });
+  });
+  await expect.soft(page.locator('h1').getByText('Parcours officiels')).toBeVisible();
+  await expect.soft(page.getByRole('link', { name: 'Reload answer' })).toBeVisible();
+  await page.getByRole('link', { name: 'Reload answer' }).click();
+  await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
+});

--- a/src/app/data-access/activity-log.service.ts
+++ b/src/app/data-access/activity-log.service.ts
@@ -15,6 +15,7 @@ const activityLogsSchema = z.array(
     activityType: z.enum([ 'result_started', 'submission', 'result_validated', 'saved_answer', 'current_answer' ]),
     at: z.coerce.date(),
     attemptId: z.string(),
+    canWatchItemAnswer: z.boolean(),
     item: z.object({
       id: z.string(),
       string: z.object({

--- a/src/app/groups/containers/group-log-view/group-log-view.component.ts
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.ts
@@ -121,7 +121,7 @@ export class GroupLogViewComponent implements OnChanges, OnDestroy {
       withLatestFrom(this.sessionService.userProfile$),
       map(([ logs, currentUserProfile ]) => logs.map(log => ({
         ...log,
-        allowToViewAnswer: log.participant.id === currentUserProfile.groupId,
+        allowToViewAnswer: log.participant.id === currentUserProfile.groupId || log.canWatchItemAnswer,
       })))
     );
   }

--- a/src/app/items/containers/item-log-view/item-log-view.component.html
+++ b/src/app/items/containers/item-log-view/item-log-view.component.html
@@ -46,7 +46,7 @@
         [loading]="state.isFetching"
         [tableStyle]="{'min-width': '599.98px'}"
         responsiveLayout="scroll"
-        *ngIf="{ isObserving: isObserving$ | async, canWatchAnswers: canWatchAnswers$ | async } as meta"
+        *ngIf="{ isObserving: isObserving$ | async } as meta"
       >
         <ng-template pTemplate="header" let-rowData let-columns>
           <tr *ngIf="rowData.length > 0">
@@ -85,7 +85,7 @@
                       <a
                         class="alg-link item-title-link"
                         [routerLink]="rowData.item | rawItemRoute | withAnswer: { id: rowData.answerId, loadAsCurrent: meta.isObserving ? undefined : true } | url"
-                        *ngIf="(!meta.isObserving || meta.canWatchAnswers) && rowData.answerId"
+                        *ngIf="(!meta.isObserving || rowData.canWatchItemAnswer) && rowData.answerId"
                       >
                         {{ (meta.isObserving ? 'observingMode' : '') | i18nSelect : {
                           observingMode: 'View answer',

--- a/src/app/items/containers/item-log-view/item-log-view.component.ts
+++ b/src/app/items/containers/item-log-view/item-log-view.component.ts
@@ -6,7 +6,6 @@ import { distinctUntilChanged, switchMap, map } from 'rxjs/operators';
 import { ItemType } from 'src/app/items/models/item-type';
 import { Item } from 'src/app/data-access/get-item-by-id.service';
 import { UserSessionService } from 'src/app/services/user-session.service';
-import { allowsWatchingAnswers } from 'src/app/items/models/item-watch-permission';
 import { DataPager } from 'src/app/utils/data-pager';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { LogActionDisplayPipe } from 'src/app/pipes/logActionDisplay';
@@ -98,10 +97,6 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
     this.store.select(fromObservation.selectObservedGroupRoute),
   ]).pipe(
     map(([ item, observedGroupRoute ]) => this.getLogColumns(item.type, observedGroupRoute)),
-  );
-
-  canWatchAnswers$ = this.item$.pipe(
-    map(item => allowsWatchingAnswers(item.permissions))
   );
 
   constructor(


### PR DESCRIPTION
## Description

Fixes #1672 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [item page](https://dev.algorea.org/branch/feature/check-user-can-watch-item-answer/en/a/home;pa=0/progress/history)
  3. Then I see "Reload answer" links

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [current user page](https://dev.algorea.org/branch/feature/check-user-can-watch-item-answer/en/groups/users/670968966872011405)
  3. Then I see "View answer" links

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [group page](https://dev.algorea.org/branch/feature/check-user-can-watch-item-answer/en/groups/by-id/4035378957038759250;p=)
  3. Then I see "View answer" links for other users

- [ ] Case 4:
  1. Given I am the usual user
  2. When I go to [other user page](https://dev.algorea.org/branch/feature/check-user-can-watch-item-answer/en/groups/users/752024252804317630)
  3. Then I see "View answer" links for another user