### PR TITLE
Fix load answer test

### DIFF
--- a/e2e/items/item-routing.spec.ts
+++ b/e2e/items/item-routing.spec.ts
@@ -59,11 +59,20 @@ test('route with missing path and service error', async ({ page }) => {
 });
 
 test('route with action parameter: action passed to subcomponents + parameter removed', async ({ page }) => {
+  const emptyAnswer = '1970981512988735785';
+  const answerWith1234567 = '4143245131838208903';
+
   await initAsUsualUser(page);
   // first reload an empty answer
-  await page.goto('/a/6379723280369399253;p=;pa=0;answerId=8006495052571134372;answerLoadAsCurrent=1');
+  await page.goto(`/a/6379723280369399253;p=;pa=0;answerId=${emptyAnswer};answerLoadAsCurrent=1`);
+
+  await test.step('checks the answer has been emptied', async () => {
+    await expect(page.frameLocator('iFrame').getByText('Programme de la tortue')).toBeVisible({ timeout: 30000 });
+    await expect(page.frameLocator('iFrame').getByText('1234567')).not.toBeVisible();
+  });
+
   // then reload a answer which contains "1234567" in the answer
-  await page.goto('/a/6379723280369399253;p=;pa=0;answerId=4143245131838208903;answerLoadAsCurrent=1');
+  await page.goto(`/a/6379723280369399253;p=;pa=0;answerId=${answerWith1234567};answerLoadAsCurrent=1`);
 
   await test.step('drop the action parameter', async () => {
     await expect(page.locator('.left-pane-title-text')).toContainText('Blockly Basic Task', { timeout: 15000 });
@@ -72,6 +81,7 @@ test('route with action parameter: action passed to subcomponents + parameter re
   });
 
   await test.step('has loaded the expected answer', async () => {
-    await expect(page.frameLocator('iFrame').getByText('1234567')).toBeVisible({ timeout: 30000 }); // to check it is the right answer
+    await expect(page.frameLocator('iFrame').getByText('Programme de la tortue')).toBeVisible({ timeout: 30000 });
+    await expect(page.frameLocator('iFrame').getByText('1234567')).toBeVisible(); // to check it is the right answer
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ import { provideState, provideStore } from '@ngrx/store';
 import { fromForum, forumEffects } from './app/forum/store';
 import { provideStoreDevtools } from '@ngrx/store-devtools';
 import { provideEffects } from '@ngrx/effects';
-import { provideRouterStore, RouterState } from '@ngrx/router-store';
+import { provideRouterStore } from '@ngrx/router-store';
 import { fromObservation, observationEffects } from './app/store/observation';
 import { fromRouter, RouterSerializer } from './app/store/router';
 import { fromUserContent, groupStoreEffects } from './app/groups/store';
@@ -133,7 +133,7 @@ bootstrapApplication(AppComponent, {
     },
     provideRouter(routes),
     provideStore(),
-    provideRouterStore({ routerState: RouterState.Minimal, serializer: RouterSerializer }),
+    provideRouterStore({ serializer: RouterSerializer }),
     provideState(fromRouter),
     provideState(fromObservation),
     provideState(fromForum),


### PR DESCRIPTION
## Description

Fix the answer loading which appears to be broken since its recent implementation using the store. Tests were passing at first because there was an error in the tests which causes them to always pass and recently it broke just because somebody changed the current answer (?).

## Notes

I tried many other options than using this `delay(0)`, without success :-/... 

## Test cases

Check the tests.

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [an answer with an empty answer](https://dev.algorea.org/branch/fix-load-answer-test/en/a/6379723280369399253;p=;pa=0;answerId=1970981512988735785;answerLoadAsCurrent=1)
  3. Then I see the answer is empty
  2. When I go to [an answer with a non-empty answer](https://dev.algorea.org/branch/fix-load-answer-test/en/a/6379723280369399253;p=;pa=0;answerId=4143245131838208903;answerLoadAsCurrent=1)
  3. And I see the answer contains a loop with "1234567"
  4. And the url has dropped the loadAsCurrent parameter
