### PR TITLE
Removes diacritical marks from search content

### DIFF
--- a/src/app/ui-components/add-content/add-content.component.ts
+++ b/src/app/ui-components/add-content/add-content.component.ts
@@ -110,6 +110,7 @@ export class AddContentComponent<Type> implements OnInit, OnDestroy {
     const existingTitleControl: Observable<string> | undefined = this.addContentForm.get('searchExisting')?.valueChanges;
     if (existingTitleControl) this.subscriptions.push(
       existingTitleControl.pipe(
+        // Removes all diacritics marks
         map(value => value.normalize('NFD').replace(/[\u0300-\u036f]/g, '').trim()),
         filter(value => this.checkLength(value)),
         debounceTime(300),


### PR DESCRIPTION
## Description

Fixes #1833

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/ignore-accents-and-diacritics-in-search/en/a/1980584647557587953;p=4702,4102;a=0/edit-children)
  3. And I do scroll down to "Add content" section
  4. Then I type "Collège" in search input
  5. Then I see "Collège Prépa Algorea" in result