### PR TITLE
Fixes lost changes e2e

### DIFF
--- a/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.ts
+++ b/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.ts
@@ -457,9 +457,17 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
       languageTag: o.string.languageTag,
       imageUrl: o.string.imageUrl || '',
     }));
+    const isDirty = this.itemForm.controls.allStrings.dirty;
 
-    this.initialLanguageValues.set([ mainLanguageStringsValue, ...values ]);
-    this.resetStringsForm();
+    this.initialLanguageValues.update(initialValues => ([ ...initialValues, ...values ]));
+
+    if (isDirty) {
+      this.itemForm.controls.allStrings.setValue([ mainLanguageStringsValue, ...values ]);
+      this.resetImageUrl();
+      this.itemForm.controls.allStrings.markAsDirty();
+    } else {
+      this.resetStringsForm();
+    }
   }
 
   private resetStringsForm(): void {


### PR DESCRIPTION
## Description

Fixes e2e lost changes

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

When the other langs are fetching and the user typed some main strings value - the form become dirty. In this case, if the form became dirty after the other langs has fetched - the form should stay as dirty after reset form.

## Test cases

- [ ] Case 1:
  1. Given I am the demo user
  2. When I go to [this page](https://dev.algorea.org/branch/bugfix/fix-e2e-lost-changes/en/a/1751831682141956756;p=;a=0/dependencies)
  3. And I switch to slow connection in dev panel
  4. Then I click on "Parameters" tab and type title while translates are fetching
  5. Then I see the "Save/Cancel" buttons appeared after translates has fetched
  6. Then I click on "Cancel changes"
  7. And I see initial values in form
