### PR TITLE
fix: keep observation while using the breaadcrumbs

### DIFF
--- a/src/app/containers/breadcrumbs/breadcrumbs.component.ts
+++ b/src/app/containers/breadcrumbs/breadcrumbs.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { Router, UrlTree } from '@angular/router';
+import { Router } from '@angular/router';
 import { TooltipModule } from 'primeng/tooltip';
 import { NgIf, NgFor, NgClass } from '@angular/common';
 import { createSelector, Store } from '@ngrx/store';
@@ -36,11 +36,8 @@ export class BreadcrumbsComponent {
     private router: Router,
   ) {}
 
-  onElementClick(el: { navigateTo?: UrlTree|(() => UrlTree) }): void {
-    if (el.navigateTo) {
-      const dest = 'root' in el.navigateTo ? el.navigateTo : el.navigateTo();
-      void this.router.navigateByUrl(dest);
-    }
+  onElementClick(el: { navigateTo?: () => void }): void {
+    if (el.navigateTo) el.navigateTo();
   }
 
 }

--- a/src/app/groups/containers/user/user.component.ts
+++ b/src/app/groups/containers/user/user.component.ts
@@ -78,8 +78,11 @@ export class UserComponent implements OnInit, OnDestroy {
           route: 'user-by-id',
           title: state.isReady ? formatUser(state.data) : undefined,
           breadcrumbs: state.isReady ? [
-            ...(breadcrumbs?.data?.slice(0,-1) ?? []).map(b => ({ title: b.name, navigateTo: this.groupRouter.url(b.route) })),
-            { title: formatUser(state.data), navigateTo: this.groupRouter.url(currentUserRoute) },
+            ...(breadcrumbs?.data?.slice(0,-1) ?? []).map(b => ({
+              title: b.name,
+              navigateTo: (): void => this.groupRouter.navigateTo(b.route)
+            })),
+            { title: formatUser(state.data), navigateTo: (): void => this.groupRouter.navigateTo(currentUserRoute) },
             { title: currentPageTitle }
           ] : undefined
         }));

--- a/src/app/groups/models/group-breadcrumbs.ts
+++ b/src/app/groups/models/group-breadcrumbs.ts
@@ -1,4 +1,3 @@
-import { UrlTree } from '@angular/router';
 import { z } from 'zod';
 import { ContentBreadcrumbs } from 'src/app/models/content/content-breadcrumbs';
 import { GroupRoute } from 'src/app/models/routing/group-route';
@@ -19,6 +18,6 @@ export type GroupBreadcrumbs = GroupBreadcrumb[];
 export function formatBreadcrumbs(breadcrumbs: GroupBreadcrumbs, groupRouter: GroupRouter): ContentBreadcrumbs {
   return breadcrumbs.map(breadcrumb => ({
     title: breadcrumb.name,
-    navigateTo: (): UrlTree => groupRouter.url(breadcrumb.route),
+    navigateTo: (): void => groupRouter.navigateTo(breadcrumb.route),
   }));
 }

--- a/src/app/items/models/item-breadcrumbs.ts
+++ b/src/app/items/models/item-breadcrumbs.ts
@@ -1,11 +1,10 @@
 import { ContentBreadcrumbs } from 'src/app/models/content/content-breadcrumbs';
 import { BreadcrumbItem } from '../data-access/get-breadcrumb.service';
 import { ItemRouter } from 'src/app/models/routing/item-router';
-import { UrlTree } from '@angular/router';
 
 export function formatBreadcrumbs(breadcrumbs: BreadcrumbItem[], itemRouter: ItemRouter): ContentBreadcrumbs {
   return breadcrumbs.map(el => ({
     title: el.title,
-    navigateTo: ():UrlTree => itemRouter.url(el.route),
+    navigateTo: (): void => itemRouter.navigateTo(el.route, { useCurrentObservation: true }),
   }));
 }

--- a/src/app/models/content/content-breadcrumbs.ts
+++ b/src/app/models/content/content-breadcrumbs.ts
@@ -1,8 +1,7 @@
-import { UrlTree } from '@angular/router';
 
 export type ContentBreadcrumbs = {
   title: string,
-  navigateTo?: UrlTree|(() => UrlTree),
+  navigateTo?: () => void,
 }[];
 
 /*


### PR DESCRIPTION
## Description

When navigating among item using the breadcrumbs, we were loosing observation. Fix it.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [an activity while observing](https://dev.algorea.org/branch/fix-breadcrumbs-observation/en/a/1407961792122993479;p=4702,1471479157476024035;a=0;og=4462192261130512818)
  3. And I click on a parent in the breadcrumbs
  4. Then I 'm still in observation
