### PR TITLE
extend the task-proxy timeout before failing on grade-answer call

### DIFF
--- a/src/app/items/api/task-proxy.ts
+++ b/src/app/items/api/task-proxy.ts
@@ -227,7 +227,7 @@ export class Task {
     return this.chan.call({
       method: 'task.gradeAnswer',
       params: [ answer, answerToken ],
-      timeout: 40000
+      timeout: 300000 // 5 min, same as the taskgrader timeout
     }).pipe(
       map(result => {
         if (result.length === 0) throw new Error('task.gradeAnswer returned no arguments');


### PR DESCRIPTION
## Description

Extend the task-proxy timeout before failing on grade-answer call. In some specific cases, the task wait for a server to grade the answer and it may take several minutes to respond. Anyway, it has no UI impact.