### PR TITLE
allow non-users (teams) in log view

### DIFF
--- a/src/app/groups/containers/group-log-view/group-log-view.component.html
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.html
@@ -83,7 +83,11 @@
             </a>
           </td>
           <td *ngIf="this.showUserColumn">
-            <a class="alg-link" [routerLink]="rowData.user | groupLink">{{ rowData.user | userCaption }}</a>
+            @if (rowData.user) {
+              <a class="alg-link" [routerLink]="rowData.user | groupLink">{{ rowData.user | userCaption }}</a>
+            } @else {
+              {{ rowData.participant.name }}
+            }
           </td>
           <td>{{ rowData.at | date:'short' }}</td>
         </tr>

--- a/src/app/items/containers/item-log-view/item-log-view.component.html
+++ b/src/app/items/containers/item-log-view/item-log-view.component.html
@@ -101,7 +101,11 @@
                   </a>
                 </ng-container>
                 <ng-container *ngSwitchCase="'item.user'">
-                  <a class="alg-link" [routerLink]="{ id: rowData.user.id, isUser: true } | groupLink">{{ rowData.user | userCaption }}</a>
+                  @if (rowData.user) {
+                    <a class="alg-link" [routerLink]="{ id: rowData.user.id, isUser: true } | groupLink">{{ rowData.user | userCaption }}</a>
+                  } @else {
+                    {{ rowData.participant.name }}
+                  }
                 </ng-container>
                 <ng-container *ngSwitchCase="'at'">
                   <alg-relative-time [value]="rowData.at"></alg-relative-time>


### PR DESCRIPTION
## Description

The log service returns a optional "user" property but we were using it as it was always given...
It is case we cannot really reproduce on our data and that we cannot really create with the UI.. with in prod legacy data, it happens... 
So the fix just display the team name without link or anything... the goal for now is just that it does not crash anymore.
