### PR TITLE
make sure primitive that cannot be converted as json (bigint, symbol, ... are printed if provided as error

### DIFF
--- a/src/app/utils/error-handling/error-conversion.ts
+++ b/src/app/utils/error-handling/error-conversion.ts
@@ -9,7 +9,7 @@ class HTTPError extends Error {
 
 class UnknownError extends Error {
   constructor(err: unknown) {
-    super(JSON.stringify(err));
+    super(typeof err === 'object' ? JSON.stringify(err) : String(err));
     this.name = 'UnknownError';
   }
 }


### PR DESCRIPTION
make sure primitive that cannot be converted as json (bigint, symbol, ... are printed if provided as error
