### PR TITLE
Renames input title param to caption in section header

### DIFF
--- a/src/app/items/containers/item-permissions/item-permissions.component.html
+++ b/src/app/items/containers/item-permissions/item-permissions.component.html
@@ -43,7 +43,7 @@
           @if (watchedGroupPermissions.isOwner) {
             <div class="permission-indicator-section">
               <alg-section-header
-                i18n-title title="Is owner"
+                i18n-caption caption="Is owner"
                 icon="ph-duotone ph-user"
                 theme="warning"
               >
@@ -55,7 +55,7 @@
           } @else {
             <div class="permission-indicator-section">
               <alg-section-header
-                i18n-title title="Can view"
+                i18n-caption caption="Can view"
                 icon="ph-duotone ph-eyeglasses"
                 theme="warning"
               >
@@ -86,7 +86,7 @@
             @if (watchedGroupPermissions | allowsViewingInfo) {
               <div class="permission-indicator-section">
                 <alg-section-header
-                  i18n-title title="Can grant view"
+                  i18n-caption caption="Can grant view"
                   icon="ph-duotone ph-key"
                   theme="warning"
                 >
@@ -104,7 +104,7 @@
             @if (watchedGroupPermissions | allowsViewingContent) {
               <div class="permission-indicator-section">
                 <alg-section-header
-                  i18n-title title="Can watch"
+                  i18n-caption caption="Can watch"
                   icon="ph-duotone ph-binoculars"
                   theme="warning"
                 >
@@ -120,7 +120,7 @@
               </div>
               <div class="permission-indicator-section">
                 <alg-section-header
-                  i18n-title title="Can edit"
+                  i18n-caption caption="Can edit"
                   icon="ph-duotone ph-pencil"
                   theme="warning"
                 >

--- a/src/app/ui-components/collapsible-section/collapsible-section.component.html
+++ b/src/app/ui-components/collapsible-section/collapsible-section.component.html
@@ -1,7 +1,7 @@
 <div class="section-container" [ngClass]="theme">
   <alg-section-header
     class="header"
-    [title]="header"
+    [caption]="header"
     [icon]="icon"
     [theme]="theme"
     [styleClass]="{ disabled: disabled, 'cursor-pointer': collapsible }"

--- a/src/app/ui-components/section-header/section-header.component.html
+++ b/src/app/ui-components/section-header/section-header.component.html
@@ -1,7 +1,7 @@
 <div class="container" [attr.class]="theme" [ngClass]="styleClass">
   <div class="left">
     <i class="icon {{ icon }}"></i>
-    <span class="title">{{ title }}</span>
+    <span class="title">{{ caption }}</span>
   </div>
   <div class="template" *ngIf="contentTemplate">
     <ng-container

--- a/src/app/ui-components/section-header/section-header.component.ts
+++ b/src/app/ui-components/section-header/section-header.component.ts
@@ -14,7 +14,7 @@ import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
 })
 export class SectionHeaderComponent {
 
-  @Input() title = '';
+  @Input() caption = '';
   @Input() icon = '';
   @Input() theme: 'success' | 'warning' | 'danger' = 'success';
   @Input() styleClass: string | string[] | Set<string> | { [klass: string]: boolean } = '';


### PR DESCRIPTION
## Description

Fixes #1820

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/feature/change-title-param-in-section-header/en/a/10886782127135168;p=;pa=0?watchedGroupId=4035378957038759250)
  3. Then I click on "Edit permissions"
  4. And I hover on "Can View"
  5. Then I see no any tooltip 
