### PR TITLE
make sure clicking on a solution link navigates to the task solution

### DIFF
--- a/src/app/forum/containers/thread-message/thread-message.component.html
+++ b/src/app/forum/containers/thread-message/thread-message.component.html
@@ -49,7 +49,7 @@
                 <a
                   class="alg-link"
                   [ngClass]="{ 'disabled': !canCurrentUserLoadAnswers }"
-                  [routerLink]="itemRoute | with: { answer: { id: event.answerId } } | url"
+                  [routerLink]="itemRoute | with: { answer: { id: event.answerId } } | url: ['task', 'editor']"
                   *ngIf="itemRoute"
                   i18n
                 >


### PR DESCRIPTION
## Description

Make sure clicking on a solution link navigates to the task solution .It was staying on the forum..

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/forum-fix-solution-link/en/a/home;pa=0/forum/others)
  3. And I click on show for [Blockly Basic Task", usr_5p020x2thuyu
  4. And I click on a solution in the thread
  5. Then I should end up on the task solution itself (not in the forum tab)