### PR TITLE
"Load answer as current" as a state

### DIFF
--- a/e2e/items/item-logs.spec.ts
+++ b/e2e/items/item-logs.spec.ts
@@ -42,7 +42,7 @@ test('checks reload link in logs on task page', async ({ page }) => {
   await expect.soft(reloadAnswerLocator).toBeVisible();
   await Promise.all([
     reloadAnswerLocator.click(),
-    expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;p=7523720120450464843;answerId=')),
+    expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;p=7523720120450464843')),
   ]);
 });
 
@@ -72,7 +72,7 @@ test('checks reload link in logs on item page', async ({ page }) => {
   await expect.soft(reloadAnswerLocator).toBeVisible();
   await Promise.all([
     reloadAnswerLocator.click(),
-    expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;answerId=')),
+    expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253')),
   ]);
 });
 

--- a/e2e/items/item-routing.spec.ts
+++ b/e2e/items/item-routing.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { initAsTesterUser, initAsUsualUser } from '../helpers/e2e_auth';
+import { initAsTesterUser } from '../helpers/e2e_auth';
 import { apiUrl } from 'e2e/helpers/e2e_http';
 
 /**
@@ -56,32 +56,4 @@ test('route with missing path and service error', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Parcours officiels' })).toBeVisible();
   });
 
-});
-
-test('route with action parameter: action passed to subcomponents + parameter removed', { tag: '@no-parallelism' }, async ({ page }) => {
-  const emptyAnswer = '1970981512988735785';
-  const answerWith1234567 = '4143245131838208903';
-
-  await initAsUsualUser(page);
-  // first reload an empty answer
-  await page.goto(`/a/6379723280369399253;p=7523720120450464843;pa=0;answerId=${emptyAnswer};answerLoadAsCurrent=1`);
-
-  await test.step('checks the answer has been emptied', async () => {
-    await expect(page.frameLocator('iFrame').getByText('Programme de la tortue')).toBeVisible({ timeout: 30000 });
-    await expect(page.frameLocator('iFrame').getByText('1234567')).not.toBeVisible();
-  });
-
-  // then reload a answer which contains "1234567" in the answer
-  await page.goto(`/a/6379723280369399253;p=7523720120450464843;pa=0;answerId=${answerWith1234567};answerLoadAsCurrent=1`);
-
-  await test.step('drop the action parameter', async () => {
-    await expect(page.locator('.left-pane-title-text')).toContainText('Blockly Basic Task', { timeout: 15000 });
-    await expect.soft(page).toHaveURL(new RegExp('/a/6379723280369399253;p=7523720120450464843;pa=0'));
-    await expect.soft(page).not.toHaveURL(/answer/);
-  });
-
-  await test.step('has loaded the expected answer', async () => {
-    await expect(page.frameLocator('iFrame').getByText('Programme de la tortue')).toBeVisible({ timeout: 30000 });
-    await expect(page.frameLocator('iFrame').getByText('1234567')).toBeVisible(); // to check it is the right answer
-  });
 });

--- a/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.html
+++ b/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.html
@@ -27,7 +27,8 @@
           <a
             class="alg-button primary mini button"
             pButton
-            [routerLink]="itemData.item | itemRoute: { answer: { id: answer.id, loadAsCurrent: true } } | url"
+            [routerLink]="itemData.item | itemRoute | url"
+            [state]="answer.id | routingStateForLoadingAnswerAsCurrent"
             i18n
           >
             Edit it

--- a/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.ts
+++ b/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.ts
@@ -20,6 +20,7 @@ import { UserSessionService } from '../../../services/user-session.service';
 import { LetDirective } from '@ngrx/component';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store/observation';
+import { LoadAnswerAsCurrentRoutingStatePipe } from '../../utils/load-answer-as-current-state';
 
 @Component({
   selector: 'alg-answer-author-indicator[answer]',
@@ -34,6 +35,7 @@ import { fromObservation } from 'src/app/store/observation';
     AsyncPipe,
     DatePipe,
     UserCaptionPipe,
+    LoadAnswerAsCurrentRoutingStatePipe,
     ScoreRingComponent,
     ButtonModule,
     ItemRoutePipe,

--- a/src/app/items/containers/item-log-view/item-log-view.component.html
+++ b/src/app/items/containers/item-log-view/item-log-view.component.html
@@ -78,9 +78,10 @@
                         <a
                           class="alg-link item-title-link"
                           [routerLink]="rowData.item | itemRoute: {
-                            answer: { id: rowData.answerId, loadAsCurrent: meta.isObserving ? undefined : true },
+                            answer: meta.isObserving ? { id: rowData.answerId } : undefined,
                             path: rowData.item.id === itemData.item.id ? itemData.route.path : undefined
                           } | url"
+                          [state]="meta.isObserving ? {} : (rowData.answerId | routingStateForLoadingAnswerAsCurrent)"
                           *ngIf="(!meta.isObserving || !!rowData.canWatchAnswer) && rowData.answerId"
                         >
                           {(meta.isObserving ? 'observingMode' : ''), select,

--- a/src/app/items/containers/item-log-view/item-log-view.component.ts
+++ b/src/app/items/containers/item-log-view/item-log-view.component.ts
@@ -27,6 +27,7 @@ import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store/observation';
 import { RawGroupRoute, isUser } from 'src/app/models/routing/group-route';
 import { LogActivityTypeIconPipe } from 'src/app/pipes/logActivityTypeIcon';
+import { LoadAnswerAsCurrentRoutingStatePipe } from '../../utils/load-answer-as-current-state';
 interface Column {
   field: string,
   header: string,
@@ -58,6 +59,7 @@ const logsLimit = 20;
     DatePipe,
     ItemRoutePipe,
     ItemRouteWithExtraPipe,
+    LoadAnswerAsCurrentRoutingStatePipe,
     RouteUrlPipe,
     GroupLinkPipe,
     UserCaptionPipe,

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -161,7 +161,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       return this.initialAnswerDataSource.answer$.pipe(
         catchError(() => EMPTY), // error is handled by initialAnswerDataSource.error$
         map(initialAnswer => ({
-          readOnly: !!route.answer && !route.answer.loadAsCurrent,
+          readOnly: !!route.answer,
           initialAnswer,
           locale: userLocale, // should use task locale if there is a way for the user to select it
         }))

--- a/src/app/items/services/initial-answer-datasource.ts
+++ b/src/app/items/services/initial-answer-datasource.ts
@@ -44,7 +44,7 @@ export class InitialAnswerDataSource implements OnDestroy {
       if (isTask === false) return { tag: 'NotApplicable' };
       if (!answer) {
         const loadAnswerAsCurrent = loadAnswerAsCurrentFromBrowserState();
-        if (loadAnswerAsCurrent){
+        if (loadAnswerAsCurrent) {
           return attemptId ? { tag: 'LoadAsCurrent', itemId: id, attemptId, answerId: loadAnswerAsCurrent } : { tag: 'Wait' };
         }
         if (isObserving) return { tag: 'EmptyInitialAnswer' };

--- a/src/app/items/services/initial-answer-datasource.ts
+++ b/src/app/items/services/initial-answer-datasource.ts
@@ -4,6 +4,8 @@ import {
   combineLatest,
   concat,
   distinctUntilChanged,
+  EMPTY,
+  forkJoin,
   map,
   Observable,
   of,
@@ -18,11 +20,16 @@ import { CurrentAnswerService } from '../data-access/current-answer.service';
 import { GetAnswerService } from '../data-access/get-answer.service';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store/observation';
+import { loadAnswerAsCurrentFromBrowserState } from '../utils/load-answer-as-current-state';
+import { areStateAnswerEqual } from '../models/answers';
+import { Answer } from './item-task.service';
+import { AnswerService } from '../data-access/answer.service';
 
 type Strategy =
   { tag: 'EmptyInitialAnswer'|'Wait'|'NotApplicable' } |
   { tag: 'LoadCurrent', itemId: string, attemptId: string } |
   { tag: 'LoadById', answerId: string } |
+  { tag: 'LoadAsCurrent', itemId: string, attemptId: string, answerId: string } |
   { tag: 'LoadBest', itemId: string, participantId?: string};
 
 @Injectable()
@@ -33,21 +40,28 @@ export class InitialAnswerDataSource implements OnDestroy {
 
   readonly answer$ = combineLatest([ this.itemInfo$, this.store.select(fromObservation.selectIsObserving) ]).pipe(
     /* we do the computation in 2 stages to prevent cancelling requests which shouldn't have been cancelled */
