### PR TITLE
Changes design for empty related activity

### DIFF
--- a/src/app/items/containers/item-children-list/item-children-list.component.html
+++ b/src/app/items/containers/item-children-list/item-children-list.component.html
@@ -62,5 +62,9 @@
 </ul>
 
 <ng-template #noChildrenSection>
-  <p class="empty-message" *ngIf="emptyMessage">{{ emptyMessage }}</p>
+  @if (emptyMessage) {
+    <alg-error>
+      {{ emptyMessage }}
+    </alg-error>
+  }
 </ng-template>

--- a/src/app/items/containers/item-children-list/item-children-list.component.scss
+++ b/src/app/items/containers/item-children-list/item-children-list.component.scss
@@ -93,8 +93,3 @@
   color: var(--alg-primary-color);
   font-size: toRem(24);
 }
-
-.empty-message {
-  text-align: left;
-  margin-left: toRem(16);
-}

--- a/src/app/items/containers/item-children-list/item-children-list.component.ts
+++ b/src/app/items/containers/item-children-list/item-children-list.component.ts
@@ -7,6 +7,7 @@ import { SkillProgressComponent } from 'src/app/ui-components/skill-progress/ski
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
 import { RouterLink } from '@angular/router';
 import { NgIf, NgClass, NgFor } from '@angular/common';
+import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 
 @Component({
   selector: 'alg-item-children-list',
@@ -23,6 +24,7 @@ import { NgIf, NgClass, NgFor } from '@angular/common';
     ItemRoutePipe,
     ItemRouteWithExtraPipe,
     RouteUrlPipe,
+    ErrorComponent,
   ],
 })
 export class ItemChildrenListComponent {


### PR DESCRIPTION
## Description

Fixes #1584

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

We are using `alg-error` for messages, so mb need to rename it

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/new-design/empty-related-activity-list/en/s/8865540088611165367;p=;a=0)
  3. Then I see new design for empty caption
