### PR TITLE
Replaces primeng table with custom one in user group invitations, add…

### DIFF
--- a/e2e/groups/pages/mine-page.ts
+++ b/e2e/groups/pages/mine-page.ts
@@ -93,12 +93,12 @@ export class MinePage {
   }
 
   async checkIsUserInvitedToGroupVisible(groupName: string): Promise<void> {
-    await expect.soft(this.userGroupInvitationsLocator.filter({ has: this.page.locator('p-table') })).toBeVisible();
+    await expect.soft(this.userGroupInvitationsLocator.filter({ has: this.page.locator('table') })).toBeVisible();
     await expect.soft(this.userGroupInvitationsLocator.getByRole('cell', { name: groupName })).toBeVisible();
   }
 
   async isUserInvitedToGroup(groupName: string): Promise<boolean> {
-    await expect.soft(this.userGroupInvitationsLocator.filter({ has: this.page.locator('p-table') })).toBeVisible();
+    await expect.soft(this.userGroupInvitationsLocator.filter({ has: this.page.locator('table') })).toBeVisible();
     return this.userGroupInvitationsLocator.getByRole('cell', { name: groupName }).isVisible();
   }
 

--- a/src/app/groups/containers/user-group-invitations/user-group-invitations.component.html
+++ b/src/app/groups/containers/user-group-invitations/user-group-invitations.component.html
@@ -9,71 +9,64 @@
       i18n-message message="Error while loading the group invitations."
     ></alg-error>
   } @else if (state.isReady) {
-    <p-table
-      class="alg-table"
-      [value]="state.data"
-      sortMode="multiple"
-      [customSort]="true"
-      (sortFunction)="onCustomSort($event)"
-    >
-      <ng-template pTemplate="sorticon" let-number>
-        <i class="ph-duotone" [ngClass]="{
-          'ph-arrows-down-up': number === 0,
-          'ph-sort-ascending': number === -1,
-          'ph-sort-descending': number === 1
-        }"></i>
-      </ng-template>
-      <ng-template pTemplate="header">
-        <tr>
-          <th><span i18n>Title</span></th>
-          <th><span i18n>Type</span></th>
-          <th pSortableColumn="at">
-            <span i18n>Requested On</span>
-            <p-sortIcon field="at"></p-sortIcon>
-          </th>
-          <th></th>
-        </tr>
-      </ng-template>
-      <ng-template
-        pTemplate="body"
-        let-rowData
-      >
-        <tr>
-          <td>{{ rowData.group.name }}</td>
-          <td>{{ rowData.group.type }}</td>
-          <td>{{ rowData.at | date: "d/MM/y" }}</td>
-          <td>
-            <div class="operations">
-              <button
-                class="stroke size-l margin-right"
-                data-testid="accept-group"
-                alg-button-icon
-                type="button"
-                icon="ph-bold ph-check"
-                (click)="openJoinGroupConfirmationDialog(rowData)"
-                [disabled]="processing"
-              ></button>
-              <button
-                class="stroke size-l"
-                data-testid="reject-group"
-                alg-button-icon
-                type="button"
-                icon="ph-bold ph-x"
-                (click)="onReject(rowData)"
-                [disabled]="processing"
-              ></button>
-            </div>
-          </td>
-        </tr>
-      </ng-template>
-      <ng-template pTemplate="emptymessage">
-        <tr>
-          <td colspan="5">
-            <p class="empty-message" i18n>No pending requests</p>
-          </td>
-        </tr>
-      </ng-template>
-    </p-table>
+    <div class="alg-table-page-wrapper">
+      <div class="alg-table-horizontal-scroll">
+        <table class="alg-table-v2" cdk-table [dataSource]="state.data" algTableSort (sortChange)="onSortChange($event)">
+          <ng-container cdkColumnDef="name">
+            <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef i18n>Title</th>
+            <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
+              {{ rowData.group.name }}
+            </td>
+          </ng-container>
+          <ng-container cdkColumnDef="type">
+            <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef i18n>Type</th>
+            <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
+              {{ rowData.group.type }}
+            </td>
+          </ng-container>
+          <ng-container cdkColumnDef="at">
+            <th class="alg-table-th" alg-table-sort-header="at" cdk-header-cell *cdkHeaderCellDef i18n>
+              Requested On
+            </th>
+            <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
+              {{ rowData.at | date: "d/MM/y" }}
+            </td>
+          </ng-container>
+          <ng-container cdkColumnDef="operations">
+            <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef></th>
+            <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
+              <div class="operations">
+                <button
+                  class="stroke size-l margin-right"
+                  data-testid="accept-group"
+                  alg-button-icon
+                  type="button"
+                  icon="ph-bold ph-check"
+                  (click)="openJoinGroupConfirmationDialog(rowData)"
+                  [disabled]="processing"
+                ></button>
+                <button
+                  class="stroke size-l"
+                  data-testid="reject-group"
+                  alg-button-icon
+                  type="button"
+                  icon="ph-bold ph-x"
+                  (click)="onReject(rowData)"
+                  [disabled]="processing"
+                ></button>
+              </div>
+            </td>
+          </ng-container>
+          <tr class="alg-table-header-tr" cdk-header-row *cdkHeaderRowDef="displayedColumns()"></tr>
+          <tr class="alg-table-body-tr" cdk-row *cdkRowDef="let row; columns: displayedColumns()"></tr>
+          <tr class="alg-table-body-tr" *cdkNoDataRow>
+            <td class="alg-table-td empty-td" [attr.colspan]="displayedColumns().length">
+              <p class="empty-message" i18n>No pending requests</p>
+            </td>
+          </tr>
+        </table>
+      </div>
+    </div>
   }
 }
 

