### PR TITLE
Removes scroll on unlocked items modal

### DIFF
--- a/src/app/items/containers/item-display/item-display.component.html
+++ b/src/app/items/containers/item-display/item-display.component.html
@@ -89,7 +89,7 @@
     [closable]="true"
     [dismissableMask]="true"
     i18n-header header="Unlocked content"
-    styleClass="alg-permissions-edit-dialog"
+    styleClass="alg-permissions-edit-dialog no-scroll"
     (visibleChange)="onCloseUnlockedItemsDialog($event)"
   >
     <p class="unlocked-items-title" i18n>You have just unlocked the following content.</p>

--- a/src/assets/scss/components/permissions-edit-dialog.scss
+++ b/src/assets/scss/components/permissions-edit-dialog.scss
@@ -15,6 +15,12 @@
     overflow: scroll;
   }
 
+  &.no-scroll {
+    .p-dialog-content {
+      overflow: hidden !important;
+    }
+  }
+
   .p-dialog-footer {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Description

Fixes #1860 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Tested on emulator:

<img width="1396" alt="Screenshot at Dec 26 18-01-28" src="https://github.com/user-attachments/assets/40486b2e-e9af-4d3c-ac2a-a7f43be038f0" />

## Test cases

- [ ] Case 1:
  1. Given I am the temp user and from Windows OS
  2. When I go to [this page](https://dev.algorea.org/branch/feature/unlocked-items-modal-remove-scroll/en/a/2004936693550411739;p=4702,7528142386663912287,7523720120450464843;pa=0)
  3. And I do scroll to down
  4. Then I see modal without horizontal and vertical scrolls
