### PR TITLE
Migration UI/save before unload dialog

### DIFF
--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -182,28 +182,3 @@
     </p>
   }
 }
-
-@if (saveBeforeUnloadError$ | async) {
-  <p-dialog
-    [visible]="true"
-    [modal]="true"
-    [closeOnEscape]="false"
-    [closable]="false"
-    i18n-header header="Leave unsaved task"
-    >
-    <p i18n>You do not appear to be connected to the Internet, if you leave this task you may loose your progress. Are you sure you want to continue?</p>
-    <ng-template pTemplate="footer">
-      <button
-        alg-button
-        class="danger"
-        (click)="skipBeforeUnload()"
-        i18n
-      >Loose progress and leave the task</button>
-      <button
-        alg-button
-        (click)="retryBeforeUnload()"
-        i18n
-      >Retry</button>
-    </ng-template>
-  </p-dialog>
-}

--- a/src/app/services/confirmation-modal.service.ts
+++ b/src/app/services/confirmation-modal.service.ts
@@ -13,6 +13,7 @@ export interface ConfirmationModalData {
   rejectButtonCaption?: string,
   rejectButtonStyleClass?: string,
   rejectButtonIcon?: string,
+  allowToClose?: boolean,
 }
 
 @Injectable({

--- a/src/app/ui-components/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/ui-components/confirmation-modal/confirmation-modal.component.html
@@ -1,8 +1,10 @@
 <div class="container">
-  <div class="header">
-    <button class="secondary" alg-button-icon icon="ph ph-x" (click)="dialogRef.close()"></button>
-  </div>
-  <div class="body">
+  @if (data().allowToClose) {
+    <div class="header">
+      <button class="secondary" alg-button-icon icon="ph ph-x" (click)="dialogRef.close()"></button>
+    </div>
+  }
+  <div class="body" [ngClass]="{ 'without-close-padding': !data().allowToClose }">
     @if (data().title; as title) {
       <div class="title alg-h4">{{ title }}</div>
     }

--- a/src/app/ui-components/confirmation-modal/confirmation-modal.component.scss
+++ b/src/app/ui-components/confirmation-modal/confirmation-modal.component.scss
@@ -15,6 +15,10 @@
 
 .body {
   margin: var(--alg-space-size-5) var(--alg-space-size-6) 0 var(--alg-space-size-6);
+
+  &.without-close-padding {
+    margin-top: var(--alg-space-size-6);
+  }
 }
 
 .title {

--- a/src/app/ui-components/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/ui-components/confirmation-modal/confirmation-modal.component.ts
@@ -3,6 +3,7 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { ConfirmationModalData } from 'src/app/services/confirmation-modal.service';
+import { NgClass } from '@angular/common';
 
 @Component({
   selector: 'alg-confirmation-modal',
@@ -12,10 +13,15 @@ import { ConfirmationModalData } from 'src/app/services/confirmation-modal.servi
   imports: [
     ButtonIconComponent,
     ButtonComponent,
+    NgClass,
   ],
 })
 export class ConfirmationModalComponent {
-  data = input({ rejectButtonStyleClass: 'stroke', ...inject<ConfirmationModalData>(DIALOG_DATA) });
+  data = input({
+    rejectButtonStyleClass: 'stroke',
+    allowToClose: true,
+    ...inject<ConfirmationModalData>(DIALOG_DATA),
+  });
   dialogRef = inject<DialogRef<boolean>>(DialogRef<boolean>);
 
   constructor() {


### PR DESCRIPTION
## Description

Related to https://github.com/France-ioi/AlgoreaFrontend/issues/1882

## Notes (out of scope, known isues, hints for reviewing code, ...)  (optional)

...

## Test cases

- [ ] Case 1:
  1. Given I am the usual user
  2. When I go to [this page](http://localhost:4200/a/9105453971757450756;p=7523720120450464843;a=0;pa=0/task/editor)
  3. And I type some text in task
  4. Then I switch network to "offline" in dev panel
  5. And click on another item in left menu
  6. Then I see confirmation modal
  7. Then I switch network to "online" in dev panel
  8. And I click on "Retry" button
  9. Then I see saving of task and then I redirected to another page

- [ ] Case 2:
  1. Given I am the usual user
  2. When I go to [this page](http://localhost:4200/a/9105453971757450756;p=7523720120450464843;a=0;pa=0/task/editor)
  3. And I type some text in task
  4. Then I switch network to "offline" in dev panel
  5. And click on another item in left menu
  6. Then I see confirmation modal
  7. Then I switch network to "online" in dev panel
  8. And I click on "Loose progress and leave the task" button
  9. Then I redirected to another page
