### PR TITLE
Display feedback on content unlock 

### DIFF
--- a/src/app/items/containers/item-display/item-display.component.ts
+++ b/src/app/items/containers/item-display/item-display.component.ts
@@ -212,6 +212,10 @@ export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDest
         else this.itemRouter.navigateTo(route);
       }
     }),
+
+    this.taskService.unlockedItems$.subscribe(items => {
+      this.actionFeedbackService.success(`Congrat, you have unlocked the follow content: ${items.map(i => i.title).join(', ')}`);
+    }),
   ];
 
   errorMessage = $localize`:@@unknownError:An unknown error occurred. ` +

--- a/src/app/items/data-access/grade.service.ts
+++ b/src/app/items/data-access/grade.service.ts
@@ -15,7 +15,7 @@ const saveGradeResultSchema = z.object({
   validated: z.boolean(),
   unlockedItems: z.array(z.object({
     itemId: z.string(),
-    languageTab: z.string(),
+    languageTag: z.string(),
     title: z.string().nullable(),
     type: itemTypeSchema,
   })),

--- a/src/app/items/data-access/grade.service.ts
+++ b/src/app/items/data-access/grade.service.ts
@@ -22,6 +22,7 @@ const saveGradeResultSchema = z.object({
 });
 
 type SaveGradeResult = z.infer<typeof saveGradeResultSchema>;
+export type UnlockedItems = SaveGradeResult['unlockedItems'];
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/items/services/item-task.service.ts
+++ b/src/app/items/services/item-task.service.ts
@@ -54,6 +54,7 @@ export class ItemTaskService implements OnDestroy {
   readonly activeView$ = this.viewsService.activeView$;
 
   readonly scoreChange$ = this.answerService.scoreChange$;
+  readonly unlockedItems$ = this.answerService.unlockedItems$;
   readonly autoSaveResult$ = this.answerService.autoSaveResult$;
 
   private navigateToNext$ = this.activityNavTreeService.navigationNeighbors$.pipe(
@@ -128,7 +129,7 @@ export class ItemTaskService implements OnDestroy {
     task.bindPlatform(platform);
   }
 
-  private validate(mode: string): Observable<unknown> {
+  private validate(mode: string): Observable<void> {
     switch (mode) {
       case 'cancel': return this.answerService.clearAnswer();
       case 'nextImmediate': return this.navigateToNextItem();


### PR DESCRIPTION
## Description

Display a toast when unlocking some content with a submission.

Note: the feedback (using the toast) is a transient solution while we develop a better one (next feature)... that's why it is not translated.

## Test cases

- [ ] Case 1:
  1. Given I am a new temp user
  2. When I go to [the basic blockly task](http://localhost:4200/a/6379723280369399253;p=4702,7528142386663912287,7523720120450464843;pa=0)
  3. And I solve the '****' version (loop 360 times: forward(1), rotate(1))
  4. Then I see a toast showing the content I have unlocked
