### PR TITLE
Replaces path suggestion primeng overlay with cdk overlay

### DIFF
--- a/src/app/containers/left-search-result/left-search-result.component.html
+++ b/src/app/containers/left-search-result/left-search-result.component.html
@@ -24,10 +24,12 @@
 <ng-container *ngFor="let item of data;">
   <div class="container">
     <ul class="result-list alg-search-result">
-      <li class="result-list-item"
-          [algShowOverlay]="op"
-          (overlayOpenEvent)="itemId.set(item.id)"
-          (overlayCloseEvent)="itemId.set(undefined)"
+      <li
+        class="result-list-item"
+        [algShowOverlay]="op"
+        (overlayOpenEvent)="itemId.set(item.id)"
+        (overlayCloseEvent)="itemId.set(undefined)"
+        #overlay="algShowOverlay"
       >
         <a class="result-list-link" [routerLink]="item | itemRoute | url" routerLinkActive="selected">
           <i
@@ -45,17 +47,12 @@
         <div class="result-list-description-wrapper" *ngIf="item.highlights.length > 0">
           <p class="result-list-description" *ngFor="let highlight of item.highlights" [innerHTML]="highlight"></p>
         </div>
+        <ng-template #op>
+          <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+        </ng-template>
       </li>
     </ul>
   </div>
 </ng-container>
 
-<p-overlayPanel
-  styleClass="alg-path-suggestion-overlay"
-  #op
->
-  <ng-container *ngIf="op.overlayVisible">
-    <alg-path-suggestion [itemId]="itemId()"></alg-path-suggestion>
-  </ng-container>
-</p-overlayPanel>
 

--- a/src/app/containers/left-search-result/left-search-result.component.ts
+++ b/src/app/containers/left-search-result/left-search-result.component.ts
@@ -1,13 +1,12 @@
 import { Component, EventEmitter, Input, Output, signal } from '@angular/core';
 import { SearchResponse } from '../../data-access/search.service';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
 import { ItemRoutePipe } from 'src/app/pipes/itemRoute';
 import { PathSuggestionComponent } from '../path-suggestion/path-suggestion.component';
 import { RouterLinkActive, RouterLink } from '@angular/router';
 import { MessageInfoComponent } from '../../ui-components/message-info/message-info.component';
 import { LeftMenuBackButtonComponent } from '../../ui-components/left-menu-back-button/left-menu-back-button.component';
-import { NgIf, NgFor, NgClass, AsyncPipe } from '@angular/common';
+import { NgIf, NgFor, NgClass } from '@angular/common';
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
 
@@ -24,9 +23,7 @@ import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/s
     RouterLinkActive,
     RouterLink,
     NgClass,
-    OverlayPanelModule,
     PathSuggestionComponent,
-    AsyncPipe,
     ItemRoutePipe,
     RouteUrlPipe,
     ShowOverlayDirective,

