### PR TITLE
move score patching to store

### DIFF
--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -356,7 +356,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
 
   onScoreChange(score: number): void {
     this.currentContentService.forceNavMenuReload();
-    this.itemDataSource.patchItemScore(score);
+    this.store.dispatch(fromItemContent.itemByIdPageActions.patchScore({ score }));
   }
 
   beforeUnload(): Observable<boolean> {

--- a/src/app/items/models/score-patching.ts
+++ b/src/app/items/models/score-patching.ts
@@ -1,0 +1,13 @@
+import { Item } from 'src/app/data-access/get-item-by-id.service';
+import { Result } from '../data-access/get-results.service';
+
+export function patchItemScore(item: Item, newScore: number): Item {
+  return { ...item, bestScore: Math.max(item.bestScore, newScore) };
+}
+
+interface Results { results: Result[], currentResult?: Result }
+export function patchResultScore(results: Results, newScore: number): Results {
+  const score = Math.max(newScore, results.currentResult?.score ?? 0);
+  const validated = newScore >= 100 || !!results.currentResult?.validated;
+  return { ...results, currentResult: results.currentResult ? { ...results.currentResult, score, validated } : undefined };
+}

--- a/src/app/items/services/item-datasource.service.ts
+++ b/src/app/items/services/item-datasource.service.ts
@@ -1,12 +1,11 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Subject, combineLatest } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, map, scan, shareReplay, startWith, switchMap, takeUntil } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { FullItemRoute } from 'src/app/models/routing/item-route';
 import { UserSessionService } from 'src/app/services/user-session.service';
 import { BreadcrumbItem } from '../data-access/get-breadcrumb.service';
 import { Item } from '../../data-access/get-item-by-id.service';
 import { Result } from '../data-access/get-results.service';
-import { FetchState } from 'src/app/utils/state';
 import { Store } from '@ngrx/store';
 import { fromItemContent } from '../store';
 import { isNotNull } from 'src/app/utils/null-undefined-predicates';
