### PR TITLE
Fixes confusing of naming for report error function

### DIFF
--- a/src/app/utils/error-handling/error-reporting.ts
+++ b/src/app/utils/error-handling/error-reporting.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/angular-ivy';
 
-export function reportError(error: unknown): void {
+export function reportAnError(error: unknown): void {
   Sentry.captureException(error);
 }

--- a/src/app/utils/operators/decode.ts
+++ b/src/app/utils/operators/decode.ts
@@ -4,6 +4,7 @@ import { ZodType, ZodTypeDef } from 'zod';
 import { OperatorFunction, pipe as rxpipe } from 'rxjs';
 import { decode } from '../decoders';
 import { snakeToCamelKeys } from '../case_conversion';
+import { reportAnError } from '../error-handling/error-reporting';
 
 /**
  * Decode an object with keys in snake_case (typically from a json) to one with its types checked and keys in camelCase
@@ -15,7 +16,7 @@ export function decodeSnakeCase<T>(decoder: D.Decoder<unknown, T>): OperatorFunc
       try {
         return decode(decoder)(input);
       } catch (err) {
-        reportError(err);
+        reportAnError(err);
         throw err;
       }
     }),
@@ -33,7 +34,7 @@ export function decodeSnakeCaseZod<
       try {
         return schema.parse(input);
       } catch (err) {
-        reportError(err);
+        reportAnError(err);
         throw err;
       }
     }),


### PR DESCRIPTION
## Description

Change name of function for avoid confusing in future and replaces browser `reportError` with Sentry `reportAnError`

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases
