### PR TITLE
display the answer author indicator on all task tabs

### DIFF
--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -53,17 +53,15 @@
               </alg-error>
             } @else {
               <ng-container *ngrxLet="taskConfig$ as taskConfig">
-                @if (taskConfig && taskConfig.readOnly && currentTab && ['alg-content', 'task'].includes(currentTab.tag)) {
+                @if (taskConfig && taskConfig.readOnly && taskConfig.initialAnswer && currentTab && currentTab?.isTaskTab) {
                   <div
                     class="indicator"
                     [ngClass]="{ 'no-left-padding': !fullFrameContentDisplayed }"
                     >
-                    @if (!!currentTab?.isTaskTab && taskConfig.initialAnswer) {
                       <alg-answer-author-indicator
                         [answer]="taskConfig.initialAnswer"
                         [itemData]="itemData"
                       ></alg-answer-author-indicator>
-                    }
                   </div>
                 }
                 <alg-item-content


### PR DESCRIPTION
## Description

Display the answer author indicator on all task tabs.

Actually... I don't understand exactly what was the previous logic.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page which opens an answer](https://dev.algorea.org/branch/display-author-indicator-on-all-task-tabs/en/a/9105453971757450756;p=694914435881177216,5,4700,4707,4702,7528142386663912287,7523720120450464843;a=0;answerId=8740238420944244640;og=4462192261130512818)
  3. And I see the answer author banner (blue)
  4. And I click on the "solve" tab
  3. And I see the answer author banner (blue)
  6. And I click on the "history" tab
  7.  And I don't see the answer author banner (blue) anymore
