### PR TITLE
E2e tests/resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
 
   e2e-no-parallelism:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.44.0-jammy
+      - image: mcr.microsoft.com/playwright:v1.47.2-noble
     resource_class: large
     steps:
       - attach_workspace:
@@ -165,7 +165,7 @@ jobs:
 
   e2e-parallelism-chromium:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.44.0-jammy
+      - image: mcr.microsoft.com/playwright:v1.47.2-noble
     parallelism: 2
     resource_class: large
     steps:
@@ -179,7 +179,7 @@ jobs:
 
   e2e-parallelism-firefox:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.44.0-jammy
+      - image: mcr.microsoft.com/playwright:v1.47.2-noble
     parallelism: 2
     resource_class: large
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,15 +163,29 @@ jobs:
           paths:
             - blob-report
 
-  e2e-parallelism:
+  e2e-parallelism-chromium:
     docker:
       - image: mcr.microsoft.com/playwright:v1.44.0-jammy
-    parallelism: 10
+    parallelism: 2
     resource_class: large
     steps:
       - attach_workspace:
           at: ./
-      - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL} --grep-invert @no-parallelism
+      - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL} --grep-invert @no-parallelism --project=chromium
+      - persist_to_workspace:
+          root: ./
+          paths:
+            - blob-report
+
+  e2e-parallelism-firefox:
+    docker:
+      - image: mcr.microsoft.com/playwright:v1.44.0-jammy
+    parallelism: 2
+    resource_class: large
+    steps:
+      - attach_workspace:
+          at: ./
+      - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npx playwright test --shard=${SHARD}/${CIRCLE_NODE_TOTAL} --grep-invert @no-parallelism --project=firefox
       - persist_to_workspace:
           root: ./
           paths:
@@ -293,13 +307,17 @@ workflows:
       - e2e-no-parallelism:
           requires:
             - deps
-      - e2e-parallelism:
+      - e2e-parallelism-chromium:
+          requires:
+            - deps
+      - e2e-parallelism-firefox:
           requires:
             - deps
       - e2e-gen-report:
           requires:
             - e2e-no-parallelism
-            - e2e-parallelism
+            - e2e-parallelism-chromium
+            - e2e-parallelism-firefox
           filters:
             branches:
               ignore: master
@@ -334,7 +352,8 @@ workflows:
             - build-master-fr
             - tests
             - e2e-no-parallelism
-            - e2e-parallelism
+            - e2e-parallelism-chromium
+            - e2e-parallelism-firefox
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
   e2e-no-parallelism:
     docker:
       - image: mcr.microsoft.com/playwright:v1.44.0-jammy
-    resource_class: medium+
+    resource_class: large
     steps:
       - attach_workspace:
           at: ./
@@ -167,7 +167,7 @@ jobs:
     docker:
       - image: mcr.microsoft.com/playwright:v1.44.0-jammy
     parallelism: 10
-    resource_class: medium+
+    resource_class: large
     steps:
       - attach_workspace:
           at: ./

