### PR TITLE
ignore new googletag error

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ Sentry.init({
   release: version,
   integrations: [],
   ignoreErrors: [
+    'Cannot redefine property: googletag',
     "Cannot read properties of undefined (reading 'sendMessage')", // a chrome extension error
     "can't access dead object", // a firefox error when add-ons keep references to DOM objects after their parent document was destroyed
   ],


### PR DESCRIPTION
Just ignore from error reporting the `Cannot redefine property: googletag` error that we got a lot recently.