@@ -29,23 +28,10 @@ export interface ItemData {
 export class ItemDataSource implements OnDestroy {
 
   private readonly destroyed$ = new Subject<void>();
-  private readonly scorePatch$ = new Subject<number | undefined>();
-  private readonly maxScorePatch$ = this.scorePatch$.pipe(
-    // Keep max score of all emitted scores. NB: adding operators to a subject makes it COLD.
-    // Since it is cold, max score is ONLY computed for values emitted during the lifetime of the subscription
-    scan<number | undefined, number | undefined>((max, score) => (score !== undefined ? Math.max(score, max ?? 0) : undefined), undefined),
-    startWith(undefined),
-    distinctUntilChanged(),
-  );
 
   /* state to put outputted */
   readonly state$ = this.store.select(fromItemContent.selectActiveContentData).pipe(
     filter(isNotNull),
-    // maxScorePatch is a cold observable, and switchMap operator acts a subscriber here
-    // so the max score patch is only valid for current item
-    switchMap(state => this.maxScorePatch$.pipe(map(score => this.patchScore(state, score)))),
-    takeUntil(this.destroyed$),
-    shareReplay(1),
   );
 
   private subscription = combineLatest([
@@ -62,29 +48,10 @@ export class ItemDataSource implements OnDestroy {
     this.store.dispatch(fromItemContent.itemByIdPageActions.refresh());
   }
 
-  patchItemScore(score: number): void {
-    this.scorePatch$.next(score);
-  }
-
   ngOnDestroy(): void {
     this.subscription.unsubscribe();
     this.destroyed$.next();
     this.destroyed$.complete();
-  }
-
-  private patchScore(state: FetchState<ItemData>, newScore?: number): FetchState<ItemData> {
-    if (!state.data || newScore === undefined) return state;
-    const score = Math.max(newScore ?? 0, state.data.currentResult?.score ?? 0);
-    const bestScore = Math.max(state.data.item.bestScore, score);
-    const validated = newScore >= 100 || !!state.data.currentResult?.validated;
-    return {
-      ...state,
-      data: {
-        ...state.data,
-        item: { ...state.data.item, bestScore },
-        currentResult: state.data.currentResult ? { ...state.data.currentResult, score, validated } : undefined,
-      },
-    };
   }
 
 }

--- a/src/app/items/store/item-content/item-content.actions.ts
+++ b/src/app/items/store/item-content/item-content.actions.ts
@@ -12,6 +12,7 @@ export const itemByIdPageActions = createActionGroup({
   source: 'Item-by-id page',
   events: {
     refresh: emptyProps(),
+    patchScore: props<{ score: number }>(),
   }
 });
 

--- a/src/app/items/store/item-content/item-content.reducer.ts
+++ b/src/app/items/store/item-content/item-content.reducer.ts
@@ -1,6 +1,8 @@
 import { createReducer, on } from '@ngrx/store';
 import { State, initialState } from './item-content.state';
-import { itemFetchingActions, itemRouteErrorHandlingActions } from './item-content.actions';
+import { itemByIdPageActions, itemFetchingActions, itemRouteErrorHandlingActions } from './item-content.actions';
+import { mapStateData } from 'src/app/utils/state';
+import { patchItemScore, patchResultScore } from '../../models/score-patching';
 
 export const reducer = createReducer(
   initialState,
@@ -24,5 +26,14 @@ export const reducer = createReducer(
     itemFetchingActions.resultsFetchStateChanged,
     (state, { fetchState }): State => ({ ...state, results: fetchState })
   ),
+
+  on(itemByIdPageActions.patchScore,
+    (state, { score }): State => ({
+      ...state,
+      item: mapStateData(state.item, i => patchItemScore(i, score)),
+      results: state.results ? mapStateData(state.results, r => patchResultScore(r, score)) : null,
+    })
+
+  )
 
 );

--- a/src/app/utils/operators/state.ts
+++ b/src/app/utils/operators/state.ts
@@ -1,6 +1,6 @@
 import { EMPTY, noop, Observable, of, OperatorFunction, pipe } from 'rxjs';
 import { catchError, filter, map, startWith, switchMap } from 'rxjs/operators';
-import { errorState, FetchError, fetchingState, FetchState, Ready, readyState } from '../state';
+import { errorState, FetchError, fetchingState, FetchState, Ready, readyState, mapStateData as mapStateDataFct } from '../state';
 
 /**
  * Rx operator which first emits a loading state and then emit a ready or error state depending on the source. Never fails.
@@ -40,15 +40,11 @@ export function readyData<T>(): OperatorFunction<FetchState<T>,T> {
 }
 
 /**
- * Rx operator which maps the data (if any) using the `dataMapper` function and keeps the state unchanged
+ * Rx operator which maps the data (if any) using the `dataMapper` function and otherwise keeps the state unchanged
  */
 export function mapStateData<T, V, U = undefined>(dataMapper: (data: T) => V): OperatorFunction<FetchState<T,U>,FetchState<V,U>> {
   return pipe(
-    map(state => {
-      if (state.isReady) return readyState(dataMapper(state.data), state.identifier);
-      if (state.isFetching) return fetchingState(state.data === undefined ? undefined : dataMapper(state.data), state.identifier);
-      return state; // error state is not changed
-    }),
+    map(s => mapStateDataFct(s, dataMapper)),
   );
 }
 

--- a/src/app/utils/state.ts
+++ b/src/app/utils/state.ts
@@ -42,3 +42,12 @@ export function errorState<U = undefined>(error: unknown, identifier?: U): Fetch
 export function isFetchingOrError<T, U = undefined>(state: FetchState<T, U>): state is Fetching<T, U>|FetchError {
   return state.isFetching || state.isError;
 }
+
+/**
+ * Maps the data (if any) using the `dataMapper` function, otherwise keeps the state unchanged
+ */
+export function mapStateData<T, V, U = undefined>(state: FetchState<T,U>, dataMapper: (data: T) => V): FetchState<V,U> {
+  if (state.isReady) return readyState(dataMapper(state.data), state.identifier);
+  if (state.isFetching) return fetchingState(state.data === undefined ? undefined : dataMapper(state.data), state.identifier);
+  return state; // error state is not changed
+}


### PR DESCRIPTION
## Description

Move score patching from data source to store (much simpler)

## Note
I have not been able to write an e2e as the palywright recorder does not record things I do in the iframe...  To be explored...

## Test cases

- [ ] Case 1:
  1. Given I am a temp user
  2. When I go to [this task](https://dev.algorea.org/branch/item-score-patching-to-store/en/a/4080996542681828;p=4702,1352246428241737349,314613032161178344,310572474623192846;a=0)
  4. And I enter as answer: 
 ```
from turtle import *
for i in range(6):
    forward(100)
    left(60)
 ```
  4. And I play the code
  5. Then I see my score change in the top bar
