### PR TITLE
Item route in store

### DIFF
--- a/e2e/items/item-routing.spec.ts
+++ b/e2e/items/item-routing.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '@playwright/test';
+import { initAsUsualUser } from '../helpers/e2e_auth';
+import { apiUrl } from 'e2e/helpers/e2e_http';
+
+/**
+ * Check that the route parameter parsing (and error handling) works as expected
+ */
+
+test('activity with full route loads', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0');
+  await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
+});
+
+test('activity with full route by alias loads', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/home');
+  await expect(page.getByRole('heading', { name: 'Parcours officiels' })).toBeVisible();
+});
+
+test('route with missing path heals', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/7523720120450464843');
+  await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
+});
+
+test('route with missing path using alias heals', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/algorea--adventure');
+  await expect(page.getByRole('heading', { name: 'ALGOREA ADVENTURE' })).toBeVisible();
+});
+
+test('route with missing attempt heals', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/7523720120450464843;p=7528142386663912287');
+  await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
+});
+
+test('route with missing attempt at root heals', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/7528142386663912287;p=');
+  await expect(page.getByRole('heading', { name: 'Algorea Testing Content for devs' })).toBeVisible();
+});
+
+test('route with missing path and service error', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.route(`${apiUrl}/items/7523720120450464843/path-from-root`, route => route.abort());
+
+  await test.step('path solving error', async () => {
+    await page.goto('/a/7523720120450464843');
+    await expect(page.getByText('Error while loading the item.')).toBeVisible();
+  });
+
+  await test.step('back to home page', async () => {
+    await page.getByRole('link', { name: 'home page' }).click();
+    await expect(page.getByRole('heading', { name: 'Parcours officiels' })).toBeVisible();
+  });
+
+});
+
+test('route with action parameter: action passed to subcomponents + parameter removed', async ({ page }) => {
+  await initAsUsualUser(page);
+  // first reload an empty answer
+  await page.goto('/a/6379723280369399253;p=;pa=0;answerId=8006495052571134372;answerLoadAsCurrent=1');
+  // then reload a answer which contains "1234567" in the answer
+  await page.goto('/a/6379723280369399253;p=;pa=0;answerId=4143245131838208903;answerLoadAsCurrent=1');
+
+  await test.step('drop the action parameter', async () => {
+    await expect(page.locator('.left-pane-title-text')).toContainText('Blockly Basic Task', { timeout: 15000 });
+    expect(page.url()).toContain('/a/6379723280369399253;p=;pa=0');
+    expect(page.url()).not.toContain('answer');
+  });
+
+  await test.step('has loaded the expected answer', async () => {
+    await expect(page.frameLocator('iFrame').getByText('1234567')).toBeVisible({ timeout: 10000 }); // to check it is the right answer
+  });
+});

--- a/src/app/items/store/index.ts
+++ b/src/app/items/store/index.ts
@@ -1,0 +1,8 @@
+import { FunctionalEffect } from '@ngrx/effects';
+import * as itemRouteEffects from './item-content/item-route.effects';
+
+export const itemStoreEffects = (): Record<string, FunctionalEffect> => ({
+  ...itemRouteEffects,
+});
+
+export { fromItemContent } from './item-content/item-content.store';

--- a/src/app/items/store/item-content/item-content.actions.ts
+++ b/src/app/items/store/item-content/item-content.actions.ts
@@ -1,0 +1,9 @@
+import { createActionGroup, props } from '@ngrx/store';
+import { State } from './item-content.state';
+
+export const itemRouteErrorHandlingActions = createActionGroup({
+  source: 'Item route error handling',
+  events: {
+    routeErrorHandlingChange: props<{ newState: State['routeErrorHandling'] }>(),
+  },
+});

--- a/src/app/items/store/item-content/item-content.reducer.ts
+++ b/src/app/items/store/item-content/item-content.reducer.ts
@@ -1,0 +1,13 @@
+import { createReducer, on } from '@ngrx/store';
+import { State, initialState } from './item-content.state';
+import { itemRouteErrorHandlingActions } from './item-content.actions';
+
+export const reducer = createReducer(
+  initialState,
+
+  on(
+    itemRouteErrorHandlingActions.routeErrorHandlingChange,
+    (state, { newState }): State => ({ ...state, routeErrorHandling: newState })
+  )
+
+);

