### PR TITLE
locked content: add specific message for content with prerequisites and temp users

### DIFF
--- a/e2e/items/item-content.spec.ts
+++ b/e2e/items/item-content.spec.ts
@@ -217,7 +217,7 @@ test('checks chapter no access message with prerequisites section', async ({ ite
     itemContentPage.waitForItemResponse('128139237432513103'),
     itemContentPage.waitForBreadcrumbsResponse('4702/4102/128139237432513103', 'parent_attempt_id=0'),
   ]);
-  await itemContentPage.checksIsChapterNoAccessMessageVisible();
+  await itemContentPage.checksIsChapterLockedMessageVisible();
   await itemContentPage.checksIsPrerequisiteSectionVisible();
 });
 

--- a/e2e/items/pages/item-content-page.ts
+++ b/e2e/items/pages/item-content-page.ts
@@ -109,16 +109,24 @@ export class ItemContentPage {
 
   async checksIsChapterNoAccessMessageVisible(): Promise<void> {
     await expect.soft(
-      this.page.getByText('Your current access rights do not allow you to list the content of this chapter.')
+      this.page.getByText('You are not connected and cannot access the content of this chapter.')
+    ).toBeVisible();
+    await expect.soft(
+      this.page.getByText('Please sign up or log in using the power button at the top right corner of this screen.')
     ).toBeVisible();
   }
 
+  async checksIsChapterLockedMessageVisible(): Promise<void> {
+    await expect.soft(this.page.getByText('This chapter is locked.')).toBeVisible();
+    await expect.soft(this.page.getByText('Fulfill one of the prerequisites below to access its content.')).toBeVisible();
+  }
+
   async checksIsPrerequisiteSectionVisible(): Promise<void> {
-    await expect.soft(this.page.getByText('Prerequisites')).toBeVisible();
+    await expect.soft(this.page.getByRole('heading', { name: 'Prerequisites' })).toBeVisible();
   }
 
   async checksIsPrerequisiteSectionNotVisible(): Promise<void> {
-    await expect.soft(this.page.getByText('Prerequisites')).not.toBeVisible();
+    await expect.soft(this.page.getByRole('heading', { name: 'Prerequisites' })).not.toBeVisible();
   }
 
   async checksExplicitEntryIsVisible(): Promise<void> {
@@ -146,11 +154,13 @@ export class ItemContentPage {
   }
 
   async checksTaskNoAccessMessageIsVisible(): Promise<void> {
-    await expect.soft(this.page.getByText('Your current access rights do not allow you to start the activity.')).toBeVisible();
+    await expect.soft(this.page.getByText('Your current access rights do not allow you')).toBeVisible();
+    await expect.soft(this.page.getByText('to start the activity.')).toBeVisible();
   }
 
   async checksSkillNoAccessMessageIsVisible(): Promise<void> {
-    await expect.soft(this.page.getByText('Your current access rights do not allow you to list the content of this skill.')).toBeVisible();
+    await expect.soft(this.page.getByText('Your current access rights do not allow you')).toBeVisible();
+    await expect.soft(this.page.getByText('to list the content of this skill.')).toBeVisible();
   }
 
   async checkToastNotification(message: string): Promise<void> {

--- a/e2e/items/unlocked-items.spec.ts
+++ b/e2e/items/unlocked-items.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from 'e2e/items/fixture';
+import { initAsTesterUser } from 'e2e/helpers/e2e_auth';
 
 test('check unlocked items and navigate to first one', async ({ page }) => {
   await page.goto('a/2004936693550411739;p=4702,7528142386663912287,7523720120450464843;pa=0');
-  expect.soft(page.getByTestId('item-title').getByText('Long text task (opentezos-like)')).toBeVisible();
+  await expect.soft(page.getByTestId('item-title').getByText('Long text task (opentezos-like)')).toBeVisible();
   await expect.soft(page.frameLocator('iFrame').getByText('A brief history of blockchain')).toBeVisible();
   const mainContentWrapperLocator = page.getByTestId('main-content-wrapper');
   await expect.soft(mainContentWrapperLocator).toBeVisible();
@@ -20,7 +21,7 @@ test('check unlocked items and navigate to first one', async ({ page }) => {
 test('check unlocked items and stay on current task', async ({ page }) => {
   await page.goto('a/2004936693550411739;p=4702,7528142386663912287,7523720120450464843;pa=0');
   const itemTitleLocator = page.getByTestId('item-title').getByText('Long text task (opentezos-like)');
-  expect.soft(itemTitleLocator).toBeVisible();
+  await expect.soft(itemTitleLocator).toBeVisible();
   await expect.soft(page.frameLocator('iFrame').getByText('A brief history of blockchain')).toBeVisible();
   const mainContentWrapperLocator = page.getByTestId('main-content-wrapper');
   await expect.soft(mainContentWrapperLocator).toBeVisible();
@@ -33,4 +34,40 @@ test('check unlocked items and stay on current task', async ({ page }) => {
   await expect.soft(continueBtnLocator).toBeVisible();
   await continueBtnLocator.click();
   await expect.soft(itemTitleLocator).toBeVisible();
+});
+
+test('check chapter is locked message for temp user', async ({ page }) => {
+  await page.goto('a/457754150968902848;p=4702,7528142386663912287,944619266928306927;pa=0');
+  const itemTitleLocator = page.getByTestId('item-title').getByText('Chapter unlocked by other tasks');
+  await expect.soft(itemTitleLocator).toBeVisible();
+  await expect.soft(page.getByText('This chapter is locked.')).toBeVisible();
+  await expect.soft(page.getByText('Fulfill one of the prerequisites below to access its content.')).toBeVisible();
+});
+
+test('check chapter is locked message for auth user', async ({ page }) => {
+  await initAsTesterUser(page);
+  await page.goto('a/457754150968902848;p=4702,7528142386663912287,944619266928306927;pa=0');
+  const itemTitleLocator = page.getByTestId('item-title').getByText('Chapter unlocked by other tasks');
+  await expect.soft(itemTitleLocator).toBeVisible();
+  await expect.soft(page.getByText('This chapter is locked.')).toBeVisible();
+  await expect.soft(page.getByText('Fulfill one of the prerequisites below to access its content.')).toBeVisible();
+});
+
+test('check the temp user is not connected to activity', async ({ page }) => {
+  await page.goto('a/6747343693587333585;p=4702,7528142386663912287,944619266928306927;pa=0');
+  const itemTitleLocator = page.getByTestId('item-title').getByText('Non-visible task');
+  await expect.soft(itemTitleLocator).toBeVisible();
+  await expect.soft(page.getByText('You are not connected and cannot start this activity.')).toBeVisible();
+  await expect.soft(
+    page.getByText('Please sign up or log in using the power button at the top right corner of this screen.')
+  ).toBeVisible();
+});
+
+test('check the auth user has no access rights to activity', async ({ page }) => {
+  await initAsTesterUser(page);
+  await page.goto('a/6747343693587333585;p=4702,7528142386663912287,944619266928306927;pa=0');
+  const itemTitleLocator = page.getByTestId('item-title').getByText('Non-visible task');
+  await expect.soft(itemTitleLocator).toBeVisible();
+  await expect.soft(page.getByText('Your current access rights do not allow you')).toBeVisible();
+  await expect.soft(page.getByText('to start the activity.')).toBeVisible();
 });

--- a/e2e/items/unlocked-items.spec.ts
+++ b/e2e/items/unlocked-items.spec.ts
@@ -36,21 +36,19 @@ test('check unlocked items and stay on current task', async ({ page }) => {
   await expect.soft(itemTitleLocator).toBeVisible();
 });
 
-test('check chapter is locked message for temp user', async ({ page }) => {
+test('check chapter is locked message for temp user', async ({ page, itemContentPage }) => {
   await page.goto('a/457754150968902848;p=4702,7528142386663912287,944619266928306927;pa=0');
   const itemTitleLocator = page.getByTestId('item-title').getByText('Chapter unlocked by other tasks');
   await expect.soft(itemTitleLocator).toBeVisible();
-  await expect.soft(page.getByText('This chapter is locked.')).toBeVisible();
-  await expect.soft(page.getByText('Fulfill one of the prerequisites below to access its content.')).toBeVisible();
+  await itemContentPage.checksIsChapterLockedMessageVisible();
 });
 
-test('check chapter is locked message for auth user', async ({ page }) => {
+test('check chapter is locked message for auth user', async ({ page, itemContentPage }) => {
   await initAsTesterUser(page);
   await page.goto('a/457754150968902848;p=4702,7528142386663912287,944619266928306927;pa=0');
   const itemTitleLocator = page.getByTestId('item-title').getByText('Chapter unlocked by other tasks');
   await expect.soft(itemTitleLocator).toBeVisible();
-  await expect.soft(page.getByText('This chapter is locked.')).toBeVisible();
-  await expect.soft(page.getByText('Fulfill one of the prerequisites below to access its content.')).toBeVisible();
+  await itemContentPage.checksIsChapterLockedMessageVisible();
 });
 
 test('check the temp user is not connected to activity', async ({ page }) => {
@@ -63,11 +61,10 @@ test('check the temp user is not connected to activity', async ({ page }) => {
   ).toBeVisible();
 });
 
-test('check the auth user has no access rights to activity', async ({ page }) => {
+test('check the auth user has no access rights to activity', async ({ page, itemContentPage }) => {
   await initAsTesterUser(page);
   await page.goto('a/6747343693587333585;p=4702,7528142386663912287,944619266928306927;pa=0');
   const itemTitleLocator = page.getByTestId('item-title').getByText('Non-visible task');
   await expect.soft(itemTitleLocator).toBeVisible();
-  await expect.soft(page.getByText('Your current access rights do not allow you')).toBeVisible();
-  await expect.soft(page.getByText('to start the activity.')).toBeVisible();
+  await itemContentPage.checksTaskNoAccessMessageIsVisible();
 });

--- a/src/app/items/containers/item-content/item-content.component.html
+++ b/src/app/items/containers/item-content/item-content.component.html
@@ -25,28 +25,53 @@
 }
 
 @else if (!canViewContent) {
-  <div class="no-access-message alg-flex-1">
-    <span class="no-access-message-icon-container">
-      <i class="ph-duotone ph-lock-key no-access-message-icon"></i>
-      <span class="no-access-message-icon-bg"></span>
-    </span>
-    @if (item | isAChapter) {
-      <span class="no-access-message-text alg-text-secondary" i18n>
-        Your current access rights do not allow you to list<br> the content of this chapter.
+  @if (hasPrerequisites !== undefined) {
+    <div class="no-access-message alg-flex-1">
+      <span class="no-access-message-icon-container">
+        <i class="ph-duotone no-access-message-icon" [ngClass]="isCurrentUserTemp() && !hasPrerequisites ? 'ph-power' : 'ph-lock-key'"></i>
+        <span class="no-access-message-icon-bg"></span>
       </span>
-    }
-    @else if (item | isASkill) {
-      <span class="no-access-message-text alg-text-secondary" i18n>
-        Your current access rights do not allow you to list<br> the content of this skill.
-      </span>
-    }
-    @else { <!-- task -->
-      <span class="no-access-message-text alg-text-secondary" i18n>
-        Your current access rights do not allow you to start<br> the activity.
-      </span>
-    }
-  </div>
-  <alg-item-unlock-access class="alg-flex-1" [itemData]="itemData()"></alg-item-unlock-access>
+      @if (item | isAChapter) {
+        <span class="no-access-message-text alg-text-secondary">
+          @if (hasPrerequisites) {
+            <ng-container i18n>This chapter is locked.<br>Fulfill one of the prerequisites below to access its content.</ng-container>
+          } @else if (isCurrentUserTemp()) {
+            <ng-container i18n>You are not connected and cannot access the content of this chapter.</ng-container>
+          } @else {
+            <ng-container i18n>Your current access rights do not allow you<br>to list the content of this chapter.</ng-container>
+          }
+        </span>
+      }
+      @else if (item | isASkill) {
+        <span class="no-access-message-text alg-text-secondary">
+          @if (hasPrerequisites) {
+            <ng-container i18n>This skill is locked.<br>Fulfill one of the prerequisites below to access its content.</ng-container>
+          } @else if (isCurrentUserTemp()) {
+            <ng-container i18n>You are not connected and cannot access the content of this skill.</ng-container>
+          } @else {
+            <ng-container i18n>Your current access rights do not allow you<br>to list the content of this skill.</ng-container>
+          }
+        </span>
+      }
+      @else { <!-- task -->
+        <span class="no-access-message-text alg-text-secondary">
+          @if (hasPrerequisites) {
+            <ng-container i18n>This activity is locked.<br>Fulfill one of the prerequisites below to access its content.</ng-container>
+          } @else if (isCurrentUserTemp()) {
+            <ng-container i18n>You are not connected and cannot start this activity.</ng-container>
+          } @else {
+            <ng-container i18n>Your current access rights do not allow you<br>to start the activity.</ng-container>
+          }
+        </span>
+      }
+      @if (isCurrentUserTemp() && !hasPrerequisites) {
+        <span class="no-access-message-text alg-text-secondary" i18n>
+          Please sign up or log in using the power button at the top right corner of this screen.
+        </span>
+      }
+    </div>
+  }
+  <alg-item-unlock-access class="alg-flex-1" [itemData]="itemData()" (hasContent)="onPrerequisiteNotify($event)"></alg-item-unlock-access>
 }
 
 @else if ((item | isAChapter) || (item | isASkill)) { <!-- with canViewContent, results may not be fetched yet-->

--- a/src/app/items/containers/item-content/item-content.component.ts
+++ b/src/app/items/containers/item-content/item-content.component.ts
@@ -23,6 +23,9 @@ import { ErrorComponent } from '../../../ui-components/error/error.component';
 import { IsAChapterPipe, IsASkillPipe, isATask } from '../../models/item-type';
 import { ExplicitEntryComponent } from '../explicit-entry/explicit-entry.component';
 import { FormsModule } from '@angular/forms';
+import { UserSessionService } from 'src/app/services/user-session.service';
+import { map } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'alg-item-content',
@@ -80,6 +83,8 @@ export class ItemContentComponent implements PendingChangesComponent {
   @Output() fullFrameTask = new EventEmitter<boolean>();
 
   isTaskLoaded = signal(false); // whether the task has finished loading, i.e. is ready or in error
+  isCurrentUserTemp = toSignal(this.userSessionService.userProfile$.pipe(map(user => user.tempUser)));
+  hasPrerequisites: boolean|undefined = undefined; // undefined while not known
 
   isDirty(): boolean {
     return !!this.itemChildrenEditFormComponent?.dirty;
@@ -89,6 +94,7 @@ export class ItemContentComponent implements PendingChangesComponent {
     private store: Store,
     private router: Router,
     private route: ActivatedRoute,
+    private userSessionService: UserSessionService,
   ) {}
 
   onEditModeEnableChange(editModeEnabled: boolean): void {
@@ -108,5 +114,9 @@ export class ItemContentComponent implements PendingChangesComponent {
 
   onTaskLoadChange(loadingComplete: boolean): void {
     this.isTaskLoaded.set(loadingComplete);
+  }
+
+  onPrerequisiteNotify(hasPrerequisites: boolean): void {
+    this.hasPrerequisites = hasPrerequisites;
   }
 }

--- a/src/app/items/containers/item-unlock-access/item-unlock-access.component.ts
+++ b/src/app/items/containers/item-unlock-access/item-unlock-access.component.ts
@@ -3,7 +3,7 @@ import { ItemData } from '../../models/item-data';
 import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { ReplaySubject, Subject, switchMap } from 'rxjs';
 import { map, share } from 'rxjs/operators';
-import { mapToFetchState } from 'src/app/utils/operators/state';
+import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { GetItemPrerequisitesService } from '../../data-access/get-item-prerequisites.service';
 import { canCurrentUserViewContent } from 'src/app/items/models/item-view-permission';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
@@ -16,6 +16,7 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
 import { NgIf, NgFor, AsyncPipe } from '@angular/common';
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
+import { outputFromObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'alg-item-unlock-access',
@@ -55,6 +56,11 @@ export class ItemUnlockAccessComponent implements OnChanges, OnDestroy {
     mapToFetchState({ resetter: this.refresh$ }),
     share(),
   );
+
+  hasContent = outputFromObservable(this.state$.pipe(
+    readyData(),
+    map(data => data.length > 0),
+  ));
 
   itemId = signal<string | undefined>(undefined);
 

--- a/src/locale/messages.fr.xlf
+++ b/src/locale/messages.fr.xlf
@@ -960,31 +960,22 @@
       <note from="description" priority="1">Button label for joining an item by (group) code</note><context-group purpose="location"><context context-type="sourcefile">src/app/items/item-by-id.component.html</context><context context-type="linenumber">13</context></context-group></trans-unit><trans-unit id="2771205002840550916" datatype="html">
         <source>Edit content</source><target state="translated">Editer le contenu</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">61</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">86</context></context-group></trans-unit><trans-unit id="7250343758473458577" datatype="html">
         <source> You do not have the permissions to edit this content. </source><target state="translated"> Vous n'avez pas les permissions d'éditer ce contenu. </target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-children-edit-form/item-children-edit-form.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="5441429049165852521" datatype="html">
         <source> This activity has not been correctly configured. </source><target state="translated"> Cette activité n'a pas été correctement configurée. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">96</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">121</context></context-group></trans-unit><trans-unit id="7327354999532189308" datatype="html">
         <source> You need to set a url in editing mode. </source><target state="translated"> Vous devez configurer une URL en mode édition. </target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">100</context></context-group></trans-unit><trans-unit id="6897999120381208807" datatype="html">
-        <source> Your current access rights do not allow you to list<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> the content of this chapter. </source><target state="translated"> Vos droits d'accès actuels ne vous permettent pas de lister<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> le contenu de ce chapitre. </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">35</context></context-group></trans-unit><trans-unit id="8697596042386823142" datatype="html">
-        <source> Your current access rights do not allow you to list<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> the content of this skill. </source><target state="translated"> Vos droits d'accès actuels ne vous permettent pas de lister<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> le contenu de cette compétence. </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="5323780775476058848" datatype="html">
-        <source> Your current access rights do not allow you to start<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> the activity. </source><target state="translated"> Vos droits d'accès actuels ne vous permettent pas commencer<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/> cette activité. </target>
-
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">45</context></context-group></trans-unit><trans-unit id="701018348223992755" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">125</context></context-group></trans-unit><trans-unit id="701018348223992755" datatype="html">
         <source>Loading the content</source><target state="translated">Chargement du contenu</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">132</context></context-group></trans-unit><trans-unit id="1105872825687577539" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">157</context></context-group></trans-unit><trans-unit id="1105872825687577539" datatype="html">
         <source>The content is taking an unexpected long time to load... please wait...</source><target state="translated">Ce contenu met plus de temps que prévu à se charger... veuillez patienter...</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">133</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context><context context-type="linenumber">158</context></context-group></trans-unit><trans-unit id="notImplemented" datatype="html">
         <source>(not implemented)</source><target state="translated">(non implémenté)</target>
 
 
@@ -1442,7 +1433,67 @@
       <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-children-edit-list/item-children-edit-list.component.html</context><context context-type="linenumber">101</context></context-group></trans-unit><trans-unit id="8390631426570727629" datatype="html">
         <source>Error while loading the children items</source><target state="translated">Erreur lors du chargement des enfants</target>
 
-      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="4605864425009617908" datatype="html">
+      <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-children-edit/item-children-edit.component.html</context><context context-type="linenumber">40</context></context-group></trans-unit><trans-unit id="1974165985511194380" datatype="html">
+        <source>This chapter is locked.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>Fulfill one of the prerequisites below to access its content.</source><target state="translated">Ce chapitre est verrouillé.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>Remplissez l’un des prérequis ci-dessous pour accéder à son contenu.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">37</context>
+        </context-group>
+      </trans-unit><trans-unit id="8051920374743623313" datatype="html">
+        <source>You are not connected and cannot access the content of this chapter.</source><target state="translated">Vous n’êtes pas connecté et ne pouvez pas accéder au contenu de ce chapitre.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">39</context>
+        </context-group>
+      </trans-unit><trans-unit id="8159564484830801720" datatype="html">
+        <source>Your current access rights do not allow you<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>to list the content of this chapter.</source><target state="translated">Vos droits d'accès actuels ne vous permettent pas<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>de consulter le contenu de ce chapitre.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">41</context>
+        </context-group>
+      </trans-unit><trans-unit id="3065590177299924722" datatype="html">
+        <source>This skill is locked.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>Fulfill one of the prerequisites below to access its content.</source><target state="translated">Cette compétence est verrouillée.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>Remplissez l’un des prérequis ci-dessous pour accéder à son contenu.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">48</context>
+        </context-group>
+      </trans-unit><trans-unit id="3004691292463847196" datatype="html">
+        <source>You are not connected and cannot access the content of this skill.</source><target state="translated">Vous n’êtes pas connecté et ne pouvez pas accéder au contenu de cette compétence.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">50</context>
+        </context-group>
+      </trans-unit><trans-unit id="3841167108110897631" datatype="html">
+        <source>Your current access rights do not allow you<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>to list the content of this skill.</source><target state="translated">Vos droits d'accès actuels ne vous permettent pas<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>de consulter le contenu de cette compétence.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">52</context>
+        </context-group>
+      </trans-unit><trans-unit id="9058564029144196029" datatype="html">
+        <source>This activity is locked.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>Fulfill one of the prerequisites below to access its content.</source><target state="translated">Cette activité est verrouillée.<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>Remplissez l’un des prérequis ci-dessous pour accéder à son contenu.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">59</context>
+        </context-group>
+      </trans-unit><trans-unit id="7086141787559582698" datatype="html">
+        <source>You are not connected and cannot start this activity.</source><target state="translated">Vous n’êtes pas connecté et ne pouvez pas démarrer cette activité.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">61</context>
+        </context-group>
+      </trans-unit><trans-unit id="9028158064856724007" datatype="html">
+        <source>Your current access rights do not allow you<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>to start the activity.</source><target state="translated">Vos droits d'accès actuels ne vous permettent pas<x id="LINE_BREAK" ctype="lb" equiv-text="&lt;br>"/>de consulter le contenu de ce chapitre.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">63</context>
+        </context-group>
+      </trans-unit><trans-unit id="96403311093859283" datatype="html">
+        <source> Please sign up or log in using the power button at the top right corner of this screen. </source><target state="translated">Ce chapitre est verrouillé.&lt;br&gt;Remplissez l’un des prérequis ci-dessous pour accéder à son contenu.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/items/containers/item-content/item-content.component.html</context>
+          <context context-type="linenumber">69,70</context>
+        </context-group>
+      </trans-unit><trans-unit id="4605864425009617908" datatype="html">
         <source>Prerequisites</source><target state="translated">Prérequis</target>
 
       <context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-dependencies/item-dependencies.component.html</context><context context-type="linenumber">2</context></context-group><context-group purpose="location"><context context-type="sourcefile">src/app/items/containers/item-unlock-access/item-unlock-access.component.html</context><context context-type="linenumber">14</context></context-group></trans-unit><trans-unit id="6971784787959352901" datatype="html">


### PR DESCRIPTION
## Description

Locked content: add specific message for content with prerequisites and temp users

Can you create e2e tests to check that the message is the correct one for the 4 cases non-temp / temp user with or without prerequisites ? 
You can use [this item for prerequisites](https://dev.algorea.org/en/a/457754150968902848;p=4702,7528142386663912287,944619266928306927;pa=0)  and [this one with no prerequisites](https://dev.algorea.org/en/a/6747343693587333585;p=4702,7528142386663912287,944619266928306927;pa=0).