### PR TITLE
bugfix: change the current forum thread if we load an answer

### DIFF
--- a/src/app/items/data-access/current-answer.service.ts
+++ b/src/app/items/data-access/current-answer.service.ts
@@ -11,6 +11,7 @@ const existingCurrentAnswerSchema = z.object({
   answer: z.string().nullable(),
   attemptId: z.string().nullable(),
   authorId: z.string(),
+  participantId: z.string(),
   id: z.string(),
   itemId: z.string(),
   score: z.number().nullable(),

--- a/src/app/items/data-access/get-answer.service.ts
+++ b/src/app/items/data-access/get-answer.service.ts
@@ -9,6 +9,7 @@ export const answerSchema = z.object({
   answer: z.string().nullable(),
   attemptId: z.string().nullable(),
   authorId: z.string(),
+  participantId: z.string(),
   createdAt: z.coerce.date(),
   gradedAt: z.coerce.date().nullable(),
   id: z.string(),

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -277,10 +277,16 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     ).subscribe(display => this.layoutService.configure({ contentDisplayType: display })),
 
     // configuring the forum parameters (if the user can open it on this content for the potentially observed group)
-    combineLatest([ this.itemState$, this.userProfile$, this.store.select(fromObservation.selectObservedGroupRoute) ]).pipe(
-      map(([ state, userProfile, observedGroupRoute ]) => {
+    combineLatest([
+      this.itemState$,
+      this.userProfile$,
+      this.store.select(fromObservation.selectObservedGroupRoute),
+      this.initialAnswerDataSource.answer$
+    ]).pipe(
+      map(([ state, userProfile, observedGroupRoute, answer ]) => {
         if (userProfile.tempUser) return null;
         if (!state.data || !isATask(state.data.item)) return null;
+        if (answer) return { participantId: answer.authorId, itemId: answer.itemId };
         if (observedGroupRoute && (!allowsWatchingAnswers(state.data.item.permissions) || !isUser(observedGroupRoute))) return null;
         if (!observedGroupRoute && !state.data.item.permissions.canRequestHelp) return null;
         return { participantId: observedGroupRoute ? observedGroupRoute.id : userProfile.groupId, itemId: state.data.item.id };

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -286,7 +286,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       map(([ state, userProfile, observedGroupRoute, answer ]) => {
         if (userProfile.tempUser) return null;
         if (!state.data || !isATask(state.data.item)) return null;
-        if (answer) return { participantId: answer.authorId, itemId: answer.itemId };
+        if (answer) return { participantId: answer.participantId, itemId: answer.itemId };
         if (observedGroupRoute && (!allowsWatchingAnswers(state.data.item.permissions) || !isUser(observedGroupRoute))) return null;
         if (!observedGroupRoute && !state.data.item.permissions.canRequestHelp) return null;
         return { participantId: observedGroupRoute ? observedGroupRoute.id : userProfile.groupId, itemId: state.data.item.id };

--- a/src/app/items/services/item-task.service.ts
+++ b/src/app/items/services/item-task.service.ts
@@ -12,7 +12,8 @@ import { ItemTaskAnswerService } from './item-task-answer.service';
 import { ItemTaskInitService } from './item-task-init.service';
 import { ItemTaskViewsService } from './item-task-views.service';
 
-export type Answer = Pick<GetAnswerType, 'id'|'authorId'|'answer'|'state'|'score'|'itemId'> & Partial<Pick<GetAnswerType, 'createdAt'>>;
+export type Answer =
+  Pick<GetAnswerType, 'id'|'authorId'|'answer'|'state'|'score'|'itemId'|'participantId'> & Partial<Pick<GetAnswerType, 'createdAt'>>;
 
 export interface TaskConfig {
   readOnly: boolean,

--- a/src/app/items/services/item-task.service.ts
+++ b/src/app/items/services/item-task.service.ts
@@ -12,7 +12,7 @@ import { ItemTaskAnswerService } from './item-task-answer.service';
 import { ItemTaskInitService } from './item-task-init.service';
 import { ItemTaskViewsService } from './item-task-views.service';
 
-export type Answer = Pick<GetAnswerType, 'id'|'authorId'|'answer'|'state'|'score'> & Partial<Pick<GetAnswerType, 'createdAt'>>;
+export type Answer = Pick<GetAnswerType, 'id'|'authorId'|'answer'|'state'|'score'|'itemId'> & Partial<Pick<GetAnswerType, 'createdAt'>>;
 
 export interface TaskConfig {
   readOnly: boolean,


### PR DESCRIPTION
## Description

When the current user opens the answer of another user and that the forum is open, we should show the forum related to the answer, so to the answer's participant and item. 

## Test cases

BEFORE:
- [ ] 
  1. Given I am the usual user
  2. When I go to a [forum page](https://dev.algorea.org/en/a/6379723280369399253;p=7523720120450464843;pa=0/forum/my-threads)
  3. And I click on "Show" to open the forum pane
  4. Then I go to "groups" (left menu), select the "AlgoreaDevs" group, go to history and then "View answer" of "Task with edit tab "
  5. And I see the for forum tab has not changed
  6. BUT if I click on the forum tab (among the item tabs)
  7. I click "show" on the user forum
  8. I see the forum has changed to " Task with edit tab " with the mention "You are helping usr_5p020x2thuyu"


AFTER:
- [ ] 
  1. Given I am the usual user
  2. When I go to a [forum page](https://dev.algorea.org/branch/change-thread-on-answer/en/a/6379723280369399253;p=7523720120450464843;pa=0/forum/my-threads)
  3. And I click on "Show" to open the forum pane
  4. Then I go to "groups" (left menu), select the "AlgoreaDevs" group, go to history and then "View answer" of "Task with edit tab "
  5. And I see the for forum tab has changed to " Task with edit tab " with the mention "You are helping usr_5p020x2thuyu"
