### PR TITLE
Replaces native scrollbar with custom for group indicator

### DIFF
--- a/src/app/groups/containers/group-indicator/group-indicator.component.html
+++ b/src/app/groups/containers/group-indicator/group-indicator.component.html
@@ -1,31 +1,33 @@
 <div class="container">
-  <ng-container [ngSwitch]="group?.currentUserMembership">
-    <div class="content" *ngSwitchCase="'direct'">
-      <span i18n>You are a member of this group.</span>
-    </div>
+  <ng-scrollbar orientation="horizontal">
+    <ng-container [ngSwitch]="group?.currentUserMembership">
+      <div class="content" *ngSwitchCase="'direct'">
+        <span i18n>You are a member of this group.</span>
+      </div>
 
-    <div class="content" *ngSwitchCase="'descendant'" i18n>
-      As a member of <alg-group-links class="links" [items]="group?.descendantsCurrentUserIsMemberOf"></alg-group-links>
-      you are a member of this group.
-    </div>
-  </ng-container>
+      <div class="content" *ngSwitchCase="'descendant'" i18n>
+        As a member of <alg-group-links class="links" [items]="group?.descendantsCurrentUserIsMemberOf"></alg-group-links>
+        you are a member of this group.
+      </div>
+    </ng-container>
 
-  <ng-container [ngSwitch]="group?.currentUserManagership">
-    <div class="content" *ngSwitchCase="'direct'" i18n>
-      <i class="icon ph-duotone ph-crown"></i>
-      You are a manager of this group.
-    </div>
+    <ng-container [ngSwitch]="group?.currentUserManagership">
+      <div class="content" *ngSwitchCase="'direct'" i18n>
+        <i class="icon ph-duotone ph-crown"></i>
+        You are a manager of this group.
+      </div>
 
-    <div class="content" *ngSwitchCase="'ancestor'" i18n>
-      <i class="icon ph-duotone ph-crown"></i>
-      As a manager of <alg-group-links class="links" [items]="group?.ancestorsCurrentUserIsManagerOf"></alg-group-links>
-      you can manage this group.
-    </div>
+      <div class="content" *ngSwitchCase="'ancestor'" i18n>
+        <i class="icon ph-duotone ph-crown"></i>
+        As a manager of <alg-group-links class="links" [items]="group?.ancestorsCurrentUserIsManagerOf"></alg-group-links>
+        you can manage this group.
+      </div>
 
-    <div class="content" *ngSwitchCase="'descendant'" i18n>
-      <i class="icon ph-duotone ph-crown"></i>
-      As a manager of <alg-group-links class="links" [items]="group?.descendantsCurrentUserIsManagerOf"></alg-group-links>
-      you can view this group.
-    </div>
-  </ng-container>
+      <div class="content" *ngSwitchCase="'descendant'" i18n>
+        <i class="icon ph-duotone ph-crown"></i>
+        As a manager of <alg-group-links class="links" [items]="group?.descendantsCurrentUserIsManagerOf"></alg-group-links>
+        you can view this group.
+      </div>
+    </ng-container>
+  </ng-scrollbar>
 </div>

--- a/src/app/groups/containers/group-indicator/group-indicator.component.scss
+++ b/src/app/groups/containers/group-indicator/group-indicator.component.scss
@@ -10,7 +10,6 @@
   border-radius: toRem(8);
   background-color: var(--alg-primary-light-color);
   min-height: toRem(40);
-  overflow-x: scroll;
 }
 
 .content {

--- a/src/app/groups/containers/group-indicator/group-indicator.component.ts
+++ b/src/app/groups/containers/group-indicator/group-indicator.component.ts
@@ -2,13 +2,14 @@ import { Component, Input } from '@angular/core';
 import { Group } from '../../data-access/get-group-by-id.service';
 import { GroupLinksComponent } from '../group-links/group-links.component';
 import { NgSwitch, NgSwitchCase } from '@angular/common';
+import { NgScrollbar } from 'ngx-scrollbar';
 
 @Component({
   selector: 'alg-group-indicator',
   templateUrl: './group-indicator.component.html',
   styleUrls: [ './group-indicator.component.scss' ],
   standalone: true,
-  imports: [ NgSwitch, NgSwitchCase, GroupLinksComponent ]
+  imports: [ NgSwitch, NgSwitchCase, GroupLinksComponent, NgScrollbar ]
 })
 export class GroupIndicatorComponent {
   @Input() group?: Group;


### PR DESCRIPTION
## Description

Fixes #1789

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Windows emulator:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4bc53d55-537b-40e3-b9a3-0d417b0bf3cd">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/d53b1dc2-0800-46c6-88ef-4ad3ce01a647">


## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/group-indicator-scroll/en/groups/by-id/3221277588634796170;p=)
  3. And I hover on group indicator
  4. Then I see custom scroll
