### PR TITLE
Replaces permissions edit dialog with angular cdk in group progress grid

### DIFF
--- a/src/app/items/containers/group-progress-grid/group-progress-grid.component.html
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid.component.html
@@ -124,16 +124,6 @@
         }
       </ng-container>
 
-      <alg-permissions-edit-dialog
-        [currentUserPermissions]="itemData.item.permissions"
-        [item]="progressDataDialog.item"
-        [group]="progressDataDialog.group"
-        [sourceGroup]="sourceGroup"
-        [permReceiverName]="progressDataDialog.groupName"
-        [permGiverName]="progressDataDialog.sourceGroupName"
-        (close)="onDialogClose()"
-        *ngIf="isPermissionsDialogOpened && itemData && progressDataDialog && sourceGroup"
-      ></alg-permissions-edit-dialog>
     </ng-template>
   </ng-container>
 </ng-container>

--- a/src/app/items/containers/permissions-edit-dialog-v2/permissions-edit-dialog.component.html
+++ b/src/app/items/containers/permissions-edit-dialog-v2/permissions-edit-dialog.component.html
@@ -1,0 +1,44 @@
+<alg-modal i18n-title title="Permission editor" [showFooter]="false" (closeEvent)="closeDialog()">
+  <alg-error
+    i18n-message message="User permissions cannot be changed via this page for the moment"
+    *ngIf="(params().group | isUser) && !params().sourceGroup; else stateBlock"
+  ></alg-error>
+
+  <ng-template #stateBlock>
+    <ng-container *ngIf="state$ | async as state">
+      <alg-loading *ngIf="state.isFetching"></alg-loading>
+
+      <alg-error *ngIf="state.isError">
+        <span class="error-message" i18n>The permissions cannot be retrieved.</span>
+        <span i18n="@@contactUs">If the problem persists, please contact us.</span>
+      </alg-error>
+
+      <div class="dialog-container" *ngIf="state.isReady">
+        <div class="dialog-content">
+          <ng-container *ngIf="params().item.string.title">
+            @if(params().permGiverName) {
+              <p class="dialog-description" i18n>
+                These are the permissions given by "{{ params().permGiverName }}" to "{{ params().permReceiverName }}" on "{{ params().item.string.title }}".
+              </p>
+            } @else {
+              <p class="dialog-description" i18n>
+                These are the permissions given to "{{ params().permReceiverName }}" on "{{ params().item.string.title }}".
+              </p>
+            }
+          </ng-container>
+
+          <alg-permissions-edit-form
+            (save)="onPermissionsDialogSave($event)"
+            (cancel)="closeDialog()"
+            [targetType]="targetType"
+            [permissions]="state.data.granted"
+            [computedPermissions]="state.data.computed"
+            [giverPermissions]="params().currentUserPermissions"
+            [acceptButtonDisabled]="updateInProcess"
+            [requiresExplicitEntry]="params().item.requiresExplicitEntry"
+          ></alg-permissions-edit-form>
+        </div>
+      </div>
+    </ng-container>
+  </ng-template>
+</alg-modal>

--- a/src/app/items/containers/permissions-edit-dialog-v2/permissions-edit-dialog.component.scss
+++ b/src/app/items/containers/permissions-edit-dialog-v2/permissions-edit-dialog.component.scss
@@ -1,0 +1,18 @@
+:host {
+  display: block;
+  width: 47.5rem;
+  max-height: 65vh;
+}
+
+.dialog-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.error-message {
+  margin-right: .3rem;
+}
+
+.dialog-description {
+  margin-top: 0;
+}

