### PR TITLE
Removes duplicated groupApprovalsDecoder declaration

### DIFF
--- a/src/app/groups/containers/group-edit/group-edit.component.ts
+++ b/src/app/groups/containers/group-edit/group-edit.component.ts
@@ -7,7 +7,7 @@ import { CreateItemService } from 'src/app/data-access/create-item.service';
 import { PendingChangesComponent } from 'src/app/guards/pending-changes-guard';
 import { NoAssociatedItem, NewAssociatedItem, ExistingAssociatedItem,
   isNewAssociatedItem, isExistingAssociatedItem } from '../associated-item/associated-item-types';
-import { Group, GroupApprovals } from '../../data-access/get-group-by-id.service';
+import { Group } from '../../data-access/get-group-by-id.service';
 import { GroupUpdateService } from '../../data-access/group-update.service';
 import { GroupDataSource } from '../../services/group-datasource.service';
 import { withManagementAdditions } from '../../models/group-management';
@@ -29,6 +29,7 @@ import { SelectionComponent } from 'src/app/ui-components/selection/selection.co
 import { MessageInfoComponent } from 'src/app/ui-components/message-info/message-info.component';
 import { InputMaskModule } from 'primeng/inputmask';
 import { InputDateComponent } from 'src/app/ui-components/input-date/input-date.component';
+import { GroupApprovals } from 'src/app/groups/models/group-approvals';
 
 @Component({
   selector: 'alg-group-edit',

--- a/src/app/groups/data-access/get-group-by-id.service.ts
+++ b/src/app/groups/data-access/get-group-by-id.service.ts
@@ -15,12 +15,6 @@ const groupShortInfo = D.struct({
   name: D.string,
 });
 
-const groupApprovalsDecoder = D.struct({
-  requireLockMembershipApprovalUntil: D.nullable(dateDecoder),
-  requirePersonalInfoAccessApproval: D.literal('none', 'view', 'edit'),
-  requireWatchApproval: D.boolean,
-});
-
 const decoder = pipe(
   D.struct({
     id: D.string,
@@ -50,7 +44,6 @@ const decoder = pipe(
 
 export type Group = D.TypeOf<typeof decoder>;
 export type GroupShortInfo = D.TypeOf<typeof groupShortInfo>;
-export type GroupApprovals = D.TypeOf<typeof groupApprovalsDecoder>;
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/groups/data-access/group-update.service.ts
+++ b/src/app/groups/data-access/group-update.service.ts
@@ -4,7 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { appConfig } from 'src/app/utils/config';
 import { assertSuccess, SimpleActionResponse } from 'src/app/data-access/action-response';
-import { GroupApprovals } from './get-group-by-id.service';
+import { GroupApprovals } from 'src/app/groups/models/group-approvals';
 
 export interface GroupChanges {
   name?: string,


### PR DESCRIPTION
## Description

Fixes duplicated groupApprovalsDecoder declaration 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Because both of 2 tickets required `groupApprovalsDecoder` and we couldn't merge it for a while, I had to create the decoder twice, and it's supposed to be removed 

## Test cases
