### PR TITLE
Bugfix/e2e tests

### DIFF
--- a/e2e/groups/user-group-invitations.spec.ts
+++ b/e2e/groups/user-group-invitations.spec.ts
@@ -39,6 +39,7 @@ const isUserInvitedToGroup = async (page: Page) => {
   await page.goto('/groups/mine');
   await page.waitForResponse(`${apiUrl}/current-user/group-memberships`);
   await expect.soft(page.getByRole('heading', { name: 'Pending invitations' })).toBeVisible();
+  await expect.soft(page.locator('alg-user-group-invitations')).toBeVisible();
   return page.locator('alg-user-group-invitations').getByRole('cell', { name: groupName }).isVisible();
 };
 
@@ -80,7 +81,7 @@ test.afterEach(async ({ page }) => {
   await expect(page.locator('alg-member-list')).not.toContainText(demoUserLogin);
 });
 
-test('Accept group invitation flow', async ({ page }) => {
+test('Accept group invitation', async ({ page }) => {
   await test.step('Invite user into group', async () => {
     await initAsUsualUser(page);
     await sendGroupInvitation(page);

--- a/e2e/groups/user-group-invitations.spec.ts
+++ b/e2e/groups/user-group-invitations.spec.ts
@@ -22,16 +22,15 @@ const leaveGroup = async (page: Page) => {
   await page.goto('/groups/mine');
   await page.waitForResponse(`${apiUrl}/current-user/group-memberships`);
   await expect.soft(page.getByRole('heading', { name: 'The groups you joined' })).toBeVisible();
-  await expect.soft(
-    page.locator('alg-joined-group-list', { hasText: groupName })
-      .getByRole('row', { name: groupName })
-      .getByRole('button')
-  ).toBeVisible();
-  await page.locator('alg-joined-group-list', { hasText: groupName })
+  const joinedGroupListLocator = page.locator('alg-joined-group-list', { hasText: groupName })
     .getByRole('row', { name: groupName })
-    .getByRole('button')
-    .click();
-  await page.getByRole('button', { name: 'Yes, leave group' }).click();
+    .getByRole('button');
+  await expect.soft(joinedGroupListLocator).toBeVisible();
+  await joinedGroupListLocator.hover();
+  await joinedGroupListLocator.click();
+  const leaveGroupButtonLocator = page.getByRole('button', { name: 'Yes, leave group' });
+  await expect.soft(leaveGroupButtonLocator).toBeVisible();
+  await leaveGroupButtonLocator.click();
   await expect.soft(page.locator('p-toastitem', { hasText: `You have left "${ groupName }"` })).toBeVisible();
 };
 
@@ -39,7 +38,7 @@ const isUserInvitedToGroup = async (page: Page) => {
   await page.goto('/groups/mine');
   await page.waitForResponse(`${apiUrl}/current-user/group-memberships`);
   await expect.soft(page.getByRole('heading', { name: 'Pending invitations' })).toBeVisible();
-  await expect.soft(page.locator('alg-user-group-invitations')).toBeVisible();
+  await expect.soft(page.locator('alg-user-group-invitations').filter({ has: page.locator('p-table') })).toBeVisible();
   return page.locator('alg-user-group-invitations').getByRole('cell', { name: groupName }).isVisible();
 };
 

--- a/e2e/groups/view-answer.spec.ts
+++ b/e2e/groups/view-answer.spec.ts
@@ -121,10 +121,10 @@ const itemLogsJson = [
 
 test('View answer in logs for current user', async ({ page }) => {
   await initAsUsualUser(page);
-  await page.goto('/groups/users/670968966872011405');
   await page.route(`${apiUrl}/items/log?limit=20`, async route => {
     await route.fulfill({ json: currentUserLogsJson });
   });
+  await page.goto('/groups/users/670968966872011405');
   await expect.soft(page.locator('h1').getByText('Armelle Bonenfant (arbonenfant)')).toBeVisible();
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
@@ -134,10 +134,10 @@ test('View answer in logs for current user', async ({ page }) => {
 
 test('View answer in logs for other user', async ({ page }) => {
   await initAsUsualUser(page);
-  await page.goto('/groups/users/752024252804317630');
   await page.route(`${apiUrl}/items/log?limit=20&watched_group_id=752024252804317630`, async route => {
     await route.fulfill({ json: otherUserJson });
   });
+  await page.goto('/groups/users/752024252804317630');
   await expect.soft(page.locator('h1').getByText('usr_5p020x2thuyu')).toBeVisible();
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
@@ -147,10 +147,10 @@ test('View answer in logs for other user', async ({ page }) => {
 
 test('View answer in logs for a group', async ({ page }) => {
   await initAsUsualUser(page);
-  await page.goto('/groups/by-id/672913018859223173;p=52767158366271444');
   await page.route(`${apiUrl}/items/log?limit=20&watched_group_id=672913018859223173`, async route => {
     await route.fulfill({ json: groupLogsJson });
   });
+  await page.goto('/groups/by-id/672913018859223173;p=52767158366271444');
   await expect.soft(page.locator('h1').getByText('Pixal')).toBeVisible();
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
@@ -160,10 +160,10 @@ test('View answer in logs for a group', async ({ page }) => {
 
 test('Reload answer in logs for a item', async ({ page }) => {
   await initAsUsualUser(page);
-  await page.goto('/a/home;pa=0/progress/history');
   await page.route(`${apiUrl}/items/4702/log?limit=20`, async route => {
     await route.fulfill({ json: itemLogsJson });
   });
+  await page.goto('/a/home;pa=0/progress/history');
   await expect.soft(page.locator('h1').getByText('Parcours officiels')).toBeVisible();
   await expect.soft(page.getByRole('link', { name: 'Reload answer' })).toBeVisible();
   await page.getByRole('link', { name: 'Reload answer' }).click();


### PR DESCRIPTION
## Description

1. Fixes group invitations e2e test cases:
 - Wait until invitations table to be rendered;
 - If Pending invitations has big list and The groups you joined is under view area - it does scroll down to this element, but primeng has affect for tooltip - any scrolls disappearing tooltip. So I had to add scroll down to element before click on button
2. Fixes view answer e2e test cases, returned real data instead mock randomly, so I've defined it before page is init

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases


