### PR TITLE
fix wrong left menu visibily condition when skills not displayed

### DIFF
--- a/src/app/containers/left-nav/left-nav.component.html
+++ b/src/app/containers/left-nav/left-nav.component.html
@@ -1,5 +1,5 @@
 <ng-container *ngIf="activeTab$ | async as activeTab;">
-  <div class="tab-view-container" *ngIf="!skillsDisabled">
+  <div class="tab-view-container">
     <div class="main-menu">
       <button
         class="main-menu-button active"


### PR DESCRIPTION
## Description

Fix wrong condition when skills are disabled. That causes the tabs not to be displayed at all in this case.

Bug introduced by #1740. The [request issue](https://github.com/France-ioi/AlgoreaFrontend/issues/1735) mentioned " In practice, there is no case anymore when the left menu tabs are not shown, you can probably remove the logic around that".