### PR TITLE
Increases clickable area for nav buttons in top bar

### DIFF
--- a/src/app/containers/content-top-bar/content-top-bar.component.scss
+++ b/src/app/containers/content-top-bar/content-top-bar.component.scss
@@ -36,6 +36,7 @@
 
 .neighbor-widget {
   display: block;
+  height: 100%;
 }
 
 .breadcrumb {
@@ -71,4 +72,5 @@
   display: flex;
   align-items: center;
   overflow: hidden;
+  height: 100%;
 }

--- a/src/app/ui-components/neighbor-widget/neighbor-widget.component.html
+++ b/src/app/ui-components/neighbor-widget/neighbor-widget.component.html
@@ -4,7 +4,7 @@
       pButton
       type="button"
       icon="ph-bold ph-caret-up"
-      class="alg-button-icon no-bg primary-color full-height nav-arrow"
+      class="alg-button-icon no-bg primary-color nav-arrow"
       (click)="parent.emit()"
     ></button>
   </div>
@@ -12,8 +12,8 @@
     <button
       pButton
       type="button"
-      icon="ph-bold ph-caret-left full-height"
-      class="alg-button-icon no-bg primary-color full-height nav-arrow"
+      icon="ph-bold ph-caret-left"
+      class="alg-button-icon no-bg primary-color nav-arrow"
       (click)="left.emit()"
       [disabled]="!navigationMode.left"
     ></button>
@@ -23,7 +23,7 @@
       pButton
       type="button"
       icon="ph-bold ph-caret-right"
-      class="alg-button-icon no-bg primary-color full-height nav-arrow"
+      class="alg-button-icon no-bg primary-color nav-arrow"
       data-testid="nav-to-next"
       (click)="right.emit()"
       [disabled]="!navigationMode.right"

--- a/src/app/ui-components/neighbor-widget/neighbor-widget.component.html
+++ b/src/app/ui-components/neighbor-widget/neighbor-widget.component.html
@@ -4,7 +4,7 @@
       pButton
       type="button"
       icon="ph-bold ph-caret-up"
-      class="alg-button-icon no-bg primary-color"
+      class="alg-button-icon no-bg primary-color full-height nav-arrow"
       (click)="parent.emit()"
     ></button>
   </div>
@@ -12,8 +12,8 @@
     <button
       pButton
       type="button"
-      icon="ph-bold ph-caret-left"
-      class="alg-button-icon no-bg primary-color"
+      icon="ph-bold ph-caret-left full-height"
+      class="alg-button-icon no-bg primary-color full-height nav-arrow"
       (click)="left.emit()"
       [disabled]="!navigationMode.left"
     ></button>
@@ -23,7 +23,7 @@
       pButton
       type="button"
       icon="ph-bold ph-caret-right"
-      class="alg-button-icon no-bg primary-color"
+      class="alg-button-icon no-bg primary-color full-height nav-arrow"
       data-testid="nav-to-next"
       (click)="right.emit()"
       [disabled]="!navigationMode.right"

--- a/src/app/ui-components/neighbor-widget/neighbor-widget.component.scss
+++ b/src/app/ui-components/neighbor-widget/neighbor-widget.component.scss
@@ -3,14 +3,18 @@
 .neighbor-widget {
   display: flex;
   align-items: center;
+  height: 100%;
 }
 
 .neighbor-widget-button {
+  display: flex;
+  align-items: center;
+  height: 100%;
+
   &:not(:last-child) {
     &:after {
       content: '|';
       color: var(--alg-border-light-color);
-      margin: 0 toRem(12);
 
       @media screen and (max-width: 599.98px) {
         margin: 0 toRem(2);

--- a/src/assets/scss/components/button-icon.scss
+++ b/src/assets/scss/components/button-icon.scss
@@ -168,4 +168,13 @@
       }
     }
   }
+
+  &.nav-arrow {
+    padding: 0 toRem(12);
+    height: 100%;
+
+    @media screen and (max-width: 599.98px) {
+      padding: 0 toRem(2);
+    }
+  }
 }


### PR DESCRIPTION
## Description

Fixes #1700

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Clickable area on mobile
<img width="300" alt="Screenshot at Jul 22 16-16-52" src="https://github.com/user-attachments/assets/9754c27c-5272-4f3c-889a-3e37bb1a47ed">

Clickable area (green) on desktop
<img width="159" alt="Screenshot at Jul 22 16-09-45" src="https://github.com/user-attachments/assets/b257e147-bcf5-49c2-86e0-c9c2f8f31767">

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/enlarge-clickable-zone-for-navigation-arrows/en/a/home;pa=0)
  3. And I hover on nav arrow in top bar
  4. Then I see the clickable area increased

