### PR TITLE
Replaces primeng tag with own html structure

### DIFF
--- a/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.html
+++ b/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.html
@@ -8,8 +8,7 @@
           icon="ph-duotone ph-door"
           [collapsible]="!canEnterWarningMessage"
           [errorMessage]="canEnterWarningMessage"
-          severity="warning"
-          messageClass="message-with-bottom-margin"
+          messageStyleClass="warning message-with-bottom-margin"
         >
           <ng-template #content let-collapsed>
             <alg-switch-field

--- a/src/app/ui-components/collapsible-section/collapsible-section.component.html
+++ b/src/app/ui-components/collapsible-section/collapsible-section.component.html
@@ -9,13 +9,11 @@
   >
     <ng-template #content>
       <div class="content">
-        <p-tag
-          [class]="messageClass"
-          *ngIf="!(collapsed && collapsible) && errorMessage"
-          styleClass="mr-2"
-          [severity]="severity"
-          [value]="errorMessage"
-        ></p-tag>
+        @if (!(collapsed && collapsible) && errorMessage) {
+          <div class="alg-tag mr-2 {{ messageStyleClass }}">
+            {{ errorMessage }}
+          </div>
+        }
         <div class="template alg-flex-1" *ngIf="contentTemplate && collapsed && collapsible">
           <ng-container
             [ngTemplateOutlet]="contentTemplate"

--- a/src/app/ui-components/collapsible-section/collapsible-section.component.ts
+++ b/src/app/ui-components/collapsible-section/collapsible-section.component.ts
@@ -2,7 +2,6 @@ import { Component, ContentChild, Input, TemplateRef } from '@angular/core';
 import { TagModule } from 'primeng/tag';
 import { SectionHeaderComponent } from '../section-header/section-header.component';
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
-import { Tag } from 'primeng/tag/tag';
 
 @Component({
   selector: 'alg-collapsible-section',
@@ -15,14 +14,13 @@ export class CollapsibleSectionComponent {
 
   @Input() header = '';
   @Input() errorMessage?: string;
-  @Input() severity: Tag['severity'] = 'danger';
   @Input() icon = '';
 
   @Input() disabled = false;
   @Input() collapsed = true;
   @Input() collapsible = true;
   @Input() theme: 'success' | 'warning' | 'danger' = 'success';
-  @Input() messageClass = '';
+  @Input() messageStyleClass = 'danger';
 
   @ContentChild('content') contentTemplate?: TemplateRef<any>;
 

--- a/src/assets/scss/components/tag.scss
+++ b/src/assets/scss/components/tag.scss
@@ -1,0 +1,23 @@
+@import 'src/assets/scss/functions';
+
+.alg-tag {
+  display: flex;
+  align-items: center;
+  padding: toRem(4) toRem(6);
+
+  border-radius: toRem(4);
+  background-color: var(--alg-message-info-color);
+  color: var(--alg-white-color);
+  font-size: toRem(12);
+  font-weight: 700;
+
+  &.success {
+    background-color: var(--alg-message-success-color);
+  }
+  &.warning {
+    background-color: var(--alg-accent-dark-color);
+  }
+  &.danger {
+    background-color: var(--alg-message-error-color);
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -35,6 +35,7 @@
 @import 'assets/scss/components/common-confirm-popup';
 @import 'assets/scss/components/common-confirm-dialog';
 @import 'assets/scss/components/slanted-grid';
+@import 'assets/scss/components/tag';
 
 // New Design
 @import 'assets/scss/text-colors';


### PR DESCRIPTION
## Description

Fixes #1876 

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

I've took colours from our new palette 

<img width="856" alt="Screenshot at Mar 10 12-37-16" src="https://github.com/user-attachments/assets/2827ab84-89b9-4f3d-aefb-06b6dc51d953" />
<img width="834" alt="Screenshot at Mar 10 12-36-58" src="https://github.com/user-attachments/assets/3c67420e-166b-42cf-ab0d-daa1037bc84b" />


## Test cases

Branch for [test](https://dev.algorea.org/branch/migration-ui/tag/en/a/3668315727545144509;p=;pa=0?watchedGroupId=5751429939100258793)
