### PR TITLE
make sure we always subscribe to the answer init to reload it even if readonly

### DIFF
--- a/src/app/items/services/item-task-answer.service.ts
+++ b/src/app/items/services/item-task-answer.service.ts
@@ -132,6 +132,7 @@ export class ItemTaskAnswerService implements OnDestroy {
   );
 
   private subscriptions = [
+    this.initializedTaskAnswer$.subscribe(),
     this.initializedTaskState$.subscribe({
       error: err => this.errorSubject.next(err),
     }),


### PR DESCRIPTION
Urgent bug fix: make sure we always subscribe to the answer init to reload it even if readonly