-    map(([{ route, isTask }, isObserving ]): Strategy => {
+    map(([{ route: { id, attemptId, answer }, isTask }, isObserving ]): Strategy => {
       if (isTask === false) return { tag: 'NotApplicable' };
-      if (!route.answer) {
+      if (!answer) {
+        const loadAnswerAsCurrent = loadAnswerAsCurrentFromBrowserState();
+        if (loadAnswerAsCurrent){
+          return attemptId ? { tag: 'LoadAsCurrent', itemId: id, attemptId, answerId: loadAnswerAsCurrent } : { tag: 'Wait' };
+        }
         if (isObserving) return { tag: 'EmptyInitialAnswer' };
         if (isTask === undefined) return { tag: 'Wait' };
-        return route.attemptId ? { tag: 'LoadCurrent', itemId: route.id, attemptId: route.attemptId } : { tag: 'Wait' };
+        return attemptId ? { tag: 'LoadCurrent', itemId: id, attemptId } : { tag: 'Wait' };
       }
-      if (route.answer.id) return { tag: 'LoadById', answerId: route.answer.id };
-      return { tag: 'LoadBest', itemId: route.id, participantId: route.answer.participantId };
+      if (answer.id) return { tag: 'LoadById', answerId: answer.id };
+      return { tag: 'LoadBest', itemId: id, participantId: answer.participantId };
     }),
     distinctUntilChanged((s1, s2) => JSON.stringify(s1) === JSON.stringify(s2)),
     switchMap(strategy => {
       if (strategy.tag === 'EmptyInitialAnswer') return of(null); // null -> no initial answer
       if (strategy.tag === 'LoadCurrent') return concat(of(undefined), this.currentAnswerService.get(strategy.itemId, strategy.attemptId));
       if (strategy.tag === 'LoadById') return concat(of(undefined), this.getAnswerService.get(strategy.answerId));
+      if (strategy.tag === 'LoadAsCurrent') {
+        return concat(of(undefined), this.getAnswerAndSaveAsCurrent(strategy.itemId, strategy.attemptId, strategy.answerId));
+      }
       if (strategy.tag === 'LoadBest') {
         return concat(of(undefined), this.getAnswerService.getBest(strategy.itemId, { watchedGroupId: strategy.participantId }));
       }
@@ -67,6 +81,7 @@ export class InitialAnswerDataSource implements OnDestroy {
     private store: Store,
     private currentAnswerService: CurrentAnswerService,
     private getAnswerService: GetAnswerService,
+    private answerService: AnswerService,
   ) {}
 
   setInfo(route: FullItemRoute, isTask: boolean|undefined): void {
@@ -77,6 +92,28 @@ export class InitialAnswerDataSource implements OnDestroy {
     this.itemInfo$.complete();
     this.destroyed$.next();
     this.destroyed$.complete();
+  }
+
+  private getAnswerAndSaveAsCurrent(itemId: string, attemptId: string, answerId: string): Observable<Answer> {
+    return forkJoin([
+      this.getAnswerService.get(answerId),
+      this.currentAnswerService.get(itemId, attemptId),
+    ]).pipe(
+      switchMap(([ newAnswer, currentAnswer ]) => {
+        if (currentAnswer) {
+          return areStateAnswerEqual(currentAnswer, newAnswer) ?
+            EMPTY : // do not do anything
+            this.answerService.save(itemId, attemptId, { answer: currentAnswer.answer ?? '', state: currentAnswer.state ?? '' }).pipe(
+              map(() => newAnswer)
+            );
+        }
+        return of(newAnswer);
+      }),
+      switchMap(newAnswer => {
+        const body = { answer: newAnswer.answer ?? '', state: newAnswer.state ?? '' };
+        return this.currentAnswerService.update(itemId, attemptId, body).pipe(map(() => newAnswer));
+      }),
+    );
   }
 
 }

--- a/src/app/items/services/item-task-answer.service.ts
+++ b/src/app/items/services/item-task-answer.service.ts
@@ -57,11 +57,8 @@ export class ItemTaskAnswerService implements OnDestroy {
   private latestSavedCurrentAnswer: { state: string, answer: string } | null = null;
 
   private initialAnswer$: Observable<Answer | null> = this.config$.pipe(
-    switchMap(({ route, attemptId, initialAnswer }) => {
+    switchMap(({ initialAnswer }) => {
       if (initialAnswer === undefined) return EMPTY;
-      if (route.answer?.loadAsCurrent && initialAnswer) {
-        return this.loadAsNewCurrentAnswer(route.id, attemptId, initialAnswer);
-      }
       return of(initialAnswer);
     }),
     retry(3),

--- a/src/app/items/store/item-content/item-fetching.effects.ts
+++ b/src/app/items/store/item-content/item-fetching.effects.ts
@@ -10,8 +10,8 @@ import { GetItemByIdService } from 'src/app/data-access/get-item-by-id.service';
 import { itemByIdPageActions, itemFetchingActions } from './item-content.actions';
 import { ItemBreadcrumbsWithFailoverService } from '../../services/item-breadcrumbs-with-failover.service';
 import { ResultFetchingService } from '../../services/result-fetching.service';
-import { routesEqualIgnoringCommands } from 'src/app/models/routing/item-route';
 import { UserSessionService } from 'src/app/services/user-session.service';
+import equal from 'fast-deep-equal/es6';
 
 const refreshTriggers = (actions$: Actions<any>, userSessionService$: UserSessionService): Observable<unknown> => merge(
   actions$.pipe(ofType(itemByIdPageActions.refresh)),
@@ -53,7 +53,7 @@ export const breadcrumbsFetchingEffect = createEffect(
     breadcrumbsService = inject(ItemBreadcrumbsWithFailoverService),
   ) => store$.select(fromItemContent.selectActiveContentRoute).pipe(
     filter(isNotNull),
-    distinctUntilChanged(routesEqualIgnoringCommands), // do not refetch if coming back on the same content
+    distinctUntilChanged((x, y) => equal(x, y)),
     switchMap(route => breadcrumbsService.get(route).pipe(
       mapToFetchState({
         resetter: refreshTriggers(actions$, userSessionService$),
@@ -74,7 +74,7 @@ export const resultsFetchingEffect = createEffect(
   ) => store$.select(fromItemContent.selectActiveContentInfoForFetchingResults).pipe(
     filter(isNotNull),
     distinctUntilChanged((x, y) => // for results, it needs to be re-fetched only if the route or perm change (+ refresh via the resetter)
-      routesEqualIgnoringCommands(x.route, y.route) && x.item.permissions.canView === y.item.permissions.canView
+      equal(x.route, y.route) && x.item.permissions.canView === y.item.permissions.canView
     ),
     switchMap(({ route, item }) => resultFetchingService.fetchResults(route, item).pipe(
       mapToFetchState({

--- a/src/app/items/store/item-content/item-route.effects.ts
+++ b/src/app/items/store/item-content/item-route.effects.ts
@@ -1,7 +1,7 @@
 import { createEffect } from '@ngrx/effects';
 import { inject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { delay, filter, map, startWith, switchMap, tap } from 'rxjs';
+import { filter, map, startWith, switchMap } from 'rxjs';
 import { isNotNull } from 'src/app/utils/null-undefined-predicates';
 import { fromItemContent } from './item-content.store';
 import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
@@ -31,18 +31,4 @@ export const routeErrorHandlingEffect = createEffect(
     map(newState => itemRouteErrorHandlingActions.routeErrorHandlingChange({ newState }))
   ),
   { functional: true },
-);
-
-export const removeActionsFromRouteEffect = createEffect(
-  (
-    store$ = inject(Store),
-    itemRouter = inject(ItemRouter),
-  ) => store$.select(fromItemContent.selectActiveContentRoute).pipe(
-    filter(isNotNull),
-    delay(0), // required in order to trigger new navigation after this one
-    tap(route => {
-      if (route.answer?.loadAsCurrent) itemRouter.navigateTo({ ...route, answer: undefined }, { navExtras: { replaceUrl: true } });
-    })
-  ),
-  { functional: true, dispatch: false },
 );

--- a/src/app/items/utils/item-route-validation.ts
+++ b/src/app/items/utils/item-route-validation.ts
@@ -10,11 +10,11 @@ import { ItemTypeCategory } from '../models/item-type';
 export type ItemRouteError = { tag: 'error' } & Pick<ItemRoute, 'id'|'contentType'> & Partial<ItemRoute>;
 
 export function itemRouteFromParams(contentType: ItemTypeCategory, params: ParamMap): FullItemRoute|ItemRouteError {
-  const { id, path, attemptId, parentAttemptId, answerId, answerBest, answerParticipantId, answerLoadAsCurrent }
+  const { id, path, attemptId, parentAttemptId, answerId, answerBest, answerParticipantId }
     = decodeItemRouterParameters(params);
   let answer: ItemRoute['answer']|undefined;
   if (answerBest) answer = { best: true, participantId: answerParticipantId ?? undefined };
-  else if (answerId) answer = { id: answerId, loadAsCurrent: answerLoadAsCurrent ? true : undefined };
+  else if (answerId) answer = { id: answerId };
 
   if (!id) throw new Error('Unexpected missing id from item param');
   if (path === null) return { tag: 'error', contentType, id, answer };

--- a/src/app/items/utils/item-route-validation.ts
+++ b/src/app/items/utils/item-route-validation.ts
@@ -6,6 +6,7 @@ import { decodeItemRouterParameters, FullItemRoute, ItemRoute } from 'src/app/mo
 import { ItemRouter } from 'src/app/models/routing/item-router';
 import { defaultAttemptId } from '../models/attempts';
 import { ItemTypeCategory } from '../models/item-type';
+import { loadAnswerAsCurrentFromBrowserState } from './load-answer-as-current-state';
 
 export type ItemRouteError = { tag: 'error' } & Pick<ItemRoute, 'id'|'contentType'> & Partial<ItemRoute>;
 
@@ -50,7 +51,7 @@ export function solveMissingPathAttempt(
     }),
     delay(0), // required in order to trigger new navigation after the current one
     switchMap(itemRoute => {
-      itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true } });
+      itemRouter.navigateTo(itemRoute, { navExtras: { replaceUrl: true }, loadAnswerIdAsCurrent: loadAnswerAsCurrentFromBrowserState() });
       return EMPTY;
     })
   );

--- a/src/app/items/utils/load-answer-as-current-state.ts
+++ b/src/app/items/utils/load-answer-as-current-state.ts
@@ -1,0 +1,28 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { AnswerId } from 'src/app/models/ids';
+import { isString } from 'src/app/utils/type-checkers';
+
+/**
+ * Routing state to pass information that task should load a specific answer as the current answer
+ */
+
+interface LoadAnswerAsCurrentState {
+  loadAnswerIdAsCurrent: AnswerId,
+}
+
+export function loadAnswerAsCurrentAsBrowserState(answerId: AnswerId): LoadAnswerAsCurrentState {
+  return { loadAnswerIdAsCurrent: answerId };
+}
+
+@Pipe({ name: 'routingStateForLoadingAnswerAsCurrent', pure: true, standalone: true })
+export class LoadAnswerAsCurrentRoutingStatePipe implements PipeTransform {
+  transform(answerId: AnswerId): LoadAnswerAsCurrentState {
+    return loadAnswerAsCurrentAsBrowserState(answerId);
+  }
+}
+
+export function loadAnswerAsCurrentFromBrowserState(): AnswerId|undefined {
+  const state = history.state as unknown;
+  if (typeof state !== 'object' || state === null || !('loadAnswerIdAsCurrent' in state)) return undefined;
+  return isString(state.loadAnswerIdAsCurrent) ? state.loadAnswerIdAsCurrent : undefined;
+}

--- a/src/app/models/routing/item-route.ts
+++ b/src/app/models/routing/item-route.ts
@@ -17,7 +17,6 @@ const attemptParamName = 'a';
 const answerParamName = 'answerId';
 const answerBestParamName = 'answerBest';
 const answerBestParticipantParamName = 'answerParticipantId';
-const answerLoadAsCurrentParamName = 'answerLoadAsCurrent';
 
 // alias for better readibility
 
@@ -41,8 +40,8 @@ export interface ItemRoute extends ContentRoute {
   attemptId?: AttemptId,
   parentAttemptId?: AttemptId,
   answer?:
-    { best?: undefined, id: AnswerId, participantId?: undefined, loadAsCurrent?: true } |
-    { best: true, id?: undefined, participantId?: string /* not set if mine */, loadAsCurrent?: undefined },
+    { best?: undefined, id: AnswerId, participantId?: undefined } |
+    { best: true, id?: undefined, participantId?: string /* not set if mine */ },
 }
 export type FullItemRoute = ItemRoute & (Required<Pick<ItemRoute, 'attemptId'>> | Required<Pick<ItemRoute, 'parentAttemptId'>>);
 export type RawItemRoute = Omit<ItemRoute, 'path'> & Partial<Pick<ItemRoute, 'path'>>;
@@ -107,7 +106,6 @@ export function decodeItemRouterParameters(params: ParamMap): {
   answerId: string|null,
   answerBest: boolean,
   answerParticipantId: string|null,
-  answerLoadAsCurrent: boolean,
 } {
   let idOrAlias = params.get('idOrAlias');
   let path = pathFromRouterParameters(params);
@@ -124,7 +122,6 @@ export function decodeItemRouterParameters(params: ParamMap): {
     answerId: params.get(answerParamName),
     answerBest: params.get(answerBestParamName) === '1',
     answerParticipantId: params.get(answerBestParticipantParamName),
-    answerLoadAsCurrent: params.get(answerLoadAsCurrentParamName) === '1',
   };
 }
 
@@ -170,7 +167,6 @@ export function urlArrayForItemRoute(route: RawItemRoute, page: string|string[] 
       if (route.answer.participantId) params[answerBestParticipantParamName] = route.answer.participantId;
     } else {
       params[answerParamName] = route.answer.id;
-      if (route.answer.loadAsCurrent) params[answerLoadAsCurrentParamName] = '1';
     }
   }
 
@@ -190,27 +186,4 @@ function aliasFor(itemId: ItemId, path: string[]|undefined): { alias: string, va
 
 function pathToAlias(path: string): string {
   return path.replace(/\//g, '--');
-}
-
-/* **********************************************************************************************************
- * Other utility functions
- * ********************************************************************************************************** */
-
-/**
- * Whether the 2 routes are equals
- * If `prev` had a "command" (e.g., loadAsCurrent) and there is no `answer` in `cur`, route are considered equal
- */
-export function routesEqualIgnoringCommands(prev: FullItemRoute, cur: FullItemRoute): boolean {
-  return prev.id === cur.id &&
-    arraysEqual(prev.path, cur.path) &&
-    prev.attemptId === cur.attemptId &&
-    prev.parentAttemptId === cur.parentAttemptId &&
-    (
-      (
-        prev.answer?.best === cur.answer?.best &&
-        prev.answer?.id === cur.answer?.id &&
-        prev.answer?.participantId === cur.answer?.participantId &&
-        prev.answer?.loadAsCurrent === cur.answer?.loadAsCurrent
-      ) || (!!prev.answer?.loadAsCurrent && !cur.answer)
-    );
 }

--- a/src/app/models/routing/item-router.ts
+++ b/src/app/models/routing/item-router.ts
@@ -2,10 +2,13 @@ import { Injectable } from '@angular/core';
 import { NavigationExtras, Router, UrlTree } from '@angular/router';
 import { ensureDefined } from '../../utils/assert';
 import { itemCategoryFromPrefix, RawItemRoute, urlArrayForItemRoute } from './item-route';
+import { AnswerId } from '../ids';
+import { loadAnswerAsCurrentAsBrowserState } from 'src/app/items/utils/load-answer-as-current-state';
 
 interface NavigateOptions {
   page?: string|string[],
   preventFullFrame?: boolean,
+  loadAnswerIdAsCurrent?: AnswerId,
   navExtras?: NavigationExtras,
 }
 
@@ -25,10 +28,16 @@ export class ItemRouter {
   navigateTo(item: RawItemRoute, {
     page,
     navExtras,
+    loadAnswerIdAsCurrent,
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     preventFullFrame = Boolean(typeof history.state === 'object' && history.state?.preventFullFrame),
   }: NavigateOptions = {}): void {
-    void this.router.navigateByUrl(this.url(item, page), { ...navExtras, state: { ...navExtras?.state, preventFullFrame } });
+    void this.router.navigateByUrl(this.url(item, page), { ...navExtras, state: {
+      ...navExtras?.state,
+      preventFullFrame,
+      ...(loadAnswerIdAsCurrent ? loadAnswerAsCurrentAsBrowserState(loadAnswerIdAsCurrent) : {}),
+    } }
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

Change the way "load answer as current" is handled. Don't pass it in the route anymore as it requires removing the parameter immediately after parsing. That makes the route handling quite complex.

(Part of continuous improvement / refactoring of routes etc)

Open question: if we have a pet task (typically a task where you enter the score you want to get), would it become easy to have an e2e test for that? @Iloveall 

## Test cases

- [ ] Case 1:
  1. Given I am a temp user
  2. When I go to [the blockly test task](https://dev.algorea.org/branch/loadAsCurrent-as-state/en/a/6379723280369399253;p=4702,7528142386663912287,7523720120450464843;a=0)
  3. Then I solve the 1 star problem
  4. Then I solve the 2 stars problem
  5. Then I go the "History" tab and reload the solution which scored 25pts
  6. And I see I am back at the state without the 2 starts solved
