### PR TITLE
Fixes switch edit mode

### DIFF
--- a/src/app/items/containers/item-content/item-content.component.html
+++ b/src/app/items/containers/item-content/item-content.component.html
@@ -57,7 +57,7 @@
   @else {
     @if ((perms | allowsEditingChildren) || editModeEnabled) {
       <div class="edit">
-        <label class="edit-label">
+        <span class="edit-label">
           <span class="alg-base-text-color" i18n>Edit content</span>
           <alg-switch
             class="edit-switch"
@@ -66,7 +66,7 @@
             [checked]="editModeEnabled"
             (change)="onEditModeEnableChange($event)"
           ></alg-switch>
-        </label>
+        </span>
       </div>
     }
     @if (editModeEnabled) {


### PR DESCRIPTION
## Description

Fixes #[1760](https://github.com/France-ioi/AlgoreaFrontend/issues/1760)

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The idea of label was to switch element on text click. After update of primeng, angular it doesn't work. As we don't use this experience in other places - I decided to remove it

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/unable-to-leave-edit-children-mode/en/a/6707691810849260111;p=;a=0)
  3. And I click on "Edit content"
  4. Then I see content for edit
  5. And I click on "Edit content"
  6. Then I see list content

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/unable-to-leave-edit-children-mode/en/a/6707691810849260111;p=;a=0/edit-children)
  3. And I click on "Edit content"
  4. Then I see list content
