### PR TITLE
fix the i18n CI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -362,18 +362,20 @@ workflows:
       - lint:
           requires:
           - deps
-      - fetch-translations:
-          context: crowdin
-          filters:
-            tags:
-              only: /^v\d+\.\d+\..*/
-            branches:
-              only: master
       - push-translation-source:
           requires:
             - deps
           context: crowdin
           filters:
+            branches:
+              only: master
+      - fetch-translations:
+          requires:
+            - push-translation-source # so that new strings appears in the translations (even if not translated)
+          context: crowdin
+          filters:
+            tags:
+              only: /^v\d+\.\d+\..*/
             branches:
               only: master
       - build-branch-en:


### PR DESCRIPTION
Small fix: require fetch-translations to have the source pushed first so that the new strings are not missing