### PR TITLE
left menu: change page directly when changing tab

### DIFF
--- a/e2e/common/lost-changes-confirmation.spec.ts
+++ b/e2e/common/lost-changes-confirmation.spec.ts
@@ -51,9 +51,6 @@ test('checks navigation to another module for item', async ({ page, lostChangesC
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.locator('alg-left-nav').getByRole('button', { name: 'Groups' }).click();
-    await page.waitForResponse(`${ apiUrl }/groups/roots`);
-    await expect.soft(page.locator('#nav-4035378957038759250')).toBeVisible();
-    await page.locator('#nav-4035378957038759250').click();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
     await lostChangesConfirmationModal.cancel();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
@@ -69,14 +66,10 @@ test('checks navigation to another module for item', async ({ page, lostChangesC
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.locator('alg-left-nav').getByRole('button', { name: 'Groups' }).click();
-    await page.waitForResponse(`${ apiUrl }/groups/roots`);
-    await expect.soft(page.locator('#nav-4035378957038759250')).toBeVisible();
-    await page.locator('#nav-4035378957038759250').click();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
     await lostChangesConfirmationModal.confirm();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
-    await expect.soft(page.getByRole('heading', { name: '!634' })).toBeVisible();
-    await expect.soft(itemEditWrapperLocator.getByText('Item Title')).not.toBeVisible();
+    await expect.soft(page.getByRole('heading', { name: 'My groups' })).toBeVisible();
   });
 });
 
@@ -116,8 +109,6 @@ test('checks navigation to another module for group', async ({ page, lostChanges
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.locator('alg-left-nav').getByRole('button', { name: 'Content' }).click();
-    await expect.soft(page.locator('#nav-4702')).toBeVisible();
-    await page.locator('#nav-4702').click();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
     await lostChangesConfirmationModal.cancel();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
@@ -130,8 +121,6 @@ test('checks navigation to another module for group', async ({ page, lostChanges
     await expect.soft(page.getByRole('textbox').nth(1)).toBeVisible();
     await page.getByRole('textbox').nth(1).fill('Some test');
     await page.locator('alg-left-nav').getByRole('button', { name: 'Content' }).click();
-    await expect.soft(page.locator('#nav-4702')).toBeVisible();
-    await page.locator('#nav-4702').click();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
     await lostChangesConfirmationModal.confirm();
     await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();

--- a/src/app/groups/containers/user/user.component.ts
+++ b/src/app/groups/containers/user/user.component.ts
@@ -2,7 +2,6 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { combineLatest, Observable, Subscription } from 'rxjs';
 import { NavigationEnd, Router, RouterLinkActive, RouterLink } from '@angular/router';
 import { map, startWith, filter, distinctUntilChanged } from 'rxjs/operators';
-import { contentInfo } from 'src/app/models/content/content-info';
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { formatUser } from 'src/app/groups/models/user';
 import { isGroupRoute } from 'src/app/models/routing/group-route';
@@ -19,6 +18,7 @@ import { Store } from '@ngrx/store';
 import { fromGroupContent } from '../../store';
 import { isNotNull } from 'src/app/utils/null-undefined-predicates';
 import { UserInfoComponent } from 'src/app/groups/containers/user-info/user-info.component';
+import { userInfo } from 'src/app/models/content/group-info';
 
 const breadcrumbHeader = $localize`Users`;
 
@@ -74,7 +74,7 @@ export class UserComponent implements OnInit, OnDestroy {
       this.store.select(fromGroupContent.selectActiveContentBreadcrumbs),
     ])
       .pipe(
-        map(([ currentUserRoute, currentPageTitle, state, breadcrumbs ]) => contentInfo({
+        map(([ currentUserRoute, currentPageTitle, state, breadcrumbs ]) => userInfo({
           title: state.isReady ? formatUser(state.data) : undefined,
           breadcrumbs: {
             category: breadcrumbHeader,

--- a/src/app/groups/store/group-content/group-content.selectors.ts
+++ b/src/app/groups/store/group-content/group-content.selectors.ts
@@ -1,5 +1,14 @@
 import { MemoizedSelector, Selector, createSelector } from '@ngrx/store';
-import { GroupRoute, RawGroupRoute, isGroupRoute, isUser, parseRouterPath } from 'src/app/models/routing/group-route';
+import {
+  GroupPage,
+  GroupRoute,
+  RawGroupRoute,
+  isGroupRoute,
+  isUser,
+  managedGroupsPage,
+  myGroupsPage,
+  parseRouterPath
+} from 'src/app/models/routing/group-route';
 import { GroupRouteError, groupRouteFromParams, isGroupRouteError } from '../../utils/group-route-validation';
 import { ObservationInfo } from 'src/app/store/observation';
 import { fromRouter } from 'src/app/store/router';
@@ -25,6 +34,7 @@ interface UserContentSelectors<T extends RootState> {
 
   selectActiveContentRoute: MemoizedSelector<T, RawGroupRoute|null>,
   selectActiveContentFullRoute: MemoizedSelector<T, GroupRoute|null>,
+  selectActiveContentRouteOrPage: MemoizedSelector<T, RawGroupRoute|GroupPage|null>,
 
   selectActiveContentUserId: MemoizedSelector<T, string|null>,
   selectActiveContentGroupId: MemoizedSelector<T, string|null>,
@@ -95,6 +105,16 @@ export function selectors<T extends RootState>(selectState: Selector<T, State>):
     route => (route && isGroupRoute(route) ? route : null),
   );
 
+  const selectActiveContentRouteOrPage = createSelector(
+    selectActiveContentRoute,
+    selectRouterPathParsingResult,
+    (route, parsingResult) => {
+      if (route) return route;
+      if (parsingResult === myGroupsPage || parsingResult === managedGroupsPage) return parsingResult;
+      return null;
+    }
+  );
+
   const selectActiveContentId = createSelector(
     selectActiveContentRoute,
     route => route?.id ?? null
@@ -163,6 +183,7 @@ export function selectors<T extends RootState>(selectState: Selector<T, State>):
     selectActiveContentRouteErrorHandlingState,
     selectActiveContentRoute,
     selectActiveContentFullRoute,
+    selectActiveContentRouteOrPage,
     selectActiveContentUserId,
     selectActiveContentGroupId,
     selectActiveContentGroup,

--- a/src/app/models/content/group-info.ts
+++ b/src/app/models/content/group-info.ts
@@ -35,3 +35,13 @@ export function myGroupsInfo(info: Omit<MyGroupsInfo, 'type'>): MyGroupsInfo {
 export function isMyGroupsInfo(info: ContentInfo|null): info is MyGroupsInfo {
   return info !== null && info.type === 'my-groups';
 }
+
+export interface UserInfo extends ContentInfo {
+  type: 'user',
+}
+export function userInfo(info: Omit<MyGroupsInfo, 'type'>): UserInfo {
+  return { ...info, type: 'user' };
+}
+export function isUserInfo(info: ContentInfo|null): info is UserInfo {
+  return info !== null && info.type === 'user';
+}

--- a/src/app/store/navigation/selected-content/selected-content.actions.ts
+++ b/src/app/store/navigation/selected-content/selected-content.actions.ts
@@ -1,9 +1,10 @@
 import { createActionGroup, props } from '@ngrx/store';
-import { ContentRoute } from 'src/app/models/routing/content-route';
+import { State } from './selected-content.state';
 
 export const changedContentActions = createActionGroup({
   source: 'Router',
   events: {
-    changeContent: props<{ route: ContentRoute|null }>(),
+    changeItemRoute: props<{ route: State['activity'] }>(),
+    changeGroupRouteOrPage: props<{ routeOrPage: State['group'] }>(),
   },
 });

--- a/src/app/store/navigation/selected-content/selected-content.effects.ts
+++ b/src/app/store/navigation/selected-content/selected-content.effects.ts
@@ -1,23 +1,28 @@
 import { createEffect } from '@ngrx/effects';
 import { inject } from '@angular/core';
-import { createSelector, Store } from '@ngrx/store';
-import { map } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { filter, map } from 'rxjs';
 import { fromItemContent } from 'src/app/items/store';
 import { changedContentActions } from './selected-content.actions';
 import { fromGroupContent } from 'src/app/groups/store';
+import { isNotNull } from 'src/app/utils/null-undefined-predicates';
 
-const selectActiveContentRoute = createSelector(
-  fromItemContent.selectActiveContentRoute,
-  fromGroupContent.selectActiveContentFullRoute,
-  fromGroupContent.selectIsUserContentActive,
-  (itemRoute, groupRoute, isUser) => itemRoute ?? (isUser ? groupRoute : null)
-);
-
-export const keepActiveContentEffect = createEffect(
+export const keepActiveItemContentEffect = createEffect(
   (
     store$ = inject(Store),
-  ) => store$.select(selectActiveContentRoute).pipe(
-    map(route => changedContentActions.changeContent({ route })),
+  ) => store$.select(fromItemContent.selectActiveContentRoute).pipe(
+    filter(isNotNull),
+    map(route => changedContentActions.changeItemRoute({ route })),
+  ),
+  { functional: true },
+);
+
+export const keepActiveGroupContentEffect = createEffect(
+  (
+    store$ = inject(Store),
+  ) => store$.select(fromGroupContent.selectActiveContentRouteOrPage).pipe(
+    filter(isNotNull),
+    map(routeOrPage => changedContentActions.changeGroupRouteOrPage({ routeOrPage })),
   ),
   { functional: true },
 );

--- a/src/app/store/navigation/selected-content/selected-content.reducer.ts
+++ b/src/app/store/navigation/selected-content/selected-content.reducer.ts
@@ -1,20 +1,28 @@
 import { createReducer, on } from '@ngrx/store';
 import { changedContentActions } from './selected-content.actions';
 import { initialState, State } from './selected-content.state';
-import { isItemRoute } from 'src/app/models/routing/item-route';
 import { isSkill } from 'src/app/items/models/item-type';
 
 export const reducer = createReducer(
   initialState,
 
   on(
-    changedContentActions.changeContent,
+    changedContentActions.changeItemRoute,
     (state, { route }): State => ({
       ...state,
-      activity: route && isItemRoute(route) && !isSkill(route.contentType) ? route : state.activity,
-      skill: route && isItemRoute(route) && isSkill(route.contentType) ? route : state.skill
+      activity: !isSkill(route.contentType) ? route : state.activity,
+      skill: isSkill(route.contentType) ? route : state.skill,
+
     })
   ),
+
+  on(
+    changedContentActions.changeGroupRouteOrPage,
+    (state, { routeOrPage }): State => ({
+      ...state,
+      group: routeOrPage
+    })
+  )
 
 
 );

--- a/src/app/store/navigation/selected-content/selected-content.state.ts
+++ b/src/app/store/navigation/selected-content/selected-content.state.ts
@@ -1,13 +1,10 @@
-import { RawGroupRoute } from 'src/app/models/routing/group-route';
+import { GroupPage, myGroupsPage, RawGroupRoute } from 'src/app/models/routing/group-route';
 import { appDefaultActivityRoute, appDefaultSkillRoute, ItemRoute } from 'src/app/models/routing/item-route';
-
-export const myGroupsPage = 'mine';
-export const managedGroupsPage = 'managed';
 
 export interface State {
   activity: ItemRoute,
-  skill?: ItemRoute,
-  group: RawGroupRoute|typeof myGroupsPage|typeof managedGroupsPage,
+  skill: ItemRoute|undefined,
+  group: RawGroupRoute|GroupPage,
 }
 
 export const initialState: State = {

--- a/src/app/store/navigation/selected-content/selected-content.store.ts
+++ b/src/app/store/navigation/selected-content/selected-content.store.ts
@@ -1,7 +1,7 @@
-import { createFeatureAlt } from 'src/app/utils/store/feature_creator';
 import { reducer } from './selected-content.reducer';
+import { createFeature } from '@ngrx/store';
 
-export const fromSelectedContent = createFeatureAlt({
+export const fromSelectedContent = createFeature({
   name: 'selectedContent',
   reducer,
 });


### PR DESCRIPTION
## Description

Change the behavior of the left menu: when changing "tab", the right content changes immediately to the selected content type (the last content on that type).

@Iloveall could you update the tests to match this new behavior?