### PR TITLE
Improvement: Compact left menu at launch

### DIFF
--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -308,12 +308,6 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       map(({ display }) => display),
     ).subscribe(display => this.layoutService.configure({ contentDisplayType: display })),
 
-    this.itemState$.pipe(
-      readyData<ItemData>(),
-      map(data => this.config.hideLeftMenuTreeOnItemIds.includes(data.route.id)),
-      distinctUntilChanged(),
-    ).subscribe(hideLeftMenuTree => this.layoutService.configure({ hideLeftMenuTree })),
-
     this.saveBeforeUnloadError$.pipe(
       filter(isError => isError),
       switchMap(() => this.confirmationModalService.open({
@@ -345,7 +339,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     this.tabService.setTabs([]);
     this.currentContent.clear();
     this.subscriptions.forEach(s => s.unsubscribe());
-    this.layoutService.configure({ contentDisplayType: ContentDisplayType.Default, hideLeftMenuTree: false });
+    this.layoutService.configure({ contentDisplayType: ContentDisplayType.Default });
     this.skipBeforeUnload$.complete();
     this.retryBeforeUnload$.complete();
     this.beforeUnload$.complete();

--- a/src/app/services/layout.service.ts
+++ b/src/app/services/layout.service.ts
@@ -1,9 +1,14 @@
+import { Location } from '@angular/common';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { ActivatedRouteSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, PRIMARY_OUTLET, UrlSerializer } from '@angular/router';
+import { Store } from '@ngrx/store';
 
 import { BehaviorSubject, Subject, combineLatest, distinctUntilChanged } from 'rxjs';
 import { debounceTime, map, scan, startWith, switchMap } from 'rxjs/operators';
+import { APPCONFIG } from 'src/app/config';
+import { parseItemUrlSegments } from 'src/app/models/routing/item-route-serialization';
+import { fromRouter } from 'src/app/store/router';
 
 export interface FullFrameContent {
   active: boolean,
@@ -18,6 +23,10 @@ export enum ContentDisplayType { Default, Show, ShowFullFrame }
 })
 export class LayoutService implements OnDestroy {
   private breakpointObserver = inject(BreakpointObserver);
+  private store = inject(Store);
+  private config = inject(APPCONFIG);
+  private location = inject(Location);
+  private urlSerializer = inject(UrlSerializer);
 
   /* state variables used to make decisions */
   private contentDisplayType$ = new BehaviorSubject<ContentDisplayType>(ContentDisplayType.Default);
@@ -27,7 +36,6 @@ export class LayoutService implements OnDestroy {
   private showTopRightControls = new BehaviorSubject(true);
   private canShowLeftMenu = new BehaviorSubject<boolean>(true);
   private canShowBreadcrumbs = new BehaviorSubject<boolean>(true);
-  private hideLeftMenuTree = new BehaviorSubject<boolean>(false);
 
   /* variables to be used by other services and components */
   isNarrowScreen$ = this.breakpointObserver.observe(Breakpoints.XSmall).pipe(
@@ -39,7 +47,15 @@ export class LayoutService implements OnDestroy {
   showTopRightControls$ = this.showTopRightControls.asObservable();
   canShowLeftMenu$ = this.canShowLeftMenu.asObservable();
   canShowBreadcrumbs$ = this.canShowBreadcrumbs.asObservable();
-  hideLeftMenuTree$ = this.hideLeftMenuTree.asObservable();
+  hideLeftMenuTree$ = this.store.select(fromRouter.selectSegments).pipe(
+    // Before the first ROUTER_NAVIGATED the router store has no segments yet. Parse the current
+    // URL synchronously so the panel is sized correctly on the very first paint (avoids the
+    // full-width -> compact width transition flashing on direct load of a compact-mode item).
+    map(segments => segments ?? this.urlSerializer.parse(this.location.path()).root.children[PRIMARY_OUTLET]?.segments ?? []),
+    map(segments => parseItemUrlSegments(segments, this.config.redirects)?.route.id ?? null),
+    map(id => id !== null && this.config.hideLeftMenuTreeOnItemIds.includes(id)),
+    distinctUntilChanged(),
+  );
   /**
    * Left menu: expected behavior
    * (note that in the following, a narrow window as the same behavior as mobile)
@@ -93,25 +109,22 @@ export class LayoutService implements OnDestroy {
     this.showTopRightControls.complete();
     this.canShowLeftMenu.complete();
     this.canShowBreadcrumbs.complete();
-    this.hideLeftMenuTree.complete();
   }
 
   /**
    * Configure layout.
    * The layout is considered not initialized (so not using animation) only until the first call.
    */
-  configure({ contentDisplayType, canShowLeftMenu, canShowBreadcrumbs, showTopRightControls, hideLeftMenuTree }: {
+  configure({ contentDisplayType, canShowLeftMenu, canShowBreadcrumbs, showTopRightControls }: {
     contentDisplayType?: ContentDisplayType,
     canShowLeftMenu?: boolean,
     canShowBreadcrumbs?: boolean,
     showTopRightControls?: boolean,
-    hideLeftMenuTree?: boolean,
   }): void {
     if (contentDisplayType !== undefined) this.contentDisplayType$.next(contentDisplayType);
     if (canShowLeftMenu !== undefined) this.canShowLeftMenu.next(canShowLeftMenu);
     if (canShowBreadcrumbs !== undefined) this.canShowBreadcrumbs.next(canShowBreadcrumbs);
     if (showTopRightControls !== undefined) this.showTopRightControls.next(showTopRightControls);
-    if (hideLeftMenuTree !== undefined) this.hideLeftMenuTree.next(hideLeftMenuTree);
   }
 
   toggleLeftMenu(visible: boolean): void {

--- a/src/app/services/layout.service.ts
+++ b/src/app/services/layout.service.ts
@@ -1,7 +1,7 @@
 import { Location } from '@angular/common';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { Injectable, OnDestroy, inject } from '@angular/core';
-import { ActivatedRouteSnapshot, PRIMARY_OUTLET, UrlSerializer } from '@angular/router';
+import { ActivatedRouteSnapshot, PRIMARY_OUTLET, UrlSegment, UrlSerializer } from '@angular/router';
 import { Store } from '@ngrx/store';
 
 import { BehaviorSubject, Subject, combineLatest, distinctUntilChanged } from 'rxjs';
@@ -17,6 +17,13 @@ export interface FullFrameContent {
 }
 
 export enum ContentDisplayType { Default, Show, ShowFullFrame }
+
+// Top-level route paths displayed without the left navigation tree (compact mode).
+// These are app-structural pages (not instance content), so unlike `hideLeftMenuTreeOnItemIds`
+// they belong in app code rather than in the deployment config. Add a path here (e.g. 'community')
+// to render it without the tree. Matched against the first URL segment so the decision is resolved
+// synchronously from the URL (no first-paint flicker).
+const treelessRoutePaths: string[] = [];
 
 @Injectable({
   providedIn: 'root'
@@ -50,10 +57,9 @@ export class LayoutService implements OnDestroy {
   hideLeftMenuTree$ = this.store.select(fromRouter.selectSegments).pipe(
     // Before the first ROUTER_NAVIGATED the router store has no segments yet. Parse the current
     // URL synchronously so the panel is sized correctly on the very first paint (avoids the
-    // full-width -> compact width transition flashing on direct load of a compact-mode item).
+    // full-width -> compact width transition flashing on direct load of a compact-mode page).
     map(segments => segments ?? this.urlSerializer.parse(this.location.path()).root.children[PRIMARY_OUTLET]?.segments ?? []),
-    map(segments => parseItemUrlSegments(segments, this.config.redirects)?.route.id ?? null),
-    map(id => id !== null && this.config.hideLeftMenuTreeOnItemIds.includes(id)),
+    map(segments => this.isTreelessUrl(segments)),
     distinctUntilChanged(),
   );
   /**
@@ -129,6 +135,16 @@ export class LayoutService implements OnDestroy {
 
   toggleLeftMenu(visible: boolean): void {
     this.manualMenuToggle$.next(visible);
+  }
+
+  /**
+   * Whether the left navigation tree should be hidden (compact mode) for the given URL segments.
+   * Combines app-structural tree-less routes with the instance-configured special item ids.
+   */
+  private isTreelessUrl(segments: UrlSegment[]): boolean {
+    if (segments[0] && treelessRoutePaths.includes(segments[0].path)) return true;
+    const id = parseItemUrlSegments(segments, this.config.redirects)?.route.id ?? null;
+    return id !== null && this.config.hideLeftMenuTreeOnItemIds.includes(id);
   }
 
 }


### PR DESCRIPTION
Ensure the menu does not fully-show-then-hide when the first item on app launch is a compact one