### PR TITLE
Fix children grid test failure

### DIFF
--- a/e2e/items/chapter-children.spec.ts
+++ b/e2e/items/chapter-children.spec.ts
@@ -9,6 +9,6 @@ test('check chapter children as a grid', async ({ page }) => {
 
   await test.step('check the path to child is correctly built', async () => {
     const href = await firstChildLink.getAttribute('href');
-    expect(href).toContain('/a/7160584978827224142;p=7528142386663912287,6621899821435600308,9151590357867554022;pa=0');
+    expect(href).toContain('/a/7160584978827224142;p=7528142386663912287,6621899821435600308,9151590357867554022;a=0');
   });
 });


### PR DESCRIPTION
Now the children as been visited, the attempt id (`a=1`) is used, not the parent attempt id (`pa=1`).
