### PR TITLE
allow bluetooth for tasks

### DIFF
--- a/src/app/items/containers/item-display/item-display.component.html
+++ b/src/app/items/containers/item-display/item-display.component.html
@@ -77,6 +77,7 @@
       [src]="iframeSrc"
       #iframe
       allowfullscreen
+      allow="bluetooth"
     ></iframe>
   </div>
 </div>


### PR DESCRIPTION
## Description

Allow task to use bluetooth and to ask for it to the browser.

## Test cases
 
- [ ] Case 1:
  1. Given I am any user
  2. And I am using chrome with experimental settings enabled (check [here](https://googlechrome.github.io/samples/web-bluetooth/device-information-characteristics.html) if that works)
  3. When I go to [this task](https://dev.algorea.org/branch/iframe-allow-bluetooth/en/a/6352862621004849212;p=4702,7528142386663912287,7523720120450464843;a=0)
  4. And I select "tymio 3"
  5. anAnd I click "connect"
  6. Then I see the "connect device" enabled 
  8. And I click on it, it browses my Bluetooth devices
