### PR TITLE
allow disabling the left nav 'groups' tab and content

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -42,7 +42,13 @@ const configSchema = z.object({
   featureFlags: z.object({
     hideTaskTabs: z.array(z.string()).default([]),
     showGroupAccessTab: z.boolean().default(false),
-    showLeftMenuTabs: z.boolean().default(true),
+
+    leftMenu: z.object({
+      groups: z.union([
+        z.object({ hide: z.literal(true), excludeUserIds: z.array(z.string()).default([]) }),
+        z.object({ hide: z.literal(false) })
+      ]).default({ hide: false }),
+    }).default({ groups: { hide: false } }),
   }),
 
   /* paths to be matched must not have a trailing slash */

--- a/src/app/containers/left-nav/left-nav.component.html
+++ b/src/app/containers/left-nav/left-nav.component.html
@@ -17,7 +17,7 @@
         <button
           class="main-menu-button"
           [ngClass]="{ 'active': activeTab.index === 1, 'compact': currentLanguage === 'fr' }"
-          *ngIf="!skillsDisabled"
+          *ngIf="!skillsTabDisabled"
           (click)="onSelectionChangedByIdx(1)"
         >
           <div class="main-menu-icon-wrapper">
@@ -30,6 +30,7 @@
           class="main-menu-button"
           [ngClass]="{ 'active': activeTab.index === 2, 'compact': currentLanguage === 'fr' }"
           data-cy="main-menu-group-btn"
+          *ngIf="!groupsTabDisabled"
           (click)="onSelectionChangedByIdx(2)"
         >
           <div class="main-menu-icon-wrapper">

--- a/src/app/containers/left-nav/left-nav.component.ts
+++ b/src/app/containers/left-nav/left-nav.component.ts
@@ -80,12 +80,13 @@ export class LeftNavComponent implements OnChanges {
     distinctUntilChanged((x,y) => x?.type === y?.type && x?.route?.id === y?.route?.id), // do not re-emit several time for a same content
     map(content => contentToTabIndex(content)),
     filter(isDefined),
+    filter(idx => !this.skillsTabDisabled || idx !== skillsTabIdx),
+    filter(idx => !this.groupsTabDisabled || idx !== groupsTabIdx),
     startWith(0),
     distinctUntilChanged(),
     map(idx => ({ index: idx })), // using object so that Angular ngIf does not ignore the "0" index
   );
 
-  showTabs = this.config.featureFlags.showLeftMenuTabs;
 
   @Output() selectElement = this.activeTab$.pipe(
     map(tab => this.navTreeServices[tab.index]),
@@ -102,7 +103,10 @@ export class LeftNavComponent implements OnChanges {
   isObserving$ = this.store.select(fromObservation.selectIsObserving);
   isNarrowScreen$ = this.layoutService.isNarrowScreen$;
 
-  skillsDisabled = this.config.defaultSkillId === undefined;
+  skillsTabDisabled = !this.config.defaultSkillId;
+  groupsTabDisabled = this.config.featureFlags.leftMenu.groups.hide;
+  showTabs = !this.groupsTabDisabled || !this.skillsTabDisabled;
+
   observationModeCaption = $localize`Observation mode`;
 
   currentLanguage = this.localeService.currentLang?.tag;


### PR DESCRIPTION
## Description

The previous solution that hide the left nav tab header was not satisfying as going on a group page (for instance the profile page) was still change the content of the left nav menu.

Instead, we now consider that "groups" can completely be disabled in the left menu. And IF groups AND skills are both disabled, the left menu tab headers is hidden.

It cannot be tested without changing the config. Now we can easily inject any config, that should be tested using e2e. 