### PR TITLE
Replaces join group confirmation dialog with custom one in user group…

### DIFF
--- a/src/app/groups/containers/join-group-confirmation-dialog-v2/join-group-confirmation-dialog.component.html
+++ b/src/app/groups/containers/join-group-confirmation-dialog-v2/join-group-confirmation-dialog.component.html
@@ -1,0 +1,53 @@
+<alg-modal i18n-title title="Joining a new group" (closeEvent)="dialogRef.close()">
+  <p class="description" i18n>Do you want to join the group "{{ data().name }}"?</p>
+  @if (form) {
+    <form class="form" [formGroup]="form">
+      @if (form.get('agreeWithPersonalInfoView')) {
+        <alg-switch-field
+          formControlName="agreeWithPersonalInfoView"
+          data-testid="switch-agree-with-personal-info-view"
+        >
+          <ng-template #label>
+            <span i18n>
+              The managers of this group will be able to
+              { data().params.requirePersonalInfoAccessApproval, select, view {view} other {edit} }
+              the personal info (firstname, lastname, email, grade, ...) you entered in your profile
+            </span>
+          </ng-template>
+        </alg-switch-field>
+      }
+      @if (form.get('agreeWithLockMembership')) {
+        <alg-switch-field
+          class="switch-field"
+          formControlName="agreeWithLockMembership"
+          data-testid="switch-agree-with-lock-membership"
+        >
+          <ng-template #label>
+            <span i18n>
+              You will not be able to leave this group until {{ data().params.requireLockMembershipApprovalUntil | date: 'short' }}
+            </span>
+          </ng-template>
+        </alg-switch-field>
+      }
+    </form>
+  }
+
+  <footer>
+    <div class="footer-container">
+      <button
+        class="stroke button"
+        icon="ph-bold ph-x"
+        (click)="dialogRef.close()"
+        alg-button
+        i18n
+      >Cancel</button>
+      <button
+        icon="ph-bold ph-check"
+        (click)="dialogRef.close({ confirmed: true })"
+        [disabled]="form?.invalid"
+        alg-button
+        i18n
+      >Join group</button>
+    </div>
+  </footer>
+</alg-modal>

--- a/src/app/groups/containers/join-group-confirmation-dialog-v2/join-group-confirmation-dialog.component.scss
+++ b/src/app/groups/containers/join-group-confirmation-dialog-v2/join-group-confirmation-dialog.component.scss
@@ -1,0 +1,28 @@
+@import '../../../../assets/scss/functions';
+
+:host {
+  display: block;
+  width: 50vw;
+}
+
+.button {
+  margin-right: var(--alg-space-size-6);
+}
+
+.description {
+  margin: 0;
+}
+
+.form {
+  margin-top: toRem(16);
+}
+
+.switch-field {
+  display: block;
+  margin-top: var(--alg-space-size-5);
+}
+
+.footer-container {
+  display: flex;
+  justify-content: center;
+}

--- a/src/app/groups/containers/join-group-confirmation-dialog-v2/join-group-confirmation-dialog.component.ts
+++ b/src/app/groups/containers/join-group-confirmation-dialog-v2/join-group-confirmation-dialog.component.ts
@@ -1,0 +1,62 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { SwitchFieldComponent } from 'src/app/ui-components/collapsible-section/switch-field/switch-field.component';
+import { DatePipe } from '@angular/common';
+import { GroupApprovals, RequirePersonalInfoAccessApproval as PIApproval } from 'src/app/groups/models/group-approvals';
+import { ButtonComponent } from 'src/app/ui-components/button/button.component';
+import { ModalComponent } from 'src/app/ui-components/modal/modal.component';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+
+export type JoinGroupConfirmationDialogResult = { confirmed: true } | undefined;
+
+@Component({
+  selector: 'alg-join-group-confirmation-dialog',
+  templateUrl: './join-group-confirmation-dialog.component.html',
+  styleUrls: [ './join-group-confirmation-dialog.component.scss' ],
+  standalone: true,
+  imports: [
+    SwitchFieldComponent,
+    ReactiveFormsModule,
+    DatePipe,
+    ButtonComponent,
+    ModalComponent,
+  ],
+})
+export class JoinGroupConfirmationDialogComponent implements OnInit {
+  dialogRef = inject(DialogRef<JoinGroupConfirmationDialogResult>);
+
+  data = signal(inject<{ name: string, params: GroupApprovals }>(DIALOG_DATA));
+
+  form?: FormGroup<{
+    agreeWithPersonalInfoView?: FormControl<boolean>,
+    agreeWithLockMembership?: FormControl<boolean>,
+  }>;
+
+  constructor(private fb: FormBuilder) {
+  }
+
+  ngOnInit(): void {
+    const { requirePersonalInfoAccessApproval, requireLockMembershipApprovalUntil } = this.data().params;
+    if (requirePersonalInfoAccessApproval !== PIApproval.None || requireLockMembershipApprovalUntil) {
+      this.form = this.fb.nonNullable.group({});
+      if (requirePersonalInfoAccessApproval !== PIApproval.None) {
+        this.form.addControl(
+          'agreeWithPersonalInfoView',
+          this.fb.nonNullable.control({
+            value: false,
+            disabled: false,
+          }, Validators.requiredTrue),
+        );
+      }
+      if (requireLockMembershipApprovalUntil) {
+        this.form.addControl(
+          'agreeWithLockMembership',
+          this.fb.nonNullable.control({
+            value: false,
+            disabled: false,
+          }, Validators.requiredTrue),
+        );
+      }
+    }
+  }
+}