--- a/src/app/items/store/item-content/item-content.selectors.ts
+++ b/src/app/items/store/item-content/item-content.selectors.ts
@@ -1,0 +1,79 @@
+import { MemoizedSelector, Selector, createSelector, createSelectorFactory, resultMemoize } from '@ngrx/store';
+import { fromRouter } from 'src/app/store/router';
+import { RootState } from 'src/app/utils/store/root_state';
+import { FullItemRoute, itemCategoryFromPrefix, routesEqualIgnoringCommands } from 'src/app/models/routing/item-route';
+import { ItemRouteError, isItemRouteError, itemRouteFromParams } from '../../utils/item-route-validation';
+import { State } from './item-content.state';
+import { equalNullableFactory } from 'src/app/utils/null-undefined-predicates';
+
+interface UserContentSelectors<T extends RootState> {
+  selectIsItemContentActive: MemoizedSelector<T, boolean>,
+  /**
+   * The route error, if any, of the current active content if it is an item
+   * To be used by the effect which handles the error
+   */
+  selectActiveContentRouteError: MemoizedSelector<T, ItemRouteError|null>,
+  /**
+   * The state of route error handling (if there is an error)
+   */
+  selectActiveContentRouteErrorHandlingState: MemoizedSelector<T, State['routeErrorHandling']|null>,
+  /**
+   * If the content is an item and there is no route error: the fully defined route
+   */
+  selectActiveContentRoute: MemoizedSelector<T, FullItemRoute|null>,
+}
+
+export function selectors<T extends RootState>(selectState: Selector<T, State>): UserContentSelectors<T> {
+
+  const selectActiveContentItemTypeCategory = createSelector(
+    fromRouter.selectPath,
+    path => (!!path && path[0] ? itemCategoryFromPrefix(path[0]) : null),
+  );
+
+  const selectIsItemContentActive = createSelector(
+    selectActiveContentItemTypeCategory,
+    category => category !== null
+  );
+
+  const selectActiveContentParams = createSelector(
+    selectActiveContentItemTypeCategory,
+    fromRouter.selectParamMap,
+    (category, paramMap) => (category ? { paramMap, category } : null)
+  );
+
+  const selectActiveContentRouteParsingResult = createSelector(
+    selectActiveContentParams,
+    params => (params ? itemRouteFromParams(params.category, params.paramMap) : null)
+  );
+
+  const selectActiveContentRouteError = createSelector(
+    selectActiveContentRouteParsingResult,
+    result => (result && isItemRouteError(result) ? result : null)
+  );
+
+  const selectActiveContentRouteErrorHandlingState = createSelector(
+    selectState,
+    selectActiveContentRouteError,
+    (state, error) => (error !== null ? state.routeErrorHandling : null)
+  );
+
+  // The commands (e.g. `answer.loadAsCurrent`) in route parameters are transient and removed once parsed (to prevent replaying the action
+  // on reload). We do not want the item content to consider that as a change, we keep the initial route.
+  // eslint-disable-next-line @ngrx/prefix-selectors-with-select
+  const createSelectorIgnoringRouteActionChanges = createSelectorFactory(
+    projectionFn => resultMemoize(projectionFn, equalNullableFactory(routesEqualIgnoringCommands))
+  // eslint-disable-next-line deprecation/deprecation
+  ) as typeof createSelector; /* fix for ngrx non-type-safety on createSelectorFactory */
+
+  const selectActiveContentRoute = createSelectorIgnoringRouteActionChanges(
+    selectActiveContentRouteParsingResult,
+    result => (result && !isItemRouteError(result) ? result : null)
+  );
+
+  return {
+    selectIsItemContentActive,
+    selectActiveContentRouteError,
+    selectActiveContentRouteErrorHandlingState,
+    selectActiveContentRoute,
+  };
+}

