### PR TITLE
use the app language as default string language for items

### DIFF
--- a/src/app/groups/containers/group-edit/group-edit.component.ts
+++ b/src/app/groups/containers/group-edit/group-edit.component.ts
@@ -33,6 +33,7 @@ import { Store } from '@ngrx/store';
 import { fromGroupContent } from '../../store';
 import { LetDirective } from '@ngrx/component';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
+import { LocaleService } from 'src/app/services/localeService';
 
 @Component({
   selector: 'alg-group-edit',
@@ -101,6 +102,7 @@ export class GroupEditComponent implements OnInit, OnDestroy, PendingChangesComp
 
   constructor(
     private store: Store,
+    private localeService: LocaleService,
     private currentContentService: CurrentContentService,
     private actionFeedbackService: ActionFeedbackService,
     private formBuilder: UntypedFormBuilder,
@@ -160,6 +162,8 @@ export class GroupEditComponent implements OnInit, OnDestroy, PendingChangesComp
       = this.groupForm.get('requireLockMembershipApprovalUntil')?.value as GroupApprovals['requireLockMembershipApprovalUntil'];
     const requirePersonalInfoAccessApproval
       = this.groupForm.get('requirePersonalInfoAccessApproval')?.value as GroupApprovals['requirePersonalInfoAccessApproval'];
+    const languageTag = this.localeService.currentLang?.tag;
+    if (!languageTag) throw new Error('unexpected: current language not defined');
 
     const rootActivity = this.groupForm.get('rootActivity')?.value as NoAssociatedItem|NewAssociatedItem|ExistingAssociatedItem;
     const rootActivityId$ = !isNewAssociatedItem(rootActivity) ? of(isExistingAssociatedItem(rootActivity) ? rootActivity.id : null) :
@@ -167,7 +171,7 @@ export class GroupEditComponent implements OnInit, OnDestroy, PendingChangesComp
         title: rootActivity.name,
         url: rootActivity.url,
         type: rootActivity.itemType,
-        languageTag: 'en',// FIXME
+        languageTag,
         asRootOfGroupId: this.initialFormData.id,
       });
 
@@ -176,7 +180,7 @@ export class GroupEditComponent implements OnInit, OnDestroy, PendingChangesComp
       this.createItemService.create({
         title: rootSkill.name,
         type: rootSkill.itemType,
-        languageTag: 'en',// FIXME
+        languageTag,
         asRootOfGroupId: this.initialFormData.id,
       });
 

--- a/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.ts
+++ b/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.ts
@@ -20,6 +20,7 @@ import { FloatingSaveComponent } from 'src/app/ui-components/floating-save/float
 import { NgIf, NgClass } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { fromItemContent } from '../../store';
+import { LocaleService } from 'src/app/services/localeService';
 
 @Component({
   selector: 'alg-item-children-edit-form',
@@ -49,6 +50,7 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
 
   constructor(
     private store: Store,
+    private localeService: LocaleService,
     private createItemService: CreateItemService,
     private updateItemService: UpdateItemService,
     private actionFeedbackService: ActionFeedbackService,
@@ -76,6 +78,9 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
       return of([]);
     }
 
+    const languageTag = this.localeService.currentLang?.tag;
+    if (!languageTag) throw new Error('unexpected: current language not defined');
+
     return forkJoin(
       this.itemChanges.children.map(child => {
         if (!this.itemData) throw new Error('Missed item data');
@@ -86,7 +91,7 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
           title: child.title,
           type: child.type,
           url: child.url,
-          languageTag: 'en',
+          languageTag,
           parent: this.itemData.item.id,
         };
         return this.createItemService


### PR DESCRIPTION
Until now all the newly created item were using English as the language tag.
Fix: use the app language now.