### PR TITLE
Adds supporting guard form changes for tabs

### DIFF
--- a/e2e/common/fixture.ts
+++ b/e2e/common/fixture.ts
@@ -1,0 +1,14 @@
+import { test as base } from '@playwright/test';
+import { LostChangesConfirmationModal } from 'e2e/common/pages/lost-changes-confirmation-modal';
+
+interface CommonFixtures {
+  lostChangesConfirmationModal: LostChangesConfirmationModal,
+}
+
+export const test = base.extend<CommonFixtures>({
+  lostChangesConfirmationModal: async ({ page }, use) => {
+    await use(new LostChangesConfirmationModal(page));
+  },
+});
+
+export { expect, Page } from '@playwright/test';

--- a/e2e/common/lost-changes-confirmation.spec.ts
+++ b/e2e/common/lost-changes-confirmation.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from './fixture';
+import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
+import { apiUrl } from 'e2e/helpers/e2e_http';
+
+test('checks navigation to another tab for item', async ({ page, lostChangesConfirmationModal }) => {
+  await initAsUsualUser(page);
+  await test.step('checks cancel modal', async () => {
+    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
+    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
+    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.getByRole('link', { name: 'Dependencies' }).click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.cancel();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByText('Item Title')).toBeVisible();
+  });
+
+  await test.step('checks confirm modal', async () => {
+    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
+    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
+    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.getByRole('link', { name: 'Dependencies' }).click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.confirm();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByRole('heading', { name: 'Prerequisites' })).toBeVisible();
+    await expect.soft(page.getByText('Item Title')).not.toBeVisible();
+  });
+});
+
+test('checks navigation to another module for item', async ({ page, lostChangesConfirmationModal }) => {
+  await initAsUsualUser(page);
+  await test.step('checks cancel modal', async () => {
+    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
+    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
+    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.locator('alg-left-nav').getByRole('button', { name: 'Groups' }).click();
+    await page.waitForResponse(`${ apiUrl }/groups/roots`);
+    await expect.soft(page.locator('#nav-4035378957038759250')).toBeVisible();
+    await page.locator('#nav-4035378957038759250').click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.cancel();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByText('Item Title')).toBeVisible();
+  });
+
+  await test.step('checks confirm modal', async () => {
+    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
+    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
+    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.locator('alg-left-nav').getByRole('button', { name: 'Groups' }).click();
+    await page.waitForResponse(`${ apiUrl }/groups/roots`);
+    await expect.soft(page.locator('#nav-4035378957038759250')).toBeVisible();
+    await page.locator('#nav-4035378957038759250').click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.confirm();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
+    await expect.soft(page.getByText('Item Title')).not.toBeVisible();
+  });
+});
+
+test('checks navigation to another tab for group', async ({ page, lostChangesConfirmationModal }) => {
+  await initAsUsualUser(page);
+  await test.step('checks cancel modal', async () => {
+    await page.goto('groups/by-id/4035378957038759250;p=/settings');
+    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.getByRole('link', { name: 'Overview' }).click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.cancel();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
+  });
+
+  await test.step('checks confirm modal', async () => {
+    await page.goto('groups/by-id/4035378957038759250;p=/settings');
+    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.getByRole('link', { name: 'Overview' }).click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.confirm();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByRole('heading', { name: 'Presentation' })).toBeVisible();
+    await expect.soft(page.getByText('Item Title')).not.toBeVisible();
+  });
+});
+
+test('checks navigation to another module for group', async ({ page, lostChangesConfirmationModal }) => {
+  await initAsUsualUser(page);
+  await test.step('checks cancel modal', async () => {
+    await page.goto('groups/by-id/4035378957038759250;p=/settings');
+    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.locator('alg-left-nav').getByRole('button', { name: 'Content' }).click();
+    await expect.soft(page.locator('#nav-4702')).toBeVisible();
+    await page.locator('#nav-4702').click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.cancel();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
+  });
+
+  await test.step('checks confirm modal', async () => {
+    await page.goto('groups/by-id/4035378957038759250;p=/settings');
+    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
+    await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
+    await page.getByRole('textbox').nth(1).fill('Some test');
+    await page.locator('alg-left-nav').getByRole('button', { name: 'Content' }).click();
+    await expect.soft(page.locator('#nav-4702')).toBeVisible();
+    await page.locator('#nav-4702').click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.confirm();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+    await expect.soft(page.getByRole('heading', { name: 'Parcours officiels' })).toBeVisible();
+    await expect.soft(page.getByRole('heading', { name: '!634' })).not.toBeVisible();
+  });
+});

--- a/e2e/common/pages/lost-changes-confirmation-modal.ts
+++ b/e2e/common/pages/lost-changes-confirmation-modal.ts
@@ -1,0 +1,32 @@
+import { Page } from '@playwright/test';
+import { expect } from 'e2e/items/fixture';
+
+export class LostChangesConfirmationModal {
+  titleLocator = this.page.getByText('Confirm Navigation');
+  messageLocator = this.page.getByText('This page has unsaved changes. Do you want to leave this page and lose its changes?');
+  confirmBtnLocator = this.page.getByRole('button', { name: 'Yes, leave page' });
+  cancelBtnLocator = this.page.getByRole('button', { name: 'No' });
+
+  constructor(private page: Page) {
+  }
+
+  async checksIsLostChangesConfirmationVisible(): Promise<void> {
+    await expect.soft(this.titleLocator).toBeVisible();
+    await expect.soft(this.messageLocator).toBeVisible();
+  }
+
+  async checksIsLostChangesConfirmationNotVisible(): Promise<void> {
+    await expect.soft(this.titleLocator).not.toBeVisible();
+    await expect.soft(this.messageLocator).not.toBeVisible();
+  }
+
+  async confirm(): Promise<void> {
+    await expect.soft(this.confirmBtnLocator).toBeVisible();
+    await this.confirmBtnLocator.click();
+  }
+
+  async cancel(): Promise<void> {
+    await expect.soft(this.cancelBtnLocator).toBeVisible();
+    await this.cancelBtnLocator.click();
+  }
+}

--- a/src/app/services/tab.service.ts
+++ b/src/app/services/tab.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { NavigationCancel, NavigationEnd, Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, filter, map, startWith, Subject, take, withLatestFrom } from 'rxjs';
+import { BehaviorSubject, combineLatest, filter, map, startWith, Subject, withLatestFrom } from 'rxjs';
 import { UrlCommand } from '../utils/url';
 import { takeUntil, tap } from 'rxjs/operators';
 
@@ -68,11 +68,12 @@ export class TabService implements OnDestroy {
         }
       }),
       filter(event => event instanceof NavigationEnd),
-      take(1),
       takeUntil(destroyed$),
-    ).subscribe(() =>
-      this.activeTab.next(tag)
-    );
+    ).subscribe(() => {
+      this.activeTab.next(tag);
+      destroyed$.next();
+      destroyed$.complete();
+    });
   }
 
   private isTabLinkActive(tab: Tab): boolean {


### PR DESCRIPTION
## Description

Fixes #1767

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The problem is the tab service switching view directly without router

## Test cases