### PR TITLE
Crash reporting: avoid several dialog

### DIFF
--- a/src/app/utils/error-handling/error-handler.ts
+++ b/src/app/utils/error-handling/error-handler.ts
@@ -10,6 +10,10 @@ import { ChunkErrorService } from '../../services/chunk-error.service';
 export class AlgErrorHandler extends ErrorHandler {
 
   private isDialogOpen = false;
+  /**
+   * list of errors which have already been reported in this session so that we do not report the same one several times
+   */
+  private reportedErrors: string[] = [];
 
   constructor(private chunkErrorService: ChunkErrorService) {
     super();
@@ -22,8 +26,10 @@ export class AlgErrorHandler extends ErrorHandler {
     }
     const error = convertToError(err);
     const eventId = Sentry.captureException(error);
-    if (!this.isDialogOpen) {
+
+    if (!this.isDialogOpen && !this.reportedErrors.includes(error.toString())) {
       this.isDialogOpen = true;
+      this.reportedErrors.push(error.toString());
       Sentry.showReportDialog({ eventId, onClose: () => this.isDialogOpen = false });
     }
   }

--- a/src/app/utils/error-handling/error-handler.ts
+++ b/src/app/utils/error-handling/error-handler.ts
@@ -9,26 +9,33 @@ import { ChunkErrorService } from '../../services/chunk-error.service';
 @Injectable()
 export class AlgErrorHandler extends ErrorHandler {
 
-  private sentryErrorHandler = Sentry.createErrorHandler({
-    showDialog: true,
-  });
+  private isDialogOpen = false;
 
   constructor(private chunkErrorService: ChunkErrorService) {
     super();
   }
 
   handleError(err: any): void {
+    if (this.isChunkLoadingError(err)) {
+      this.chunkErrorService.emitError();
+      return;
+    }
+    const error = convertToError(err);
+    const eventId = Sentry.captureException(error);
+    if (!this.isDialogOpen) {
+      this.isDialogOpen = true;
+      Sentry.showReportDialog({ eventId, onClose: () => this.isDialogOpen = false });
+    }
+  }
+
+  isChunkLoadingError(err: any): boolean {
     const chunkErrormessages = [
       'Loading chunk [a-z_\\d]+ failed', // older ?
       'Failed to fetch dynamically imported module', // chrome
       'error loading dynamically imported module', // firefox
       'Importing a module script failed', // safari
     ];
-    if (new RegExp(chunkErrormessages.map(m => `(${m})`).join('|')).test(convertToError(err).message)) {
-      this.chunkErrorService.emitError();
-      return;
-    }
-    this.sentryErrorHandler.handleError(convertToError(err));
+    return new RegExp(chunkErrormessages.map(m => `(${m})`).join('|')).test(convertToError(err).message);
   }
 
 }


### PR DESCRIPTION
## Description

Apparently, if several errors are triggered, several crash reporting dialog were showing up, on top of each other so not allowing the user to enter his feedback.
So now: 
- the dialog is not displayed if a dialog is already being displayed
- the dialog is not redisplayed if the same error happens several time (was already done by sentry but needs to be reimplemented with the previous change)

## Test cases

I had to cause crashes in a branch to trigger that :-/
