### PR TITLE
fix the row 'noScore' and not the one from the top chapter

### DIFF
--- a/src/app/items/containers/chapter-user-progress/chapter-user-progress.component.ts
+++ b/src/app/items/containers/chapter-user-progress/chapter-user-progress.component.ts
@@ -111,7 +111,7 @@ export class ChapterUserProgressComponent implements OnChanges, OnDestroy {
           score: itemData.score,
           validated: itemData.validated,
           currentUserPermissions: itemData.currentUserPermissions,
-          noScore: item.noScore,
+          noScore: itemData.noScore,
         })),
       ])))
     ),


### PR DESCRIPTION
## Description

FIX: use the "no score" value of the row instead of the top chapter

## Test cases

BEFORE: 
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/en/a/home;pa=0/progress/chapter)
  3. There are no score for all chapters (while visible in the left menu)

AFTER FIX:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/fix-chapter-progress-noscore/en/a/home;pa=0/progress/chapter)
  3. There are are score for all but the parent
