### PR TITLE
Replaces propagation advanced configuration dialog with angular cdk i…

### DIFF
--- a/e2e/items/pages/propagation-advanced-configuration-dialog-component.ts
+++ b/e2e/items/pages/propagation-advanced-configuration-dialog-component.ts
@@ -44,7 +44,7 @@ export class PropagationAdvancedConfigurationDialogComponent {
       has: this.page.getByText(option, { exact: true }),
     });
     await expect.soft(progressSelectionLocation).toBeVisible();
-    await progressSelectionLocation.hover({ force: true });
+    await progressSelectionLocation.hover({ position: { x: 10, y: 10 }, force: true });
   }
 
   async hoverOnSwitchValue(name: string): Promise<void> {

--- a/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.html
+++ b/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.html
@@ -177,11 +177,3 @@
     }
   }
 </ng-template>
-
-@let modalData = this.advancedPermPropagationConfigurationDialogData();
-@if (modalData) {
-  <alg-propagation-advanced-configuration-dialog
-    [data]="modalData.data"
-    (closeEvent)="closeAdvancedPermPropagationConfigurationDialog(modalData.childIdx, $event)"
-  ></alg-propagation-advanced-configuration-dialog>
-}

--- a/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.html
+++ b/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.html
@@ -1,24 +1,4 @@
-<p-dialog
-  [visible]="true"
-  [modal]="true"
-  [draggable]="false"
-  [closable]="false"
-  styleClass="alg-permissions-edit-dialog"
-  appendTo="body"
->
-  <p-header>
-    <div class="dialog-header">
-      <span class="dialog-title" i18n>Permission propagation configuration</span>
-      <button
-        type="button"
-        class="stroke size-l"
-        icon="ph-bold ph-x"
-        (click)="closeEvent.emit(undefined)"
-        alg-button-icon
-      ></button>
-    </div>
-  </p-header>
-
+<alg-modal i18n-title title="Permission propagation configuration" (closeEvent)="dialogRef.close()" [showFooter]="false">
   <div class="dialog-container">
     <p class="description">
       @let item = data().item;
@@ -40,7 +20,7 @@
     <alg-propagation-advanced-configuration-form
       [giverPermissions]="data().permissions"
       [itemPropagations]="data().itemPropagations"
-      (closeEvent)="closeEvent.emit($event)"
+      (closeEvent)="dialogRef.close($event)"
     ></alg-propagation-advanced-configuration-form>
   </div>
-</p-dialog>
+</alg-modal>

--- a/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.scss
+++ b/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.scss
@@ -1,19 +1,14 @@
 @import 'src/assets/scss/functions';
 
+:host {
+  display: block;
+  width: 47.5rem;
+  max-height: 65vh;
+}
+
 .dialog-container {
   display: flex;
   flex-direction: column;
-}
-
-.dialog-header {
-  display: flex;
-  align-items: center;
-  position: relative;
-}
-
-.dialog-title {
-  font-size: toRem(20);
-  flex: 1;
 }
 
 .description {

--- a/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.ts
+++ b/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.ts
@@ -1,11 +1,11 @@
-import { Component, input, output } from '@angular/core';
-import { DialogModule } from 'primeng/dialog';
-import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
+import { Component, inject, input, output } from '@angular/core';
 import {
   PropagationAdvancedConfigurationFormComponent
 } from 'src/app/items/containers/propagation-advanced-configuration-form/propagation-advanced-configuration-form.component';
 import { ItemCorePerm } from 'src/app/items/models/item-permissions';
 import { ItemPermPropagations } from 'src/app/items/models/item-perm-propagation';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { ModalComponent } from 'src/app/ui-components/modal/modal.component';
 
 export interface PropagationAdvancedConfigurationDialogData {
   item: {
@@ -23,13 +23,14 @@ export interface PropagationAdvancedConfigurationDialogData {
   styleUrls: [ 'propagation-advanced-configuration-dialog.component.scss' ],
   standalone: true,
   imports: [
-    DialogModule,
-    ButtonIconComponent,
     PropagationAdvancedConfigurationFormComponent,
+    ModalComponent,
   ],
 })
 export class PropagationAdvancedConfigurationDialogComponent {
-  data = input.required<PropagationAdvancedConfigurationDialogData>();
+  data = input(inject<PropagationAdvancedConfigurationDialogData>(DIALOG_DATA));
+
+  dialogRef = inject(DialogRef);
 
   closeEvent = output<ItemPermPropagations | undefined>();
 }

--- a/src/app/ui-components/modal/modal.component.scss
+++ b/src/app/ui-components/modal/modal.component.scss
@@ -4,8 +4,15 @@
   display: flex;
   flex-direction: column;
   max-width: 100%;
+  max-height: inherit;
   background: var(--alg-white-color);
   border-radius: toRem(8);
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  max-height: inherit;
 }
 
 .header {
@@ -35,6 +42,8 @@
 
 .body {
   padding: var(--alg-space-size-5) var(--alg-space-size-5);
+  overflow: scroll;
+  box-sizing: border-box;
 }
 
 .footer {


### PR DESCRIPTION

## Description

Related to [#1882](https://github.com/France-ioi/AlgoreaFrontend/issues/1882)

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

Covered by e2e

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/propagation-advanced-configuration-dialog/en/a/6143113533448544714;p=1751831682141956756;a=0/edit-children)
  3. And I click on "eye" icon and then "Advanced configuration"
  4. Then I see new modal
