### PR TITLE
Fixes redirect for remove item flow

### DIFF
--- a/src/app/items/containers/item-remove-button/item-remove-button.component.ts
+++ b/src/app/items/containers/item-remove-button/item-remove-button.component.ts
@@ -55,6 +55,8 @@ export class ItemRemoveButtonComponent implements OnDestroy {
 
   deletionInProgress = signal(false);
 
+  defaultActivityRoute = inject(DEFAULT_ACTIVITY_ROUTE);
+
   constructor(
     private getItemChildrenService: GetItemChildrenService,
     private confirmationService: ConfirmationService,
@@ -102,8 +104,7 @@ export class ItemRemoveButtonComponent implements OnDestroy {
   }
 
   postDeletionNavigation(): void {
-    const defaultActivityRoute = inject(DEFAULT_ACTIVITY_ROUTE);
-    this.itemRouter.navigateTo(parentRoute(this.itemData().route, defaultActivityRoute));
+    this.itemRouter.navigateTo(parentRoute(this.itemData().route, this.defaultActivityRoute));
   }
 
   refresh(): void {


### PR DESCRIPTION
## Description

Fixes redirecting after item has removed

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The error after remove the item - https://angular.dev/errors/NG0203

I'm gonna cover this case by e2e in modal changes branch

## Test cases

- [ ] Case 1 (Current):
  1. Given I am the test user
  2. When I go to (with opened console) [this page](https://dev.algorea.org/en/a/6135500717997589014;p=1751831682141956756;pa=0/parameters)
  3. And I click on "Delete this item"
  4. And redirect is not done
  5. Then I see in console the error "ERROR T: NG0203"

- [ ] Case 2 (Fixed):
  1. Given I am the test user
  2. When I go to (with opened console) [this page](https://dev.algorea.org/branch/bugfix/remove-item-redirecting/en/a/2038038981303600676;p=1751831682141956756;pa=0/parameters)
  3. And I click on "Delete this item"
  4. And redirect has done
  5. And I see no errors in console log
