### PR TITLE
Adds scroll into edit permissions modal

### DIFF
--- a/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.scss
+++ b/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.scss
@@ -3,12 +3,9 @@
 .container {
   display: flex;
   flex-direction: column;
-  max-height: toRem(450);
-  overflow: hidden;
 }
 
 .controls-container {
-  overflow: auto;
   flex: 1;
 }
 

--- a/src/assets/scss/components/permissions-edit-dialog.scss
+++ b/src/assets/scss/components/permissions-edit-dialog.scss
@@ -12,7 +12,7 @@
   }
 
   .p-dialog-content {
-    overflow: hidden;
+    overflow: scroll;
   }
 
   .p-dialog-footer {


### PR DESCRIPTION
## Description

Fixes #1677

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/en/a/6707691810849260111;p=;pa=0?watchedGroupId=4035378957038759250)
  3. And I click on permissions panel
  4. Then I click on "Edit permissions" button
  5. And I open few collapsable sections
  6. Then I see scroll