--- a/src/app/containers/path-suggestion/path-suggestion.component.scss
+++ b/src/app/containers/path-suggestion/path-suggestion.component.scss
@@ -2,6 +2,8 @@
 
 :host {
   display: block;
+  width: 100%;
+  overflow: scroll;
 }
 
 .breadcrumbs-title {

--- a/src/app/groups/containers/group-log-view/group-log-view.component.html
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.html
@@ -72,6 +72,7 @@
             [algShowOverlay]="op"
             (overlayOpenEvent)="itemId.set(rowData.item.id)"
             (overlayCloseEvent)="itemId.set(undefined)"
+            #overlay="algShowOverlay"
           >
             <a
               class="alg-link"
@@ -81,6 +82,9 @@
             >
               {{ rowData.item.string.title }}
             </a>
+            <ng-template #op>
+              <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+            </ng-template>
           </td>
           <td *ngIf="this.showUserColumn">
             @if (rowData.user) {
@@ -118,12 +122,3 @@
     </p-table>
   </ng-container>
 </ng-container>
-
-<p-overlayPanel
-  styleClass="alg-path-suggestion-overlay"
-  #op
->
-  <ng-container *ngIf="op.overlayVisible">
-    <alg-path-suggestion [itemId]="itemId()"></alg-path-suggestion>
-  </ng-container>
-</p-overlayPanel>

--- a/src/app/groups/containers/group-log-view/group-log-view.component.ts
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.ts
@@ -8,7 +8,6 @@ import {
 import { Observable } from 'rxjs';
 import { map, withLatestFrom } from 'rxjs/operators';
 import { ActivityLogs, ActivityLogService } from 'src/app/data-access/activity-log.service';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { DataPager } from 'src/app/utils/data-pager';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { LogActionDisplayPipe } from 'src/app/pipes/logActionDisplay';
@@ -46,7 +45,6 @@ const logsLimit = 20;
     ScoreRingComponent,
     NgClass,
     RouterLink,
-    OverlayPanelModule,
     PathSuggestionComponent,
     AsyncPipe,
     DatePipe,

--- a/src/app/items/containers/item-dependencies/item-dependencies.component.html
+++ b/src/app/items/containers/item-dependencies/item-dependencies.component.html
@@ -25,6 +25,7 @@
               [algShowOverlay]="op"
               (overlayOpenEvent)="itemId.set(item.id)"
               (overlayCloseEvent)="itemId.set(undefined)"
+              #overlay="algShowOverlay"
             >
               <a
                 class="alg-link"
@@ -40,6 +41,9 @@
                 (click)="onRemove(item.id)"
                 alg-button-icon
               ></button>
+              <ng-template #op>
+                <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+              </ng-template>
             </li>
           </ul>
           <p class="note-caption" i18n>
@@ -78,11 +82,12 @@
       <ng-container *ngIf="state.data.length > 0; else noOtherContent">
         <ul class="list">
           <li
-              class="list-item"
-              *ngFor="let item of state.data; let i = index"
-              [algShowOverlay]="op"
-              (overlayOpenEvent)="itemId.set(item.id)"
-              (overlayCloseEvent)="itemId.set(undefined)"
+            class="list-item"
+            *ngFor="let item of state.data; let i = index"
+            [algShowOverlay]="op"
+            (overlayOpenEvent)="itemId.set(item.id)"
+            (overlayCloseEvent)="itemId.set(undefined)"
+            #overlay="algShowOverlay"
           >
             <a
                 class="alg-link list-item-link"
@@ -91,6 +96,9 @@
             >
               {{ item.string.title }}
             </a>
+            <ng-template #op>
+              <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+            </ng-template>
           </li>
         </ul>
         <p class="note-caption" i18n>
@@ -117,16 +125,4 @@
   <ng-template #notAllowToView>
     <alg-error icon="ph ph-prohibit" i18n>You are not allowed to view dependencies for this content</alg-error>
   </ng-template>
-
-  <p-overlayPanel
-    styleClass="alg-path-suggestion-overlay"
-    #op
-  >
-    <ng-container *ngIf="op.overlayVisible">
-      <alg-path-suggestion
-        [itemId]="itemId()"
-        (resize)="op.align()"
-      ></alg-path-suggestion>
-    </ng-container>
-  </p-overlayPanel>
 </ng-container>

--- a/src/app/items/containers/item-dependencies/item-dependencies.component.ts
+++ b/src/app/items/containers/item-dependencies/item-dependencies.component.ts
@@ -3,7 +3,6 @@ import { GetItemPrerequisitesService } from '../../data-access/get-item-prerequi
 import { ReplaySubject, Subject, switchMap } from 'rxjs';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { map, share } from 'rxjs/operators';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { ItemData } from '../../models/item-data';
 import { AddedContent } from 'src/app/ui-components/add-content/add-content.component';
 import { ItemType } from 'src/app/items/models/item-type';
@@ -36,7 +35,6 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
     NgFor,
     RouterLink,
     AddDependencyComponent,
-    OverlayPanelModule,
     PathSuggestionComponent,
     AsyncPipe,
     ItemRoutePipe,

--- a/src/app/items/containers/item-unlock-access/item-unlock-access.component.html
+++ b/src/app/items/containers/item-unlock-access/item-unlock-access.component.html
@@ -20,6 +20,7 @@
         [algShowOverlay]="op"
         (overlayOpenEvent)="itemId.set(item.id)"
         (overlayCloseEvent)="itemId.set(undefined)"
+        #overlay="algShowOverlay"
       >
         <div class="list-item-left">
           <span class="activity-progress">
@@ -38,16 +39,11 @@
           </a>
         </div>
         <i class="lock-icon ph-duotone ph-lock" *ngIf="item.isLocked"></i>
+        <ng-template #op>
+          <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+        </ng-template>
       </li>
     </ul>
 
-    <p-overlayPanel
-      styleClass="alg-path-suggestion-overlay"
-      #op
-    >
-      <ng-container *ngIf="op.overlayVisible">
-        <alg-path-suggestion [itemId]="itemId()"></alg-path-suggestion>
-      </ng-container>
-    </p-overlayPanel>
   </ng-container>
 </ng-container>

--- a/src/app/items/containers/item-unlock-access/item-unlock-access.component.ts
+++ b/src/app/items/containers/item-unlock-access/item-unlock-access.component.ts
@@ -1,6 +1,5 @@
 import { Component, ElementRef, Input, OnChanges, OnDestroy, QueryList, signal, ViewChildren } from '@angular/core';
 import { ItemData } from '../../models/item-data';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
 import { ReplaySubject, Subject, switchMap } from 'rxjs';
 import { map, share } from 'rxjs/operators';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
@@ -30,7 +29,6 @@ import { outputFromObservable } from '@angular/core/rxjs-interop';
     NgFor,
     ScoreRingComponent,
     RouterLink,
-    OverlayPanelModule,
     PathSuggestionComponent,
     AsyncPipe,
     ItemRoutePipe,

--- a/src/app/ui-components/add-content/add-content.component.html
+++ b/src/app/ui-components/add-content/add-content.component.html
@@ -78,6 +78,7 @@
           [algShowOverlay]="op"
           (overlayOpenEvent)="itemId.set(item.id)"
           (overlayCloseEvent)="itemId.set(undefined)"
+          #overlay="algShowOverlay"
         >
           <div class="add-content-list-left">
             <span class="add-content-type">{{ item.type }}</span>
@@ -98,6 +99,9 @@
               (click)="addExisting(item)"
             >{{ addedIds.includes(item.id || '') ? addedText : selectExistingText }}</button>
           </div>
+          <ng-template #op>
+            <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+          </ng-template>
         </li>
       </ul>
       <ng-template #emptyMessage>
@@ -109,12 +113,3 @@
     </div>
   </ng-container>
 </ng-template>
-
-<p-overlayPanel
-  styleClass="alg-path-suggestion-overlay"
-  #op
->
-  <ng-container *ngIf="op.overlayVisible">
-    <alg-path-suggestion [itemId]="itemId()"></alg-path-suggestion>
-  </ng-container>
-</p-overlayPanel>

--- a/src/app/ui-components/add-content/add-content.component.ts
+++ b/src/app/ui-components/add-content/add-content.component.ts
@@ -8,8 +8,7 @@ import { FetchState } from '../../utils/state';
 import { LoadingComponent } from '../loading/loading.component';
 import { TooltipModule } from 'primeng/tooltip';
 import { InputComponent } from '../input/input.component';
-import { NgIf, NgClass, NgFor, SlicePipe, AsyncPipe } from '@angular/common';
-import { OverlayPanelModule } from 'primeng/overlaypanel';
+import { NgIf, NgClass, NgFor, SlicePipe } from '@angular/common';
 import { PathSuggestionComponent } from '../../containers/path-suggestion/path-suggestion.component';
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
@@ -46,9 +45,7 @@ const defaultFormValues = { title: '', url: '', searchExisting: '' };
     LoadingComponent,
     NgFor,
     SlicePipe,
-    OverlayPanelModule,
     PathSuggestionComponent,
-    AsyncPipe,
     ShowOverlayDirective,
     ShowOverlayHoverTargetDirective,
     ButtonComponent,

--- a/src/app/ui-components/overlay/show-overlay.directive.ts
+++ b/src/app/ui-components/overlay/show-overlay.directive.ts
@@ -1,27 +1,48 @@
-import { AfterViewInit, ContentChild, Directive, HostListener, Input, OnDestroy, output } from '@angular/core';
+import {
+  AfterViewInit,
+  contentChild,
+  Directive,
+  HostListener,
+  inject,
+  input,
+  OnDestroy,
+  output,
+  TemplateRef,
+  ViewContainerRef
+} from '@angular/core';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
-import { BehaviorSubject, EMPTY, fromEvent, merge, Subject } from 'rxjs';
-import { debounceTime, distinctUntilChanged, filter, shareReplay, switchMap, takeUntil } from 'rxjs/operators';
-import { OverlayPanel } from 'primeng/overlaypanel';
+import { BehaviorSubject, fromEvent, merge, Subject } from 'rxjs';
+import { debounceTime, distinctUntilChanged, filter, shareReplay, takeUntil } from 'rxjs/operators';
 import { canCloseOverlay } from 'src/app/utils/overlay';
+import { Overlay } from '@angular/cdk/overlay';
+import { TemplatePortal } from '@angular/cdk/portal';
 
 @Directive({
   selector: '[algShowOverlay]',
   standalone: true,
+  exportAs: 'algShowOverlay',
 })
 export class ShowOverlayDirective implements OnDestroy, AfterViewInit {
   overlayOpenEvent = output<Event>();
   overlayCloseEvent = output();
-  @Input({ required: true }) algShowOverlay!: OverlayPanel;
+  algShowOverlay = input.required<TemplateRef<unknown>>();
 
-  @ContentChild(ShowOverlayHoverTargetDirective) overlayHoverTarget?: ShowOverlayHoverTargetDirective;
+  overlayHoverTarget = contentChild.required(ShowOverlayHoverTargetDirective);
 
   readonly destroyed$ = new Subject<void>();
   private readonly showOverlaySubject$ = new BehaviorSubject<Event|undefined>(undefined);
-  showOverlay$ = merge(
+  private showOverlay$ = merge(
     this.showOverlaySubject$.pipe(debounceTime(750)),
     this.showOverlaySubject$.pipe(filter(value => !value)), // this allows to close the overlay immediately and not after debounce delay
   ).pipe(distinctUntilChanged(), shareReplay(1));
+
+  private overlay = inject(Overlay);
+  private viewContainerRef = inject(ViewContainerRef);
+
+  private overlayRef = this.overlay.create({
+    scrollStrategy: this.overlay.scrollStrategies.reposition(),
+    panelClass: 'alg-path-suggestion-overlay',
+  });
 
   @HostListener('mouseleave', [ '$event' ]) onHover(event: MouseEvent): void {
     if (canCloseOverlay(event)) {
@@ -30,33 +51,77 @@ export class ShowOverlayDirective implements OnDestroy, AfterViewInit {
   }
 
   ngAfterViewInit(): void {
-    if (!this.overlayHoverTarget) throw new Error('Unexpected: No "ShowOverlayHoverTargetDirective" provided');
+    this.overlayRef.updatePositionStrategy(
+      this.overlay.position().flexibleConnectedTo(
+        this.overlayHoverTarget().nativeElement,
+      ).withPositions([
+        {
+          originX: 'start',
+          originY: 'bottom',
+          overlayX: 'start',
+          overlayY: 'top',
+        },
+        {
+          originX: 'start',
+          originY: 'top',
+          overlayX: 'start',
+          overlayY: 'bottom',
+        },
+        {
+          originX: 'start',
+          originY: 'center',
+          overlayX: 'end',
+          overlayY: 'center',
+        },
+        {
+          originX: 'end',
+          originY: 'center',
+          overlayX: 'start',
+          overlayY: 'center',
+        },
+      ])
+    );
 
     this.showOverlay$.pipe(takeUntil(this.destroyed$)).subscribe(event => {
       if (event) {
-        this.algShowOverlay.toggle(event, event.target);
+        this.attachOverlay();
         this.overlayOpenEvent.emit(event);
       } else {
-        this.algShowOverlay.hide();
+        this.detachOverlay();
         this.overlayCloseEvent.emit();
       }
     });
 
-    fromEvent(this.overlayHoverTarget.nativeElement, 'mouseenter').pipe(takeUntil(this.destroyed$)).subscribe(event => {
+    fromEvent(this.overlayHoverTarget().nativeElement, 'mouseenter').pipe(takeUntil(this.destroyed$)).subscribe(event => {
       this.showOverlaySubject$.next(event);
     });
 
-    this.algShowOverlay.onShow.pipe(
-      switchMap(() => (this.algShowOverlay.container ? fromEvent(this.algShowOverlay.container, 'mouseleave') : EMPTY)),
-      takeUntil(this.destroyed$),
-    ).subscribe(() => {
-      this.showOverlaySubject$.next(undefined);
-    });
+    fromEvent(this.overlayRef.hostElement, 'mouseleave').pipe(takeUntil(this.destroyed$)).subscribe(() =>
+      this.showOverlaySubject$.next(undefined)
+    );
   }
 
   ngOnDestroy(): void {
     this.showOverlaySubject$.complete();
     this.destroyed$.next();
     this.destroyed$.complete();
+    this.detachOverlay();
+  }
+
+  private attachOverlay(): void {
+    if (!this.overlayRef.hasAttached()) {
+      const portal = new TemplatePortal(this.algShowOverlay(), this.viewContainerRef);
+      this.overlayRef.attach(portal);
+    }
+  }
+
+  private detachOverlay(): void {
+    if (this.overlayRef.hasAttached()) {
+      this.overlayRef.detach();
+    }
+  }
+
+  updatePosition(): void {
+    this.overlayRef.updatePosition();
   }
 }

--- a/src/assets/scss/components/path-suggestion-overlay.scss
+++ b/src/assets/scss/components/path-suggestion-overlay.scss
@@ -1,6 +1,6 @@
 @import 'src/assets/scss/functions';
 
-.alg-path-suggestion-overlay, .alg-menu-overlay {
+.alg-menu-overlay {
   min-width: 30rem;
   max-width: 50rem;
   background-color: var(--alg-primary-color);
@@ -37,5 +37,18 @@
 
   @media screen and (max-width: 1100px) {
     max-width: 40rem;
+  }
+}
+
+.alg-path-suggestion-overlay {
+  min-width: 30rem;
+  max-width: 50rem;
+  background-color: var(--alg-primary-color);
+  border-radius: toRem(10);
+  border: none;
+  z-index: 2;
+
+  @media screen and (max-width: 1100px) {
+    max-width: 100vw;
   }
 }


### PR DESCRIPTION
## Description

Fixes #1873

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

I didn't put triangle in this version as the position depends on viewport and can be too varius. Also I've added scroll inside path suggestion content, so less chance that the user can't reach content, as it was before.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/path-suggestion-overlay/en/groups/by-id/9213510114403290476;p=/history)
  3. And I hover on content item in table
  4. Then I see new path suggestion
