### PR TITLE
do not error task loading if task was unable to load the answer

### DIFF
--- a/e2e/items/task-loading.spec.ts
+++ b/e2e/items/task-loading.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+import { initAsUsualUser } from '../helpers/e2e_auth';
+
+test('task which cannot load its previous answer does not cause the display of the loading error', async ({ page }) => {
+  await initAsUsualUser(page);
+  await page.goto('/a/6211720186308979018;p=7528142386663912287,3327328786400474746;a=0');
+  await expect(page.getByText('Loading the content')).toBeVisible();
+  // make sure that when the loading is over, the error is not displayed
+  await expect(page.getByText('Loading the content')).not.toBeVisible();
+  await expect(page.getByText('An unknown error occurred')).not.toBeVisible();
+});

--- a/src/app/items/services/item-task-answer.service.ts
+++ b/src/app/items/services/item-task-answer.service.ts
@@ -84,9 +84,14 @@ export class ItemTaskAnswerService implements OnDestroy {
     this.loadedTask$,
   ]).pipe(
     delayWhen(() => this.initializedTaskState$),
-    switchMap(([ initialAnswer, task ]) =>
-      (initialAnswer?.answer ? task.reloadAnswer(initialAnswer.answer).pipe(map(() => undefined)) : of(undefined))
-    ),
+    switchMap(([ initialAnswer, task ]) => (initialAnswer?.answer ?
+      task.reloadAnswer(initialAnswer.answer).pipe(
+        map(() => undefined),
+        // if the task reports an error while loading the answer, consider it ready anyway (task will show the appropriate error message)
+        catchError(() => of(undefined)),
+      ) :
+      of(undefined)
+    )),
     takeUntil(this.destroyed$),
     shareReplay(1),
   );
@@ -127,9 +132,6 @@ export class ItemTaskAnswerService implements OnDestroy {
   );
 
   private subscriptions = [
-    this.initializedTaskAnswer$.subscribe({
-      error: err => this.errorSubject.next(err),
-    }),
     this.initializedTaskState$.subscribe({
       error: err => this.errorSubject.next(err),
     }),


### PR DESCRIPTION
## Description

Currently, if a task is unable to load an answer (for instance, wrong format), the task loading fails. 

New behavior: it will load the task and let the task explain that the answer was not loaded


## Test cases

- [ ] Case 1: BEFORE
  1. Given I am the usual user
  2. When I go to [this task which always fails on answer loading](https://dev.algorea.org/en/a/6211720186308979018;p=7528142386663912287,3327328786400474746;a=0)
  4. Then I see the platform error for loading

- [ ] Case 2: AFTER
  1. Given I am the usual user
  2. When I go to [this task which always fails on answer loading](https://dev.algorea.org/branch/donotfailontaskanswerloadfailure/en/a/6211720186308979018;p=7528142386663912287,3327328786400474746;a=0)
  4. Then I see the task loads