### PR TITLE
use the double caret as icon to show the left menu

### DIFF
--- a/src/app/containers/content-top-bar/content-top-bar.component.html
+++ b/src/app/containers/content-top-bar/content-top-bar.component.html
@@ -6,7 +6,7 @@
           class="sidebar-toggle-btn"
           alg-button-icon
           type="button"
-          icon="ph ph-sidebar"
+          icon="ph ph-caret-double-right"
           aria-label="Open sidebar"
           i18n-aria-label
           algTooltip="Open sidebar"

--- a/src/app/items/containers/chapter-children/chapter-children.component.html
+++ b/src/app/items/containers/chapter-children/chapter-children.component.html
@@ -93,7 +93,7 @@
             This chapter's content is only accessible from the left menu.
             Open it to browse and navigate between items.
           </p>
-          <button alg-button class="size-l" type="button" icon="ph ph-sidebar" (click)="showLeftMenu()" i18n>
+          <button alg-button class="size-l" type="button" icon="ph ph-caret-double-right" (click)="showLeftMenu()" i18n>
             Show the left menu
           </button>
         </div>


### PR DESCRIPTION
Very small change: use the double caret as icon to show the left menu