### PR TITLE
Modernize Angular components (batch 7).

### DIFF
--- a/src/app/items/containers/composition-filter/composition-filter.component.html
+++ b/src/app/items/containers/composition-filter/composition-filter.component.html
@@ -1,7 +1,7 @@
 <div class="selection-tool">
   <alg-selection
     [items]="typeFilters"
-    [selected]="selectedTypeFilter"
+    [selected]="selectedTypeFilter()"
     type="square"
     (change)="onTypeFilterChanged($event)"
   ></alg-selection>

--- a/src/app/items/containers/composition-filter/composition-filter.component.ts
+++ b/src/app/items/containers/composition-filter/composition-filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, linkedSignal, output } from '@angular/core';
 import { ensureDefined } from 'src/app/utils/assert';
 import { TypeFilter } from '../../models/composition-filter';
 import { SelectionComponent } from 'src/app/ui-components/selection/selection.component';
@@ -7,16 +7,12 @@ import { SelectionComponent } from 'src/app/ui-components/selection/selection.co
   selector: 'alg-composition-filter',
   templateUrl: './composition-filter.component.html',
   styleUrls: [ './composition-filter.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ SelectionComponent ]
 })
-export class CompositionFilterComponent implements OnInit {
+export class CompositionFilterComponent {
+  defaultValue = input<TypeFilter>();
 
-  @Input() defaultValue?: TypeFilter;
-
-  @Output() change = new EventEmitter<TypeFilter>();
-
-  selectedTypeFilter = 0;
+  change = output<TypeFilter>();
 
   readonly typeFilters: {icon:string, label:string, value:TypeFilter}[] = [
     {
@@ -36,15 +32,19 @@ export class CompositionFilterComponent implements OnInit {
     },
   ];
 
-  ngOnInit(): void {
-    if (this.defaultValue) {
-      this.selectedTypeFilter = this.typeFilters.findIndex(filter => filter.value === this.defaultValue);
-    }
-  }
+  selectedTypeFilter = linkedSignal({
+    source: this.defaultValue,
+    computation: defaultValue => {
+      if (defaultValue) {
+        const index = this.typeFilters.findIndex(filter => filter.value === defaultValue);
+        return index >= 0 ? index : 0;
+      }
+      return 0;
+    },
+  });
 
   onTypeFilterChanged(index: number): void {
     this.change.emit(ensureDefined(this.typeFilters[index]).value);
-    this.selectedTypeFilter = index;
+    this.selectedTypeFilter.set(index);
   }
-
 }

--- a/src/app/items/containers/composition-filter/composition-filter.component.ts
+++ b/src/app/items/containers/composition-filter/composition-filter.component.ts
@@ -10,7 +10,7 @@ import { SelectionComponent } from 'src/app/ui-components/selection/selection.co
   imports: [ SelectionComponent ]
 })
 export class CompositionFilterComponent {
-  defaultValue = input<TypeFilter>();
+  defaultValue = input.required<TypeFilter>();
 
   change = output<TypeFilter>();
 
@@ -35,11 +35,8 @@ export class CompositionFilterComponent {
   selectedTypeFilter = linkedSignal({
     source: this.defaultValue,
     computation: defaultValue => {
-      if (defaultValue) {
-        const index = this.typeFilters.findIndex(filter => filter.value === defaultValue);
-        return index >= 0 ? index : 0;
-      }
-      return 0;
+      const index = this.typeFilters.findIndex(filter => filter.value === defaultValue);
+      return index >= 0 ? index : 0;
     },
   });
 

--- a/src/app/items/containers/item-children-list/item-children-list.component.html
+++ b/src/app/items/containers/item-children-list/item-children-list.component.html
@@ -5,12 +5,12 @@
   >
     @for (item of children(); track item; let i = $index) {
       <li class="data-list-item">
-        @if (routeParams()) {
+        @if (routeParams(); as routeParams) {
           <a
             class="item-link"
             [class.locked]="item.isLocked"
-            [routerLink]="item | itemRoute: { path: routeParams()!.path } |
-              with: (item.result && item.result.attemptId ? { attemptId : item.result.attemptId } : { parentAttemptId: routeParams()!.parentAttemptId }) |
+            [routerLink]="item | itemRoute: { path: routeParams.path } |
+              with: (item.result && item.result.attemptId ? { attemptId : item.result.attemptId } : { parentAttemptId: routeParams.parentAttemptId }) |
               url"
           >
             <div class="left-container">

--- a/src/app/items/containers/item-children-list/item-children-list.component.html
+++ b/src/app/items/containers/item-children-list/item-children-list.component.html
@@ -1,16 +1,16 @@
-@if (children.length > 0) {
+@if (children().length > 0) {
   <ul
     class="data-list-container"
-    [ngClass]="{'activity-type': type === 'activity'}"
+    [class.activity-type]="type() === 'activity'"
   >
-    @for (item of children; track item; let i = $index) {
+    @for (item of children(); track item; let i = $index) {
       <li class="data-list-item">
-        @if (routeParams) {
+        @if (routeParams()) {
           <a
             class="item-link"
-            [ngClass]="{ locked: item.isLocked }"
-            [routerLink]="item | itemRoute: { path: routeParams.path } |
-              with: (item.result && item.result.attemptId ? { attemptId : item.result.attemptId } : { parentAttemptId: routeParams.parentAttemptId }) |
+            [class.locked]="item.isLocked"
+            [routerLink]="item | itemRoute: { path: routeParams()!.path } |
+              with: (item.result && item.result.attemptId ? { attemptId : item.result.attemptId } : { parentAttemptId: routeParams()!.parentAttemptId }) |
               url"
           >
             <div class="left-container">
@@ -32,7 +32,7 @@
               @if (item.isLocked) {
                 <i class="item-icon ph-duotone ph-lock-key"></i>
               } @else {
-                @if (type === 'activity') {
+                @if (type() === 'activity') {
                   @if (!item.noScore && (!item.watchedGroup && item.result) || (item.watchedGroup && item.watchedGroup.avgScore !== undefined)) {
                     <alg-score-ring
                       [currentScore]="(item.watchedGroup ? item.watchedGroup.avgScore : item.result?.score) ?? 0"
@@ -41,11 +41,11 @@
                     ></alg-score-ring>
                   } @else {
                     <div class="alg-rounded-icon-wrapper">
-                      <i class="ph-duotone" [ngClass]="{ 'ph-files': item.type === 'Task', 'ph-folders': item.type === 'Chapter' }"></i>
+                      <i class="ph-duotone" [class.ph-files]="item.type === 'Task'" [class.ph-folders]="item.type === 'Chapter'"></i>
                     </div>
                   }
                 }
-                @if (type === 'skill' && item.result) {
+                @if (type() === 'skill' && item.result) {
                   @if (item.result.validated) {
                     <div class="alg-rounded-icon-wrapper">
                       <i class="ph-duotone ph-duotone ph-medal"></i>
@@ -66,12 +66,11 @@
     }
   </ul>
 } @else {
-  @if (emptyMessage) {
+  @if (emptyMessage(); as message) {
     <alg-empty-content
       class="empty-content"
       icon="ph-duotone ph-folder-simple-minus"
-      [message]="emptyMessage"
+      [message]="message"
     ></alg-empty-content>
   }
 }
-

--- a/src/app/items/containers/item-children-list/item-children-list.component.ts
+++ b/src/app/items/containers/item-children-list/item-children-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ItemTypeCategory } from 'src/app/items/models/item-type';
 import { ItemChildWithAdditions } from './item-children';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
@@ -6,16 +6,13 @@ import { ItemRoutePipe, ItemRouteWithExtraPipe } from 'src/app/pipes/itemRoute';
 import { SkillProgressComponent } from 'src/app/ui-components/skill-progress/skill-progress.component';
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
 import { RouterLink } from '@angular/router';
-import { NgClass } from '@angular/common';
 import { EmptyContentComponent } from 'src/app/ui-components/empty-content/empty-content.component';
 
 @Component({
   selector: 'alg-item-children-list',
   templateUrl: './item-children-list.component.html',
   styleUrls: [ './item-children-list.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
-    NgClass,
     RouterLink,
     ScoreRingComponent,
     SkillProgressComponent,
@@ -26,11 +23,11 @@ import { EmptyContentComponent } from 'src/app/ui-components/empty-content/empty
   ]
 })
 export class ItemChildrenListComponent {
-  @Input() type: ItemTypeCategory = 'activity';
-  @Input() children: ItemChildWithAdditions[] = [];
-  @Input() emptyMessage?: string;
-  @Input() routeParams?: {
+  type = input<ItemTypeCategory>('activity');
+  children = input.required<ItemChildWithAdditions[]>();
+  emptyMessage = input<string>();
+  routeParams = input<{
     path: string[],
     parentAttemptId: string,
-  };
+  }>();
 }

--- a/src/app/items/containers/item-edit-content/item-edit-content.component.html
+++ b/src/app/items/containers/item-edit-content/item-edit-content.component.html
@@ -20,12 +20,10 @@
 </div>
 @switch (activeTab()) {
   @case ('write') {
-    <alg-textarea [parentForm]="parentForm" inputName="description" [resizable]="true" data-testid="edit-item-description"></alg-textarea>
+    <alg-textarea [parentForm]="parentForm()" inputName="description" [resizable]="true" data-testid="edit-item-description"></alg-textarea>
   }
   @case ('preview') {
-    @if (parentForm) {
-      <alg-preview-html [textContent]="parentForm.value.description"></alg-preview-html>
-    }
+    <alg-preview-html [textContent]="parentForm().value.description"></alg-preview-html>
   }
   @case ('help') {
     <alg-item-edit-content-help data-testid="edit-item-description-help"></alg-item-edit-content-help>

--- a/src/app/items/containers/item-edit-content/item-edit-content.component.ts
+++ b/src/app/items/containers/item-edit-content/item-edit-content.component.ts
@@ -1,6 +1,5 @@
-import { Component, EventEmitter, Input, Output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
-import { PossiblyInvisibleChildData } from '../../containers/item-children-edit/item-children-edit.component';
 import { TextareaComponent } from 'src/app/ui-components/textarea/textarea.component';
 import { PreviewHtmlComponent } from 'src/app/containers/preview-html/preview-html.component';
 import { ItemEditContentHelpComponent } from './item-edit-content-help/item-edit-content-help.component';
@@ -11,13 +10,10 @@ type Tab = 'write' | 'preview' | 'help';
   selector: 'alg-item-edit-content',
   templateUrl: './item-edit-content.component.html',
   styleUrls: [ './item-edit-content.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ TextareaComponent, PreviewHtmlComponent, ItemEditContentHelpComponent ]
 })
 export class ItemEditContentComponent {
-  @Input() parentForm?: UntypedFormGroup;
-
-  @Output() childrenChanges = new EventEmitter<PossiblyInvisibleChildData[]>();
+  parentForm = input.required<UntypedFormGroup>();
 
   activeTab = signal<Tab>('write');
 

--- a/src/app/items/containers/item-header/item-header.component.html
+++ b/src/app/items/containers/item-header/item-header.component.html
@@ -2,8 +2,8 @@
   <div class="item-header">
     <div class="item-title-container">
       <h1 class="item-title alg-h1" data-testid="item-title">{{ itemData().item.string.title }}</h1>
-      @if (itemData().item.string.subtitle) {
-        <p class="item-subtitle">{{ itemData().item.string.subtitle }}</p>
+      @if (itemData().item.string.subtitle; as subtitle) {
+        <p class="item-subtitle">{{ subtitle }}</p>
       }
     </div>
   </div>

--- a/src/app/items/containers/item-header/item-header.component.html
+++ b/src/app/items/containers/item-header/item-header.component.html
@@ -1,12 +1,10 @@
-@if (itemData) {
-  <div class="item-header-container">
-    <div class="item-header">
-      <div class="item-title-container">
-        <h1 class="item-title alg-h1" data-testid="item-title">{{ itemData.item.string.title }}</h1>
-        @if (itemData.item.string.subtitle) {
-          <p class="item-subtitle">{{ itemData.item.string.subtitle }}</p>
-        }
-      </div>
+<div class="item-header-container">
+  <div class="item-header">
+    <div class="item-title-container">
+      <h1 class="item-title alg-h1" data-testid="item-title">{{ itemData().item.string.title }}</h1>
+      @if (itemData().item.string.subtitle) {
+        <p class="item-subtitle">{{ itemData().item.string.subtitle }}</p>
+      }
     </div>
   </div>
-}
+</div>

--- a/src/app/items/containers/item-header/item-header.component.ts
+++ b/src/app/items/containers/item-header/item-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { ItemData } from '../../models/item-data';
 
 
@@ -6,10 +6,7 @@ import { ItemData } from '../../models/item-data';
   selector: 'alg-item-header',
   templateUrl: './item-header.component.html',
   styleUrls: [ './item-header.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: []
 })
 export class ItemHeaderComponent {
-  @Input() itemData?: ItemData;
-
+  itemData = input.required<ItemData>();
 }

--- a/src/app/items/containers/propagation-edit-menu/propagation-edit-menu.component.html
+++ b/src/app/items/containers/propagation-edit-menu/propagation-edit-menu.component.html
@@ -13,7 +13,7 @@
     <button
       class="menu-item-button"
       type="button"
-      [ngClass]="{'active': childData?.contentViewPropagation === 'none'}"
+      [class.active]="childData().contentViewPropagation === 'none'"
       (click)="onClick('none')"
     >
       <div class="menu-item-title" i18n>Locked and hidden</div>
@@ -26,8 +26,8 @@
     <button
       class="menu-item-button"
       type="button"
-      [ngClass]="{ 'active': childData?.contentViewPropagation === 'as_info' }"
-      [disabled]="!((childData?.permissions && (childData!.permissions! | allowsGrantingView)) || [ 'as_info', 'as_content' ].includes(childData?.contentViewPropagation || ''))"
+      [class.active]="childData().contentViewPropagation === 'as_info'"
+      [disabled]="!((childData().permissions && (childData().permissions! | allowsGrantingView)) || [ 'as_info', 'as_content' ].includes(childData().contentViewPropagation || ''))"
       (click)="onClick('as_info')"
     >
       <div class="menu-item-title" i18n>Locked</div>
@@ -42,8 +42,8 @@
     <button
       class="menu-item-button"
       type="button"
-      [ngClass]="{ 'active': childData?.contentViewPropagation === 'as_content' }"
-      [disabled]="!((childData?.permissions && (childData!.permissions! | allowsGrantingContentView)) || childData?.contentViewPropagation === 'as_content')"
+      [class.active]="childData().contentViewPropagation === 'as_content'"
+      [disabled]="!((childData().permissions && (childData().permissions! | allowsGrantingContentView)) || childData().contentViewPropagation === 'as_content')"
       (click)="onClick('as_content')"
     >
       <div class="menu-item-title" i18n>Open</div>

--- a/src/app/items/containers/propagation-edit-menu/propagation-edit-menu.component.ts
+++ b/src/app/items/containers/propagation-edit-menu/propagation-edit-menu.component.ts
@@ -1,7 +1,6 @@
-import { Component, Output, EventEmitter, Input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { PossiblyInvisibleChildData } from '../item-children-edit/item-children-edit.component';
 import { AllowsGrantingViewItemPipe, AllowsGrantingContentViewItemPipe } from 'src/app/items/models/item-grant-view-permission';
-import { NgClass } from '@angular/common';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directive';
 
@@ -9,9 +8,7 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
   selector: 'alg-propagation-edit-menu',
   templateUrl: 'propagation-edit-menu.component.html',
   styleUrls: [ 'propagation-edit-menu.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
-    NgClass,
     AllowsGrantingViewItemPipe,
     AllowsGrantingContentViewItemPipe,
     ButtonComponent,
@@ -20,8 +17,8 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
 })
 export class PropagationEditMenuComponent {
   openAdvancedConfigurationDialogEvent = output<void>();
-  @Input() childData?: PossiblyInvisibleChildData;
-  @Output() clickEvent = new EventEmitter<'none' | 'as_info' | 'as_content'>();
+  childData = input.required<PossiblyInvisibleChildData>();
+  clickEvent = output<'none' | 'as_info' | 'as_content'>();
 
   onClick(contentViewPropagation: 'none' | 'as_info' | 'as_content'): void {
     this.clickEvent.emit(contentViewPropagation);

--- a/src/app/items/containers/task-loader/task-loader.component.html
+++ b/src/app/items/containers/task-loader/task-loader.component.html
@@ -1,14 +1,13 @@
 <div class="container alg-flex-1">
   <div class="loading text-center">
-    @if (label) {
-      <div class="alg-text-secondary">{{ label }}</div>
+    @if (label()) {
+      <div class="alg-text-secondary">{{ label() }}</div>
     }
     <alg-loading></alg-loading>
-    @if (delayedLabel) {
-      <div class="sub-label" [style.visibility]="showDelayedLabel ? undefined : 'hidden'">
-        {{ delayedLabel }}
+    @if (delayedLabel()) {
+      <div class="sub-label" [style.visibility]="showDelayedLabel() ? undefined : 'hidden'">
+        {{ delayedLabel() }}
       </div>
     }
   </div>
 </div>
-

--- a/src/app/items/containers/task-loader/task-loader.component.spec.ts
+++ b/src/app/items/containers/task-loader/task-loader.component.spec.ts
@@ -1,0 +1,36 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TaskLoaderComponent } from './task-loader.component';
+import { SECONDS } from 'src/app/utils/duration';
+
+
+describe('TaskLoaderComponent', () => {
+  let fixture: ComponentFixture<TaskLoaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ TaskLoaderComponent ],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  // jasmine.clock() (not fakeAsync + tick): zone.js 0.16 fakeAsync does not advance RxJS timer().
+  it('should show delayed label after delay', () => {
+    jasmine.clock().install();
+    try {
+      fixture = TestBed.createComponent(TaskLoaderComponent);
+      fixture.componentRef.setInput('delayedLabel', 'Please wait...');
+      fixture.componentRef.setInput('delay', 1);
+      fixture.detectChanges();
+      TestBed.flushEffects();
+
+      expect(fixture.componentInstance.showDelayedLabel()).toBe(false);
+      jasmine.clock().tick(SECONDS);
+      expect(fixture.componentInstance.showDelayedLabel()).toBe(true);
+    } finally {
+      jasmine.clock().uninstall();
+    }
+  });
+});

--- a/src/app/items/containers/task-loader/task-loader.component.ts
+++ b/src/app/items/containers/task-loader/task-loader.component.ts
@@ -20,6 +20,8 @@ export class TaskLoaderComponent {
   showDelayedLabel = signal(false);
 
   constructor() {
+    // effect() restarts the timer when delayedLabel or delay inputs change; a field-initialized
+    // timer().pipe(takeUntilDestroyed()) would only run once at construction time.
     effect(onCleanup => {
       const delayedLabel = this.delayedLabel();
       this.showDelayedLabel.set(false);

--- a/src/app/items/containers/task-loader/task-loader.component.ts
+++ b/src/app/items/containers/task-loader/task-loader.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
-import { Subscription, timer } from 'rxjs';
+import { Component, effect, input, signal } from '@angular/core';
+import { timer } from 'rxjs';
 import { SECONDS } from 'src/app/utils/duration';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
 
@@ -8,28 +8,26 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
   selector: 'alg-task-loader',
   templateUrl: './task-loader.component.html',
   styleUrls: [ './task-loader.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ LoadingComponent ]
 })
-export class TaskLoaderComponent implements OnInit, OnDestroy {
-
-  @Input() label = '';
+export class TaskLoaderComponent {
+  label = input('');
   /** label displayed after a delay (by default 5s) */
-  @Input() delayedLabel?: string;
+  delayedLabel = input<string>();
   /** delay in seconds after which the delayedLabel is displayed */
-  @Input() delay = 5;
+  delay = input(5);
 
-  showDelayedLabel = false;
-  subscription?: Subscription;
+  showDelayedLabel = signal(false);
 
-  ngOnInit(): void {
-    if (this.delayedLabel) {
-      this.subscription = timer(this.delay*SECONDS).subscribe(() => this.showDelayedLabel = true);
-    }
+  constructor() {
+    effect(onCleanup => {
+      const delayedLabel = this.delayedLabel();
+      this.showDelayedLabel.set(false);
+      if (!delayedLabel) {
+        return;
+      }
+      const sub = timer(this.delay() * SECONDS).subscribe(() => this.showDelayedLabel.set(true));
+      onCleanup(() => sub.unsubscribe());
+    });
   }
-
-  ngOnDestroy(): void {
-    this.subscription?.unsubscribe();
-  }
-
 }


### PR DESCRIPTION
## Summary
- Modernize six items leaf components to Angular 22 patterns: signal inputs/outputs, `linkedSignal`/`effect` for OnPush-safe async state, `[class.*]` bindings.
- Batch 7 from `.cursor/plans/modernize-batch-7-items-leaves.md`.
- Removed dead `@Output childrenChanges` from `item-edit-content`. Parent templates unchanged.

## Scope
- **item-header** — `itemData` → `input.required()`
- **item-children-list** — 4 inputs → `input()`, `NgClass` → class bindings
- **item-edit-content** — `parentForm` → `input.required()`, dead output removed
- **task-loader** — inputs → `input()`, `showDelayedLabel` → `signal` + `effect()` timer
- **propagation-edit-menu** — `childData` → `input.required()`, `clickEvent` → `output()`
- **composition-filter** — `defaultValue` → `input()`, `selectedTypeFilter` → `linkedSignal`

## Risks / manual checks
- **item-children-list** on chapter/skill browsing critical path — e2e covers indirectly.
- **task-loader** delayed label: e2e only checks loader disappearance, not the "taking long" message after ~5s — manual smoke recommended.
- **propagation-edit-menu** covered by `e2e/items/propagation-edit-menu.spec.ts`.
- No unit specs for these 6 components.

## Verification
- [x] `npm run lint`
- [x] `rg 'alg-item-header|…' src e2e`
- [x] `ng build --configuration=e2e`
- [x] Manual smoke: chapter children list, skill lists, propagation menu, group progress filter tabs, item edit tabs, task-loader delayed label