### PR TITLE
Answer handling improvements

### DIFF
--- a/src/app/items/containers/item-display/item-display.component.ts
+++ b/src/app/items/containers/item-display/item-display.component.ts
@@ -139,11 +139,11 @@ export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDest
   );
 
   private subscriptions = [
-    this.taskService.saveAnswerAndStateInterval$
-      .pipe(startWith({ success: true }), pairwise())
+    this.taskService.autoSaveResult$
+      .pipe(startWith(true), pairwise())
       .subscribe(([ previous, next ]) => {
-        const shouldDisplayError = !next.success && !this.actionFeedbackService.hasFeedback;
-        const shouldDisplaySuccess = !previous.success && next.success;
+        const shouldDisplayError = !next && !this.actionFeedbackService.hasFeedback;
+        const shouldDisplaySuccess = !previous && next;
         if (shouldDisplayError) {
           const message = $localize`Your current progress could not have been saved. Are you connected to the internet?`;
           this.actionFeedbackService.error(message, { life: 24*HOURS });
@@ -255,7 +255,7 @@ export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDest
     this.destroyed$.complete();
   }
 
-  saveAnswerAndState(): Observable<{ saving: boolean }> {
+  saveAnswerAndState(): ReturnType<ItemTaskService['saveAnswerAndState']> {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());
     return this.taskService.saveAnswerAndState();
   }

--- a/src/app/items/models/answers.ts
+++ b/src/app/items/models/answers.ts
@@ -1,0 +1,7 @@
+import { Answer } from '../data-access/get-answer.service';
+
+type StateAnswer = Pick<Answer, 'answer'|'state'>;
+
+export function areStateAnswerEqual(x: StateAnswer, y: StateAnswer): boolean {
+  return (x.answer ?? '') === (y.answer ?? '') && (y.state ?? '') === (y.state ?? '');
+}

--- a/src/app/items/models/answers.ts
+++ b/src/app/items/models/answers.ts
@@ -3,5 +3,5 @@ import { Answer } from '../data-access/get-answer.service';
 type StateAnswer = Pick<Answer, 'answer'|'state'>;
 
 export function areStateAnswerEqual(x: StateAnswer, y: StateAnswer): boolean {
-  return (x.answer ?? '') === (y.answer ?? '') && (y.state ?? '') === (y.state ?? '');
+  return (x.answer ?? '') === (y.answer ?? '') && (x.state ?? '') === (y.state ?? '');
 }

--- a/src/app/items/services/item-task-answer.service.ts
+++ b/src/app/items/services/item-task-answer.service.ts
@@ -1,23 +1,20 @@
 import { Injectable, OnDestroy } from '@angular/core';
-import { combineLatest, EMPTY, forkJoin, interval, merge, Observable, of, ReplaySubject, Subject } from 'rxjs';
+import { combineLatest, EMPTY, forkJoin, interval, Observable, of, Subject } from 'rxjs';
 import {
   catchError,
   defaultIfEmpty,
   delayWhen,
-  distinctUntilChanged,
   filter,
   map,
   retry,
   shareReplay,
-  startWith,
   switchMap,
   take,
   takeUntil,
+  tap,
   timeout,
-  withLatestFrom,
 } from 'rxjs/operators';
 import { SECONDS } from 'src/app/utils/duration';
-import { repeatLatestWhen } from 'src/app/utils/operators/repeatLatestWhen';
 import { AnswerTokenService } from '../data-access/answer-token.service';
 import { AnswerService } from '../data-access/answer.service';
 import { CurrentAnswerService } from '../data-access/current-answer.service';
@@ -25,6 +22,8 @@ import { GradeService } from '../data-access/grade.service';
 import { ItemTaskConfig, ItemTaskInitService } from './item-task-init.service';
 import { Answer } from './item-task.service';
 import { areStateAnswerEqual } from '../models/answers';
+import { mapToFetchState } from 'src/app/utils/operators/state';
+import { FetchState } from 'src/app/utils/state';
 
 const answerAndStateSaveInterval = 60*SECONDS;
 
@@ -41,9 +40,6 @@ export class ItemTaskAnswerService implements OnDestroy {
   private scoreChange = new Subject<number>();
   readonly scoreChange$ = this.scoreChange.asObservable();
 
-  private saved$ = new ReplaySubject<{ answer: string, state: string }>();
-  private saveError$ = new Subject<Error>();
-
   private loadedTask$ = this.taskInitService.loadedTask$.pipe(
     catchError(() => EMPTY), // error handled in subscriptions
     takeUntil(this.error$)
@@ -54,6 +50,8 @@ export class ItemTaskAnswerService implements OnDestroy {
     filter((config): config is RunningItemTaskConfig => config.attemptId !== undefined)
   );
   private taskToken$ = this.taskInitService.taskToken$.pipe(takeUntil(this.error$));
+
+  private latestSavedCurrentAnswer: { state: string, answer: string } | null = null;
 
   private initialAnswer$: Observable<Answer | null> = this.config$.pipe(
     switchMap(({ route, attemptId, initialAnswer }) => {
@@ -96,39 +94,28 @@ export class ItemTaskAnswerService implements OnDestroy {
     shareReplay(1),
   );
 
+  /**
+   * Wait for the task state & answer to have been initialized to allow auto-saves
+   */
   private canStartSaveInterval$: Observable<void> = this.config$.pipe(
     take(1),
     filter(({ readOnly }) => !readOnly),
     map(() => undefined),
-    delayWhen(() => combineLatest([ this.saved$, this.initializedTaskState$, this.initializedTaskAnswer$ ])),
+    delayWhen(() => combineLatest([ this.initializedTaskState$, this.initializedTaskAnswer$ ])),
   );
 
-  private refreshAnswerAndStatePeriod = Math.max(answerAndStateSaveInterval, (window.taskSaveIntervalInSec ?? 0)*SECONDS);
-  private answerOrStateChange$ = interval(this.refreshAnswerAndStatePeriod).pipe(
-    takeUntil(this.destroyed$),
-    switchMap(() => this.loadedTask$),
-    switchMap(task => forkJoin({ answer: task.getAnswer(), state: task.getState() })),
-    distinctUntilChanged((a, b) => a.answer === b.answer && a.state === b.state),
+  private autoSaveCurrentState$ = this.canStartSaveInterval$.pipe( // wait for the task answer+state to have been initialized
+    switchMap(() => interval(answerAndStateSaveInterval)),
+    switchMap(() => this.saveTaskStateAnswerAsCurrent()),
+    takeUntil(this.destroyed$), // make sure the repetition ends when the service gets destroyed
+    shareReplay(1), // do not save several times in parallel if there are more subscribers
   );
-
-  private autoSaveInterval$: Observable<{ answer: string, state: string } | Error> = this.canStartSaveInterval$.pipe(
-    switchMap(() => this.saved$),
-    repeatLatestWhen(this.saveError$),
-    switchMap(saved => this.answerOrStateChange$.pipe(
-      filter(current => current.answer !== saved.answer || current.state !== saved.state),
-      take(1),
-    )),
-    withLatestFrom(this.config$),
-    catchError(() => EMPTY),
-    switchMap(([ current, { route, attemptId }]) => this.currentAnswerService.update(route.id, attemptId, current).pipe(
-      map(() => current),
-      catchError(() => of(new Error('auto save failed'))),
-    )),
-  );
-
-  readonly saveAnswerAndStateInterval$ = merge(
-    this.saved$.pipe(map(() => ({ success: true }))),
-    this.saveError$.pipe(map(() => ({ success: false }))),
+  autoSaveResult$ = this.autoSaveCurrentState$.pipe(
+    switchMap(state => {
+      if (state.isError) return of(false);
+      if (state.isReady) return of(true);
+      return EMPTY; // if the save is "waiting"
+    })
   );
 
   private subscriptions = [
@@ -139,15 +126,11 @@ export class ItemTaskAnswerService implements OnDestroy {
     this.taskInitService.loadedTask$.subscribe({
       error: err => this.errorSubject.next(err),
     }),
-    this.initialAnswer$
-      .subscribe({
-        next: initial => this.saved$.next({ answer: initial?.answer ?? '', state: initial?.state ?? '' }),
-        error: err => this.errorSubject.next(err),
-      }),
-    this.autoSaveInterval$.subscribe(savedOrError => {
-      if (savedOrError instanceof Error) this.saveError$.next(savedOrError);
-      else this.saved$.next(savedOrError);
+    this.initialAnswer$.subscribe({
+      next: answer => this.latestSavedCurrentAnswer = answer ? { answer: answer.answer ?? '', state: answer.state ?? '' } : null,
+      error: err => this.errorSubject.next(err),
     }),
+    this.autoSaveCurrentState$.subscribe(),
   ];
 
   constructor(
@@ -197,7 +180,7 @@ export class ItemTaskAnswerService implements OnDestroy {
       takeUntil(this.destroyed$),
       shareReplay(1),
     );
-    combineLatest([ grade$, saveGrade$, this.saveAnswerAndState() ])
+    combineLatest([ grade$, saveGrade$, this.saveTaskStateAnswerAsCurrent() ])
       .pipe(catchError(() => EMPTY)) // error is handled elsewhere by returning saveGrade$
       .subscribe(([ grade ]) => {
         if (grade.score !== undefined) this.scoreChange.next(grade.score);
@@ -209,34 +192,53 @@ export class ItemTaskAnswerService implements OnDestroy {
     return this.loadedTask$.pipe(take(1), switchMap(task => task.reloadAnswer('')));
   }
 
-  saveAnswerAndState(): Observable<{ saving: boolean }> {
-    return combineLatest([ this.saved$, this.loadedTask$, this.config$ ]).pipe(
+  /**
+   * Ask the task for its current state and answer, and save it as current.
+   */
+  saveTaskStateAnswerAsCurrent(): Observable<FetchState<void>> {
+    return this.taskStateAnswer().pipe(
+      switchMap(answer => this.saveAsCurrentAnswer(answer)),
+      defaultIfEmpty(undefined), // emit a ready state if taskStateAnswer or saveAsCurrentAnswer are empty
+      mapToFetchState(),
+      shareReplay(1),
+    );
+  }
+
+  /**
+   * Observable that emits the current state and answer received from the task
+   * Completes without emitting if there is no loaded task
+   * Errors if there is no loaded task or if the task fails in responding to answer or state request
+   */
+  private taskStateAnswer(): Observable<{ state: string, answer: string }> {
+    return this.loadedTask$.pipe(
       take(1),
-      // save action must applied straight away ONLY if there is an available config & task & saved-value couple
-      // if such couple is not available straight away, it means the user has navigated so quickly that the task could not be initialized
-      // therefore, no user action on the task could have been made, so there's no treatment to apply (catchError -> Empty)
-      timeout(1),
-      catchError(() => EMPTY),
+      timeout(1), // loaded task must be available immediately
+      catchError(() => EMPTY), // no task is not considered as an error but a normal case doing nothing
+      switchMap(task => forkJoin({ answer: task.getAnswer(), state: task.getState() })),
+    );
+  }
 
-      switchMap(([ saved, task, config ]) => forkJoin({
-        config: of(config),
-        saved: of(saved),
-        current: forkJoin({ answer: task.getAnswer(), state: task.getState() }),
-      })),
-
-      switchMap(({ saved, current, config: { route, attemptId, readOnly } }) => {
-        if (readOnly) return of({ saving: false });
-        const currentIsSaved = saved.answer === current.answer && saved.state === current.state;
-        if (currentIsSaved) return of({ saving: false });
-
-        return this.currentAnswerService.update(route.id, attemptId, current).pipe(
-          map(() => ({ saving: false })),
-          startWith({ saving: true }),
+  /**
+   * Save the given state-answer as current.
+   * Emit when the save is done
+   * Complete without emitting if the save has been skipped (because no config, read-only answer or state unchanged)
+   * Errors if the config was not set or if the save failed
+   */
+  private saveAsCurrentAnswer(answer: { state: string, answer: string }): Observable<void> {
+    return this.config$.pipe(
+      take(1),
+      timeout(1), // skip the saving if there are no config immediately
+      catchError(() => EMPTY), // no config is not considered as an error but a normal case doing nothing
+      switchMap(({ route, attemptId, readOnly }) => {
+        // skip save if readonly
+        if (readOnly) return EMPTY;
+        // skip save if no change since latest successful save
+        if (this.latestSavedCurrentAnswer && areStateAnswerEqual(this.latestSavedCurrentAnswer, answer)) return EMPTY;
+        return this.currentAnswerService.update(route.id, attemptId, answer).pipe(
+          tap(() => this.latestSavedCurrentAnswer = answer),
+          map(() => undefined),
         );
       }),
-      defaultIfEmpty({ saving: false }), // when a timeout is caught, the observable is empty
-      takeUntil(this.destroyed$),
-      shareReplay(1),
     );
   }
 

--- a/src/app/items/services/item-task-answer.service.ts
+++ b/src/app/items/services/item-task-answer.service.ts
@@ -197,7 +197,7 @@ export class ItemTaskAnswerService implements OnDestroy {
       takeUntil(this.destroyed$),
       shareReplay(1),
     );
-    combineLatest([ grade$, saveGrade$ ])
+    combineLatest([ grade$, saveGrade$, this.saveAnswerAndState() ])
       .pipe(catchError(() => EMPTY)) // error is handled elsewhere by returning saveGrade$
       .subscribe(([ grade ]) => {
         if (grade.score !== undefined) this.scoreChange.next(grade.score);

--- a/src/app/items/services/item-task.service.ts
+++ b/src/app/items/services/item-task.service.ts
@@ -54,7 +54,7 @@ export class ItemTaskService implements OnDestroy {
   readonly activeView$ = this.viewsService.activeView$;
 
   readonly scoreChange$ = this.answerService.scoreChange$;
-  readonly saveAnswerAndStateInterval$ = this.answerService.saveAnswerAndStateInterval$;
+  readonly autoSaveResult$ = this.answerService.autoSaveResult$;
 
   private navigateToNext$ = this.activityNavTreeService.navigationNeighbors$.pipe(
     map(neighborsState => (neighborsState.isReady ? (neighborsState.data?.next ?? neighborsState.data?.parent)?.navigateTo : undefined)),
@@ -95,8 +95,8 @@ export class ItemTaskService implements OnDestroy {
     this.viewsService.showView(view);
   }
 
-  saveAnswerAndState(): Observable<{ saving: boolean }> {
-    return this.answerService.saveAnswerAndState();
+  saveAnswerAndState(): ReturnType<ItemTaskAnswerService['saveTaskStateAnswerAsCurrent']> {
+    return this.answerService.saveTaskStateAnswerAsCurrent();
   }
 
   private bindPlatform(task: Task): void {


### PR DESCRIPTION
## Description

Fixes several issues with answer saving:
1) if there is a change when changing task, it should be saved (was not if we hadn't waiting the 60sec delay)
2) on submit, there should be a current answer save (was not if we hadn't waiting the 60sec delay)

Recommendation: test it on https://dev.algorea.org/branch/answer-handling-improvements/en/a/773396873861865944;p=4702,7528142386663912287,7523720120450464843;a=0

You can see if a change as been saved because 1) you see the call (PUT), 2) if you refresh the page, you see the change

## Test cases
- there is no save at task launch
- if there is change immediately, it is saved by autosave
- if there one failed auto save (every 60sec), a message is displayed, but it is  retried at the next interval
- if there is no change, no autosave is done 
- submitting triggers a current state save
- changing task triggers a (visible) current state save when the state has changed
  - if this save fails, the user can choose to retry
  - if this save fails, the user can choose to loose changes
- changing task does not trigger a current state save when the state has not changed
  - even just after the app was launched (past bug: was saving just after app launch if even if no change)
- on a task which cannot be loaded (e.g., https://dev.algorea.org/branch/answer-handling-improvements/en/a/1414822370876733593;p=4702,100575556387408660,1788359139685642917;pa=0), the next-prev navigation still work (may be blocked by unload protection if buggy)
- if I change task while the autosave is request is running, the "current" answer must still have been saved somehow

