### PR TITLE
Fixes navigation for other group pages

### DIFF
--- a/src/app/groups/store/group-content/group-content.selectors.ts
+++ b/src/app/groups/store/group-content/group-content.selectors.ts
@@ -58,7 +58,7 @@ export function selectors<T extends RootState>(selectState: Selector<T, State>):
     selectIsUserContentActive,
     selectIdParameter,
     selectPathParameter,
-    (isActive, isUser, id, path) => (isActive ? groupRouteFromParams(id, path, isUser) : null)
+    (isActive, isUser, id, path) => (isActive && id ? groupRouteFromParams(id, path, isUser) : null)
   );
 
   const selectActiveContentRouteError = createSelector(


### PR DESCRIPTION
## Description

Fixes navigation for groups without `id`

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases
