### PR TITLE
Adds padding for access code in item view

### DIFF
--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -6,12 +6,14 @@
           <alg-item-header [itemData]="itemData"></alg-item-header>
         }
         @if (showAccessCodeField$ | async) {
-          <alg-access-code-view
-            i18n-sectionLabel sectionLabel="Access to activity"
-            i18n-buttonLabel="Button label for joining an item by (group) code" buttonLabel="Access"
-            [itemData]="itemData"
-            (groupJoined)="reloadItem()"
-          ></alg-access-code-view>
+          <div class="access-code-view">
+            <alg-access-code-view
+              i18n-sectionLabel sectionLabel="Access to activity"
+              i18n-buttonLabel="Button label for joining an item by (group) code" buttonLabel="Access"
+              [itemData]="itemData"
+              (groupJoined)="reloadItem()"
+            ></alg-access-code-view>
+          </div>
         }
         @if (observedGroup$ | async; as observedGroup) {
           <alg-item-permissions

--- a/src/app/items/item-by-id.component.scss
+++ b/src/app/items/item-by-id.component.scss
@@ -51,3 +51,7 @@
     margin-right: var(--alg-space-size-5);
   }
 }
+
+.access-code-view {
+  margin-bottom: var(--alg-space-size-4);
+}


### PR DESCRIPTION
## Description

Fixes #1682

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the e2e user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/add-padding-for-group-code-access/en/a/1667525548838093512;p=4702,7528142386663912287,944619266928306927;pa=0)
  3. Then I see bottom padding for group code section
