### PR TITLE
remove (unused) attribute which will change name in a future release of the backend

### DIFF
--- a/src/app/data-access/get-breadcrumbs-from-roots.service.ts
+++ b/src/app/data-access/get-breadcrumbs-from-roots.service.ts
@@ -18,7 +18,6 @@ const breadcrumbsFromRootElementSchema = z.object({
 export type BreadcrumbsFromRootElement = z.infer<typeof breadcrumbsFromRootElementSchema>;
 
 const breadcrumbsFromRootSchema = z.object({
-  startedByParticipant: z.boolean(),
   path: z.array(breadcrumbsFromRootElementSchema)
 });
 


### PR DESCRIPTION
## Description

Just ignore an attribute from the fetch response so that a future backend change (a rename of this attribute) does not break the frontend.