### PR TITLE
Fixes e2e issues with input date

### DIFF
--- a/e2e/groups/group-edit-requires-approval.spec.ts
+++ b/e2e/groups/group-edit-requires-approval.spec.ts
@@ -80,6 +80,8 @@ test('check invalid date validation', { tag: '@no-parallelism' },async ({ page, 
     await groupSettingsPage.enableLockMembershipUntilInputDate();
   });
 
+  const minInputDate = new Date();
+
   if (browser.browserType().name() === 'chromium') {
     await test.step('checks invalid time in Chrome', async () => {
       await groupSettingsPage.fillDate('21/05/2024 60:60');
@@ -93,9 +95,8 @@ test('check invalid date validation', { tag: '@no-parallelism' },async ({ page, 
   });
 
   await test.step('fill past date', async () => {
-    const currentDate = new Date();
-    await groupSettingsPage.fillDate(convertDateToString(currentDate));
-    await expect.soft(page.getByText(`The date must be greater than: ${ convertDateToString(currentDate) }`)).toBeVisible();
+    await groupSettingsPage.fillDate(convertDateToString(minInputDate));
+    await expect.soft(page.getByText(`The date must be greater than: ${ convertDateToString(minInputDate) }`)).toBeVisible();
   });
 
   await test.step('clear invalid date and check validation message is gone', async () => {

--- a/e2e/groups/pages/group-settings-page.ts
+++ b/e2e/groups/pages/group-settings-page.ts
@@ -27,6 +27,8 @@ export class GroupSettingsPage {
     await expect.soft(this.page.getByTestId('switch-require-lock-until-enabled')).toBeVisible();
     await this.page.getByTestId('switch-require-lock-until-enabled').click();
     await expect.soft(this.inputDateLocator).toBeVisible();
+    await this.inputDateLocator.click();
+    await expect.soft(this.inputDateLocator).toHaveValue('dd/mm/yyyy hh:mm');
   }
 
   async disableLockMembershipUntilInputDate(): Promise<void> {


### PR DESCRIPTION
## Description

Fixes e2e issue with input date

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The problem was with mask that put placeholder as value. As playwright working very fast (unlike human) sometimes it filled the value before p-input emits mask and as result the mask override the value. For self, I can see the best way how to reproduce kind race condition issues in future - is the run tests 50-100 times

<img width="859" alt="image" src="https://github.com/user-attachments/assets/6e67ff2c-5a40-45b5-95fa-f225de732ea4">

## Test cases


