### PR TITLE
Fixes propagation selection issue

### DIFF
--- a/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.html
+++ b/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.html
@@ -118,7 +118,7 @@
       @if (childData) {
         <alg-propagation-edit-menu
           [childData]="childData"
-          (clickEvent)="onContentViewPropagationChanged($event)"
+          (clickEvent)="onContentViewPropagationChanged($event, propagationEditItemIdx)"
           (openAdvancedConfigurationDialogEvent)="openAdvancedPermPropagationConfigurationDialog(childData, propagationEditItemIdx)"
         ></alg-propagation-edit-menu>
       }

--- a/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.ts
+++ b/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.ts
@@ -141,10 +141,9 @@ export class ItemChildrenEditListComponent implements OnChanges {
     );
   }
 
-  onContentViewPropagationChanged(contentViewPropagation: 'none' | 'as_info' | 'as_content'): void {
+  onContentViewPropagationChanged(contentViewPropagation: 'none' | 'as_info' | 'as_content', childIdx: number): void {
     this.op?.hide();
-    if (!this.propagationEditItemIdx) throw new Error('Unexpected: Missed propagationEditItemIdx');
-    this.emitChildPermPropagations({ contentViewPropagation }, this.propagationEditItemIdx);
+    this.emitChildPermPropagations({ contentViewPropagation }, childIdx);
     this.propagationEditItemIdx = undefined;
   }
 


### PR DESCRIPTION
## Description

By my mistake it does checking for equal `false` value instead for `undefined`. As that case already handled in template - I've decided to simplify this part

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases
