### PR TITLE
on narrow screen, when only the left menu is displayed, hide the menu when selecting the 'join' or 'manage' button

### DIFF
--- a/src/app/groups/containers/manage-groups/manage-groups.component.ts
+++ b/src/app/groups/containers/manage-groups/manage-groups.component.ts
@@ -10,6 +10,7 @@ import { CurrentContentService } from 'src/app/services/current-content.service'
 import { Store } from '@ngrx/store';
 import { fromCurrentContent } from 'src/app/store/navigation/current-content/current-content.store';
 import { managedGroupsPage } from 'src/app/models/routing/group-route';
+import { ContentDisplayType, LayoutService } from 'src/app/services/layout.service';
 
 @Component({
   selector: 'alg-manage-groups',
@@ -28,6 +29,7 @@ export class ManageGroupsComponent implements OnInit, OnDestroy {
 
   constructor(
     private store: Store,
+    private layoutService: LayoutService,
     private currentContent: CurrentContentService,
     private sessionService: UserSessionService,
   ) {
@@ -35,6 +37,7 @@ export class ManageGroupsComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.currentContent.replace(myGroupsInfo({}));
+    this.layoutService.configure({ contentDisplayType: ContentDisplayType.Show });
     this.store.dispatch(fromCurrentContent.contentPageActions.changeContent({
       route: managedGroupsPage,
       title: $localize`Manage groups`,

--- a/src/app/groups/containers/my-groups/my-groups.component.ts
+++ b/src/app/groups/containers/my-groups/my-groups.component.ts
@@ -13,6 +13,7 @@ import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { myGroupsPage } from 'src/app/models/routing/group-route';
 import { Store } from '@ngrx/store';
 import { fromCurrentContent } from 'src/app/store/navigation/current-content/current-content.store';
+import { ContentDisplayType, LayoutService } from 'src/app/services/layout.service';
 
 @Component({
   selector: 'alg-my-groups',
@@ -36,12 +37,14 @@ export class MyGroupsComponent implements OnDestroy, OnInit {
 
   constructor(
     private store: Store,
+    private layoutService: LayoutService,
     private currentContent: CurrentContentService,
     private sessionService: UserSessionService,
   ) {}
 
   ngOnInit(): void {
     this.currentContent.replace(myGroupsInfo({}));
+    this.layoutService.configure({ contentDisplayType: ContentDisplayType.Show });
     this.store.dispatch(fromCurrentContent.contentPageActions.changeContent({
       route: myGroupsPage,
       title: $localize`My groups`,


### PR DESCRIPTION
when selecting the 'join' or 'manage' button

## Test cases

- [ ] Case 1:
  1. Given I am any user
  2. I go the website https://dev.algorea.org/branch/close-left-menu-on-summary-group-pages/en/
  3. If I use a narrow screen and display the left menu 
  4. If I select the "join" or "manage" button in the left menu
  5. The left menu closes