### PR TITLE
Adds overflow param for message info, adds text overflow for observat…

### DIFF
--- a/src/app/containers/observation-bar-with-button/observation-bar-with-button.component.scss
+++ b/src/app/containers/observation-bar-with-button/observation-bar-with-button.component.scss
@@ -1,5 +1,9 @@
 @import 'src/assets/scss/functions';
 
+:host {
+  overflow: hidden;
+}
+
 .container {
   display: flex;
   justify-content: flex-start;

--- a/src/app/containers/observation-bar/observation-bar.component.html
+++ b/src/app/containers/observation-bar/observation-bar.component.html
@@ -15,7 +15,7 @@
         Only the content visible by the group you are observing ({{ observedGroup.name }}) is shown.
       </ng-template>
     </ng-template>
-    <span class="title" *ngIf="!onlyIcon">
+    <span class="title text-dots" *ngIf="!onlyIcon">
       @if(caption) {
         <span class="alg-secondary-color">{{ caption }}</span>
       } @else if(observedGroup.name) {

--- a/src/app/containers/observation-bar/observation-bar.component.scss
+++ b/src/app/containers/observation-bar/observation-bar.component.scss
@@ -1,5 +1,9 @@
 @import 'src/assets/scss/functions';
 
+:host {
+  overflow: hidden;
+}
+
 .wrapper {
   display: flex;
   justify-content: flex-start;
@@ -24,9 +28,13 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  overflow: hidden;
 }
 
 .title {
   margin: 0 toRem(16);
   font-size: toRem(12);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }

--- a/src/app/groups/containers/associated-item/associated-item.component.html
+++ b/src/app/groups/containers/associated-item/associated-item.component.html
@@ -5,19 +5,19 @@
 
   <alg-loading size="medium" *ngIf="state.isFetching"></alg-loading>
 
-  <alg-message-info class="message-info height-auto" icon="ph-duotone ph-info">
+  <alg-message-info class="message-info" icon="ph-duotone ph-info">
     @if (contentType === 'skill') {
-      <p i18n>
+      <p class="alg-no-top-margin" i18n>
         Attaching a skill to a group makes it available to its members at the top level of the "Skills" tab of the left panel, assuming they have been given the access rights to this skill. It also makes it easier for you to track their progress.
       </p>
-      <p i18n>
+      <p class="alg-no-bottom-margin" i18n>
         You may create a new skill folder to list all the skills you expect this group's users to work on. You may associate an existing skill if your goal is simply for members to work on this existing skill.
       </p>
     } @else {
-      <p i18n>
+      <p class="alg-no-top-margin" i18n>
         Attaching an activity to a group makes it available to its members at the top level of the "Content" tab of the left panel, assuming they have been given the access rights to this activity. It also makes it easier for you to track their progress.
       </p>
-      <p i18n>
+      <p class="alg-no-bottom-margin" i18n>
         You may create a new chapter folder to list all the content you expect this group's users to work on. You may associate an existing chapter if your goal is simply for members to work on this existing content.
       </p>
     }

--- a/src/app/ui-components/message-info/message-info.component.scss
+++ b/src/app/ui-components/message-info/message-info.component.scss
@@ -7,16 +7,23 @@
     }
   }
 
-  &.height-auto {
+  &.overflow {
     .container {
-      height: auto;
+      padding: 0 toRem(12);
+      height: toRem(40);
+    }
+
+    .message-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
   }
 }
 
 .container {
-  padding: 0 toRem(12);
-  height: toRem(40);
+  padding: toRem(12);
+  height: auto;
   display: flex;
   justify-content: flex-start;
   align-items: center;

--- a/src/assets/scss/helpers.scss
+++ b/src/assets/scss/helpers.scss
@@ -103,3 +103,11 @@
 .alg-button-margin-right {
   margin-right: toRem(8);
 }
+
+.alg-no-top-margin {
+  margin-top: 0;
+}
+
+.alg-no-bottom-margin {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Description

Fixes #1817

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

1. The observation bar doesn't use message info component, I've fixed it seprated
2. Overflow type I've tested locally as we have no cases in app:

<img width="400" alt="Screenshot at Oct 29 16-44-31" src="https://github.com/user-attachments/assets/6b26c777-ba43-4524-8b24-c8435ba93a18">

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  4. When I go to [this page](https://dev.algorea.org/branch/feature/upgrade-message-info/en/groups/by-id/8894246582084793867;p=?watchedGroupId=8894246582084793867)
  5. Then I see truncated text in observation bar