--- a/e2e/app-routes.spec.ts
+++ b/e2e/app-routes.spec.ts
@@ -4,7 +4,7 @@ async function expect404Message(page: Page): Promise<void> {
   await expect.soft(page.getByText('Oops… We didn’t find that page')).toBeVisible();
   await page.getByRole('link', { name: 'Back to home page' }).click();
   await expect.soft(page.getByRole('heading', { name: 'Parcours officiels' })).toBeVisible();
-  expect.soft(page.url()).toContain('/a/home;pa=0');
+  await expect.soft(page).toHaveURL(new RegExp('/a/home;pa=0'));
 }
 
 test('global not existing page', async ({ page }) => {

--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from './helpers/e2e_auth';
+import { initAsTesterUser } from './helpers/e2e_auth';
 import { apiUrl } from './helpers/e2e_http';
 
 test('home page loaded', async ({ page }) => {
@@ -17,10 +17,10 @@ test('home page loaded', async ({ page }) => {
 });
 
 test('home page loaded as usual user', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/');
   await expect.soft(page.getByRole('heading', { name: 'Parcours officiels' })).toBeVisible();
-  await expect.soft(page.locator('alg-top-right-menu')).toContainText('arbonenfant');
+  await expect.soft(page.locator('alg-top-right-menu')).toContainText('e2e-tests');
 });
 
 test('backend is down', async ({ page }) => {

--- a/e2e/common/lost-changes-confirmation.spec.ts
+++ b/e2e/common/lost-changes-confirmation.spec.ts
@@ -1,26 +1,29 @@
 import { test, expect } from './fixture';
-import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
+import { initAsTesterUser } from 'e2e/helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
+const itemId = '7523720120450464843';
+
 test.skip('checks navigation to another tab for item', async ({ page, lostChangesConfirmationModal }) => {
-  await initAsUsualUser(page);
+  const itemEditWrapperLocator = page.locator('alg-item-edit-wrapper');
+  await initAsTesterUser(page);
   await test.step('checks cancel modal', async () => {
-    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
-    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
-    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await page.goto(`a/${itemId};p=;a=0/parameters`);
+    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.getByRole('link', { name: 'Dependencies' }).click();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
     await lostChangesConfirmationModal.cancel();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
-    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
   });
 
   await test.step('checks confirm modal', async () => {
-    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
-    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
-    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await page.goto(`a/${itemId};p=;a=0/parameters`);
+    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.getByRole('link', { name: 'Dependencies' }).click();
@@ -28,16 +31,17 @@ test.skip('checks navigation to another tab for item', async ({ page, lostChange
     await lostChangesConfirmationModal.confirm();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
     await expect.soft(page.getByRole('heading', { name: 'Prerequisites' })).toBeVisible();
-    await expect.soft(page.getByText('Item Title')).not.toBeVisible();
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).not.toBeVisible();
   });
 });
 
 test.skip('checks navigation to another module for item', async ({ page, lostChangesConfirmationModal }) => {
-  await initAsUsualUser(page);
+  const itemEditWrapperLocator = page.locator('alg-item-edit-wrapper');
+  await initAsTesterUser(page);
   await test.step('checks cancel modal', async () => {
-    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
-    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
-    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await page.goto(`a/${itemId};p=;a=0/parameters`);
+    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.locator('alg-left-nav').getByRole('button', { name: 'Groups' }).click();
@@ -47,13 +51,13 @@ test.skip('checks navigation to another module for item', async ({ page, lostCha
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
     await lostChangesConfirmationModal.cancel();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
-    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
   });
 
   await test.step('checks confirm modal', async () => {
-    await page.goto('a/39530140456452546;p=4702,4102,1980584647557587953;a=0/parameters');
-    await page.waitForResponse(`${ apiUrl }/items/39530140456452546/attempts?attempt_id=0`);
-    await expect.soft(page.getByText('Item Title')).toBeVisible();
+    await page.goto(`a/${itemId};p=;a=0/parameters`);
+    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.locator('alg-left-nav').getByRole('button', { name: 'Groups' }).click();
@@ -64,12 +68,12 @@ test.skip('checks navigation to another module for item', async ({ page, lostCha
     await lostChangesConfirmationModal.confirm();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
     await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
-    await expect.soft(page.getByText('Item Title')).not.toBeVisible();
+    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).not.toBeVisible();
   });
 });
 
 test.skip('checks navigation to another tab for group', async ({ page, lostChangesConfirmationModal }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await test.step('checks cancel modal', async () => {
     await page.goto('groups/by-id/4035378957038759250;p=/settings');
     await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
@@ -97,7 +101,7 @@ test.skip('checks navigation to another tab for group', async ({ page, lostChang
 });
 
 test.skip('checks navigation to another module for group', async ({ page, lostChangesConfirmationModal }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await test.step('checks cancel modal', async () => {
     await page.goto('groups/by-id/4035378957038759250;p=/settings');
     await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();

--- a/e2e/common/lost-changes-confirmation.spec.ts
+++ b/e2e/common/lost-changes-confirmation.spec.ts
@@ -8,8 +8,10 @@ test.skip('checks navigation to another tab for item', async ({ page, lostChange
   const itemEditWrapperLocator = page.locator('alg-item-edit-wrapper');
   await initAsTesterUser(page);
   await test.step('checks cancel modal', async () => {
-    await page.goto(`a/${itemId};p=;a=0/parameters`);
-    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await Promise.all([
+      page.goto(`a/${itemId};p=;a=0/parameters`),
+      page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`),
+    ]);
     await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
@@ -21,8 +23,10 @@ test.skip('checks navigation to another tab for item', async ({ page, lostChange
   });
 
   await test.step('checks confirm modal', async () => {
-    await page.goto(`a/${itemId};p=;a=0/parameters`);
-    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await Promise.all([
+      page.goto(`a/${itemId};p=;a=0/parameters`),
+      page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`),
+    ]);
     await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
@@ -39,8 +43,10 @@ test.skip('checks navigation to another module for item', async ({ page, lostCha
   const itemEditWrapperLocator = page.locator('alg-item-edit-wrapper');
   await initAsTesterUser(page);
   await test.step('checks cancel modal', async () => {
-    await page.goto(`a/${itemId};p=;a=0/parameters`);
-    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await Promise.all([
+      page.goto(`a/${itemId};p=;a=0/parameters`),
+      page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`),
+    ]);
     await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
@@ -55,8 +61,10 @@ test.skip('checks navigation to another module for item', async ({ page, lostCha
   });
 
   await test.step('checks confirm modal', async () => {
-    await page.goto(`a/${itemId};p=;a=0/parameters`);
-    await page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`);
+    await Promise.all([
+      page.goto(`a/${itemId};p=;a=0/parameters`),
+      page.waitForResponse(`${ apiUrl }/items/${itemId}/attempts?attempt_id=0`),
+    ]);
     await expect.soft(itemEditWrapperLocator.getByText('Item Title')).toBeVisible();
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');

--- a/e2e/fr-translation.spec.ts
+++ b/e2e/fr-translation.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from './groups/fixture';
-import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
+import { initAsTesterUser, initAsUsualUser } from 'e2e/helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 // It runs "fr" version of app
 test.use({ baseURL: 'http://localhost:4100' });
 
 test('checks plural in left menu', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/home;pa=0');
   await expect.soft(page.getByText('(via le groupe: Pixal)')).toBeVisible();
 });
@@ -28,7 +28,7 @@ test('checks plural in chapter user progress', async ({ page }) => {
 });
 
 test('checks select in item log view', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('a/7528142386663912287;p=;a=0/progress/history');
   await expect.soft(page.getByRole('link', { name: 'Recharger la réponse' }).first()).toBeVisible();
 });
@@ -108,7 +108,7 @@ test('checks select in item dependencies', async ({ page }) => {
 });
 
 test('checks select in user progress table', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/6379723280369399253;p=;pa=0/progress/chapter?watchedGroupId=123456');
   const selectionLocator = page.getByText('équipes');
   await expect.soft(selectionLocator).toBeVisible();

--- a/e2e/fr-translation.spec.ts
+++ b/e2e/fr-translation.spec.ts
@@ -88,8 +88,8 @@ test('checks select in associated item', async ({ page }) => {
   });
 
   await test.step('checks error caption', async () => {
-    await page.goto('groups/by-id/672913018859223173;p=52767158366271444/settings');
     await page.route(`${apiUrl}/items/6707691810849260111`, route => route.abort());
+    await page.goto('groups/by-id/672913018859223173;p=52767158366271444/settings');
     await expect.soft(page.getByText('Erreur de chargement de la activité racine')).toBeVisible();
   });
 });

--- a/e2e/groups/delete-children-group.spec.ts
+++ b/e2e/groups/delete-children-group.spec.ts
@@ -1,5 +1,5 @@
 import { test } from './fixture';
-import { initAsTesterUser, initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 import { apiUrl } from '../helpers/e2e_http';
 
 const groupChildrenJson = [

--- a/e2e/groups/delete-children-group.spec.ts
+++ b/e2e/groups/delete-children-group.spec.ts
@@ -1,5 +1,5 @@
 import { test } from './fixture';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser, initAsUsualUser } from '../helpers/e2e_auth';
 import { apiUrl } from '../helpers/e2e_http';
 
 const groupChildrenJson = [
@@ -36,7 +36,7 @@ const groupChildrenJson = [
 const groupName = 'Pixal';
 
 test('delete subgroup when children are not empty', async ({ page, groupMembersPage }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/by-id/672913018859223173;p=52767158366271444/members');
   await page.route(`${apiUrl}/groups/672913018859223173/children?types_exclude=Team,Session,User`, async route => {
     await route.fulfill({ json: groupChildrenJson });
@@ -58,7 +58,7 @@ test('delete subgroup when children are not empty', async ({ page, groupMembersP
 });
 
 test('delete subgroup when children are empty', async ({ page, groupMembersPage }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/by-id/672913018859223173;p=52767158366271444/members');
   await page.route(`${apiUrl}/groups/672913018859223173/children?types_exclude=Team,Session,User`, async route => {
     await route.fulfill({ json: groupChildrenJson });
@@ -86,7 +86,7 @@ test('delete subgroup when children are empty', async ({ page, groupMembersPage 
 });
 
 test('delete multiple subgroups when children are empty and non empty', async ({ page, groupMembersPage }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/by-id/672913018859223173;p=52767158366271444/members');
   await page.route(`${apiUrl}/groups/672913018859223173/children?types_exclude=Team,Session,User`, async route => {
     await route.fulfill({ json: groupChildrenJson });
@@ -108,7 +108,7 @@ test('delete multiple subgroups when children are empty and non empty', async ({
 });
 
 test('checks reject confirmations for empty group', async ({ page, groupMembersPage }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/by-id/672913018859223173;p=52767158366271444/members');
   await page.route(`${apiUrl}/groups/672913018859223173/children?types_exclude=Team,Session,User`, async route => {
     await route.fulfill({ json: groupChildrenJson });

--- a/e2e/groups/group-subtitle.spec.ts
+++ b/e2e/groups/group-subtitle.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from 'e2e/groups/create-group-fixture';
-import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
+import { initAsTesterUser } from 'e2e/helpers/e2e_auth';
 
 const associatedItemName = 'Task #1';
 
 test.beforeEach(async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
 });
 
 test.afterEach(({ deleteGroup }) => {

--- a/e2e/groups/groups.spec.ts
+++ b/e2e/groups/groups.spec.ts
@@ -1,30 +1,30 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 
 /**
  * Just check the basics of groups
  */
 
 test('"my groups" page', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/mine');
   await expect(page.getByRole('heading', { name: 'My groups' })).toBeVisible();
 });
 
 test('a group page', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/by-id/4462192261130512818;p=');
   await expect(page.getByRole('heading', { name: 'AlgoreaDevs' })).toBeVisible();
 });
 
 test('a non-existing group page', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/by-id/404');
   await expect(page.getByText('You are not allowed to view this group page')).toBeVisible();
 });
 
 test('another user\'s page', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/groups/users/752024252804317630');
   await expect(page.getByRole('heading', { name: 'usr_5p020x2thuyu' })).toBeVisible();
 });

--- a/e2e/groups/my-groups.spec.ts
+++ b/e2e/groups/my-groups.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from './fixture';
-import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
+import { initAsTesterUser } from 'e2e/helpers/e2e_auth';
 
 test('checks my group pages', async ({ page, minePage, manageGroupsPage }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await minePage.goto();
   const joinLinkBtnLocator = page.getByTestId('group-left-menu').getByRole('link', { name: 'Join' });
   const manageLinkBtnLocator = page.getByTestId('group-left-menu').getByRole('link', { name: 'Manage' });

--- a/e2e/groups/user-data.spec.ts
+++ b/e2e/groups/user-data.spec.ts
@@ -5,8 +5,10 @@ test('checks current user profile', async ({ page, userPage }) => {
   await initAsUsualUser(page);
 
   await test.step('checks tabs is visible', async () => {
-    await userPage.goto('/groups/users/670968966872011405');
-    await userPage.waitForLogsResponse();
+    await Promise.all([
+      userPage.goto('/groups/users/670968966872011405'),
+      userPage.waitForLogsResponse(),
+    ]);
     await userPage.checksIsHeaderVisible('Armelle Bonenfant (arbonenfant)');
     await userPage.checksIsTabVisible('Personal data');
   });
@@ -27,8 +29,10 @@ test('checks other\'s user profile', async ({ page, userPage }) => {
   await initAsUsualUser(page);
 
   await test.step('checks tabs is not visible', async () => {
-    await userPage.goto('/groups/users/6351969043660203734');
-    await userPage.waitForLogsResponse('6351969043660203734');
+    await Promise.all([
+      userPage.goto('/groups/users/6351969043660203734'),
+      userPage.waitForLogsResponse('6351969043660203734'),
+    ]);
     await userPage.checksIsHeaderVisible('user-no-access');
     await userPage.checksIsTabNotVisible('Personal data');
   });

--- a/e2e/groups/user-group-invitations.spec.ts
+++ b/e2e/groups/user-group-invitations.spec.ts
@@ -17,8 +17,10 @@ const sendGroupInvitation = async (page: Page) => {
 };
 
 const rejectGroupInvitation = async (page: Page) => {
-  await page.goto('/groups/mine');
-  await page.waitForResponse(`${apiUrl}/current-user/group-invitations`);
+  await Promise.all([
+    page.goto('/groups/mine'),
+    page.waitForResponse(`${apiUrl}/current-user/group-invitations`),
+  ]);
   await expect.soft(page.getByRole('heading', { name: 'My groups' })).toBeVisible();
   await expect.soft(page.getByRole('heading', { name: 'Pending invitations' })).toBeVisible();
   await expect.soft(page.getByRole('cell', { name: groupName })).toBeVisible();
@@ -29,8 +31,8 @@ const rejectGroupInvitation = async (page: Page) => {
 
 test.beforeEach(async ({ page, minePage }) => {
   await initAsDemoUser(page);
-  await minePage.goto();
   await Promise.all([
+    minePage.goto(),
     minePage.waitGroupInvitationsResponse(),
     minePage.waitGroupMembershipsResponse(),
   ]);
@@ -45,8 +47,10 @@ test.beforeEach(async ({ page, minePage }) => {
 
 test.afterEach(async ({ page }) => {
   await initAsUsualUser(page);
-  await page.goto(`/groups/by-id/${ groupId };p=/members`);
-  await page.waitForResponse(`${apiUrl}/groups/${ groupId }/members?limit=25`);
+  await Promise.all([
+    page.goto(`/groups/by-id/${ groupId };p=/members`),
+    page.waitForResponse(`${apiUrl}/groups/${ groupId }/members?limit=25`),
+  ]);
   await expect.soft(page.locator('li').filter({ hasText: 'Users' })).toBeVisible();
   await expect.soft(page.locator('alg-member-list')).not.toContainText(demoUserLogin);
 });
@@ -59,8 +63,10 @@ test('Accept group invitation', { tag: '@no-parallelism' }, async ({ page, mineP
 
   await test.step('Accept a group', async () => {
     await initAsDemoUser(page);
-    await minePage.goto();
-    await minePage.waitGroupInvitationsResponse();
+    await Promise.all([
+      minePage.goto(),
+      minePage.waitGroupInvitationsResponse(),
+    ]);
     await minePage.checkIsPendingInvitationsVisible();
     if (await minePage.isUserInvitedToGroup(groupName)) {
       await expect.soft(page.getByRole('row', { name: groupName }).getByTestId('accept-group')).toBeVisible();
@@ -76,15 +82,19 @@ test('Accept group invitation', { tag: '@no-parallelism' }, async ({ page, mineP
 
   await test.step('Check the user accepted group invitation in member list', async () => {
     await initAsUsualUser(page);
-    await page.goto(`/groups/by-id/${ groupId };p=/members`);
-    await page.waitForResponse(`${apiUrl}/groups/${ groupId }/members?limit=25`);
+    await Promise.all([
+      page.goto(`/groups/by-id/${ groupId };p=/members`),
+      page.waitForResponse(`${apiUrl}/groups/${ groupId }/members?limit=25`),
+    ]);
     await expect.soft(page.locator('alg-member-list').getByRole('link', { name: demoUserLogin })).toBeVisible();
   });
 
   await test.step('Leave a group', async () => {
     await initAsDemoUser(page);
-    await minePage.goto();
-    await minePage.waitGroupMembershipsResponse();
+    await Promise.all([
+      minePage.goto(),
+      minePage.waitGroupMembershipsResponse(),
+    ]);
     await minePage.checkJoinedGroupsSectionIsVisible();
     await minePage.leaveGroup(groupName);
   });
@@ -117,8 +127,10 @@ test('Cancel "Joining a new group" modal', { tag: '@no-parallelism' }, async ({ 
 
   await test.step('Open "Joining a new group" modal and do cancel', async () => {
     await initAsDemoUser(page);
-    await minePage.goto();
-    await minePage.waitGroupInvitationsResponse();
+    await Promise.all([
+      minePage.goto(),
+      minePage.waitGroupInvitationsResponse(),
+    ]);
     await minePage.checkIsPendingInvitationsVisible();
     if (await minePage.isUserInvitedToGroup(groupName)) {
       await expect.soft(page.getByRole('row', { name: groupName }).getByTestId('accept-group')).toBeVisible();

--- a/e2e/groups/view-answer.spec.ts
+++ b/e2e/groups/view-answer.spec.ts
@@ -129,7 +129,7 @@ test('View answer in logs for current user', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
   await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
-  expect(page.url()).toContain('answerId=6216264238928088073');
+  await expect.soft(page).toHaveURL(new RegExp('answerId=6216264238928088073'));
 });
 
 test('View answer in logs for other user', async ({ page }) => {
@@ -142,7 +142,7 @@ test('View answer in logs for other user', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
   await expect.soft(page.locator('h1').getByText('Blockly Basic Task')).toBeVisible();
-  expect(page.url()).toContain('answerId=113722894726386992');
+  await expect.soft(page).toHaveURL(new RegExp('answerId=113722894726386992'));
 });
 
 test('View answer in logs for a group', async ({ page }) => {
@@ -155,7 +155,7 @@ test('View answer in logs for a group', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
   await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
-  expect(page.url()).toContain('answerId=6216264238928088073');
+  await expect.soft(page).toHaveURL(new RegExp('answerId=6216264238928088073'));
 });
 
 test('Reload answer in logs for a item', async ({ page }) => {
@@ -168,5 +168,5 @@ test('Reload answer in logs for a item', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'Reload answer' })).toBeVisible();
   await page.getByRole('link', { name: 'Reload answer' }).click();
   await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
-  expect(page.url()).not.toContain('answerId=');
+  await expect.soft(page).not.toHaveURL(new RegExp('answerId='));
 });

--- a/e2e/groups/view-answer.spec.ts
+++ b/e2e/groups/view-answer.spec.ts
@@ -129,7 +129,7 @@ test('View answer in logs for current user', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
   await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
-  await expect.soft(page).toHaveURL(new RegExp('answerId=6216264238928088073'));
+  await expect.soft(page).toHaveURL(/answerId=6216264238928088073/);
 });
 
 test('View answer in logs for other user', async ({ page }) => {
@@ -142,7 +142,7 @@ test('View answer in logs for other user', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
   await expect.soft(page.locator('h1').getByText('Blockly Basic Task')).toBeVisible();
-  await expect.soft(page).toHaveURL(new RegExp('answerId=113722894726386992'));
+  await expect.soft(page).toHaveURL(/answerId=113722894726386992/);
 });
 
 test('View answer in logs for a group', async ({ page }) => {
@@ -155,7 +155,7 @@ test('View answer in logs for a group', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'View answer' })).toBeVisible();
   await page.getByRole('link', { name: 'View answer' }).click();
   await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
-  await expect.soft(page).toHaveURL(new RegExp('answerId=6216264238928088073'));
+  await expect.soft(page).toHaveURL(/answerId=6216264238928088073/);
 });
 
 test('Reload answer in logs for a item', async ({ page }) => {
@@ -168,5 +168,5 @@ test('Reload answer in logs for a item', async ({ page }) => {
   await expect.soft(page.getByRole('link', { name: 'Reload answer' })).toBeVisible();
   await page.getByRole('link', { name: 'Reload answer' }).click();
   await expect.soft(page.locator('h1').getByText('Task with edit tab')).toBeVisible();
-  await expect.soft(page).not.toHaveURL(new RegExp('answerId='));
+  await expect.soft(page).not.toHaveURL(/answerId=/);
 });

--- a/e2e/helpers/e2e_auth.ts
+++ b/e2e/helpers/e2e_auth.ts
@@ -17,3 +17,9 @@ export function initAsDemoUser(page: Page): Promise<void> {
   if (!key) throw new Error('a key for the demo key should be provided in "E2E_DEMOUSER_TOKEN" env var');
   return setForcedToken(page, key);
 }
+
+export function initAsTesterUser(page: Page): Promise<void> {
+  const key = process.env.E2E_TESTERUSER_TOKEN;
+  if (!key) throw new Error('a key for the demo key should be provided in "E2E_TESTERUSER_TOKEN" env var');
+  return setForcedToken(page, key);
+}

--- a/e2e/items/can-enter-permissions.spec.ts
+++ b/e2e/items/can-enter-permissions.spec.ts
@@ -1,36 +1,35 @@
 import { test } from './fixture';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 import { convertDateToString } from 'src/app/utils/input-date';
 import { farFutureDateString } from 'src/app/utils/date';
 import { HOURS } from 'src/app/utils/duration';
 import { expect } from 'e2e/groups/fixture';
 
 test('check can enter permissions', { tag: '@no-parallelism' }, async ({ page, editPermissionsModal }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   const fromDateValue = convertDateToString(new Date(Date.now() + HOURS));
   const untilDateValue = convertDateToString(new Date(Date.now() + (HOURS * 2)));
 
   await test.step('checks can enter permission is off', async () => {
-    await initAsUsualUser(page);
-    await page.goto('a/3668315727545144509;p=;pa=0?watchedGroupId=5751429939100258793');
+    await page.goto('a/8470006805577401679;p=3244687538937221949;pa=0?watchedGroupId=3686890982243872917');
     await editPermissionsModal.openPermissionsBlock();
     await editPermissionsModal.openPermissionsModal();
-    await editPermissionsModal.waitForPermissionsResponse('groups/5751429939100258793/permissions/5751429939100258793/3668315727545144509');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/8470006805577401679');
     await editPermissionsModal.checksIsCanEnterSwitchFieldVisible();
     await editPermissionsModal.toggleCanEnterSwitchField();
     if (await editPermissionsModal.isFromUntilInputsVisible()) {
       await editPermissionsModal.toggleCanEnterSwitch();
       await editPermissionsModal.checksIsFromUntilInputsNotVisible();
       await editPermissionsModal.savePermissions();
-      await editPermissionsModal.waitForPermissionsResponse('groups/5751429939100258793/permissions/5751429939100258793/3668315727545144509');
+      await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/8470006805577401679');
     }
   });
 
   await test.step('checks can enter control is visible', async () => {
-    await page.goto('a/3668315727545144509;p=;pa=0?watchedGroupId=5751429939100258793');
+    await page.goto('a/8470006805577401679;p=3244687538937221949;pa=0?watchedGroupId=3686890982243872917');
     await editPermissionsModal.openPermissionsBlock();
     await editPermissionsModal.openPermissionsModal();
-    await editPermissionsModal.waitForPermissionsResponse('groups/5751429939100258793/permissions/5751429939100258793/3668315727545144509');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/8470006805577401679');
   });
 
   await test.step('checks can enter control is visible', async () => {
@@ -53,14 +52,14 @@ test('check can enter permissions', { tag: '@no-parallelism' }, async ({ page, e
     await editPermissionsModal.toggleCanEnterSwitchField();
     await editPermissionsModal.checksIsCanEnterValueInHeaderVisible(`${fromDateValue} - ${untilDateValue}`);
     await editPermissionsModal.savePermissions();
-    await editPermissionsModal.waitForPermissionsResponse('groups/5751429939100258793/permissions/5751429939100258793/3668315727545144509');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/8470006805577401679');
     await editPermissionsModal.checksIsPermissionsModalNotVisible();
   });
 
   await test.step('checks can enter switch is enable', async () => {
     await editPermissionsModal.openPermissionsBlock();
     await editPermissionsModal.openPermissionsModal();
-    await editPermissionsModal.waitForPermissionsResponse('groups/5751429939100258793/permissions/5751429939100258793/3668315727545144509');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/8470006805577401679');
     await editPermissionsModal.toggleCanEnterSwitchField();
     await editPermissionsModal.checksIsFromUntilInputsVisible();
   });
@@ -78,15 +77,15 @@ test('check can enter permissions', { tag: '@no-parallelism' }, async ({ page, e
 });
 
 test('check can enter fields behaviour', async ({ page, editPermissionsModal }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   const fromDateValue = convertDateToString(new Date(Date.now() + (HOURS * 2)));
   const untilDateValue = convertDateToString(new Date(Date.now() + (HOURS * 3)));
 
   await test.step('checks can enter control is visible', async () => {
-    await page.goto('a/6379723280369399253;p=7523720120450464843;pa=0?watchedGroupId=123456');
+    await page.goto('a/2999322914037656296;p=3244687538937221949;a=0?watchedGroupId=3686890982243872917');
     await editPermissionsModal.openPermissionsBlock();
     await editPermissionsModal.openPermissionsModal();
-    await editPermissionsModal.waitForPermissionsResponse('groups/123456/permissions/123456/6379723280369399253');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/2999322914037656296');
   });
 
   await test.step('checks can enter control is visible', async () => {
@@ -136,12 +135,12 @@ test('check can enter fields behaviour', async ({ page, editPermissionsModal }) 
 });
 
 test('check can enter warning', async ({ page, editPermissionsModal }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await test.step('checks can enter control is visible', async () => {
-    await page.goto('a/899800937596940136;p=694914435881177216,5,4700,4707,4702,4102;pa=0?watchedGroupId=917454091139548680');
+    await page.goto('a/2999322914037656296;p=3244687538937221949;a=0?watchedGroupId=3686890982243872917');
     await editPermissionsModal.openPermissionsBlock();
     await editPermissionsModal.openPermissionsModal();
-    await editPermissionsModal.waitForPermissionsResponse('groups/917454091139548680/permissions/917454091139548680/899800937596940136');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/2999322914037656296');
   });
 
   await test.step('checks can enter warning for form value', async () => {
@@ -154,22 +153,22 @@ test('check can enter warning', async ({ page, editPermissionsModal }) => {
   });
 
   await test.step('checks can enter warning for grand view', async () => {
-    await page.goto('a/1980584647557587953;p=;pa=0?watchedGroupId=917454091139548680');
+    await page.goto('a/1749804273409471901;p=3244687538937221949;a=0?watchedGroupId=3686890982243872917');
     await editPermissionsModal.openPermissionsBlock();
     await editPermissionsModal.openPermissionsModal();
-    await editPermissionsModal.waitForPermissionsResponse('groups/917454091139548680/permissions/917454091139548680/1980584647557587953');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/1749804273409471901');
     await editPermissionsModal.checksIsCanEnterSwitchFieldVisible();
     await editPermissionsModal.checksIsCanEnterWarningVisible();
   });
 });
 
 test('checks item with no explicit entry',async ({ page, editPermissionsModal }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await test.step('checks can enter control is not visible', async () => {
-    await page.goto('a/2268458803184278714;p=;pa=0?watchedGroupId=123456');
+    await page.goto('a/422346871652804072;p=3244687538937221949;a=0?watchedGroupId=3686890982243872917');
     await editPermissionsModal.openPermissionsBlock();
     await editPermissionsModal.openPermissionsModal();
-    await editPermissionsModal.waitForPermissionsResponse('groups/123456/permissions/123456/2268458803184278714');
+    await editPermissionsModal.waitForPermissionsResponse('3686890982243872917/permissions/3686890982243872917/422346871652804072');
     await editPermissionsModal.checksIsCanEnterSwitchFieldNotVisible();
   });
 });

--- a/e2e/items/chapter-user-progress.spec.ts
+++ b/e2e/items/chapter-user-progress.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 
 test('check chapter children', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0/progress/chapter');
   const firstChildLink = page.locator('alg-chapter-user-progress tbody tr:nth-child(2) a');
   await expect(firstChildLink).toBeVisible();

--- a/e2e/items/dependencies.spec.ts
+++ b/e2e/items/dependencies.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser, initAsUsualUser } from '../helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 test('empty dependencies and prerequisites', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;pa=0/dependencies');
   await expect.soft(page.getByText('There are no prerequisites')).toBeVisible();
   await expect.soft(page.getByRole('heading', { name: 'Add a new prerequisite' })).toBeVisible();
@@ -14,7 +14,7 @@ test('error/retry on dependencies/prerequisites services', async ({ page }) => {
   await test.step('test error', async () => {
     await page.route(`${apiUrl}/items/7523720120450464843/prerequisites`, route => route.abort());
     await page.route(`${apiUrl}/items/7523720120450464843/dependencies`, route => route.abort());
-    await initAsUsualUser(page);
+    await initAsTesterUser(page);
     await page.goto('/a/7523720120450464843;p=7528142386663912287;pa=0/dependencies');
     await expect.soft(page.getByText('Unable to load the prerequisites')).toBeVisible();
     await expect.soft(page.getByText('Unable to load the dependencies')).toBeVisible();

--- a/e2e/items/group-progress-grid.spec.ts
+++ b/e2e/items/group-progress-grid.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 
 test('check table header', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0/progress/chapter?watchedGroupId=4462192261130512818');
 
   await test.step('check the path is the same as this page', async () => {
@@ -20,9 +20,9 @@ test('check table header', async ({ page }) => {
 });
 
 test('check user progress detail', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0/progress/chapter?watchedGroupId=4462192261130512818');
-  await page.locator('alg-group-progress-grid p-table tr:nth-child(1) td:nth-child(3) alg-score-ring').click();
+  await page.locator('alg-group-progress-grid p-table tr:nth-child(2) td:nth-child(3) alg-score-ring').click();
 
   await test.step('check view answer row', async () => {
     const viewAnswerRow = page.getByText('View answer');

--- a/e2e/items/item-children.spec.ts
+++ b/e2e/items/item-children.spec.ts
@@ -1,14 +1,14 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 
 test('check chapter children as a list', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0');
   const firstChildLink = page.locator('alg-item-children-list > ul > li:first-child > a');
   await expect(firstChildLink).toBeVisible();
 
   await test.step('check the path to child is correctly built', async () => {
     const href = await firstChildLink.getAttribute('href');
-    expect(href).toContain('/a/6379723280369399253;p=7528142386663912287,7523720120450464843;a=0');
+    expect(href).toContain('/a/6379723280369399253;p=7528142386663912287,7523720120450464843;a=1');
   });
 });

--- a/e2e/items/item-content.spec.ts
+++ b/e2e/items/item-content.spec.ts
@@ -169,8 +169,8 @@ test('checks item description', async ({ page, itemContentPage }) => {
 
   // Task with description: description should not be shown
   await test.step('checks description is not visible for "Task"', async () => {
-    await itemContentPage.goto('/a/6379723280369399253;p=;a=0');
     await Promise.all([
+      itemContentPage.goto('/a/6379723280369399253;p=;a=0'),
       itemContentPage.waitForItemResponse('6379723280369399253'),
       itemContentPage.waitForBreadcrumbsResponse('6379723280369399253'),
     ]);
@@ -179,8 +179,8 @@ test('checks item description', async ({ page, itemContentPage }) => {
 
   // Chapter with description: description should be shown
   await test.step('checks description is visible for "Chapter"', async () => {
-    await itemContentPage.goto('/a/7523720120450464843;p=;a=0');
     await Promise.all([
+      itemContentPage.goto('/a/7523720120450464843;p=;a=0'),
       itemContentPage.waitForItemResponse('7523720120450464843'),
       itemContentPage.waitForBreadcrumbsResponse('7523720120450464843'),
     ]);
@@ -190,8 +190,8 @@ test('checks item description', async ({ page, itemContentPage }) => {
   // Skill with description: description should be shown
   await test.step('checks description is visible for "Skill"', async () => {
     await initAsUsualUser(page);
-    await itemContentPage.goto('/s/8865540088611165367;p=;a=0');
     await Promise.all([
+      itemContentPage.goto('/s/8865540088611165367;p=;a=0'),
       itemContentPage.waitForItemResponse('8865540088611165367'),
       itemContentPage.waitForBreadcrumbsResponse('8865540088611165367'),
     ]);
@@ -201,8 +201,8 @@ test('checks item description', async ({ page, itemContentPage }) => {
 
 // Chapter, with no view content perm, not explicit entry item, no prerequisite: chapter specific message, no prerequisite part
 test('checks chapter no access message with no prerequisites section', async ({ itemContentPage }) => {
-  await itemContentPage.goto('a/902356740789159624;p=4702,4102;pa=0');
   await Promise.all([
+    itemContentPage.goto('a/902356740789159624;p=4702,4102;pa=0'),
     itemContentPage.waitForItemResponse('902356740789159624'),
     itemContentPage.waitForBreadcrumbsResponse('4702/4102/902356740789159624', 'parent_attempt_id=0'),
   ]);
@@ -212,8 +212,8 @@ test('checks chapter no access message with no prerequisites section', async ({ 
 
 // Chapter, with no view content perm, not explicit entry item, with prerequisite: chapter specific message, with prerequisite part
 test('checks chapter no access message with prerequisites section', async ({ itemContentPage }) => {
-  await itemContentPage.goto('a/128139237432513103;p=4702,4102;pa=0');
   await Promise.all([
+    itemContentPage.goto('a/128139237432513103;p=4702,4102;pa=0'),
     itemContentPage.waitForItemResponse('128139237432513103'),
     itemContentPage.waitForBreadcrumbsResponse('4702/4102/128139237432513103', 'parent_attempt_id=0'),
   ]);
@@ -224,8 +224,8 @@ test('checks chapter no access message with prerequisites section', async ({ ite
 // Chapter, with view content perm, no edit perm, not explicit entry, : load/show children (or empty)
 test('checks chapter children list is visible with view content perm no edit perm not explicit entry', async ({ itemContentPage, page }) => {
   await initAsUsualUser(page);
-  await itemContentPage.goto('a/home;a=0');
   await Promise.all([
+    itemContentPage.goto('a/home;a=0'),
     itemContentPage.waitForItemResponse('4702'),
     itemContentPage.waitForBreadcrumbsResponse('4702'),
     itemContentPage.waitForChildrenResponse('4702'),
@@ -250,8 +250,8 @@ test('checks chapter children list is visible with view content perm, no edit pe
 // children edition switch shown, no skill sub/parent shown
 test('checks chapter children edition switch is visible, sub/parent skills is not visible with view content', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('a/6707691810849260111;p=;a=0');
   await Promise.all([
+    itemContentPage.goto('a/6707691810849260111;p=;a=0'),
     itemContentPage.waitForItemResponse('6707691810849260111'),
     itemContentPage.waitForBreadcrumbsResponse('6707691810849260111'),
     itemContentPage.waitForChildrenResponse('6707691810849260111'),
@@ -265,8 +265,8 @@ test('checks chapter children edition switch is visible, sub/parent skills is no
 // children edition comp shown, no skill sub/parent shown
 test('checks chapter edit mode: children edition switch is visible, children edition view is visible, sub/parent skills is not visible', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('a/6707691810849260111;p=;a=0/edit-children');
   await Promise.all([
+    itemContentPage.goto('a/6707691810849260111;p=;a=0/edit-children'),
     itemContentPage.waitForItemResponse('6707691810849260111'),
     itemContentPage.waitForBreadcrumbsResponse('6707691810849260111'),
     itemContentPage.waitForChildrenResponse('6707691810849260111', 'attempt_id=0&show_invisible_items=1'),
@@ -281,8 +281,8 @@ test('checks chapter edit mode: children edition switch is visible, children edi
 // children edition comp shown with message, no skill sub/parent shown
 test('checks chapter edit mode: children edition switch is visible children no edit message is not visible, sub/parent skills is visible', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('a/home;a=0/edit-children');
   await Promise.all([
+    itemContentPage.goto('a/home;a=0/edit-children'),
     itemContentPage.waitForItemResponse('4702'),
     itemContentPage.waitForBreadcrumbsResponse('4702'),
   ]);
@@ -297,8 +297,8 @@ test('checks chapter edit mode: children edition switch is visible children no e
 // children edition switch shown, sub skills sub shown, skill parent shown
 test('checks skill children edition switch is visible, sub/parent skills is visible with view content perm, edit children perm, not explicit entry', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('s/568547986401741399;p=;a=0');
   await Promise.all([
+    itemContentPage.goto('s/568547986401741399;p=;a=0'),
     itemContentPage.waitForItemResponse('568547986401741399'),
     itemContentPage.waitForBreadcrumbsResponse('568547986401741399'),
   ]);
@@ -310,8 +310,8 @@ test('checks skill children edition switch is visible, sub/parent skills is visi
 // children edition switch shown, children edition comp shown, sub skills comp NOT shown, skill parent shown
 test('checks skill on children-edit url: children edition switch is visible, children edition is visible, sub skills is not visible, parent skills is visible with view content perm, edit children perm, not explicit entry', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('s/568547986401741399;p=;a=0/edit-children');
   await Promise.all([
+    itemContentPage.goto('s/568547986401741399;p=;a=0/edit-children'),
     itemContentPage.waitForItemResponse('568547986401741399'),
     itemContentPage.waitForBreadcrumbsResponse('568547986401741399'),
   ]);
@@ -327,8 +327,10 @@ test('checks skill no access message', async ({ itemContentPage, page }) => {
   await page.route(`${apiUrl}/items/568547986401741399`, async route => {
     await route.fulfill({ json: skillResponse });
   });
-  await itemContentPage.goto('s/568547986401741399;p=;a=0');
-  await itemContentPage.waitForBreadcrumbsResponse('568547986401741399');
+  await Promise.all([
+    itemContentPage.goto('s/568547986401741399;p=;a=0'),
+    itemContentPage.waitForBreadcrumbsResponse('568547986401741399'),
+  ]);
   await itemContentPage.checksSkillNoAccessMessageIsVisible();
 });
 
@@ -336,20 +338,22 @@ test('checks skill no access message', async ({ itemContentPage, page }) => {
 // item-display in dom with opacity 0, "Loading the content" shown
 test('checks task loading the content message with view content perm, explicit entry, non empty url, a current result available', async ({ itemContentPage, page }) => {
   await initAsUsualUser(page);
-  await itemContentPage.goto('a/8762331199149369455;p=694914435881177216,5,4700,4707,4702,7528142386663912287,944619266928306927;a=0');
   await Promise.all([
+    itemContentPage.goto('a/8762331199149369455;p=694914435881177216,5,4700,4707,4702,7528142386663912287,944619266928306927;a=0'),
     itemContentPage.waitForItemResponse('8762331199149369455'),
     itemContentPage.waitForBreadcrumbsResponse('694914435881177216/5/4700/4707/4702/7528142386663912287/944619266928306927/8762331199149369455'),
   ]);
-  await itemContentPage.checksLoadingContentMessageIsVisible();
-  await itemContentPage.checksItemDisplayHasZeroOpacity();
+  await Promise.all([
+    itemContentPage.checksLoadingContentMessageIsVisible(),
+    itemContentPage.checksItemDisplayHasZeroOpacity(),
+  ]);
 });
 
 // Task with view content perm, no edit perm, not explicit entry, empty url: error message
 test('checks task empty url message', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('a/1501663083087440078;p=7528142386663912287,3327328786400474746;a=0');
   await Promise.all([
+    itemContentPage.goto('a/1501663083087440078;p=7528142386663912287,3327328786400474746;a=0'),
     itemContentPage.waitForItemResponse('1501663083087440078'),
     itemContentPage.waitForBreadcrumbsResponse('7528142386663912287/3327328786400474746/1501663083087440078'),
   ]);
@@ -359,8 +363,8 @@ test('checks task empty url message', async ({ itemContentPage, page }) => {
 // Task with view content perm, edit perm, not explicit entry, empty url: other error message
 test('checks task empty url message with can edit perm', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('a/878263964159393890;p=7528142386663912287,7523720120450464843;pa=0');
   await Promise.all([
+    itemContentPage.goto('a/878263964159393890;p=7528142386663912287,7523720120450464843;pa=0'),
     itemContentPage.waitForItemResponse('878263964159393890'),
     itemContentPage.waitForBreadcrumbsResponse('7528142386663912287/7523720120450464843/878263964159393890', 'parent_attempt_id=0'),
   ]);
@@ -371,20 +375,22 @@ test('checks task empty url message with can edit perm', async ({ itemContentPag
 // Task with view content perm, not explicit entry, non empty url: item-display in dom with opacity 0, "Loading the content" shown
 test('checks task loading the content message with view content perm, not explicit entry, non empty url', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('a/8760146602351467826;p=7528142386663912287,7523720120450464843;a=0');
   await Promise.all([
+    itemContentPage.goto('a/8760146602351467826;p=7528142386663912287,7523720120450464843;a=0'),
     itemContentPage.waitForItemResponse('8760146602351467826'),
     itemContentPage.waitForBreadcrumbsResponse('7528142386663912287/7523720120450464843/8760146602351467826'),
   ]);
-  await itemContentPage.checksLoadingContentMessageIsVisible();
-  await itemContentPage.checksItemDisplayHasZeroOpacity();
+  await Promise.all([
+    itemContentPage.checksLoadingContentMessageIsVisible(),
+    itemContentPage.checksItemDisplayHasZeroOpacity(),
+  ]);
 });
 
 // Task, with no view content perm, not explicit entry item: task specific message
 test('checks task no access message with no view content perm, not explicit entry', async ({ itemContentPage, page }) => {
   await initAsDemoUser(page);
-  await itemContentPage.goto('a/6747343693587333585;p=4702,7528142386663912287,944619266928306927;pa=0');
   await Promise.all([
+    itemContentPage.goto('a/6747343693587333585;p=4702,7528142386663912287,944619266928306927;pa=0'),
     itemContentPage.waitForItemResponse('6747343693587333585'),
     itemContentPage.waitForBreadcrumbsResponse('4702/7528142386663912287/944619266928306927/6747343693587333585', 'parent_attempt_id=0'),
   ]);
@@ -410,8 +416,8 @@ test('checks explicit entry component is visible and item-display not in DOM', a
   await page.route(`${apiUrl}/items/851659072357188051/attempts?attempt_id=0`, async route => {
     await route.fulfill({ json: attemptsResponse });
   });
-  await itemContentPage.goto('/a/851659072357188051;p=4702,7528142386663912287,944619266928306927;pa=0');
   await Promise.all([
+    itemContentPage.goto('/a/851659072357188051;p=4702,7528142386663912287,944619266928306927;pa=0'),
     itemContentPage.waitForItemResponse('851659072357188051'),
     itemContentPage.waitForBreadcrumbsResponse('4702/7528142386663912287/944619266928306927/851659072357188051', 'parent_attempt_id=0'),
   ]);
@@ -422,8 +428,8 @@ test('checks explicit entry component is visible and item-display not in DOM', a
 // Task, with view content perm, explicit entry, results fetched but empty so undefined current result:
 // "This activity requires explicit entry", item-display NOT in dom
 test('checks that explicit entry component is visible and item-display not in DOM with view content perm, explicit entry, no results', async ({ itemContentPage, page }) => {
-  await itemContentPage.goto('/a/1480462971860767879;p=4702,7528142386663912287,944619266928306927;pa=0');
   await Promise.all([
+    itemContentPage.goto('/a/1480462971860767879;p=4702,7528142386663912287,944619266928306927;pa=0'),
     itemContentPage.waitForItemResponse('1480462971860767879'),
     itemContentPage.waitForBreadcrumbsResponse('4702/7528142386663912287/944619266928306927/1480462971860767879', 'parent_attempt_id=0'),
     itemContentPage.waitForAttemptsResponse('1480462971860767879', 'parent_attempt_id=0'),

--- a/e2e/items/item-fetching.spec.ts
+++ b/e2e/items/item-fetching.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser, initAsUsualUser } from '../helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 /**
@@ -7,7 +7,7 @@ import { apiUrl } from 'e2e/helpers/e2e_http';
  */
 
 test('visit an already-started chapter', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0');
 
   await test.step('check breadcrumbs', async () => {
@@ -22,7 +22,7 @@ test('visit an already-started chapter', async ({ page }) => {
 });
 
 test('wrong path auto-healing', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=404;a=0');
 
   await test.step('check content', async () => {
@@ -45,12 +45,8 @@ test('refresh when observation change (check the score)', async ({ page }) => {
   });
 });
 
-
-
-
-
 test('route with missing path and service error', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.route(`${apiUrl}/items/7523720120450464843/path-from-root`, route => route.abort());
 
   await test.step('path solving error', async () => {

--- a/e2e/items/item-logs.spec.ts
+++ b/e2e/items/item-logs.spec.ts
@@ -40,8 +40,10 @@ test('checks reload link in logs on task page', async ({ page }) => {
   await expect.soft(page.getByRole('heading', { name: 'Blockly Basic Task' })).toBeVisible();
   const reloadAnswerLocator = page.getByRole('link', { name: 'Reload answer' }).first();
   await expect.soft(reloadAnswerLocator).toBeVisible();
-  await reloadAnswerLocator.click();
-  expect(page.url()).toContain('/a/6379723280369399253;p=7523720120450464843;answerId=');
+  await Promise.all([
+    reloadAnswerLocator.click(),
+    expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;p=7523720120450464843;answerId=')),
+  ]);
 });
 
 test('checks view link in logs on task page', async ({ page }) => {
@@ -53,8 +55,10 @@ test('checks view link in logs on task page', async ({ page }) => {
   await expect.soft(page.getByRole('heading', { name: 'Blockly Basic Task' })).toBeVisible();
   const reloadAnswerLocator = page.getByRole('link', { name: 'View answer' }).first();
   await expect.soft(reloadAnswerLocator).toBeVisible();
-  await reloadAnswerLocator.click();
-  expect(page.url()).toContain('/a/6379723280369399253;p=7523720120450464843;answerId=');
+  await Promise.all([
+    reloadAnswerLocator.click(),
+    expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;p=7523720120450464843;answerId=')),
+  ]);
 });
 
 test('checks reload link in logs on item page', async ({ page }) => {
@@ -66,8 +70,10 @@ test('checks reload link in logs on item page', async ({ page }) => {
   await expect.soft(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
   const reloadAnswerLocator = page.getByRole('link', { name: 'Reload answer' }).first();
   await expect.soft(reloadAnswerLocator).toBeVisible();
-  await reloadAnswerLocator.click();
-  expect(page.url()).toContain('/a/6379723280369399253;answerId=');
+  await Promise.all([
+    reloadAnswerLocator.click(),
+    expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;answerId=')),
+  ]);
 });
 
 test('checks view link in logs on item page', async ({ page }) => {
@@ -79,6 +85,8 @@ test('checks view link in logs on item page', async ({ page }) => {
   await expect.soft(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
   const reloadAnswerLocator = page.getByRole('link', { name: 'View answer' }).first();
   await expect.soft(reloadAnswerLocator).toBeVisible();
-  await reloadAnswerLocator.click();
-  expect(page.url()).toContain('/a/6379723280369399253;answerId=');
+  await Promise.all([
+    reloadAnswerLocator.click(),
+    expect(page).toHaveURL(new RegExp('/a/6379723280369399253;answerId=')),
+  ]);
 });

--- a/e2e/items/item-logs.spec.ts
+++ b/e2e/items/item-logs.spec.ts
@@ -33,8 +33,10 @@ const otherItemJson = [
 
 test('checks reload link in logs on task page', async ({ page }) => {
   await initAsUsualUser(page);
-  await page.goto('/a/6379723280369399253;p=7523720120450464843;a=0/progress/history');
-  await page.waitForResponse(`${apiUrl}/items/6379723280369399253/log?limit=20`);
+  await Promise.all([
+    page.goto('/a/6379723280369399253;p=7523720120450464843;a=0/progress/history'),
+    page.waitForResponse(`${apiUrl}/items/6379723280369399253/log?limit=20`),
+  ]);
   await expect.soft(page.getByRole('heading', { name: 'Blockly Basic Task' })).toBeVisible();
   const reloadAnswerLocator = page.getByRole('link', { name: 'Reload answer' }).first();
   await expect.soft(reloadAnswerLocator).toBeVisible();
@@ -44,8 +46,10 @@ test('checks reload link in logs on task page', async ({ page }) => {
 
 test('checks view link in logs on task page', async ({ page }) => {
   await initAsUsualUser(page);
-  await page.goto('/a/6379723280369399253;p=7523720120450464843;a=0/progress/history/?watchedGroupId=123456');
-  await page.waitForResponse(`${apiUrl}/items/6379723280369399253/log?limit=20&watched_group_id=123456`);
+  await Promise.all([
+    page.goto('/a/6379723280369399253;p=7523720120450464843;a=0/progress/history/?watchedGroupId=123456'),
+    page.waitForResponse(`${apiUrl}/items/6379723280369399253/log?limit=20&watched_group_id=123456`),
+  ]);
   await expect.soft(page.getByRole('heading', { name: 'Blockly Basic Task' })).toBeVisible();
   const reloadAnswerLocator = page.getByRole('link', { name: 'View answer' }).first();
   await expect.soft(reloadAnswerLocator).toBeVisible();

--- a/e2e/items/item-parameters.spec.ts
+++ b/e2e/items/item-parameters.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser, initAsUsualUser } from '../helpers/e2e_auth';
 
 test('checks no access message', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('a/1625159049301502151;p=4702;a=0/parameters');
   await expect.soft(page.getByText('You do not have the permissions to edit this content.')).toBeVisible();
 });

--- a/e2e/items/item-params-entering-fileds.spec.ts
+++ b/e2e/items/item-params-entering-fileds.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test';
-import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
+import { initAsTesterUser } from 'e2e/helpers/e2e_auth';
 import { apiUrl } from '../helpers/e2e_http';
 import { convertDateToString } from 'src/app/utils/input-date';
 
 test('checks entering date fields in item permissions', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   const firstAllowedEnteringTimeLocator = page.getByText('First allowed entering time');
   const latestAllowedEnteringTimeLocator = page.getByText('Latest allowed entering time');
   const enteringTimeMinContainerLocator = page.getByTestId('entering-time-min-container');
@@ -21,9 +21,9 @@ test('checks entering date fields in item permissions', async ({ page }) => {
     .getByRole('textbox');
 
   await test.step('checks entering date fields are visible', async () => {
-    await page.goto('a/1980584647557587953;p=4702,4102;a=0/parameters');
-    await page.waitForResponse(`${apiUrl}/items/1980584647557587953/navigation?attempt_id=0`);
-    await expect.soft(page.getByTestId('item-title').getByText('L1S1 Computer science')).toBeVisible();
+    await page.goto('a/4892052901432763219;p=3244687538937221949;pa=0/parameters');
+    await page.waitForResponse(`${apiUrl}/items/4892052901432763219/attempts?parent_attempt_id=0`);
+    await expect.soft(page.getByTestId('item-title').getByText('Entering Fields')).toBeVisible();
     await expect.soft(firstAllowedEnteringTimeLocator).toBeVisible();
     await expect.soft(latestAllowedEnteringTimeLocator).toBeVisible();
     await expect.soft(enteringTimeMinSwitchLocator).toBeVisible();

--- a/e2e/items/item-params-entering-fileds.spec.ts
+++ b/e2e/items/item-params-entering-fileds.spec.ts
@@ -21,8 +21,10 @@ test('checks entering date fields in item permissions', async ({ page }) => {
     .getByRole('textbox');
 
   await test.step('checks entering date fields are visible', async () => {
-    await page.goto('a/4892052901432763219;p=3244687538937221949;pa=0/parameters');
-    await page.waitForResponse(`${apiUrl}/items/4892052901432763219/attempts?parent_attempt_id=0`);
+    await Promise.all([
+      page.goto('a/4892052901432763219;p=3244687538937221949;pa=0/parameters'),
+      page.waitForResponse(`${apiUrl}/items/4892052901432763219/attempts?parent_attempt_id=0`),
+    ]);
     await expect.soft(page.getByTestId('item-title').getByText('Entering Fields')).toBeVisible();
     await expect.soft(firstAllowedEnteringTimeLocator).toBeVisible();
     await expect.soft(latestAllowedEnteringTimeLocator).toBeVisible();

--- a/e2e/items/item-routing.spec.ts
+++ b/e2e/items/item-routing.spec.ts
@@ -76,8 +76,8 @@ test('route with action parameter: action passed to subcomponents + parameter re
 
   await test.step('drop the action parameter', async () => {
     await expect(page.locator('.left-pane-title-text')).toContainText('Blockly Basic Task', { timeout: 15000 });
-    expect(page.url()).toContain('/a/6379723280369399253;p=;pa=0');
-    expect(page.url()).not.toContain('answer');
+    await expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;p=;pa=0'));
+    await expect.soft(page).not.toHaveURL(new RegExp('answer'));
   });
 
   await test.step('has loaded the expected answer', async () => {

--- a/e2e/items/item-routing.spec.ts
+++ b/e2e/items/item-routing.spec.ts
@@ -77,7 +77,7 @@ test('route with action parameter: action passed to subcomponents + parameter re
   await test.step('drop the action parameter', async () => {
     await expect(page.locator('.left-pane-title-text')).toContainText('Blockly Basic Task', { timeout: 15000 });
     await expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;p=;pa=0'));
-    await expect.soft(page).not.toHaveURL(new RegExp('answer'));
+    await expect.soft(page).not.toHaveURL(/answer/);
   });
 
   await test.step('has loaded the expected answer', async () => {

--- a/e2e/items/item-routing.spec.ts
+++ b/e2e/items/item-routing.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { initAsTesterUser } from '../helpers/e2e_auth';
+import { initAsTesterUser, initAsUsualUser } from '../helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 /**
@@ -62,7 +62,7 @@ test('route with action parameter: action passed to subcomponents + parameter re
   const emptyAnswer = '1970981512988735785';
   const answerWith1234567 = '4143245131838208903';
 
-  await initAsTesterUser(page);
+  await initAsUsualUser(page);
   // first reload an empty answer
   await page.goto(`/a/6379723280369399253;p=;pa=0;answerId=${emptyAnswer};answerLoadAsCurrent=1`);
 

--- a/e2e/items/item-routing.spec.ts
+++ b/e2e/items/item-routing.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 /**
@@ -7,43 +7,43 @@ import { apiUrl } from 'e2e/helpers/e2e_http';
  */
 
 test('activity with full route loads', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0');
   await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
 });
 
 test('activity with full route by alias loads', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/home');
   await expect(page.getByRole('heading', { name: 'Parcours officiels' })).toBeVisible();
 });
 
 test('route with missing path heals', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843');
   await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
 });
 
 test('route with missing path using alias heals', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/algorea--adventure');
   await expect(page.getByRole('heading', { name: 'ALGOREA ADVENTURE' })).toBeVisible();
 });
 
 test('route with missing attempt heals', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287');
   await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
 });
 
 test('route with missing attempt at root heals', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7528142386663912287;p=');
   await expect(page.getByRole('heading', { name: 'Algorea Testing Content for devs' })).toBeVisible();
 });
 
 test('route with missing path and service error', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.route(`${apiUrl}/items/7523720120450464843/path-from-root`, route => route.abort());
 
   await test.step('path solving error', async () => {
@@ -62,7 +62,7 @@ test('route with action parameter: action passed to subcomponents + parameter re
   const emptyAnswer = '1970981512988735785';
   const answerWith1234567 = '4143245131838208903';
 
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   // first reload an empty answer
   await page.goto(`/a/6379723280369399253;p=;pa=0;answerId=${emptyAnswer};answerLoadAsCurrent=1`);
 

--- a/e2e/items/items.spec.ts
+++ b/e2e/items/items.spec.ts
@@ -1,24 +1,24 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 
 /**
  * Just check the basics of items
  */
 
 test('activity loads', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0');
   await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
 });
 
 test('item loads with path missing', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843');
   await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
 });
 
 test('item loads with invalid path', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=404;a=0');
   await expect(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
 });

--- a/e2e/items/pages/edit-permissions-modal.ts
+++ b/e2e/items/pages/edit-permissions-modal.ts
@@ -33,7 +33,7 @@ export class EditPermissionsModal {
   }
 
   async waitForPermissionsResponse(url: string): Promise<void> {
-    await this.page.waitForResponse(`${apiUrl}/${url}`);
+    await this.page.waitForResponse(`${apiUrl}/groups/${url}`);
   }
 
   async checksIsCanEnterSwitchFieldVisible(): Promise<void> {

--- a/e2e/items/skill-content.spec.ts
+++ b/e2e/items/skill-content.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 // TODO: Tests to be improved to cover empty / non-empty cases, but that would require to improve to clean the dataset first
 
 test('skill loads with activities and parents, no subskills,', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/s/3001;p=3000;a=0');
   await expect.soft(page.getByRole('heading', { name: 'Depth First Search (DFS)' })).toBeVisible();
 
@@ -23,7 +23,7 @@ test('skill loads with activities and parents, no subskills,', async ({ page }) 
 });
 
 test('skill loads, with subskills', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/s/3002;p=3000;a=0');
 
   await test.step('check subskills', async () => {
@@ -36,7 +36,7 @@ test('skill sub-tables loading errors', async ({ page }) => {
   await page.route(`${apiUrl}/items/3001/parents*`, route => route.abort());
   await page.route(`${apiUrl}/items/3001/children*`, route => route.abort());
 
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/s/3001;p=3000;a=0');
   await expect.soft(page.getByRole('heading', { name: 'Depth First Search (DFS)' })).toBeVisible();
 

--- a/e2e/items/task-switching.spec.ts
+++ b/e2e/items/task-switching.spec.ts
@@ -10,5 +10,5 @@ test('activity with full route loads', async ({ page }) => {
   await page.goto('/a/1414822370876733593;p=4702,100575556387408660,1788359139685642917;pa=0');
   await page.locator('alg-neighbor-widget').getByTestId('nav-to-next').click();
 
-  expect(page.url()).toContain('/a/1667741628301295500;p=4702,100575556387408660,1788359139685642917');
+  await expect.soft(page).toHaveURL(new RegExp('/a/1667741628301295500;p=4702,100575556387408660,1788359139685642917'));
 });

--- a/e2e/items/task-switching.spec.ts
+++ b/e2e/items/task-switching.spec.ts
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 
 /**
  * Check that we can switch between tasks (i.e., that the task unload rule when leaving a task does not block everything)
  */
 
 test('activity with full route loads', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/1414822370876733593;p=4702,100575556387408660,1788359139685642917;pa=0');
   await page.locator('alg-neighbor-widget').getByTestId('nav-to-next').click();
 

--- a/e2e/items/user-progress-tooltip.spec.ts
+++ b/e2e/items/user-progress-tooltip.spec.ts
@@ -4,8 +4,10 @@ import { apiUrl } from 'e2e/helpers/e2e_http';
 
 test('checks user progress tooltip', async ({ page }) => {
   await initAsTesterUser(page);
-  await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0/progress/chapter?watchedGroupId=4462192261130512818');
-  await page.waitForResponse(`${apiUrl}/groups/4462192261130512818/user-progress?parent_item_ids=7523720120450464843&limit=25`);
+  await Promise.all([
+    page.goto('/a/7523720120450464843;p=7528142386663912287;a=0/progress/chapter?watchedGroupId=4462192261130512818'),
+    page.waitForResponse(`${apiUrl}/groups/4462192261130512818/user-progress?parent_item_ids=7523720120450464843&limit=25`),
+  ]);
 
   await test.step('checks group progress grid is visible', async () => {
     await expect.soft(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
@@ -33,8 +35,10 @@ test('checks user progress tooltip', async ({ page }) => {
 
   await test.step('checks user progress tooltip not started is visible', async () => {
     await initAsUsualUser(page);
-    await page.goto('/a/504065524219241180;p=694914435881177216,5,4700,4707,4702,4102,1980584647557587953,39530140456452546;a=0/progress/chapter?watchedGroupId=123456');
-    await page.waitForResponse(`${apiUrl}/groups/123456/user-progress?parent_item_ids=504065524219241180&limit=25`);
+    await Promise.all([
+      page.goto('/a/504065524219241180;p=694914435881177216,5,4700,4707,4702,4102,1980584647557587953,39530140456452546;a=0/progress/chapter?watchedGroupId=123456'),
+      page.waitForResponse(`${apiUrl}/groups/123456/user-progress?parent_item_ids=504065524219241180&limit=25`),
+    ]);
     await expect.soft(page.getByRole('heading', { name: 'Echauffement' })).toBeVisible();
     const notStartedCellLocator = cellLocator.locator('nth=3');
     await expect.soft(notStartedCellLocator).toBeVisible();

--- a/e2e/items/user-progress-tooltip.spec.ts
+++ b/e2e/items/user-progress-tooltip.spec.ts
@@ -1,22 +1,25 @@
 import { test, expect } from '@playwright/test';
-import { initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsUsualUser, initAsTesterUser } from '../helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 test('checks user progress tooltip', async ({ page }) => {
-  await initAsUsualUser(page);
+  await initAsTesterUser(page);
   await page.goto('/a/7523720120450464843;p=7528142386663912287;a=0/progress/chapter?watchedGroupId=4462192261130512818');
+  await page.waitForResponse(`${apiUrl}/groups/4462192261130512818/user-progress?parent_item_ids=7523720120450464843&limit=25`);
 
   await test.step('checks group progress grid is visible', async () => {
     await expect.soft(page.getByRole('heading', { name: 'Tasks Showcase' })).toBeVisible();
-    await page.waitForResponse(`${apiUrl}/groups/4462192261130512818/user-progress?parent_item_ids=7523720120450464843&limit=25`);
     const groupProgressGridLocator = page.locator('alg-group-progress-grid');
     await expect.soft(groupProgressGridLocator).toBeVisible();
   });
 
-  const cellLocator = page.getByTestId('user-progress-tooltip-target');
+  const targetRow = page.locator('alg-chapter-group-progress').getByRole('row').filter({
+    has: page.getByRole('link', { name: 'usr_5p020x2thuyu' }),
+  });
+  const cellLocator = targetRow.getByTestId('user-progress-tooltip-target');
 
   await test.step('checks user progress tooltip is visible', async () => {
-    await expect.soft(page.getByRole('link', { name: 'usr_5p020x2thuyu' })).toBeVisible();
+    await expect.soft(targetRow).toBeVisible();
     const firstCellLocator = cellLocator.first();
     await expect.soft(firstCellLocator).toBeVisible();
     await firstCellLocator.click({ force: true });
@@ -29,10 +32,11 @@ test('checks user progress tooltip', async ({ page }) => {
   });
 
   await test.step('checks user progress tooltip not started is visible', async () => {
+    await initAsUsualUser(page);
     await page.goto('/a/504065524219241180;p=694914435881177216,5,4700,4707,4702,4102,1980584647557587953,39530140456452546;a=0/progress/chapter?watchedGroupId=123456');
-    await expect.soft(page.getByRole('heading', { name: 'Echauffement' })).toBeVisible();
     await page.waitForResponse(`${apiUrl}/groups/123456/user-progress?parent_item_ids=504065524219241180&limit=25`);
-    const notStartedCellLocator = cellLocator.first();
+    await expect.soft(page.getByRole('heading', { name: 'Echauffement' })).toBeVisible();
+    const notStartedCellLocator = cellLocator.locator('nth=3');
     await expect.soft(notStartedCellLocator).toBeVisible();
     await notStartedCellLocator.click({ force: true });
     await expect.soft(page.getByText('Not started')).toBeVisible();

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "@angular/language-service": "^18.1.4",
         "@angular/localize": "^18.1.4",
         "@ngrx/eslint-plugin": "^18.0.2",
-        "@playwright/test": "^1.44.0",
+        "@playwright/test": "^1.47.2",
         "@sentry/cli": "^2.36.1",
         "@stylistic/eslint-plugin-ts": "^2.6.2",
         "@types/express": "^4.17.12",
@@ -4635,18 +4635,18 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.44.0.tgz",
-      "integrity": "sha512-rNX5lbNidamSUorBhB4XZ9SQTjAqfe5M+p37Z8ic0jPFBMo5iCtQz1kRWkEMg+rYOKSlVycpQmpqjSFq7LXOfg==",
+      "version": "1.47.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.2.tgz",
+      "integrity": "sha512-jTXRsoSPONAs8Za9QEQdyjFn+0ZQFjCiIztAIF6bi1HqhBzG9Ma7g1WotyiGqFSBRZjIEqMdT8RUlbk1QVhzCQ==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.44.0"
+        "playwright": "1.47.2"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -15858,33 +15858,33 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.44.0.tgz",
-      "integrity": "sha512-F9b3GUCLQ3Nffrfb6dunPOkE5Mh68tR7zN32L4jCk4FjQamgesGay7/dAAe1WaMEGV04DkdJfcJzjoCKygUaRQ==",
+      "version": "1.47.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.2.tgz",
+      "integrity": "sha512-nx1cLMmQWqmA3UsnjaaokyoUpdVaaDhJhMoxX2qj3McpjnsqFHs516QAKYhqHAgOP+oCFTEOCOAaD1RgD/RQfA==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.44.0"
+        "playwright-core": "1.47.2"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.44.0.tgz",
-      "integrity": "sha512-ZTbkNpFfYcGWohvTTl+xewITm7EOuqIqex0c7dNZ+aXsbrLj0qI8XlGKfPpipjm0Wny/4Lt4CJsWJk1stVS5qQ==",
+      "version": "1.47.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.2.tgz",
+      "integrity": "sha512-3JvMfF+9LJfe16l7AbSmU555PaTl2tPyQsVInqm3id16pdDfvZ8TTZ/pyzmkbDrZTQefyzU7AIHlZqQnxpqHVQ==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@angular/language-service": "^18.1.4",
     "@angular/localize": "^18.1.4",
     "@ngrx/eslint-plugin": "^18.0.2",
-    "@playwright/test": "^1.44.0",
+    "@playwright/test": "^1.47.2",
     "@sentry/cli": "^2.36.1",
     "@stylistic/eslint-plugin-ts": "^2.6.2",
     "@types/express": "^4.17.12",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   expect: {
-    timeout: 10*1000,
+    timeout: 30*1000,
   },
 
   /* Configure projects for major browsers */


### PR DESCRIPTION
## Description

- Fixes race conditions;
- Splits tests on groups chromium, firefox - to decrease time of execution and possible re run, also it would reduce loading on docker resource. 
- Updates playwright packages
- Moves simple tests to new test user - requires to move more cases but will take some time so in next PR
- Increased timeout - for possible cases when long waiting of multiple response before render needed part for test

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Generally the issues with tests is race condition, it works very fast and can catch some cases the real user can't (kind filled form before BE returned all needed data). We need to see future errors and improve step by step our tests. Also I realised that need to test new cases with extra loading on BE (ex. 4-6 workers for 1 test case) and so when BE became in hot state and works faster - in result we getting unexpected behaviour.

## Test cases
