### PR TITLE
Fix bug on item state

### DIFF
--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -66,7 +66,13 @@ import { ItemBreadcrumbsWithFailoverService } from './services/item-breadcrumbs-
 import { ItemExtraTimeComponent } from './containers/item-extra-time/item-extra-time.component';
 import { itemRouteAsUrlCommand } from '../models/routing/item-route-serialization';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
-import equal from 'fast-deep-equal/es6';
+import { createSelector } from '@ngrx/store';
+
+const selectState = createSelector(
+  fromItemContent.selectActiveContentRouteErrorHandlingState,
+  fromItemContent.selectActiveContentData,
+  (routeErrorHandlingState, itemData) => (routeErrorHandlingState === null ? itemData : routeErrorHandlingState)
+);
 
 /**
  * ItemByIdComponent is just a container for detail or edit page but manages the fetching on id change and (un)setting the current content.
@@ -120,10 +126,10 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     filter(isNotNull),
   );
 
-  state$: Observable<FetchState<ItemData>> = merge(
-    this.store.select(fromItemContent.selectActiveContentRouteErrorHandlingState).pipe(filter(isNotNull)),
-    this.itemState$.pipe(distinctUntilChanged((x, y) => equal(x.data, y.data))),
-  );
+  /**
+   * The general state, either the route error handling state, or if not routing error, the item data
+   */
+  state$: Observable<FetchState<ItemData>> = this.store.select(selectState).pipe(filter(isNotNull));
 
   // to prevent looping indefinitely in case of bug in services (wrong path > item without path > fetch path > item with path > wrong path)
   hasRedirected = false;


### PR DESCRIPTION
Fix a bug that may cause the item by id to be stuck on fetching if we change route while staying on the same item

It was introduced by https://github.com/France-ioi/AlgoreaFrontend/pull/1967.

Explanation: 
> Actually the fix is not correct, that may create some new bugs in some scenarios (maybe not possible when the code was written): If we stay on the same item page with the same data (navigate from an item to the same item id) but have a route error in the middle (for instance the path or attempt is missing): as the data hasn't changed, it does not re-emit and so state$ stays on what was last emitted from this.store.select(fromItemContent.selectActiveContentRouteErrorHandlingState).pipe(filter(isNotNull) which is a fetching state; and so the item page stays on fetching forever while the actual item state is ready.

Tested: the bug fixed by #1967 did not reappeared.