--- a/src/app/items/containers/permissions-edit-dialog-v2/permissions-edit-dialog.component.ts
+++ b/src/app/items/containers/permissions-edit-dialog-v2/permissions-edit-dialog.component.ts
@@ -1,0 +1,126 @@
+import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
+import { ItemCorePerm } from 'src/app/items/models/item-permissions';
+import { RawGroupRoute, isUser } from 'src/app/models/routing/group-route';
+import { GroupPermissions, GroupPermissionsService } from 'src/app/data-access/group-permissions.service';
+import { ReplaySubject, switchMap } from 'rxjs';
+import { shareReplay } from 'rxjs/operators';
+import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
+import { HttpErrorResponse } from '@angular/common/http';
+import { TypeFilter } from '../../models/composition-filter';
+import { mapToFetchState } from 'src/app/utils/operators/state';
+import { CurrentContentService } from 'src/app/services/current-content.service';
+import { PermissionsEditFormComponent } from '../permissions-edit-dialog-form/permissions-edit-form.component';
+import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
+import { ErrorComponent } from 'src/app/ui-components/error/error.component';
+import { NgIf, AsyncPipe } from '@angular/common';
+import { GroupIsUserPipe } from 'src/app/pipes/groupIsUser';
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { ModalComponent } from 'src/app/ui-components/modal/modal.component';
+
+export interface PermissionsEditDialogParams {
+  currentUserPermissions: ItemCorePerm,
+  item: { id: string, requiresExplicitEntry: boolean, string: { title: string | null } },
+  group: RawGroupRoute,
+  permReceiverName: string,
+  sourceGroup?: RawGroupRoute,
+  permGiverName?: string,
+}
+
+@Component({
+  selector: 'alg-permissions-edit-dialog',
+  templateUrl: './permissions-edit-dialog.component.html',
+  styleUrls: [ './permissions-edit-dialog.component.scss' ],
+  standalone: true,
+  imports: [
+    NgIf,
+    ErrorComponent,
+    LoadingComponent,
+    PermissionsEditFormComponent,
+    AsyncPipe,
+    GroupIsUserPipe,
+    ModalComponent,
+  ],
+})
+export class PermissionsEditDialogComponent implements OnDestroy, OnInit {
+  params = signal(inject<PermissionsEditDialogParams>(DIALOG_DATA));
+  private dialogRef = inject(DialogRef);
+
+  private params$ = new ReplaySubject<{ sourceGroupId: string, groupId: string, itemId: string }>(1);
+  state$ = this.params$.pipe(
+    switchMap(params =>
+      this.groupPermissionsService.getPermissions(params.sourceGroupId, params.groupId, params.itemId)
+    ),
+    mapToFetchState(),
+    shareReplay(1),
+  );
+
+  permissions?: Omit<GroupPermissions,'canEnterFrom'|'canEnterUntil'>;
+  updateInProcess = false;
+  targetType: TypeFilter = 'Users';
+
+  constructor(
+    private groupPermissionsService: GroupPermissionsService,
+    private actionFeedbackService: ActionFeedbackService,
+    private currentContentService: CurrentContentService,
+  ) {
+  }
+
+  ngOnDestroy(): void {
+    this.params$.complete();
+  }
+
+  ngOnInit(): void {
+    if (isUser(this.params().group) && !this.params().sourceGroup) {
+      return;
+    }
+
+    const sourceGroup = this.params().sourceGroup;
+    if (sourceGroup && isUser(sourceGroup)) {
+      throw new Error('Unexpected: Source group must not be a user');
+    }
+
+    this.targetType = isUser(this.params().group) ? 'Users' : 'Groups';
+    this.params$.next({
+      sourceGroupId: this.params().sourceGroup?.id ?? this.params().group.id,
+      groupId: this.params().group.id,
+      itemId: this.params().item.id,
+    });
+  }
+
+  onPermissionsDialogSave(permissions: Partial<GroupPermissions>): void {
+    const sourceGroup = this.params().sourceGroup;
+    if (sourceGroup && isUser(sourceGroup)) {
+      throw new Error('Unexpected: Source group must not be a user');
+    }
+
+    if (isUser(this.params().group) && !this.params().sourceGroup) {
+      throw new Error('Unexpected: A user group must be provided with source group');
+    }
+
+    this.updateInProcess = true;
+    this.groupPermissionsService.updatePermissions(
+      this.params().sourceGroup?.id ?? this.params().group.id,
+      this.params().group.id,
+      this.params().item.id,
+      permissions,
+    )
+      .subscribe({
+        next: () => {
+          this.updateInProcess = false;
+          this.actionFeedbackService.success($localize`:@@permissionsUpdated:Permissions successfully updated.`);
+          this.currentContentService.forceNavMenuReload();
+          this.closeDialog(true);
+        },
+        error: err => {
+          this.updateInProcess = false;
+          this.actionFeedbackService.unexpectedError();
+          this.currentContentService.forceNavMenuReload();
+          if (!(err instanceof HttpErrorResponse)) throw err;
+        },
+      });
+  }
+
+  closeDialog(changed = false): void {
+    this.dialogRef.close(changed);
+  }
+}


### PR DESCRIPTION
## Description

Related to [#1882](https://github.com/France-ioi/AlgoreaFrontend/issues/1882)

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

I guess some issue with CI today https://status.circleci.com/

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/permissions-edit-dialog/en/a/899800937596940136;p=;pa=0;og=917454091139548680/progress/chapter)
  3. And I click on some user's score cell
  4. Then I click on "Access"
  5. Then I see modal with new design
  6. Then I change some permissions, for example "is owner"
  7. And I click on "Proceed" 
  8. Then I see "Success" notification

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](https://dev.algorea.org/branch/migration-ui/permissions-edit-dialog/en/a/899800937596940136;p=;pa=0;og=917454091139548680/progress/chapter)
  3. And I click on some user's score cell
  4. Then I click on "Access"
  5. Then I see modal with new design
  6. And I click on "Cancel"
  7. Then I see the modal is closed