--- a/src/app/groups/containers/user-group-invitations/user-group-invitations.component.ts
+++ b/src/app/groups/containers/user-group-invitations/user-group-invitations.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnDestroy, Output } from '@angular/core';
+import { Component, EventEmitter, OnDestroy, Output, signal } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { GetRequestsService, GroupInvitation } from '../../data-access/get-requests.service';
@@ -10,15 +10,28 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
 import { AsyncPipe, DatePipe, NgClass, NgForOf, NgIf, NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { ProcessGroupInvitationService } from '../../data-access/process-group-invitation.service';
-import { TableModule } from 'primeng/table';
 import { UserCaptionPipe } from 'src/app/pipes/userCaption';
-import { SortEvent } from 'primeng/api/sortevent';
 import { mapToFetchState } from 'src/app/utils/operators/state';
 import {
   JoinGroupConfirmationDialogComponent,
 } from '../join-group-confirmation-dialog/join-group-confirmation-dialog.component';
 import { GroupApprovals, mapGroupApprovalParamsToValues } from 'src/app/groups/models/group-approvals';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
+import {
+  CdkCell,
+  CdkCellDef,
+  CdkColumnDef,
+  CdkHeaderCell,
+  CdkHeaderCellDef,
+  CdkHeaderRow,
+  CdkHeaderRowDef,
+  CdkNoDataRow,
+  CdkRow,
+  CdkRowDef,
+  CdkTable
+} from '@angular/cdk/table';
+import { TableSortDirective } from 'src/app/ui-components/table-sort/table-sort.directive';
+import { SortEvent, TableSortHeaderComponent } from 'src/app/ui-components/table-sort/table-sort-header/table-sort-header.component';
 
 @Component({
   selector: 'alg-user-group-invitations',
@@ -33,7 +46,6 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
     DatePipe,
     NgForOf,
     NgSwitchCase,
-    TableModule,
     UserCaptionPipe,
     NgSwitch,
     NgSwitchDefault,
@@ -41,6 +53,19 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
     NgClass,
     JoinGroupConfirmationDialogComponent,
     ButtonIconComponent,
+    CdkTable,
+    CdkCell,
+    CdkCellDef,
+    CdkColumnDef,
+    CdkHeaderCell,
+    CdkHeaderCellDef,
+    CdkHeaderRow,
+    CdkHeaderRowDef,
+    CdkRow,
+    CdkRowDef,
+    CdkNoDataRow,
+    TableSortDirective,
+    TableSortHeaderComponent,
   ],
 })
 export class UserGroupInvitationsComponent implements OnDestroy {
@@ -62,6 +87,8 @@ export class UserGroupInvitationsComponent implements OnDestroy {
     )
   );
 