--- a/src/app/groups/containers/user-group-invitations/user-group-invitations.component.html
+++ b/src/app/groups/containers/user-group-invitations/user-group-invitations.component.html
@@ -69,12 +69,3 @@
     </div>
   }
 }
-
-@if (pendingJoinRequest) {
-  <alg-join-group-confirmation-dialog
-    [name]="pendingJoinRequest.name"
-    [params]="pendingJoinRequest.params"
-    (confirmEvent)="accept(pendingJoinRequest.id, pendingJoinRequest.name)"
-    (cancelEvent)="closeModal()"
-  ></alg-join-group-confirmation-dialog>
-}

--- a/src/app/ui-components/modal/modal.component.html
+++ b/src/app/ui-components/modal/modal.component.html
@@ -1,0 +1,24 @@
+<div class="container">
+  <ng-content select="header">
+    <div class="header">
+      <ng-content select="title">
+        <p class="title">{{ title() }}</p>
+      </ng-content>
+      @if (allowToClose()) {
+        <div class="close-wrapper">
+          <button type="button" class="secondary" alg-button-icon icon="ph ph-x" (click)="closeEvent.emit()"></button>
+        </div>
+      }
+    </div>
+  </ng-content>
+
+  <div class="body">
+    <ng-content></ng-content>
+  </div>
+
+  @if (showFooter()) {
+    <div class="footer">
+      <ng-content select="footer"></ng-content>
+    </div>
+  }
+</div>

--- a/src/app/ui-components/modal/modal.component.scss
+++ b/src/app/ui-components/modal/modal.component.scss
@@ -1,0 +1,43 @@
+@import 'src/assets/scss/functions';
+
+:host {
+  display: flex;
+  flex-direction: column;
+  max-width: 100%;
+  background: var(--alg-white-color);
+  border-radius: toRem(8);
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: (calc(var(--alg-space-size-6) + toRem(4))) (calc(var(--alg-space-size-6) + toRem(4))) (calc(var(--alg-space-size-6) + toRem(4))) var(--alg-space-size-5);
+  border-bottom: 1px solid var(--alg-border-color);
+}
+
+.title {
+  margin: 0;
+  font-size: toRem(18);
+  font-weight: 600;
+}
+
+.close-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.icon-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.body {
+  padding: var(--alg-space-size-5) var(--alg-space-size-5);
+}
+
+.footer {
+  padding: (calc(var(--alg-space-size-6) + toRem(4))) var(--alg-space-size-5);
+  border-top: 1px solid var(--alg-border-color);
+}

--- a/src/app/ui-components/modal/modal.component.ts
+++ b/src/app/ui-components/modal/modal.component.ts
@@ -1,0 +1,19 @@
+import { Component, input, output } from '@angular/core';
+import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
+
+@Component({
+  selector: 'alg-modal',
+  templateUrl: './modal.component.html',
+  styleUrls: [ './modal.component.scss' ],
+  standalone: true,
+  imports: [
+    ButtonIconComponent,
+  ]
+})
+export class ModalComponent {
+  closeEvent = output<void>();
+
+  title = input<string | undefined>(undefined);
+  allowToClose = input(true);
+  showFooter = input(true);
+}


### PR DESCRIPTION
## Description

Fixes #1882

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

The full flow covered by e2e, so I give steps for to check design

- [ ] Case 1:
  1. Given I am the demo user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/join-confirmation-dialog/en/groups/mine)
  3. Then I see "Pending invitations" section
  4. And I click on accept of "SubGroups-001"
  5. Then I see confirmation modal with switch options

- [ ] Case 2:
  1. Given I am the demo user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/join-confirmation-dialog/en/groups/mine)
  3. Then I see "Pending invitations" section
  4. And I click on accept of "DIU 2019"
  5. Then I see confirmation modal without switch options
