### PR TITLE
Fix: use the new backend service for logs in threads

### DIFF
--- a/src/app/forum/store/current-thread/event-fetching.effects.ts
+++ b/src/app/forum/store/current-thread/event-fetching.effects.ts
@@ -1,31 +1,25 @@
 import { createEffect } from '@ngrx/effects';
 import { inject } from '@angular/core';
-import { EMPTY, map, switchMap } from 'rxjs';
+import { filter, map, switchMap } from 'rxjs';
 import { ActivityLogService } from 'src/app/data-access/activity-log.service';
 import { Store } from '@ngrx/store';
-import { UserSessionService } from 'src/app/services/user-session.service';
-import { combineLatest } from 'rxjs';
 import { fromForum } from '..';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { eventFetchingActions } from './event-fetching.actions';
 import { convertActivityLogsToThreadEvents, convertThreadMessageToThreadEvents } from '../../models/thread-events-conversions';
 import { ThreadMessageService } from 'src/app/data-access/thread-message.service';
+import { isNotNull } from 'src/app/utils/null-undefined-predicates';
 
 export const logEventFetchingEffect = createEffect(
   (
     store$ = inject(Store),
-    userSessionService = inject(UserSessionService),
     activityLogService = inject(ActivityLogService),
-  ) => combineLatest([ store$.select(fromForum.selectThreadId), userSessionService.userProfile$ ]).pipe(
-    switchMap(([ threadId, profile ]) => {
-      if (!threadId) return EMPTY;
-      const isMine = threadId.participantId === profile.groupId;
-      const watchedGroupId = isMine ? undefined : threadId.participantId; // FIXME: will not work for teams
-      return activityLogService.getActivityLog(threadId.itemId, { watchedGroupId, limit: 11 }).pipe(
-        map(convertActivityLogsToThreadEvents),
-        mapToFetchState(),
-      );
-    }),
+  ) => store$.select(fromForum.selectThreadId).pipe(
+    filter(isNotNull),
+    switchMap(threadId => activityLogService.getThreadActivityLog(threadId, { limit: 11 }).pipe(
+      map(convertActivityLogsToThreadEvents),
+      mapToFetchState(),
+    )),
     map(fetchState => eventFetchingActions.logEventsFetchStateChanged({ fetchState })),
   ),
   { functional: true }


### PR DESCRIPTION
## Description

Fix the forum which could not be loaded for non owner or watchers.

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/forum-fix-logs/en/a/home;pa=0/forum/my-threads)
  3. And I click on on my thread, it loads
 In other's requests: 
  5. If I click on a thread from usr_5p020x2thuyu , it loads
  6. If I click on a thread from profile-test (that I cannot watch) , it loads