### PR TITLE
Refactor routes: Don't force id & path in routes

### DIFF
--- a/src/app/groups/store/group-content/group-content.selectors.ts
+++ b/src/app/groups/store/group-content/group-content.selectors.ts
@@ -16,8 +16,9 @@ import { GroupInState, State, UserInState } from './group-content.state';
 import { fetchingState } from 'src/app/utils/state';
 import { formatUser } from 'src/app/groups/models/user';
 import { RootState } from 'src/app/utils/store/root_state';
-import { selectIdParameter, selectPathParameter } from 'src/app/models/routing/content-route-selectors';
+import { selectIdParameter } from 'src/app/models/routing/content-route-selectors';
 import { groupGroupTypeCategory, userGroupTypeCategory } from '../../models/group-types';
+import { selectPathParameter } from 'src/app/models/routing/path-parameter';
 
 interface UserContentSelectors<T extends RootState> {
   selectIsGroupContentActive: MemoizedSelector<T, boolean>,

--- a/src/app/items/containers/item-display/item-display.component.ts
+++ b/src/app/items/containers/item-display/item-display.component.ts
@@ -46,7 +46,7 @@ import { ItemRouter } from 'src/app/models/routing/item-router';
 import { openNewTab, replaceWindowUrl } from 'src/app/utils/url';
 import { GetBreadcrumbsFromRootsService } from 'src/app/data-access/get-breadcrumbs-from-roots.service';
 import { typeCategoryOfItem } from 'src/app/items/models/item-type';
-import { closestBreadcrumbs } from 'src/app/models/routing/content-route';
+import { closestBreadcrumbs } from 'src/app/models/content/content-breadcrumbs';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
 import { ButtonModule } from 'primeng/button';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';

--- a/src/app/models/content/content-breadcrumbs.spec.ts
+++ b/src/app/models/content/content-breadcrumbs.spec.ts
@@ -1,4 +1,4 @@
-import { closestBreadcrumbs } from './content-route';
+import { closestBreadcrumbs } from './content-breadcrumbs';
 
 const basePath = [ '1', '2', '3' ];
 
@@ -6,7 +6,7 @@ function wrap(path: string[]): { id: string }[] {
   return path.map(e => ({ id: e }));
 }
 
-describe('closestPath', () => {
+describe('closestBreadcrumbs', () => {
   it('should throw an exception if the list is empty', () => {
     expect(function () {
       closestBreadcrumbs(basePath, []);

--- a/src/app/models/content/content-breadcrumbs.ts
+++ b/src/app/models/content/content-breadcrumbs.ts
@@ -4,3 +4,22 @@ export type ContentBreadcrumbs = {
   title: string,
   navigateTo?: UrlTree|(() => UrlTree),
 }[];
+
+/*
+ * Returns, among the given list of breadcrumbs given as path, the one which is the closest from the base.
+ * The closest path is the shortest path with the longest common prefix. (if several ones, any of these is returned)
+ * `list` must not be empty, otherwise throw an exception!
+ */
+export function closestBreadcrumbs<T extends { id: string }>(base: string[], list: T[][]): T[] {
+  const sol = list.map(breadcrumbs => {
+    for (let i = 0; i < base.length; i++) {
+      if (base[i] !== breadcrumbs[i]?.id) return { common: i, breadcrumbs };
+    }
+    return { common: base.length, breadcrumbs };
+  }).reduce((prev, cur) => {
+    if (prev.common > cur.common) return prev;
+    if (cur.common > prev.common) return cur;
+    return prev.breadcrumbs.length > cur.breadcrumbs.length ? cur : prev;
+  });
+  return sol.breadcrumbs;
+}

--- a/src/app/models/content/content-info.ts
+++ b/src/app/models/content/content-info.ts
@@ -1,13 +1,12 @@
-import { ContentRoute } from '../routing/content-route';
-import { arraysEqual } from '../../utils/array';
+import { EntityPathRoute } from '../routing/entity-route';
 
 export interface ContentInfo {
   type: string,
-  route?: ContentRoute,
+  route?: EntityPathRoute,
 }
 
 export interface RoutedContentInfo extends ContentInfo {
-  route: ContentRoute,
+  route: EntityPathRoute,
 }
 
 /**
@@ -15,16 +14,4 @@ export interface RoutedContentInfo extends ContentInfo {
  */
 export function contentInfo(c: Omit<ContentInfo, 'type'>): ContentInfo {
   return { ...c, type: 'misc' };
-}
-
-export function areSiblings(c1: RoutedContentInfo, c2: RoutedContentInfo): boolean {
-  return c1.type === c2.type && arraysEqual(c1.route.path, c2.route.path);
-}
-
-export function areParentChild(c: { parent: RoutedContentInfo, child: RoutedContentInfo }): boolean {
-  return c.parent.type === c.child.type && arraysEqual([ ...c.parent.route.path, c.parent.route.id ], c.child.route.path);
-}
-
-export function areSameElements(c1: RoutedContentInfo, c2: RoutedContentInfo): boolean {
-  return c1.type === c2.type && c1.route.id === c2.route.id && arraysEqual(c1.route.path, c2.route.path);
 }

--- a/src/app/models/left-nav-loading/nav-tree-data.ts
+++ b/src/app/models/left-nav-loading/nav-tree-data.ts
@@ -1,13 +1,12 @@
 import { arraysEqual } from 'src/app/utils/array';
 import { ensureDefined } from 'src/app/utils/assert';
-import { ContentRoute } from 'src/app/models/routing/content-route';
+import { EntityPathRoute } from '../routing/entity-route';
 
-type Id = string;
 export enum GroupManagership { False = 'false', True = 'true', Descendant = 'descendant' }
 
 export interface NavTreeElement {
   // generic
-  route: ContentRoute,
+  route: EntityPathRoute,
   title: string,
   hasChildren: boolean,
   children?: this[],
@@ -34,15 +33,15 @@ export class NavTreeData {
 
   constructor(
     public readonly elements: NavTreeElement[], // level 1 elements (which may have children)
-    public readonly pathToElements: Id[], // path from root to the elements (so including the parent if any)
+    public readonly pathToElements: EntityPathRoute['path'], // path from root to the elements (so including the parent if any)
     public readonly parent?: NavTreeElement, // level 0 element
-    public readonly selectedElementId?: Id, // the selected element is among elements
+    public readonly selectedElementId?: EntityPathRoute['id'], // the selected element is among elements
   ) {}
 
   /**
    * Return this with selected element changed
    */
-  withSelection(id: Id): NavTreeData {
+  withSelection(id: EntityPathRoute['id']): NavTreeData {
     return new NavTreeData(this.elements, this.pathToElements, this.parent, id);
   }
 
@@ -50,8 +49,8 @@ export class NavTreeData {
    * Return this with the element from `elements` (identified by its id) replaced by the given one
    * If the element is not found, return this unchanged.
    */
-  withUpdatedElement(route: ContentRoute, update: (el:NavTreeElement)=>NavTreeElement): NavTreeData {
-    let l1Id: ContentRoute['id'];
+  withUpdatedElement(route: EntityPathRoute, update: (el:NavTreeElement)=>NavTreeElement): NavTreeData {
+    let l1Id: EntityPathRoute['id'];
     if (arraysEqual(route.path, this.pathToElements)) l1Id = route.id;
     else if (arraysEqual(route.path.slice(0, -1), this.pathToElements)) l1Id = ensureDefined(route.path[route.path.length-1]);
     else throw new Error('unexpected: updated element not among tree elements');
@@ -69,8 +68,8 @@ export class NavTreeData {
    * Return this with children added to the element from `elements` (identified by its route)
    * If the element is not found, return this unchanged.
    */
-  withChildren(route: ContentRoute, children: NavTreeElement[]): NavTreeData {
-    let id: ContentRoute['id'];
+  withChildren(route: EntityPathRoute, children: NavTreeElement[]): NavTreeData {
+    let id: EntityPathRoute['id'];
     if (arraysEqual(route.path, this.pathToElements)) id = route.id;
     else if (arraysEqual(route.path.slice(0, -1), this.pathToElements)) id = ensureDefined(route.path[route.path.length-1]);
     else throw new Error('unexpected: children parent not among tree elements');

--- a/src/app/models/routing/content-route-selectors.ts
+++ b/src/app/models/routing/content-route-selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@ngrx/store';
 import { fromRouter } from 'src/app/store/router';
-import { pathFromParamValue, pathParamName } from './content-route';
+import { pathFromParamValue, pathParamName } from './path-parameter';
 
 /**
  * A selector on the "id" parameter extracted from the route.

--- a/src/app/models/routing/content-route-selectors.ts
+++ b/src/app/models/routing/content-route-selectors.ts
@@ -1,20 +1,7 @@
-import { createSelector } from '@ngrx/store';
 import { fromRouter } from 'src/app/store/router';
-import { pathFromParamValue, pathParamName } from './path-parameter';
 
 /**
  * A selector on the "id" parameter extracted from the route.
  * Using this selector instead of getting it from param map allows memoizing
  */
 export const selectIdParameter = fromRouter.selectParam('id');
-
-const selectRawPathParameter = fromRouter.selectParam(pathParamName);
-
-/**
- * A selector on the path parameter extracted from the route
- * Using this selector instead of getting it from param map allows memoizing
- */
-export const selectPathParameter = createSelector(
-  selectRawPathParameter,
-  rawPath => (rawPath !== null ? pathFromParamValue(rawPath) : null)
-);

--- a/src/app/models/routing/content-route.ts
+++ b/src/app/models/routing/content-route.ts
@@ -1,8 +1,3 @@
-import { ParamMap } from '@angular/router';
-import { UrlCommandParameters } from '../../utils/url';
-
-/* for url */
-export const pathParamName = 'p';
 
 type Id = string;
 
@@ -10,22 +5,6 @@ export interface ContentRoute {
   contentType: string,
   id: Id,
   path: Id[],
-}
-
-export function pathFromRouterParameters(params: ParamMap): string[]|null {
-  const pathAsString = params.get(pathParamName);
-  if (pathAsString === null) return null;
-  return pathFromParamValue(pathAsString);
-}
-
-export function pathFromParamValue(path: string): string[] {
-  return path === '' ? [] : path.split(',');
-}
-
-export function pathAsParameter(value: string[]): UrlCommandParameters {
-  const params: UrlCommandParameters = {};
-  params[pathParamName] = value;
-  return params;
 }
 
 /*

--- a/src/app/models/routing/content-route.ts
+++ b/src/app/models/routing/content-route.ts
@@ -3,8 +3,6 @@ type Id = string;
 
 export interface ContentRoute {
   contentType: string,
-  id: Id,
-  path: Id[],
 }
 
 /*

--- a/src/app/models/routing/content-route.ts
+++ b/src/app/models/routing/content-route.ts
@@ -1,25 +1,4 @@
 
-type Id = string;
-
 export interface ContentRoute {
   contentType: string,
-}
-
-/*
- * Returns, among the given list of breadcrumbs, the one which is the closest from the base.
- * The closest path is the shortest path with the longest common prefix. (if several ones, any of these is returned)
- * `list` must not be empty, otherwise throw an exception!
- */
-export function closestBreadcrumbs<T extends { id: Id }>(base: Id[], list: T[][]): T[] {
-  const sol = list.map(breadcrumbs => {
-    for (let i = 0; i < base.length; i++) {
-      if (base[i] !== breadcrumbs[i]?.id) return { common: i, breadcrumbs };
-    }
-    return { common: base.length, breadcrumbs };
-  }).reduce((prev, cur) => {
-    if (prev.common > cur.common) return prev;
-    if (cur.common > prev.common) return cur;
-    return prev.breadcrumbs.length > cur.breadcrumbs.length ? cur : prev;
-  });
-  return sol.breadcrumbs;
 }

--- a/src/app/models/routing/entity-route.ts
+++ b/src/app/models/routing/entity-route.ts
@@ -1,0 +1,29 @@
+import { arraysEqual } from 'src/app/utils/array';
+import { ContentRoute } from './content-route';
+
+/**
+ * Specific type of content which has an identifier
+ */
+export interface EntityRoute extends ContentRoute {
+  id: string,
+}
+
+/**
+ * Specific type of entity which has an identifier path
+ */
+export interface EntityPathRoute extends EntityRoute {
+  path: string[],
+}
+
+
+export function areSiblings(c1: EntityPathRoute, c2: EntityPathRoute): boolean {
+  return c1.contentType === c2.contentType && arraysEqual(c1.path, c2.path);
+}
+
+export function areParentChild(c: { parent: EntityPathRoute, child: EntityPathRoute }): boolean {
+  return c.parent.contentType === c.child.contentType && arraysEqual([ ...c.parent.path, c.parent.id ], c.child.path);
+}
+
+export function areSameElements(c1: EntityPathRoute, c2: EntityPathRoute): boolean {
+  return c1.contentType === c2.contentType && c1.id === c2.id && arraysEqual(c1.path, c2.path);
+}

--- a/src/app/models/routing/group-route.ts
+++ b/src/app/models/routing/group-route.ts
@@ -1,10 +1,9 @@
-import { ParamMap } from '@angular/router';
 import { Group } from 'src/app/groups/data-access/get-group-by-id.service';
 import { User } from 'src/app/groups/models/user';
 import { UrlCommand } from '../../utils/url';
 import { ContentRoute } from './content-route';
 import { groupGroupTypeCategory, GroupTypeCategory, userGroupTypeCategory } from '../../groups/models/group-types';
-import { pathAsParameter, pathFromRouterParameters } from './path-parameter';
+import { pathAsParameter } from './path-parameter';
 
 export const myGroupsPage = 'mine';
 export const managedGroupsPage = 'manage';
@@ -86,11 +85,4 @@ function isUserPage(page: string[]): boolean {
 function isGroupPage(page: string[]): boolean {
   if (!page[0]) return false;
   return [ 'members', 'managers', 'settings', 'access' ].includes(page[0]);
-}
-
-export function decodeGroupRouterParameters(params: ParamMap): { id: string | null, path: string[] | null } {
-  return {
-    id: params.get('id'),
-    path: pathFromRouterParameters(params),
-  };
 }

--- a/src/app/models/routing/group-route.ts
+++ b/src/app/models/routing/group-route.ts
@@ -2,8 +2,9 @@ import { ParamMap } from '@angular/router';
 import { Group } from 'src/app/groups/data-access/get-group-by-id.service';
 import { User } from 'src/app/groups/models/user';
 import { UrlCommand } from '../../utils/url';
-import { ContentRoute, pathAsParameter, pathFromRouterParameters } from './content-route';
+import { ContentRoute } from './content-route';
 import { groupGroupTypeCategory, GroupTypeCategory, userGroupTypeCategory } from '../../groups/models/group-types';
+import { pathAsParameter, pathFromRouterParameters } from './path-parameter';
 
 export const myGroupsPage = 'mine';
 export const managedGroupsPage = 'manage';

--- a/src/app/models/routing/group-route.ts
+++ b/src/app/models/routing/group-route.ts
@@ -4,6 +4,7 @@ import { UrlCommand } from '../../utils/url';
 import { ContentRoute } from './content-route';
 import { groupGroupTypeCategory, GroupTypeCategory, userGroupTypeCategory } from '../../groups/models/group-types';
 import { pathAsParameter } from './path-parameter';
+import { GroupId, GroupPath } from '../ids';
 
 export const myGroupsPage = 'mine';
 export const managedGroupsPage = 'manage';
@@ -15,8 +16,10 @@ export const groupPathRouterSubPrefix = 'by-id';
 
 export interface GroupRoute extends ContentRoute {
   contentType: GroupTypeCategory,
+  id: GroupId,
+  path: GroupPath,
 }
-export type RawGroupRoute = Omit<GroupRoute, 'path'> & Partial<Pick<ContentRoute, 'path'>>;
+export type RawGroupRoute = Omit<GroupRoute, 'path'> & Partial<Pick<GroupRoute, 'path'>>;
 
 export type GroupLike =
   | { id: Group['id'], contentType: GroupTypeCategory }
@@ -55,7 +58,8 @@ export function groupRoute(group: GroupLike, path: string[]): GroupRoute {
 }
 
 export function isGroupRoute(route: ContentRoute | RawGroupRoute): route is GroupRoute {
-  return (route.contentType === groupGroupTypeCategory || route.contentType === userGroupTypeCategory) && route.path !== undefined;
+  return (route.contentType === groupGroupTypeCategory || route.contentType === userGroupTypeCategory)
+    && 'path' in route && Array.isArray(route.path);
 }
 
 export function isRawGroupRoute(route?: unknown): route is RawGroupRoute {

--- a/src/app/models/routing/item-route.ts
+++ b/src/app/models/routing/item-route.ts
@@ -6,7 +6,7 @@ import { ItemTypeCategory } from '../../items/models/item-type';
 import { isString } from '../../utils/type-checkers';
 import { UrlCommand } from '../../utils/url';
 import { arraysEqual } from '../../utils/array';
-import { AnswerId, AttemptId, ItemId } from '../ids';
+import { AnswerId, AttemptId, ItemId, ItemPath } from '../ids';
 import { pathAsParameter, pathFromRouterParameters } from './path-parameter';
 
 // url parameter names
@@ -36,6 +36,8 @@ const answerLoadAsCurrentParamName = 'answerLoadAsCurrent';
 // STRUCTURES
 export interface ItemRoute extends ContentRoute {
   contentType: ItemTypeCategory,
+  id: ItemId,
+  path: ItemPath,
   attemptId?: AttemptId,
   parentAttemptId?: AttemptId,
   answer?:

--- a/src/app/models/routing/item-route.ts
+++ b/src/app/models/routing/item-route.ts
@@ -1,12 +1,13 @@
 import { ParamMap } from '@angular/router';
 import { defaultAttemptId } from '../../items/models/attempts';
 import { appConfig } from '../../utils/config';
-import { ContentRoute, pathAsParameter, pathFromRouterParameters } from './content-route';
+import { ContentRoute } from './content-route';
 import { ItemTypeCategory } from '../../items/models/item-type';
 import { isString } from '../../utils/type-checkers';
 import { UrlCommand } from '../../utils/url';
 import { arraysEqual } from '../../utils/array';
 import { AnswerId, AttemptId, ItemId } from '../ids';
+import { pathAsParameter, pathFromRouterParameters } from './path-parameter';
 
 // url parameter names
 export const activityPrefix = 'a';

--- a/src/app/models/routing/path-parameter.ts
+++ b/src/app/models/routing/path-parameter.ts
@@ -1,20 +1,35 @@
 import { ParamMap } from '@angular/router';
 import { UrlCommandParameters } from '../../utils/url';
+import { fromRouter } from 'src/app/store/router';
+import { createSelector } from '@ngrx/store';
 
-export const pathParamName = 'p';
+/**
+ * How the path parameter is named in the routing parameters / urls
+ */
+const pathParamName = 'p';
 
 export function pathFromRouterParameters(params: ParamMap): string[]|null {
   const pathAsString = params.get(pathParamName);
   if (pathAsString === null) return null;
-  return pathFromParamValue(pathAsString);
-}
-
-export function pathFromParamValue(path: string): string[] {
-  return path === '' ? [] : path.split(',');
+  return parsePath(pathAsString);
 }
 
 export function pathAsParameter(value: string[]): UrlCommandParameters {
   const params: UrlCommandParameters = {};
   params[pathParamName] = value;
   return params;
+}
+
+/**
+ * A selector on the path parameter extracted from the route
+ * Using this selector instead of getting it from param map allows memoizing
+ */
+export const selectPathParameter = createSelector(
+  fromRouter.selectParam(pathParamName),
+  rawPath => (rawPath !== null ? parsePath(rawPath) : null)
+);
+
+
+function parsePath(path: string): string[] {
+  return path === '' ? [] : path.split(',');
 }

--- a/src/app/models/routing/path-parameter.ts
+++ b/src/app/models/routing/path-parameter.ts
@@ -1,0 +1,20 @@
+import { ParamMap } from '@angular/router';
+import { UrlCommandParameters } from '../../utils/url';
+
+export const pathParamName = 'p';
+
+export function pathFromRouterParameters(params: ParamMap): string[]|null {
+  const pathAsString = params.get(pathParamName);
+  if (pathAsString === null) return null;
+  return pathFromParamValue(pathAsString);
+}
+
+export function pathFromParamValue(path: string): string[] {
+  return path === '' ? [] : path.split(',');
+}
+
+export function pathAsParameter(value: string[]): UrlCommandParameters {
+  const params: UrlCommandParameters = {};
+  params[pathParamName] = value;
+  return params;
+}

--- a/src/app/services/navigation/group-nav-tree.service.ts
+++ b/src/app/services/navigation/group-nav-tree.service.ts
@@ -3,13 +3,13 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ContentInfo } from 'src/app/models/content/content-info';
 import { groupInfo, GroupInfo, isGroupInfo } from 'src/app/models/content/group-info';
-import { ContentRoute } from 'src/app/models/routing/content-route';
 import { groupRoute, isGroupRoute, isUser } from 'src/app/models/routing/group-route';
 import { GroupRouter } from 'src/app/models/routing/group-router';
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { GroupNavigationService, GroupNavigationChild, GroupNavigationData } from '../../data-access/group-navigation.service';
 import { NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
 import { NavTreeService } from './nav-tree.service';
+import { EntityPathRoute } from 'src/app/models/routing/entity-route';
 
 @Injectable({
   providedIn: 'root'
@@ -33,7 +33,7 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     return !isUser(content.route);
   }
 
-  fetchNavData(route: ContentRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
+  fetchNavData(route: EntityPathRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
     return this.groupNavigationService.getGroupNavigation(route.id).pipe(
       map(data => this.mapNavData(data, route.path))
     );

--- a/src/app/services/navigation/item-nav-tree.service.ts
+++ b/src/app/services/navigation/item-nav-tree.service.ts
@@ -4,7 +4,6 @@ import { map, skip, switchMap, take } from 'rxjs/operators';
 import { bestAttemptFromResults, defaultAttemptId } from 'src/app/items/models/attempts';
 import { isSkill, ItemTypeCategory, typeCategoryOfItem } from 'src/app/items/models/item-type';
 import { ContentInfo } from 'src/app/models/content/content-info';
-import { ContentRoute } from 'src/app/models/routing/content-route';
 import { isActivityInfo, isItemInfo, itemInfo, ItemInfo } from 'src/app/models/content/item-info';
 import { itemRoute, isItemRoute, isFullItemRoute, isRouteWithSelfAttempt } from 'src/app/models/routing/item-route';
 import { mayHaveChildren } from 'src/app/items/models/item-type';
@@ -17,6 +16,7 @@ import { allowsViewingContent, canCurrentUserViewContent } from 'src/app/items/m
 import { isGroupTypeVisible } from 'src/app/groups/models/group-types';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store/observation';
+import { EntityPathRoute } from 'src/app/models/routing/entity-route';
 
 abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
 
@@ -52,7 +52,7 @@ abstract class ItemNavTreeService extends NavTreeService<ItemInfo> {
     return !!content.route.attemptId; // an attempt is required to fetch children
   }
 
-  fetchNavData(route: ContentRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
+  fetchNavData(route: EntityPathRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }> {
     if (!isItemRoute(route)) throw new Error('expect requesting nav data with a route which is an item route');
     const attemptId = route.attemptId;
     if (!attemptId) throw new Error('attemptId cannot be determined (should have been checked by canFetchChildren)');

--- a/src/app/services/navigation/nav-tree.service.ts
+++ b/src/app/services/navigation/nav-tree.service.ts
@@ -6,9 +6,9 @@ import { isDefined } from 'src/app/utils/null-undefined-predicates';
 import { FetchState, readyState } from 'src/app/utils/state';
 import { ContentInfo, RoutedContentInfo } from 'src/app/models/content/content-info';
 import { mapStateData, mapToFetchState } from 'src/app/utils/operators/state';
-import { ContentRoute } from 'src/app/models/routing/content-route';
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { NavTreeData, NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
+import { EntityPathRoute } from 'src/app/models/routing/entity-route';
 
 export interface NeighborInfo {
   navigateTo: () => void,
@@ -21,7 +21,7 @@ export interface NavigationNeighbors {
 }
 
 interface FetchInfo {
-  path: ContentRoute['path'], /* path to the fetched elements */
+  path: EntityPathRoute['path'], /* path to the fetched elements */
   fetch: Observable<FetchState<NavTreeData>>,
 }
 
@@ -210,7 +210,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
    */
   protected abstract canFetchChildren(content: ContentInfo): boolean;
 
-  protected abstract fetchNavData(route: ContentRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }>;
+  protected abstract fetchNavData(route: EntityPathRoute): Observable<{ parent: NavTreeElement, elements: NavTreeElement[] }>;
 
   private fetchChildrenNav(content: RoutedContentInfo): FetchInfo|undefined {
     if (!this.canFetchChildren(content)) return undefined;
@@ -234,7 +234,7 @@ export abstract class NavTreeService<ContentT extends RoutedContentInfo> {
     } else return this.fetchRootNav();
   }
 
-  private fetch(path: ContentRoute['path'], fetch: Observable<NavTreeData>): FetchInfo {
+  private fetch(path: EntityPathRoute['path'], fetch: Observable<NavTreeData>): FetchInfo {
     return {
       path: path,
       fetch: fetch.pipe(

--- a/src/app/store/navigation/current-content/current-content.reducer.ts
+++ b/src/app/store/navigation/current-content/current-content.reducer.ts
@@ -1,7 +1,7 @@
 import { createReducer, on } from '@ngrx/store';
 import { initialState, State } from './current-content.state';
 import { contentPageActions } from './current-content.actions';
-import { isString } from 'src/app/utils/type-checkers';
+import equal from 'fast-deep-equal/es6';
 
 export const reducer = createReducer(
   initialState,
@@ -9,7 +9,7 @@ export const reducer = createReducer(
   on(
     contentPageActions.changeContent,
     (state, { route, title, breadcrumbs }): State => {
-      const sameContent = !isString(route) && !isString(state.route) ? state.route.id === route.id : state.route === route;
+      const sameContent = equal(route, state.route);
       return {
         route,
         title: title ?? (sameContent ? state.title : undefined),


### PR DESCRIPTION
## Description

Make "content route" not use by default an `id` and a `path` in order to write (soon) routes for "mine" and "managed" pages without having to use union type with string as it is done currently.