### PR TITLE
clear cache on menu left reload

### DIFF
--- a/src/app/data-access/group-navigation.service.ts
+++ b/src/app/data-access/group-navigation.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { Observable } from 'rxjs';
 import { APPCONFIG } from '../app.config';
 import { inject } from '@angular/core';
@@ -7,8 +7,11 @@ import { decodeSnakeCase } from 'src/app/utils/operators/decode';
 import { Cacheable } from 'ts-cacheable';
 import { z } from 'zod';
 import { SECONDS } from '../utils/duration';
+import { Subject } from 'rxjs';
+import { CurrentContentService } from '../services/current-content.service';
 
-const cacheConfig = { maxAge: 10*SECONDS, maxCacheCount: 5 };
+const cacheBuster$ = new Subject<void>();
+const cacheConfig = { maxAge: 10*SECONDS, maxCacheCount: 5, cacheBusterObserver: cacheBuster$ };
 
 const groupNavigationChildSchema = z.object({
   id: z.string(),
@@ -32,10 +35,16 @@ export type GroupNavigationData = z.infer<typeof groupNavigationSchema>;
 @Injectable({
   providedIn: 'root'
 })
-export class GroupNavigationService {
+export class GroupNavigationService implements OnDestroy {
   private config = inject(APPCONFIG);
 
-  constructor(private http: HttpClient) {}
+  private subscription = this.currentContent.navMenuReload$.subscribe(() => cacheBuster$.next());
+
+  constructor(private http: HttpClient, private currentContent: CurrentContentService) {}
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
 
   @Cacheable(cacheConfig)
   getGroupNavigation(groupId: string): Observable<GroupNavigationData> {

--- a/src/app/data-access/item-navigation.service.ts
+++ b/src/app/data-access/item-navigation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -13,8 +13,11 @@ import { groupBy } from 'src/app/utils/array';
 import { z } from 'zod';
 import { SECONDS } from '../utils/duration';
 import { Cacheable } from 'ts-cacheable';
+import { Subject } from 'rxjs';
+import { CurrentContentService } from '../services/current-content.service';
 
-const cacheConfig = { maxAge: 10*SECONDS, maxCacheCount: 5 };
+const cacheBuster$ = new Subject<void>();
+const cacheConfig = { maxAge: 10*SECONDS, maxCacheCount: 5, cacheBusterObserver: cacheBuster$ };
 
 const itemNavigationChildBaseSchema = z.object({
   id: z.string(),
@@ -88,11 +91,13 @@ export type RootItem = z.infer<typeof itemNavigationChildBaseSchema> & { groups:
 @Injectable({
   providedIn: 'root'
 })
-export class ItemNavigationService {
+export class ItemNavigationService implements OnDestroy {
 
   private config = inject(APPCONFIG);
 
-  constructor(private http: HttpClient) {}
+  private subscription = this.currentContent.navMenuReload$.subscribe(() => cacheBuster$.next());
+
+  constructor(private http: HttpClient, private currentContent: CurrentContentService) {}
 
   @Cacheable(cacheConfig)
   getItemNavigation(
@@ -142,6 +147,10 @@ export class ItemNavigationService {
       this.getRootSkills(watchedGroupId).pipe(map(groups => groups.map(g => ({ ...g, item: g.skill })))) :
       this.getRootActivities(watchedGroupId).pipe(map(groups => groups.map(g => ({ ...g, item: g.activity }))));
     return rootAsGroupList$.pipe(map(groupList => this.mapToItemList(groupList)));
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 
   /**


### PR DESCRIPTION
## Description
 
In order to fix the problem seen in e2e tests (and in actual app): the left menu cache is cleared when the menu is forced reload so that the cache is not used in this case (was only the case if requested within a 10sec delay)