### PR TITLE
support for showToUserIds config for groups and skills

### DIFF
--- a/src/app/config/index.ts
+++ b/src/app/config/index.ts
@@ -45,10 +45,14 @@ const configSchema = z.object({
 
     leftMenu: z.object({
       groups: z.union([
-        z.object({ hide: z.literal(true), excludeUserIds: z.array(z.string()).default([]) }),
+        z.object({ hide: z.literal(true), showToUserIds: z.array(z.string()).default([]) }),
         z.object({ hide: z.literal(false) })
       ]).default({ hide: false }),
-    }).default({ groups: { hide: false } }),
+      skills: z.union([
+        z.object({ hide: z.literal(true), showToUserIds: z.array(z.string()).default([]) }),
+        z.object({ hide: z.literal(false) })
+      ]).default({ hide: false }),
+    }).default({ groups: { hide: false }, skills: { hide: false } }),
   }),
 
   /* paths to be matched must not have a trailing slash */

--- a/src/app/config/left-menu-config.service.ts
+++ b/src/app/config/left-menu-config.service.ts
@@ -1,0 +1,38 @@
+import { inject, Injectable } from '@angular/core';
+import { APPCONFIG } from '.'; // Adjusted path
+import { UserSessionService } from '../services/user-session.service';
+import { combineLatest, map, of, switchMap } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LeftMenuConfigService {
+
+  private config = inject(APPCONFIG);
+
+  skillsTabEnabled$ = of({ hasDefault: !!this.config.defaultSkillId, visibilityConfig: this.config.featureFlags.leftMenu.skills }).pipe(
+    switchMap(({ hasDefault, visibilityConfig }) => {
+      if (!hasDefault) return of(false);
+      if (!visibilityConfig.hide) return of(true);
+      if (visibilityConfig.showToUserIds.length === 0) return of(false);
+      return this.userSession.userProfile$.pipe(
+        map(({ groupId }) => visibilityConfig.showToUserIds.includes(groupId))
+      );
+    })
+  );
+  groupsTabEnabled$ = of(this.config.featureFlags.leftMenu.groups).pipe(
+    switchMap(groupsConfig => {
+      if (!groupsConfig.hide) return of(true);
+      if (groupsConfig.showToUserIds.length === 0) return of(false);
+      return this.userSession.userProfile$.pipe(
+        map(({ groupId }) => groupsConfig.showToUserIds.includes(groupId))
+      );
+    })
+  );
+  showTabBar$ = combineLatest([ this.skillsTabEnabled$, this.groupsTabEnabled$ ]).pipe(
+    map(([ skillsTabEnabled, groupsTabEnabled ]) => skillsTabEnabled || groupsTabEnabled)
+  );
+
+  constructor(private userSession: UserSessionService) {}
+
+}

--- a/src/app/containers/left-nav/left-nav.component.html
+++ b/src/app/containers/left-nav/left-nav.component.html
@@ -1,6 +1,6 @@
 <ng-container *ngIf="activeTab$ | async as activeTab;">
 
-  @if (showTabs) {
+  @if (showTabs$ | async) {
     <div class="tab-view-container">
       <div class="main-menu">
         <button
@@ -17,7 +17,7 @@
         <button
           class="main-menu-button"
           [ngClass]="{ 'active': activeTab.index === 1, 'compact': currentLanguage === 'fr' }"
-          *ngIf="!skillsTabDisabled"
+          *ngIf="skillsTabEnabled$ | async"
           (click)="onSelectionChangedByIdx(1)"
         >
           <div class="main-menu-icon-wrapper">
@@ -30,7 +30,7 @@
           class="main-menu-button"
           [ngClass]="{ 'active': activeTab.index === 2, 'compact': currentLanguage === 'fr' }"
           data-cy="main-menu-group-btn"
-          *ngIf="!groupsTabDisabled"
+          *ngIf="groupsTabEnabled$ | async"
           (click)="onSelectionChangedByIdx(2)"
         >
           <div class="main-menu-icon-wrapper">


### PR DESCRIPTION
## Description

Allow defining a set of user (by id) who can see groups (or skills) in the left menu even when it is hidden.

Not really testable here, added to #1950.
