### PR TITLE
Fix task unload

### DIFF
--- a/e2e/items/task-switching.spec.ts
+++ b/e2e/items/task-switching.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { initAsUsualUser } from '../helpers/e2e_auth';
+
+/**
+ * Check that we can switch between tasks (i.e., that the task unload rule when leaving a task does not block everything)
+ */
+
+test('activity with full route loads', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/1414822370876733593;p=4702,100575556387408660,1788359139685642917;pa=0');
+  await page.locator('alg-neighbor-widget').getByTestId('nav-to-next').click();
+
+  expect(page.url()).toContain('/a/1667741628301295500;p=4702,100575556387408660,1788359139685642917');
+});

--- a/src/app/items/store/item-content/item-route.effects.ts
+++ b/src/app/items/store/item-content/item-route.effects.ts
@@ -1,7 +1,7 @@
-import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { createEffect } from '@ngrx/effects';
 import { inject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { delay, filter, map, startWith, switchMap, take, tap } from 'rxjs';
+import { delay, filter, map, startWith, switchMap, tap } from 'rxjs';
 import { isNotNull } from 'src/app/utils/null-undefined-predicates';
 import { fromItemContent } from './item-content.store';
 import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
@@ -13,7 +13,6 @@ import { ItemRouter } from 'src/app/models/routing/item-router';
 import { mapErrorToState } from 'src/app/utils/operators/state';
 import { itemRouteErrorHandlingActions } from './item-content.actions';
 import { fetchingState } from 'src/app/utils/state';
-import { ROUTER_NAVIGATED } from '@ngrx/router-store';
 
 export const routeErrorHandlingEffect = createEffect(
   (
@@ -37,11 +36,8 @@ export const routeErrorHandlingEffect = createEffect(
 export const removeActionsFromRouteEffect = createEffect(
   (
     store$ = inject(Store),
-    actions$ = inject(Actions),
     itemRouter = inject(ItemRouter),
-  ) => actions$.pipe(
-    ofType(ROUTER_NAVIGATED), // only trigger this effect when a navigation has completed
-    switchMap(() => store$.select(fromItemContent.selectActiveContentRoute).pipe(take(1))), // pick the current active content route
+  ) => store$.select(fromItemContent.selectActiveContentRoute).pipe(
     filter(isNotNull),
     delay(0), // required in order to trigger new navigation after this one
     tap(route => {

--- a/src/app/items/utils/item-route-validation.ts
+++ b/src/app/items/utils/item-route-validation.ts
@@ -1,5 +1,5 @@
 import { ParamMap } from '@angular/router';
-import { EMPTY, Observable, map, of, switchMap } from 'rxjs';
+import { EMPTY, Observable, delay, map, of, switchMap } from 'rxjs';
 import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
 import { ResultActionsService } from 'src/app/data-access/result-actions.service';
 import { decodeItemRouterParameters, FullItemRoute, ItemRoute } from 'src/app/models/routing/item-route';
@@ -48,6 +48,7 @@ export function solveMissingPathAttempt(
         map(attemptId => ({ contentType, id, path, parentAttemptId: attemptId, answer }))
       );
     }),
+    delay(0), // required in order to trigger new navigation after the current one
     switchMap(itemRoute => {
       itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
       return EMPTY;

--- a/src/app/ui-components/neighbor-widget/neighbor-widget.component.html
+++ b/src/app/ui-components/neighbor-widget/neighbor-widget.component.html
@@ -24,6 +24,7 @@
       type="button"
       icon="ph-bold ph-caret-right"
       class="alg-button-icon no-bg primary-color"
+      data-testid="nav-to-next"
       (click)="right.emit()"
       [disabled]="!navigationMode.right"
     ></button>

--- a/src/main.ts
+++ b/src/main.ts
@@ -35,7 +35,7 @@ import { provideState, provideStore } from '@ngrx/store';
 import { fromForum, forumEffects } from './app/forum/store';
 import { provideStoreDevtools } from '@ngrx/store-devtools';
 import { provideEffects } from '@ngrx/effects';
-import { provideRouterStore } from '@ngrx/router-store';
+import { NavigationActionTiming, provideRouterStore } from '@ngrx/router-store';
 import { fromObservation, observationEffects } from './app/store/observation';
 import { fromRouter, RouterSerializer } from './app/store/router';
 import { fromUserContent, groupStoreEffects } from './app/groups/store';
@@ -135,7 +135,7 @@ bootstrapApplication(AppComponent, {
     },
     provideRouter(routes),
     provideStore(),
-    provideRouterStore({ serializer: RouterSerializer }),
+    provideRouterStore({ serializer: RouterSerializer, navigationActionTiming: NavigationActionTiming.PostActivation }),
     provideState(fromRouter),
     provideState(fromObservation),
     provideState(fromForum),


### PR DESCRIPTION
## Description

Fix the following bug: if arriving on a task, and switching to another task, the url of the task was not changing (the page content was changing) ... as a consequence there were problem when changing tabs within the task.

## Notes

There is a test which is not passing, but that's related with groups: "turn on and turn off approval rules 


## Test cases

There is now a new test checking that case.

## Reviews

- The first one fixes the problem
- The next one revert a "hack" which is not needed anymore with the previous fix
- The next one: fix a potential other bug because of a missing `delay(0)` before navigation
- The next one is the new test

