### PR TITLE
disable sentry on non crash reporting communications

### DIFF
--- a/src/app/utils/error-handling/setup-error-tracking.ts
+++ b/src/app/utils/error-handling/setup-error-tracking.ts
@@ -13,6 +13,9 @@ export function initErrorTracking(): void {
     environment: environment.production ? `prod-${window.location.hostname}` : 'dev',
     release: version,
     integrations: [],
+    profilesSampleRate: 0, // disable profiling
+    autoSessionTracking: false,
+    enableTracing: false,
     ignoreErrors: [
       'Cannot redefine property: googletag',
       "Cannot read properties of undefined (reading 'sendMessage')", // a chrome extension error


### PR DESCRIPTION
## Description

Disable sentry for all but crash reporting

Can only be tested in prod.