--- a/src/app/items/store/item-content/item-content.state.ts
+++ b/src/app/items/store/item-content/item-content.state.ts
@@ -1,0 +1,13 @@
+import { FetchError, Fetching, fetchingState } from 'src/app/utils/state';
+
+export interface State {
+  /**
+   * If there is a route error: whether it is currently fetching more info or there was an error while handling the error``
+   * Otherwise, the value is irrelevant.
+   */
+  routeErrorHandling: Fetching<undefined>|FetchError,
+}
+
+export const initialState: State = {
+  routeErrorHandling: fetchingState(),
+};

--- a/src/app/items/store/item-content/item-content.store.ts
+++ b/src/app/items/store/item-content/item-content.store.ts
@@ -1,0 +1,11 @@
+import { createFeatureAlt } from 'src/app/utils/store/feature_creator';
+import { reducer } from './item-content.reducer';
+import { selectors } from './item-content.selectors';
+import * as actions from './item-content.actions';
+
+export const fromItemContent = createFeatureAlt({
+  name: 'itemContent',
+  reducer,
+  extraSelectors: ({ selectItemContentState }) => ({ ...selectors(selectItemContentState) }),
+  actionGroups: actions
+});

--- a/src/app/items/store/item-content/item-route.effects.spec.ts
+++ b/src/app/items/store/item-content/item-route.effects.spec.ts
@@ -1,0 +1,139 @@
+import { Store } from '@ngrx/store';
+import { shareReplay, toArray } from 'rxjs';
+import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
+import { ResultActionsService } from 'src/app/data-access/result-actions.service';
+import { ItemRouter } from 'src/app/models/routing/item-router';
+import { routeErrorHandlingEffect } from './item-route.effects';
+import { UserSessionService } from 'src/app/services/user-session.service';
+import { TestScheduler } from 'rxjs/testing';
+import { errorState, fetchingState } from 'src/app/utils/state';
+import { itemRouteErrorHandlingActions } from './item-content.actions';
+
+describe('routeParamParsingEffect', () => {
+  const mockError = new Error('mock service error');
+
+  const getItemPathServiceSpy = jasmine.createSpyObj<GetItemPathService>('GetItemPathService', [ 'getItemPath' ]);
+  getItemPathServiceSpy.getItemPath.and.callFake(() => {
+    throw mockError;
+  });
+  const resultActionsServiceSpy = jasmine.createSpyObj<ResultActionsService>('ResultActionsService', [ 'startWithoutAttempt' ]);
+  const itemRouterSpy = jasmine.createSpyObj<ItemRouter>('ItemRouter', [ 'navigateTo' ]);
+  const testScheduler = new TestScheduler((actual, expected) => {
+    expect(actual).toEqual(expected);
+  });
+
+  const fetchingAction = itemRouteErrorHandlingActions.routeErrorHandlingChange({ newState: fetchingState() });
+  const errorAction = itemRouteErrorHandlingActions.routeErrorHandlingChange({ newState: errorState(mockError) });
+
+  beforeEach(() => {
+    itemRouterSpy.navigateTo.calls.reset();
+  });
+
+  it('does not emit action when there is no error', done => {
+    testScheduler.run(({ hot }) => {
+      const selectActiveContentItemParams$ = hot('-x--|', { x: null }).pipe(shareReplay(1));
+      const userSessionNoChangeMock$ = { userChanged$: hot('--x-|', { x: null }) } as unknown as UserSessionService;
+      const storeMock$ = { select: () => selectActiveContentItemParams$ } as unknown as Store;
+
+      routeErrorHandlingEffect(
+        storeMock$,
+        userSessionNoChangeMock$,
+        getItemPathServiceSpy, // not called
+        resultActionsServiceSpy, // not called
+        itemRouterSpy
+      ).subscribe({
+        next: () => fail('should not emit'),
+        complete: () => {
+          expect(itemRouterSpy.navigateTo).toHaveBeenCalledTimes(0);
+          done();
+        }
+      });
+    });
+  });
+
+  it('only emits fetching on error handling success', done => {
+    testScheduler.run(({ hot }) => {
+      const routeError = { tag: 'error', contentType: 'activity', id: '1', path: [] };
+      const selectActiveContentItemParams$ = hot('-x--|', { x: routeError }).pipe(shareReplay(1));
+      const userSessionNoChangeMock$ = { userChanged$: hot('----|', { x: null }) } as unknown as UserSessionService;
+      const storeMock$ = { select: () => selectActiveContentItemParams$ } as unknown as Store;
+
+      routeErrorHandlingEffect(
+        storeMock$,
+        userSessionNoChangeMock$,
+        getItemPathServiceSpy, // not called in this case (path given)
+        resultActionsServiceSpy, // not called in this case (path empty)
+        itemRouterSpy
+      ).pipe(toArray()).subscribe(events => {
+        expect(events).toEqual([ fetchingAction ]);
+        expect(itemRouterSpy.navigateTo).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it('restarts the fetching in case of user change during the fetching', done => {
+    testScheduler.run(({ hot, cold }) => {
+      const routeError = { tag: 'error', contentType: 'activity', id: '1', path: [ 2 ] };
+      const selectActiveContentItemParams$ = hot('-x---|', { x: routeError }).pipe(shareReplay(1));
+      const userSessionNoChangeMock$ = { userChanged$: hot('--x--|', { x: null }) } as unknown as UserSessionService;
+      const storeMock$ = { select: () => selectActiveContentItemParams$ } as unknown as Store;
+      resultActionsServiceSpy.startWithoutAttempt.and.callFake(() => cold('--x|', { x: '1' }));
+
+      routeErrorHandlingEffect(
+        storeMock$,
+        userSessionNoChangeMock$,
+        getItemPathServiceSpy, // not called in this case (path given)
+        resultActionsServiceSpy,
+        itemRouterSpy
+      ).pipe(toArray()).subscribe(events => {
+        expect(events).toEqual([ fetchingAction, fetchingAction ]);
+        expect(itemRouterSpy.navigateTo).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
+  });
+
+  it('emits error on error handling error', done => {
+    testScheduler.run(({ hot }) => {
+      const routeError = { tag: 'error', contentType: 'activity', id: '1' };
+      const selectActiveContentItemParams$ = hot('-x--|', { x: routeError }).pipe(shareReplay(1));
+      const userSessionNoChangeMock$ = { userChanged$: hot('----|', { x: null }) } as unknown as UserSessionService;
+      const storeMock$ = { select: () => selectActiveContentItemParams$ } as unknown as Store;
+
+      routeErrorHandlingEffect(
+        storeMock$,
+        userSessionNoChangeMock$,
+        getItemPathServiceSpy,
+        resultActionsServiceSpy, // not called as getItemPathServiceSpy fails before
+        itemRouterSpy
+      ).pipe(toArray()).subscribe(events => {
+        expect(events).toEqual([ fetchingAction, errorAction ]);
+        expect(itemRouterSpy.navigateTo).toHaveBeenCalledTimes(0);
+        done();
+      });
+    });
+  });
+
+  it('retry if the user change', done => {
+    testScheduler.run(({ hot }) => {
+      const routeError = { tag: 'error', contentType: 'activity', id: '1' };
+      const selectActiveContentItemParams$ = hot('-x--|', { x: routeError }).pipe(shareReplay(1));
+      const userSessionNoChangeMock$ = { userChanged$: hot('--x-|', { x: null }) } as unknown as UserSessionService;
+      const storeMock$ = { select: () => selectActiveContentItemParams$ } as unknown as Store;
+
+      routeErrorHandlingEffect(
+        storeMock$,
+        userSessionNoChangeMock$,
+        getItemPathServiceSpy,
+        resultActionsServiceSpy, // not called as getItemPathServiceSpy fails before
+        itemRouterSpy
+      ).pipe(toArray()).subscribe(events => {
+        expect(events).toEqual([ fetchingAction, errorAction, fetchingAction, errorAction ]);
+        expect(itemRouterSpy.navigateTo).toHaveBeenCalledTimes(0);
+        done();
+      });
+    });
+  });
+
+});

--- a/src/app/items/store/item-content/item-route.effects.ts
+++ b/src/app/items/store/item-content/item-route.effects.ts
@@ -1,0 +1,47 @@
+import { createEffect } from '@ngrx/effects';
+import { inject } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { filter, map, startWith, switchMap, tap } from 'rxjs';
+import { isNotNull } from 'src/app/utils/null-undefined-predicates';
+import { fromItemContent } from './item-content.store';
+import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
+import { UserSessionService } from 'src/app/services/user-session.service';
+import { repeatLatestWhen } from 'src/app/utils/operators/repeatLatestWhen';
+import { solveMissingPathAttempt } from '../../utils/item-route-validation';
+import { ResultActionsService } from 'src/app/data-access/result-actions.service';
+import { ItemRouter } from 'src/app/models/routing/item-router';
+import { mapErrorToState } from 'src/app/utils/operators/state';
+import { itemRouteErrorHandlingActions } from './item-content.actions';
+import { fetchingState } from 'src/app/utils/state';
+
+export const routeErrorHandlingEffect = createEffect(
+  (
+    store$ = inject(Store),
+    userSessionService = inject(UserSessionService),
+    getItemPathService = inject(GetItemPathService),
+    resultActionsService = inject(ResultActionsService),
+    itemRouter = inject(ItemRouter),
+  ) => store$.select(fromItemContent.selectActiveContentRouteError).pipe(
+    filter(isNotNull),
+    repeatLatestWhen(userSessionService.userChanged$),
+    switchMap(routeError => solveMissingPathAttempt(routeError, getItemPathService, resultActionsService, itemRouter).pipe(
+      startWith(fetchingState()),
+      mapErrorToState(),
+    )),
+    map(newState => itemRouteErrorHandlingActions.routeErrorHandlingChange({ newState }))
+  ),
+  { functional: true },
+);
+
+export const removeActionsFromRoute = createEffect(
+  (
+    store$ = inject(Store),
+    itemRouter = inject(ItemRouter),
+  ) => store$.select(fromItemContent.selectActiveContentRoute).pipe(
+    filter(isNotNull),
+    tap(route => {
+      if (route.answer?.loadAsCurrent) itemRouter.navigateTo({ ...route, answer: undefined }, { navExtras: { replaceUrl: true } });
+    })
+  ),
+  { functional: true, dispatch: false },
+);

--- a/src/app/items/utils/item-route-validation.ts
+++ b/src/app/items/utils/item-route-validation.ts
@@ -1,22 +1,22 @@
 import { ParamMap } from '@angular/router';
-import { ItemTypeCategory } from 'src/app/items/models/item-type';
-import { decodeItemRouterParameters, FullItemRoute, itemCategoryFromPrefix, ItemRoute } from 'src/app/models/routing/item-route';
+import { EMPTY, Observable, map, of, switchMap } from 'rxjs';
+import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
+import { ResultActionsService } from 'src/app/data-access/result-actions.service';
+import { decodeItemRouterParameters, FullItemRoute, ItemRoute } from 'src/app/models/routing/item-route';
+import { ItemRouter } from 'src/app/models/routing/item-router';
+import { defaultAttemptId } from '../models/attempts';
+import { ItemTypeCategory } from '../models/item-type';
 
-interface ItemRouteError extends Partial<ItemRoute> {
-  tag: 'error',
-  contentType: ItemTypeCategory,
-}
+export type ItemRouteError = { tag: 'error' } & Pick<ItemRoute, 'id'|'contentType'> & Partial<ItemRoute>;
 
-export function itemRouteFromParams(prefix: string, params: ParamMap): FullItemRoute|ItemRouteError {
-  const contentType = itemCategoryFromPrefix(prefix);
-  if (contentType === null) throw new Error('Unexpected item path prefix');
+export function itemRouteFromParams(contentType: ItemTypeCategory, params: ParamMap): FullItemRoute|ItemRouteError {
   const { id, path, attemptId, parentAttemptId, answerId, answerBest, answerParticipantId, answerLoadAsCurrent }
     = decodeItemRouterParameters(params);
   let answer: ItemRoute['answer']|undefined;
   if (answerBest) answer = { best: true, participantId: answerParticipantId ?? undefined };
   else if (answerId) answer = { id: answerId, loadAsCurrent: answerLoadAsCurrent ? true : undefined };
 
-  if (!id) return { tag: 'error', contentType };
+  if (!id) throw new Error('Unexpected missing id from item param');
   if (path === null) return { tag: 'error', contentType, id, answer };
   if (attemptId) return { contentType, id: id, path, attemptId, answer };
   if (parentAttemptId) return { contentType, id, path, parentAttemptId, answer };
@@ -25,4 +25,32 @@ export function itemRouteFromParams(prefix: string, params: ParamMap): FullItemR
 
 export function isItemRouteError(route: FullItemRoute|ItemRouteError): route is ItemRouteError {
   return 'tag' in route && route.tag === 'error';
+}
+
+/**
+ * Called when either path or attempt is missing. Will fetch the path if missing, then will be fetch the attempt.
+ * Will redirect when relevant data has been fetched (and emit nothing).
+ * May emit errors.
+ */
+export function solveMissingPathAttempt(
+  { contentType, id, path, answer }: ItemRouteError,
+  getItemPathService: GetItemPathService,
+  resultActionsService: ResultActionsService,
+  itemRouter: ItemRouter
+): Observable<never> {
+  return of(path).pipe(
+    switchMap(path => (path ? of(path) : getItemPathService.getItemPath(id))),
+    switchMap(path => {
+      // for empty path (root items), consider the item has a (fake) parent attempt id 0
+      if (path.length === 0) return of({ contentType, id, path, parentAttemptId: defaultAttemptId, answer });
+      // else, will start all path but the current item
+      return resultActionsService.startWithoutAttempt(path).pipe(
+        map(attemptId => ({ contentType, id, path, parentAttemptId: attemptId, answer }))
+      );
+    }),
+    switchMap(itemRoute => {
+      itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
+      return EMPTY;
+    })
+  );
 }

--- a/src/app/models/routing/item-route.ts
+++ b/src/app/models/routing/item-route.ts
@@ -182,3 +182,26 @@ function aliasFor(itemId: ItemId, path: string[]|undefined): { alias: string, va
 function pathToAlias(path: string): string {
   return path.replace(/\//g, '--');
 }
+
+/* **********************************************************************************************************
+ * Other utility functions
+ * ********************************************************************************************************** */
+
+/**
+ * Whether the 2 routes are equals
+ * If `prev` had a "command" (e.g., loadAsCurrent) and there is no `answer` in `cur`, route are considered equal
+ */
+export function routesEqualIgnoringCommands(prev: FullItemRoute, cur: FullItemRoute): boolean {
+  return prev.id === cur.id &&
+    arraysEqual(prev.path, cur.path) &&
+    prev.attemptId === cur.attemptId &&
+    prev.parentAttemptId === cur.parentAttemptId &&
+    (
+      (
+        prev.answer?.best === cur.answer?.best &&
+        prev.answer?.id === cur.answer?.id &&
+        prev.answer?.participantId === cur.answer?.participantId &&
+        prev.answer?.loadAsCurrent === cur.answer?.loadAsCurrent
+      ) || (!!prev.answer?.loadAsCurrent && !cur.answer)
+    );
+}

--- a/src/app/store/router/router.selectors.ts
+++ b/src/app/store/router/router.selectors.ts
@@ -1,6 +1,6 @@
 import { MemoizedSelector, Selector, createSelector } from '@ngrx/store';
 import { State } from './router.state';
-import { Params, convertToParamMap } from '@angular/router';
+import { ParamMap, Params, convertToParamMap } from '@angular/router';
 import { RouterReducerState } from '@ngrx/router-store';
 
 interface Selectors<T> {
@@ -10,6 +10,7 @@ interface Selectors<T> {
   selectState: MemoizedSelector<T, State | undefined>,
   selectNavigationId: MemoizedSelector<T, RouterReducerState['navigationId'] | undefined>,
   selectPath: MemoizedSelector<T, string[] | undefined>,
+  selectParamMap: MemoizedSelector<T, ParamMap>,
   selectParam: (param: string) => MemoizedSelector<T, string | null>,
   selectQueryParam: (param: string) => MemoizedSelector<T, string | null>,
 }
@@ -57,5 +58,5 @@ export function selectors<T>(baseSelectRouterState: Selector<T, RouterReducerSta
   const selectQueryParam = (param: string): MemoizedSelector<T, string | null> =>
     createSelector(selectQueryParamMap, paramMap => paramMap.get(param));
 
-  return { selectRouterState, selectState, selectNavigationId, selectPath, selectParam, selectQueryParam };
+  return { selectRouterState, selectState, selectNavigationId, selectPath, selectParamMap, selectParam, selectQueryParam };
 }

--- a/src/app/utils/null-undefined-predicates.ts
+++ b/src/app/utils/null-undefined-predicates.ts
@@ -12,3 +12,14 @@ export function isNotUndefined<T>(e: T|undefined): e is T {
 }
 
 export const isDefined = isNotUndefined;
+
+/**
+ * Factory for building an T|null comparator by wrapping a T comparator
+ */
+export function equalNullableFactory<T>(fct: (v1: T, v2: T) => boolean): (v1: T|null, v2: T|null) => boolean {
+  return (v1: T|null, v2: T|null) => {
+    if (v1 === v2) return true;
+    if (v1 === null || v2 === null) return false;
+    return fct(v1, v2);
+  };
+}

--- a/src/app/utils/operators/state.ts
+++ b/src/app/utils/operators/state.ts
@@ -1,6 +1,6 @@
 import { EMPTY, noop, Observable, of, OperatorFunction, pipe } from 'rxjs';
 import { catchError, filter, map, startWith, switchMap } from 'rxjs/operators';
-import { errorState, fetchingState, FetchState, Ready, readyState } from '../state';
+import { errorState, FetchError, fetchingState, FetchState, Ready, readyState } from '../state';
 
 /**
  * Rx operator which first emits a loading state and then emit a ready or error state depending on the source. Never fails.
@@ -14,7 +14,7 @@ export function mapToFetchState<T>(config?: { resetter?: Observable<unknown> }):
   return pipe(
     map(val => readyState(val)),
     startWith(fetchingState()),
-    mapErrorToState<T>(),
+    mapErrorToState(),
     source => resetter.pipe(
       startWith(noop),
       switchMap(() => source),
@@ -53,7 +53,7 @@ export function mapStateData<T, U>(dataMapper: (data: T) => U): OperatorFunction
 /**
  * Rx operator which convert observable error to "error state". To be used when the state is built "manually".
  */
-export function mapErrorToState<T>(): OperatorFunction<FetchState<T>,FetchState<T>> {
+export function mapErrorToState<T>(): OperatorFunction<T, T|FetchError> {
   return pipe(
     catchError(e => of(errorState(e))),
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,7 @@ import { provideRouterStore, RouterState } from '@ngrx/router-store';
 import { fromObservation, observationEffects } from './app/store/observation';
 import { fromRouter, RouterSerializer } from './app/store/router';
 import { fromUserContent, groupStoreEffects } from './app/groups/store';
+import { fromItemContent, itemStoreEffects } from './app/items/store';
 
 const DEFAULT_SCROLLBAR_OPTIONS: NgScrollbarOptions = {
   visibility: 'hover',
@@ -137,7 +138,8 @@ bootstrapApplication(AppComponent, {
     provideState(fromObservation),
     provideState(fromForum),
     provideState(fromUserContent),
-    provideEffects(observationEffects, forumEffects(), groupStoreEffects()),
+    provideState(fromItemContent),
+    provideEffects(observationEffects, forumEffects(), groupStoreEffects(), itemStoreEffects()),
     provideStoreDevtools({ maxAge: 25, logOnly: !isDevMode() , connectInZone: true }),
     provideAnimations(),
     provideHttpClient(withInterceptorsFromDi()),


### PR DESCRIPTION
## Description

Simplify the item-by-id component by moving out all the item routing part.

Add e2e tests to check the different cases.

## Test cases

See e2e tests
