### PR TITLE
revert PR #1787 as it prevents switching between task tabs

### DIFF
--- a/e2e/common/lost-changes-confirmation.spec.ts
+++ b/e2e/common/lost-changes-confirmation.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from './fixture';
 import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
-test('checks navigation to another tab for item', async ({ page, lostChangesConfirmationModal }) => {
+test.skip('checks navigation to another tab for item', async ({ page, lostChangesConfirmationModal }) => {
   await initAsUsualUser(page);
   await test.step('checks cancel modal', async () => {
     await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
@@ -32,7 +32,7 @@ test('checks navigation to another tab for item', async ({ page, lostChangesConf
   });
 });
 
-test('checks navigation to another module for item', async ({ page, lostChangesConfirmationModal }) => {
+test.skip('checks navigation to another module for item', async ({ page, lostChangesConfirmationModal }) => {
   await initAsUsualUser(page);
   await test.step('checks cancel modal', async () => {
     await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
@@ -68,7 +68,7 @@ test('checks navigation to another module for item', async ({ page, lostChangesC
   });
 });
 
-test('checks navigation to another tab for group', async ({ page, lostChangesConfirmationModal }) => {
+test.skip('checks navigation to another tab for group', async ({ page, lostChangesConfirmationModal }) => {
   await initAsUsualUser(page);
   await test.step('checks cancel modal', async () => {
     await page.goto('groups/by-id/4035378957038759250;p=/settings');
@@ -96,7 +96,7 @@ test('checks navigation to another tab for group', async ({ page, lostChangesCon
   });
 });
 
-test('checks navigation to another module for group', async ({ page, lostChangesConfirmationModal }) => {
+test.skip('checks navigation to another module for group', async ({ page, lostChangesConfirmationModal }) => {
   await initAsUsualUser(page);
   await test.step('checks cancel modal', async () => {
     await page.goto('groups/by-id/4035378957038759250;p=/settings');

--- a/src/app/services/tab.service.ts
+++ b/src/app/services/tab.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { NavigationCancel, NavigationEnd, Router } from '@angular/router';
-import { BehaviorSubject, combineLatest, filter, map, startWith, take, withLatestFrom } from 'rxjs';
+import { NavigationEnd, Router } from '@angular/router';
+import { BehaviorSubject, combineLatest, filter, map, startWith, withLatestFrom } from 'rxjs';
 import { UrlCommand } from '../utils/url';
 
 interface Tab {
@@ -58,12 +58,7 @@ export class TabService implements OnDestroy {
   }
 
   setActiveTab(tag: string|undefined): void {
-    this.router.events.pipe(
-      filter(event => event instanceof NavigationEnd || event instanceof NavigationCancel),
-      take(1),
-    ).subscribe(event => {
-      if (event instanceof NavigationEnd) this.activeTab.next(tag);
-    });
+    this.activeTab.next(tag);
   }
 
   private isTabLinkActive(tab: Tab): boolean {


### PR DESCRIPTION
Revert #1787 while we do not have to properly tested solution.

It was not possible to switch between different tabs of a task, which is more annoying than the bug fixed by #1787.