### PR TITLE
Fixes issue with more than 2 translates in config

### DIFF
--- a/e2e/items/item-edit-strings.spec.ts
+++ b/e2e/items/item-edit-strings.spec.ts
@@ -10,7 +10,7 @@ test.afterEach(({ deleteItem }) => {
   if (!deleteItem) throw new Error('Unexpected: missed deleted item data');
 });
 
-test.skip('checks item edit strings', async ({ page, createItem, itemContentPage }) => {
+test('checks item edit strings', async ({ page, createItem, itemContentPage }) => {
   if (!createItem) throw new Error('The item is not created');
 
   const itemStringsSectionLocator = page.locator('alg-item-strings-control');


### PR DESCRIPTION
## Description

Fixes issues with handling of 404 error when more than 2 translates in config

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the demo user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/multiply-translates/en/a/3733428171751696856;p=1751831682141956756;pa=0/parameters)
  3. And I click on "Translate to de"
  4. And I fill new translates
  5. And I click "Save" button
  6. Then I see translated (DE) section
