### PR TITLE
left menu for groups: display chevron only for groups with children + allow closing the chevron

### DIFF
--- a/src/app/containers/left-nav-tree/left-nav-tree.component.html
+++ b/src/app/containers/left-nav-tree/left-nav-tree.component.html
@@ -39,7 +39,7 @@
           <i
             class="ph-thin"
             [class]="node.expanded ? 'ph-caret-down' : 'ph-caret-right'"
-            (click)="node.type === 'chapter' ? onChevronClick($event, node) : null"
+            (click)="onChevronClick($event, node)"
           ></i>
         } @else {
           <i class="ph-thin ph-caret-right"></i>

--- a/src/app/containers/left-nav-tree/left-nav-tree.component.ts
+++ b/src/app/containers/left-nav-tree/left-nav-tree.component.ts
@@ -132,6 +132,7 @@ export class LeftNavTreeComponent {
   }
 
   onChevronClick(event: Event, node: TreeNode<NavTreeElement>): void {
+    if (!node.inL1 || !node.isExpandable) return;
     event.stopPropagation();
     this.toggleFolder(node);
   }

--- a/src/app/data-access/group-navigation.service.ts
+++ b/src/app/data-access/group-navigation.service.ts
@@ -20,6 +20,7 @@ const groupNavigationChildSchema = z.object({
   type: z.enum([ 'Class', 'Team', 'Club', 'Friends', 'Other', 'User', 'Session', 'Base' ]),
   currentUserManagership: z.enum([ 'none', 'direct', 'ancestor', 'descendant' ]),
   currentUserMembership: z.enum([ 'none', 'direct', 'descendant' ]),
+  hasVisibleChildren: z.boolean(),
 });
 
 export type GroupNavigationChild = z.infer<typeof groupNavigationChildSchema>;

--- a/src/app/services/navigation/group-nav-tree.service.ts
+++ b/src/app/services/navigation/group-nav-tree.service.ts
@@ -29,6 +29,9 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     return groupInfo({ route: e.route });
   }
 
+  // hasChildren on tree elements uses hasVisibleChildren from the API, but GroupInfo (route only)
+  // does not carry that flag, so we cannot skip the l2 fetch here. Selecting a leaf group may
+  // trigger a navigation call that returns no children; that is an acceptable extra request.
   canFetchChildren(content: GroupInfo): boolean {
     return !isUser(content.route);
   }
@@ -69,7 +72,7 @@ export class GroupNavTreeService extends NavTreeService<GroupInfo> {
     return {
       route: route,
       title: child.name,
-      hasChildren: child.type !== 'User',
+      hasChildren: child.hasVisibleChildren,
       navigateTo: (): void => this.groupRouter.navigateTo(route),
       groupRelation: { isMember: isCurrentUserMember(child), managership: child.currentUserManagership }
     };


### PR DESCRIPTION
Code written with the help of AI, already reviewed locally.