### PR TITLE
Fixes scrolling in task

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -12,6 +12,7 @@
           [showTopRightControls]="!!(showTopRightControls$ | async) && !(isNarrowScreen$ | async)"
         ></alg-top-bar>
         <div
+          id="main-content-wrapper"
           data-testid="main-content-wrapper"
           class="main-content-wrapper alg-flex-1"
           algHtmlElLoaded

--- a/src/app/items/services/item-task-views.service.ts
+++ b/src/app/items/services/item-task-views.service.ts
@@ -41,8 +41,10 @@ export class ItemTaskViewsService implements OnDestroy {
       this.initService.iframe$,
       this.display$.pipe(map(display => display.scrollTop), filter(isNotUndefined)),
     ]).subscribe(([ iframe, scrollTopInPx ]) => {
-      const iframeTopInPx = iframe.getBoundingClientRect().top + globalThis.scrollY;
-      globalThis.scrollTo({ behavior: 'smooth', top: iframeTopInPx + scrollTopInPx });
+      const mainContentWrapperEl = window.document.querySelector('#main-content-wrapper');
+      if (!mainContentWrapperEl) throw new Error('Unexpected: Missed main content wrapper element');
+      const iframeTopInPx = iframe.getBoundingClientRect().top + mainContentWrapperEl.scrollTop;
+      mainContentWrapperEl.scrollTo({ behavior: 'smooth', top: iframeTopInPx + scrollTopInPx });
     }),
   ];
 


### PR DESCRIPTION
## Description

Fixes #1897

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The issue is - it calls global scroll while our scroll is inside specific container

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/scroll-in-task/en/a/5515805070397494516;p=694914435881177216,5,4700,4707,4702,7528142386663912287,7523720120450464843,6963488196048051083;pa=0)
  3. And I click on "Scroll frame (n)"
  4. Then I see it scrolled to selected frame
