### PR TITLE
Replaces primeng table with custome one in group log view

### DIFF
--- a/e2e/common/show-path-suggestion-overflow.spec.ts
+++ b/e2e/common/show-path-suggestion-overflow.spec.ts
@@ -66,11 +66,11 @@ test('checks path suggestion in group logs', async ({ page, showOverflow }) => {
 
   await page.goto('/groups/by-id/4306830013673248439;p=614090468359597091/history');
 
-  const firstRowLocator = page.locator('alg-group-log-view').locator('p-table').locator('tbody').locator('tr').first();
+  const firstRowLocator = page.locator('alg-group-log-view').locator('table').locator('tbody').locator('tr').first();
   const targetLinkLocator = firstRowLocator.locator('td').nth(1).locator('a');
 
   await test.step('checks logs are visible', async () => {
-    await expect.soft(page.locator('alg-group-log-view').locator('p-table')).toBeVisible();
+    await expect.soft(page.locator('alg-group-log-view').locator('table')).toBeVisible();
     await expect.soft(firstRowLocator).toBeVisible();
     await expect.soft(targetLinkLocator).toBeVisible();
   });

--- a/e2e/groups/pages/group-history-page.ts
+++ b/e2e/groups/pages/group-history-page.ts
@@ -1,7 +1,7 @@
 import { Page, expect } from '@playwright/test';
 
 export class GroupHistoryPage {
-  tableLocator = this.page.locator('alg-group-log-view').locator('p-table');
+  tableLocator = this.page.locator('alg-group-log-view').locator('table');
   forbiddenMessageLocator = this.page
     .getByText('You don\'t have permission to view this group\'s history.');
 

--- a/src/app/groups/containers/group-log-view/group-log-view.component.html
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.html
@@ -22,103 +22,105 @@
         Refresh
       </button>
     </div>
-    <p-table
-      class="alg-table"
-      [value]="state.data"
-      [loading]="state.isFetching"
-      [tableStyle]="{'min-width': '599.98px'}"
-      responsiveLayout="scroll"
-    >
-      <ng-template pTemplate="header" let-rowData>
-        <tr *ngIf="state.data.length > 0">
-          <th i18n>Action</th>
-          <th i18n>Content</th>
-          <th i18n *ngIf="this.showUserColumn">User</th>
-          <th i18n>Time</th>
-        </tr>
-      </ng-template>
 
-      <ng-template
-          pTemplate="body"
-          let-rowData
-          let-index="rowIndex"
-      >
-        <tr>
-          <td>
-            <div class="item-title-section">
-              <div class="item-title-section-left">
-                <alg-score-ring
-                  [currentScore]="rowData.score"
-                  [diameter]="32"
-                  *ngIf="rowData.score; else iconSection"
-                ></alg-score-ring>
-                <ng-template #iconSection>
-                  <i class="item-icon {{ rowData.activityType | logActivityTypeIcon }}"></i>
-                </ng-template>
+    <div class="alg-table-page-wrapper">
+      <div class="alg-table-horizontal-scroll">
+        <table class="alg-table-v2" cdk-table [dataSource]="state.data">
+          <ng-container cdkColumnDef="action">
+            <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef i18n>Action</th>
+            <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
+              <div class="item-title-section">
+                <div class="item-title-section-left">
+                  <alg-score-ring
+                    [currentScore]="rowData.score"
+                    [diameter]="32"
+                    *ngIf="rowData.score; else iconSection"
+                  ></alg-score-ring>
+                  <ng-template #iconSection>
+                    <i class="item-icon {{ rowData.activityType | logActivityTypeIcon }}"></i>
+                  </ng-template>
+                </div>
+                <div class="item-title">
+                  <p class="item-title-caption">{{ rowData.activityType | logActionDisplay }}</p>
+                  <a
+                    class="alg-link"
+                    [routerLink]="rowData.item | itemRoute: $any({ answer: { id: rowData.answerId } }) | url"
+                    *ngIf="rowData.allowToViewAnswer && [ 'submission', 'saved_answer' ].includes(rowData.activityType) && rowData.answerId"
+                  >
+                    View answer
+                  </a>
+                </div>
               </div>
-              <div class="item-title">
-                <p class="item-title-caption">{{ rowData.activityType | logActionDisplay }}</p>
-                <a
-                  class="alg-link"
-                  [routerLink]="rowData.item | itemRoute: $any({ answer: { id: rowData.answerId } }) | url"
-                  *ngIf="rowData.allowToViewAnswer && [ 'submission', 'saved_answer' ].includes(rowData.activityType) && rowData.answerId"
-                >
-                  View answer
-                </a>
-              </div>
-            </div>
-          </td>
-          <td
-            [algShowOverlay]="op"
-            (overlayOpenEvent)="itemId.set(rowData.item.id)"
-            (overlayCloseEvent)="itemId.set(undefined)"
-            #overlay="algShowOverlay"
-          >
-            <a
-              class="alg-link"
-              [ngClass]="{'disabled': !rowData.item}"
-              [routerLink]="rowData.item | itemRoute | url"
-              algShowOverlayHoverTarget
+            </td>
+          </ng-container>
+
+          <ng-container cdkColumnDef="content">
+            <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef i18n>Content</th>
+            <td
+              class="alg-table-td"
+              cdk-cell
+              *cdkCellDef="let rowData"
+              [algShowOverlay]="op"
+              (overlayOpenEvent)="itemId.set(rowData.item.id)"
+              (overlayCloseEvent)="itemId.set(undefined)"
+              #overlay="algShowOverlay"
             >
-              {{ rowData.item.string.title }}
-            </a>
-            <ng-template #op>
-              <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
-            </ng-template>
-          </td>
-          <td *ngIf="this.showUserColumn">
-            @if (rowData.user) {
-              <a class="alg-link" [routerLink]="rowData.user | groupLink">{{ rowData.user | userCaption }}</a>
-            } @else {
-              {{ rowData.participant.name }}
-            }
-          </td>
-          <td>{{ rowData.at | date:'short' }}</td>
-        </tr>
-      </ng-template>
-      <ng-template pTemplate="emptymessage">
-        <tr>
-          <td>
-            <span i18n>There is no progress to report for this group/user.</span>
-          </td>
-        </tr>
-      </ng-template>
-      <ng-template pTemplate="footer">
-        <tr *ngIf="datapager.canLoadMore$ | async">
-          <td [attr.colspan]="this.showUserColumn ? 4 : 3">
-            <div class="text-center">
-              <button
-                alg-button
-                class="size-s stroke"
-                icon="ph-duotone ph-arrow-circle-down"
-                (click)="fetchMoreRows()"
-                [disabled]="state.isFetching || state.isError"
-                i18n
-              >Load more</button>
-            </div>
-          </td>
-        </tr>
-      </ng-template>
-    </p-table>
+              <a
+                class="alg-link"
+                [ngClass]="{'disabled': !rowData.item}"
+                [routerLink]="rowData.item | itemRoute | url"
+                algShowOverlayHoverTarget
+              >
+                {{ rowData.item.string.title }}
+              </a>
+              <ng-template #op>
+                <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+              </ng-template>
+            </td>
+          </ng-container>
+
+          <ng-container cdkColumnDef="user">
+            <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef i18n>User</th>
+            <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
+              @if (rowData.user) {
+                <a class="alg-link" [routerLink]="rowData.user | groupLink">{{ rowData.user | userCaption }}</a>
+              } @else {
+                {{ rowData.participant.name }}
+              }
+            </td>
+          </ng-container>
+
+          <ng-container cdkColumnDef="time">
+            <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef i18n>Time</th>
+            <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
+              {{ rowData.at | date:'short' }}
+            </td>
+          </ng-container>
+
+          @if (state.data.length > 0) {
+            <tr class="alg-table-header-tr" cdk-header-row *cdkHeaderRowDef="displayedColumns()"></tr>
+          }
+          <tr class="alg-table-body-tr" cdk-row *cdkRowDef="let row; columns: displayedColumns()"></tr>
+          <tr class="alg-table-body-tr" *cdkNoDataRow>
+            <td class="alg-table-td empty-td" [attr.colspan]="displayedColumns().length">
+              <span i18n>There is no progress to report for this group/user.</span>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
+
+    @if (datapager.canLoadMore$ | async) {
+      <div class="alg-table-load-more">
+        <button
+          alg-button
+          class="size-s stroke"
+          icon="ph-duotone ph-arrow-circle-down"
+          (click)="fetchMoreRows()"
+          [disabled]="state.isFetching || state.isError"
+          i18n
+        >Load more</button>
+      </div>
+    }
   </ng-container>
 </ng-container>

--- a/src/app/groups/containers/group-log-view/group-log-view.component.ts
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.ts
@@ -1,5 +1,7 @@
 import {
   Component,
+  computed,
+  input,
   Input,
   OnChanges,
   signal,
@@ -19,7 +21,6 @@ import { PathSuggestionComponent } from 'src/app/containers/path-suggestion/path
 import { RouterLink } from '@angular/router';
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
 import { SharedModule } from 'primeng/api';
-import { TableModule } from 'primeng/table';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
 import { NgIf, NgClass, AsyncPipe, DatePipe } from '@angular/common';
@@ -28,6 +29,19 @@ import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/s
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
 import { LogActivityTypeIconPipe } from 'src/app/pipes/logActivityTypeIcon';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
+import {
+  CdkCell,
+  CdkCellDef,
+  CdkColumnDef,
+  CdkHeaderCell,
+  CdkHeaderCellDef,
+  CdkHeaderRow,
+  CdkHeaderRowDef,
+  CdkNoDataRow,
+  CdkRow,
+  CdkRowDef,
+  CdkTable
+} from '@angular/cdk/table';
 
 const logsLimit = 20;
 
@@ -40,7 +54,6 @@ const logsLimit = 20;
     NgIf,
     LoadingComponent,
     ErrorComponent,
-    TableModule,
     SharedModule,
     ScoreRingComponent,
     NgClass,
@@ -57,14 +70,31 @@ const logsLimit = 20;
     ShowOverlayDirective,
     LogActivityTypeIconPipe,
     ButtonComponent,
+    CdkTable,
+    CdkColumnDef,
+    CdkHeaderCell,
+    CdkHeaderCellDef,
+    CdkCell,
+    CdkCellDef,
+    CdkHeaderRow,
+    CdkHeaderRowDef,
+    CdkRow,
+    CdkRowDef,
+    CdkNoDataRow,
   ],
 })
 export class GroupLogViewComponent implements OnChanges {
 
   @Input() groupId?: string;
-  @Input() showUserColumn = true;
+  showUserColumn = input(true);
 
   itemId = signal<string | undefined>(undefined);
+  displayedColumns = computed(() => [
+    'action',
+    'content',
+    ...(this.showUserColumn() ? [ 'user' ] : []),
+    'time',
+  ]);
 
   datapager = new DataPager({
     fetch: (pageSize, latestRow?: ActivityLogs[number]): Observable<ActivityLogs> => this.getRows(pageSize, latestRow),


### PR DESCRIPTION
## Description

Fixes #1872

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/grop-log-view-table/en/groups/by-id/5121055722873780306;p=/history)
  3. Then I see new table with same design

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/grop-log-view-table/en/groups/users/670968966872011405)
  3. Then I see new table without user column

- [ ] Case 3:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/grop-log-view-table/en/groups/by-id/8385260527422849505;p=5121055722873780306/history)
  3. Then I see new table with no data state