+  displayedColumns = signal([ 'name', 'type', 'at', 'operations' ]);
+
   constructor(
     private getRequestsService: GetRequestsService,
     private actionFeedbackService: ActionFeedbackService,
@@ -79,9 +106,9 @@ export class UserGroupInvitationsComponent implements OnDestroy {
     }
   }
 
-  onCustomSort(event: SortEvent): void {
-    const sortMeta = event.multiSortMeta?.map(meta => (meta.order === -1 ? `-${meta.field}` : meta.field));
-    if (sortMeta) this.onFetch(sortMeta);
+  onSortChange(event: SortEvent[]): void {
+    const sortMeta = event.map(meta => (meta.order === -1 ? `-${meta.field}` : meta.field));
+    if (sortMeta.length > 0) this.onFetch(sortMeta);
   }
 
   openJoinGroupConfirmationDialog(groupInvitation: GroupInvitation): void {

--- a/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.html
+++ b/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.html
@@ -1,0 +1,15 @@
+@let icon = sortOrder() === 1
+  ? 'ph-duotone ph-sort-ascending'
+  : sortOrder() === -1
+    ? 'ph-duotone ph-sort-descending'
+    : 'ph-duotone ph-arrows-down-up';
+<label class="label">
+  <ng-content></ng-content>
+  <button
+    class="button secondary size-s"
+    type="button"
+    alg-button-icon
+    [icon]="icon"
+    (click)="toggle()"
+  ></button>
+</label>

--- a/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.scss
+++ b/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.scss
@@ -1,0 +1,9 @@
+.label {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.button {
+  margin-left: var(--alg-space-size-6);
+}

--- a/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.ts
+++ b/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.ts
@@ -1,0 +1,28 @@
+import { Component, input, signal } from '@angular/core';
+import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
+
+export interface SortEvent {
+  field: string,
+  order: 0 | 1 | -1,
+}
+
+@Component({
+  selector: 'th[alg-table-sort-header]',
+  templateUrl: './table-sort-header.component.html',
+  styleUrls: [ './table-sort-header.component.scss' ],
+  standalone: true,
+  imports: [ ButtonIconComponent ],
+})
+export class TableSortHeaderComponent {
+  sortField = input.required<string>({ alias: 'alg-table-sort-header' });
+  sortOrder = signal<SortEvent['order']>(0);
+  sortState = signal<SortEvent | undefined>(undefined);
+
+  toggle(): void {
+    this.sortOrder.update(n => (n === 0 ? 1 : n === 1 ? -1 : 0));
+    this.sortState.set({
+      field: this.sortField(),
+      order: this.sortOrder(),
+    });
+  }
+}

--- a/src/app/ui-components/table-sort/table-sort.directive.ts
+++ b/src/app/ui-components/table-sort/table-sort.directive.ts
@@ -1,0 +1,21 @@
+import { contentChildren, Directive, effect, output } from '@angular/core';
+import { isNotUndefined } from 'src/app/utils/null-undefined-predicates';
+import { SortEvent, TableSortHeaderComponent } from 'src/app/ui-components/table-sort/table-sort-header/table-sort-header.component';
+
+@Directive({
+  selector: '[algTableSort]',
+  standalone: true,
+})
+export class TableSortDirective {
+  sortChange = output<SortEvent[]>();
+
+  sortHeaderChildren = contentChildren(TableSortHeaderComponent);
+
+  emitChangesEff = effect(() => {
+    const sortEvents = this.sortHeaderChildren().map(c => c.sortState()).filter(isNotUndefined);
+    if (sortEvents.length > 0) {
+      this.sortChange.emit(sortEvents);
+    }
+  });
+
+}


### PR DESCRIPTION
…s sort table feature

## Description

Fixes #1872

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

The sorting works as before, but initially it works not really correct, as the table refreshing with layout no chance to keep right icon state

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/user-group-invitations-table/en/groups/mine)
  3. And I see new table with sorting
  4. And I click on sort icon
  5. The I see sorted list