### PR TITLE
Fix redundants call in nav menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "primeicons": "^6.0.1",
         "primeng": "^17.18.8",
         "rxjs": "~7.8.1",
+        "ts-cacheable": "^1.0.10",
         "tslib": "^2.3.1",
         "zod": "^3.22.4",
         "zone.js": "~0.14.2"
@@ -18645,6 +18646,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-cacheable": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ts-cacheable/-/ts-cacheable-1.0.10.tgz",
+      "integrity": "sha512-eWPYcbbiXE6TSw39RCTrKBhGDoepcuufhh51bwSxa5qQKwQ8EHbCj+QOL5aOEoLsitwZZiW5/sTxiU8WycA0sw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "rxjs": "^6.6.0 || ^7.4.0"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "primeicons": "^6.0.1",
     "primeng": "^17.18.8",
     "rxjs": "~7.8.1",
+    "ts-cacheable": "^1.0.10",
     "tslib": "^2.3.1",
     "zod": "^3.22.4",
     "zone.js": "~0.14.2"

--- a/src/app/data-access/group-navigation.service.ts
+++ b/src/app/data-access/group-navigation.service.ts
@@ -3,7 +3,11 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { appConfig } from 'src/app/utils/config';
 import { decodeSnakeCaseZod } from 'src/app/utils/operators/decode';
+import { Cacheable } from 'ts-cacheable';
 import { z } from 'zod';
+import { SECONDS } from '../utils/duration';
+
+const cacheConfig = { maxAge: 10*SECONDS, maxCacheCount: 5 };
 
 const groupNavigationChildSchema = z.object({
   id: z.string(),
@@ -31,12 +35,14 @@ export class GroupNavigationService {
 
   constructor(private http: HttpClient) {}
 
+  @Cacheable(cacheConfig)
   getGroupNavigation(groupId: string): Observable<GroupNavigationData> {
     return this.http.get<unknown>(`${appConfig.apiUrl}/groups/${groupId}/navigation`).pipe(
       decodeSnakeCaseZod(groupNavigationSchema),
     );
   }
 
+  @Cacheable(cacheConfig)
   getRoot(): Observable<GroupNavigationChild[]> {
     return this.http.get<unknown>(`${appConfig.apiUrl}/groups/roots`).pipe(
       decodeSnakeCaseZod(z.array(groupNavigationChildSchema)),

--- a/src/app/data-access/item-navigation.service.ts
+++ b/src/app/data-access/item-navigation.service.ts
@@ -10,6 +10,10 @@ import { itemViewPermSchema } from 'src/app/items/models/item-view-permission';
 import { itemCorePermSchema } from 'src/app/items/models/item-permissions';
 import { groupBy } from 'src/app/utils/array';
 import { z } from 'zod';
+import { SECONDS } from '../utils/duration';
+import { Cacheable } from 'ts-cacheable';
+
+const cacheConfig = { maxAge: 10*SECONDS, maxCacheCount: 5 };
 
 const itemNavigationChildBaseSchema = z.object({
   id: z.string(),
@@ -87,6 +91,7 @@ export class ItemNavigationService {
 
   constructor(private http: HttpClient) {}
 
+  @Cacheable(cacheConfig)
   getItemNavigation(
     itemId: string,
     options: ({ attemptId: string} | { childRoute: FullItemRoute }) & { skillOnly?: boolean, watchedGroupId?: string }
@@ -103,6 +108,7 @@ export class ItemNavigationService {
     );
   }
 
+  @Cacheable(cacheConfig)
   getRootActivities(watchedGroupId?: string): Observable<GroupWithRootActivity[]> {
     let httpParams = new HttpParams();
 
@@ -115,6 +121,7 @@ export class ItemNavigationService {
     );
   }
 
+  @Cacheable(cacheConfig)
   getRootSkills(watchedGroupId?: string): Observable<GroupWithRootSkill[]> {
     let httpParams = new HttpParams();
 

--- a/src/app/utils/operators/log-ref-count.ts
+++ b/src/app/utils/operators/log-ref-count.ts
@@ -1,0 +1,21 @@
+import { defer, finalize, noop, OperatorFunction, pipe } from 'rxjs';
+
+/**
+ * For debugging, allow doing an action (such as logging) on subscription count update.
+ */
+export function logRefCount<T>(onCountUpdate: (n: number) => void = noop): OperatorFunction<T, T> {
+  let counter = 0;
+
+  return pipe(
+    source => defer(() => {
+      counter++;
+      onCountUpdate(counter);
+      return source;
+    }),
+    finalize(() => {
+      counter--;
+      onCountUpdate(counter);
+    }),
+  );
+}
+


### PR DESCRIPTION
## Description

Currently, the navigation service is called 3 times when it should be called once. It's due to a change in behavior of the share refcount which is harder to fix than expected.

As a quickfix, I introduce in the PR some short caching for item and group menu services.
