### PR TITLE
Modernize Angular components (batch 8).

### DIFF
--- a/src/app/groups/containers/group-composition-filter/group-composition-filter.component.html
+++ b/src/app/groups/containers/group-composition-filter/group-composition-filter.component.html
@@ -1,12 +1,12 @@
 <alg-selection
   [items]="typeFilters"
-  [selected]="selectedTypeFilter"
+  [selected]="selectedTypeFilter()"
   (change)="onTypeFilterChanged($event)"
 ></alg-selection>
-@if (allowToCheckAllDescendants) {
+@if (allowToCheckAllDescendants()) {
   <div class="switch-control">
     <alg-switch
-      [(ngModel)]="allDescendantsChecked"
+      [ngModel]="allDescendantsChecked()"
       (ngModelChange)="onChildrenFilterChanged($event)"
     ></alg-switch>
     <p class="switch-control-caption" i18n>All descendants</p>

--- a/src/app/groups/containers/group-composition-filter/group-composition-filter.component.spec.ts
+++ b/src/app/groups/containers/group-composition-filter/group-composition-filter.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { Filter, GroupCompositionFilterComponent, TypeFilter } from './group-composition-filter.component';
+
+describe('GroupCompositionFilterComponent', () => {
+  let component: GroupCompositionFilterComponent;
+  let fixture: ComponentFixture<GroupCompositionFilterComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ GroupCompositionFilterComponent ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GroupCompositionFilterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('setFilter', () => {
+    it('should sync derived state from the given filter', () => {
+      const filter: Filter = { type: TypeFilter.Groups, directChildren: false };
+
+      component.setFilter(filter);
+
+      expect(component.value()).toEqual(filter);
+      expect(component.allDescendantsChecked()).toBe(true);
+      expect(component.selectedTypeFilter()).toBe(0);
+      expect(component.allowToCheckAllDescendants()).toBe(false);
+    });
+  });
+
+  describe('change output', () => {
+    it('should emit a new object reference on type filter change', () => {
+      const emitted: Filter[] = [];
+      component.change.subscribe(value => emitted.push(value));
+      const before = component.value();
+
+      component.onTypeFilterChanged(0);
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0]).not.toBe(before);
+      expect(emitted[0]).toEqual({ type: TypeFilter.Groups, directChildren: true });
+    });
+  });
+});

--- a/src/app/groups/containers/group-composition-filter/group-composition-filter.component.ts
+++ b/src/app/groups/containers/group-composition-filter/group-composition-filter.component.ts
@@ -79,6 +79,8 @@ export class GroupCompositionFilterComponent implements OnInit {
   onChildrenFilterChanged(checked: boolean): void {
     this.allDescendantsChecked.set(checked);
     this.value.update(current => ({ ...current, directChildren: !checked }));
+    // Re-resolve type index after directChildren changes: some filters only allow direct children,
+    // so allowToCheckAllDescendants must be refreshed from the canonical typeFilters entry.
     this.selectedTypeFilter.set(this.typeFilters.findIndex(typeFilter => typeFilter.value === this.value().type));
     this.value.update(current => ({ ...current, type: ensureDefined(this.typeFilters[this.selectedTypeFilter()]).value }));
     this.allowToCheckAllDescendants.set(!ensureDefined(this.typeFilters[this.selectedTypeFilter()]).directOnly);

--- a/src/app/groups/containers/group-composition-filter/group-composition-filter.component.ts
+++ b/src/app/groups/containers/group-composition-filter/group-composition-filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, OnInit, output, signal } from '@angular/core';
 import { ensureDefined } from 'src/app/utils/assert';
 import { FormsModule } from '@angular/forms';
 import { SwitchComponent } from 'src/app/ui-components/switch/switch.component';
@@ -20,19 +20,18 @@ export interface Filter {
   selector: 'alg-group-composition-filter',
   templateUrl: './group-composition-filter.component.html',
   styleUrls: [ './group-composition-filter.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ SelectionComponent, SwitchComponent, FormsModule ]
 })
-export class GroupCompositionFilterComponent implements OnInit{
-  @Input() defaultValue?: Filter;
+export class GroupCompositionFilterComponent implements OnInit {
+  defaultValue = input<Filter>();
 
-  @Output() change = new EventEmitter<Filter>();
+  change = output<Filter>();
 
-  value: Filter = { type: TypeFilter.Users, directChildren: true };
+  value = signal<Filter>({ type: TypeFilter.Users, directChildren: true });
 
-  allowToCheckAllDescendants = false;
-  allDescendantsChecked = false;
-  selectedTypeFilter = 0;
+  allowToCheckAllDescendants = signal(false);
+  allDescendantsChecked = signal(false);
+  selectedTypeFilter = signal(0);
 
   readonly typeFilters: { label: string, value: TypeFilter, directOnly: boolean }[] = [
     {
@@ -57,30 +56,32 @@ export class GroupCompositionFilterComponent implements OnInit{
   ];
 
   ngOnInit(): void {
-    if (this.defaultValue) {
-      this.setFilter(this.defaultValue);
+    const defaultVal = this.defaultValue();
+    if (defaultVal) {
+      this.setFilter(defaultVal);
     }
   }
 
   public setFilter(filter: Filter): void {
-    this.value = filter;
-    this.allDescendantsChecked = !this.value.directChildren;
-    this.selectedTypeFilter = Math.max(0, this.typeFilters.findIndex(typeFilter => typeFilter.value === this.value.type));
-    this.allowToCheckAllDescendants = !ensureDefined(this.typeFilters[this.selectedTypeFilter]).directOnly;
+    this.value.set(filter);
+    this.allDescendantsChecked.set(!this.value().directChildren);
+    this.selectedTypeFilter.set(Math.max(0, this.typeFilters.findIndex(typeFilter => typeFilter.value === this.value().type)));
+    this.allowToCheckAllDescendants.set(!ensureDefined(this.typeFilters[this.selectedTypeFilter()]).directOnly);
   }
 
   onTypeFilterChanged(index: number): void {
-    this.selectedTypeFilter = index;
-    this.value.type = ensureDefined(this.typeFilters[index]).value;
-    this.allowToCheckAllDescendants = !ensureDefined(this.typeFilters[index]).directOnly;
-    this.change.emit(this.value);
+    this.selectedTypeFilter.set(index);
+    this.value.update(current => ({ ...current, type: ensureDefined(this.typeFilters[index]).value }));
+    this.allowToCheckAllDescendants.set(!ensureDefined(this.typeFilters[index]).directOnly);
+    this.change.emit({ ...this.value() });
   }
 
   onChildrenFilterChanged(checked: boolean): void {
-    this.value.directChildren = !checked;
-    this.selectedTypeFilter = this.typeFilters.findIndex(typeFilter => typeFilter.value === this.value.type);
-    this.value.type = ensureDefined(this.typeFilters[this.selectedTypeFilter]).value;
-    this.allowToCheckAllDescendants = !ensureDefined(this.typeFilters[this.selectedTypeFilter]).directOnly;
-    this.change.emit(this.value);
+    this.allDescendantsChecked.set(checked);
+    this.value.update(current => ({ ...current, directChildren: !checked }));
+    this.selectedTypeFilter.set(this.typeFilters.findIndex(typeFilter => typeFilter.value === this.value().type));
+    this.value.update(current => ({ ...current, type: ensureDefined(this.typeFilters[this.selectedTypeFilter()]).value }));
+    this.allowToCheckAllDescendants.set(!ensureDefined(this.typeFilters[this.selectedTypeFilter()]).directOnly);
+    this.change.emit({ ...this.value() });
   }
 }

--- a/src/app/groups/containers/group-leave/group-leave.component.html
+++ b/src/app/groups/containers/group-leave/group-leave.component.html
@@ -1,23 +1,21 @@
-@if (group) {
-  <p>
-    @if (group.isMembershipLocked) {
-      <ng-container i18n>
-        You are currently not allowed to leave this group.
-      </ng-container>
-    } @else {
-      <ng-container i18n>
-        You can freely leave this group. Note that you may lose access to content if this group was granting some permissions to its members.
-      </ng-container>
-    }
-  </p>
-  <div class="button">
-    <button
-      class="size-l"
-      icon="ph-bold ph-x"
-      (click)="leaveGroup()"
-      [disabled]="group.isMembershipLocked"
-      alg-button
-      i18n
-    >Leave this group</button>
-  </div>
-}
+<p>
+  @if (group().isMembershipLocked) {
+    <ng-container i18n>
+      You are currently not allowed to leave this group.
+    </ng-container>
+  } @else {
+    <ng-container i18n>
+      You can freely leave this group. Note that you may lose access to content if this group was granting some permissions to its members.
+    </ng-container>
+  }
+</p>
+<div class="button">
+  <button
+    class="size-l"
+    icon="ph-bold ph-x"
+    (click)="leaveGroup()"
+    [disabled]="group().isMembershipLocked"
+    alg-button
+    i18n
+  >Leave this group</button>
+</div>

--- a/src/app/groups/containers/group-leave/group-leave.component.ts
+++ b/src/app/groups/containers/group-leave/group-leave.component.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, EventEmitter, Input, Output, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { GroupLeaveService } from 'src/app/data-access/group-leave.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { Group } from '../../models/group';
@@ -10,23 +10,18 @@ import { ButtonComponent } from 'src/app/ui-components/button/button.component';
   selector: 'alg-group-leave',
   templateUrl: './group-leave.component.html',
   styleUrls: [ './group-leave.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ ButtonComponent ]
 })
 export class GroupLeaveComponent {
   private groupLeaveService = inject(GroupLeaveService);
   private actionFeedbackService = inject(ActionFeedbackService);
 
-  @Output() leave = new EventEmitter<void>();
+  leave = output<void>();
 
-  @Input() group?: Group;
+  group = input.required<Group>();
 
   leaveGroup(): void {
-    if (!this.group) {
-      throw new Error('Unexpected: missed group');
-    }
-
-    this.groupLeaveService.leave(this.group.id).subscribe({
+    this.groupLeaveService.leave(this.group().id).subscribe({
       next: () => {
         this.actionFeedbackService.success($localize`You've left group`);
         this.leave.emit();

--- a/src/app/groups/containers/group-manager-add/group-manager-add.component.html
+++ b/src/app/groups/containers/group-manager-add/group-manager-add.component.html
@@ -5,13 +5,13 @@
     type="text"
     i18n-placeholder="Placeholder of field for searching for user by login" placeholder="Login of a user"
     [(ngModel)]="login"
-    [disabled]="state === 'loading'"
+    [disabled]="state() === 'loading'"
   >
   <div class="button-section">
     <button
       class="size-l"
       icon="ph-bold ph-plus"
-      [disabled]="login === '' || state === 'loading'"
+      [disabled]="login === '' || state() === 'loading'"
       (click)="onClick()"
       alg-button
     >Add</button>

--- a/src/app/groups/containers/group-manager-add/group-manager-add.component.ts
+++ b/src/app/groups/containers/group-manager-add/group-manager-add.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output, signal } from '@angular/core';
 import { switchMap } from 'rxjs/operators';
 import { Manager } from '../../data-access/get-group-managers.service';
 import { GetUserByLoginService } from 'src/app/data-access/get-user-by-login.service';
@@ -14,7 +14,6 @@ import { Group } from '../../models/group';
   selector: 'alg-group-manager-add',
   templateUrl: './group-manager-add.component.html',
   styleUrls: [ './group-manager-add.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ FormsModule, ButtonComponent ]
 })
 export class GroupManagerAddComponent {
@@ -22,38 +21,34 @@ export class GroupManagerAddComponent {
   private groupCreateManagerService = inject(GroupCreateManagerService);
   private actionFeedbackService = inject(ActionFeedbackService);
 
-  @Output() added = new EventEmitter<void>();
+  added = output<void>();
 
-  @Input({ required: true }) group!: Group;
-  @Input() managers?: Manager[];
+  group = input.required<Group>();
+  managers = input.required<Manager[]>();
 
-  state: 'ready' | 'error' | 'loading' = 'ready';
+  state = signal<'ready' | 'error' | 'loading'>('ready');
   login = '';
 
   onClick(): void {
-    if (!this.managers) {
-      throw new Error('Unexpected: Missed managers');
-    }
-
-    if (this.managers.some(manager => manager.login === this.login)) {
+    if (this.managers().some(manager => manager.login === this.login)) {
       this.actionFeedbackService.error($localize`This user is already a manager of this group.`);
       return;
     }
 
-    const groupId = this.group.id;
+    const groupId = this.group().id;
 
-    this.state = 'loading';
+    this.state.set('loading');
     this.getUserByLoginService.get(this.login).pipe(
       switchMap(user => this.groupCreateManagerService.create(groupId, user.groupId)),
     ).subscribe({
       next: () => {
-        this.state = 'ready';
+        this.state.set('ready');
         this.actionFeedbackService.success($localize`Manager added!`);
         this.login = '';
         this.added.emit();
       },
       error: error => {
-        this.state = 'error';
+        this.state.set('error');
 
         if (errorIsHTTPNotFound(error)) {
           this.actionFeedbackService.error($localize`The login you entered does not exist or is not visible to you.`);

--- a/src/app/groups/containers/group-overview/group-overview.component.html
+++ b/src/app/groups/containers/group-overview/group-overview.component.html
@@ -1,12 +1,10 @@
-@if (group) {
-  <h2 class="alg-h2" i18n>Presentation</h2>
-  @if (group.description ) {
-    <p>{{ group.description }}</p>
-  } @else {
-    <span i18n>This group has no description</span>
-  }
-  @if (group | isCurrentUserMember) {
-    <h2 class="alg-h2" i18n>Leave the group?</h2>
-    <alg-group-leave [group]="group" (leave)="onLeave()"></alg-group-leave>
-  }
+<h2 class="alg-h2" i18n>Presentation</h2>
+@if (group().description ) {
+  <p>{{ group().description }}</p>
+} @else {
+  <span i18n>This group has no description</span>
+}
+@if (group() | isCurrentUserMember) {
+  <h2 class="alg-h2" i18n>Leave the group?</h2>
+  <alg-group-leave [group]="group()" (leave)="onLeave()"></alg-group-leave>
 }

--- a/src/app/groups/containers/group-overview/group-overview.component.ts
+++ b/src/app/groups/containers/group-overview/group-overview.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { Group } from '../../models/group';
 import { Router } from '@angular/router';
 import { GroupLeaveComponent } from '../group-leave/group-leave.component';
@@ -9,7 +9,6 @@ import { IsCurrentUserMemberPipe } from '../../models/group-membership';
   selector: 'alg-group-overview',
   templateUrl: './group-overview.component.html',
   styleUrls: [ './group-overview.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     GroupLeaveComponent,
     IsCurrentUserMemberPipe,
@@ -18,13 +17,13 @@ import { IsCurrentUserMemberPipe } from '../../models/group-membership';
 export class GroupOverviewComponent {
   private router = inject(Router);
 
-  @Output() groupRefreshRequired = new EventEmitter<void>();
-  @Output() leftGroup = new EventEmitter<void>();
+  groupRefreshRequired = output<void>();
+  leftGroup = output<void>();
 
-  @Input() group?: Group;
+  group = input.required<Group>();
 
   onLeave(): void {
-    if (this.group?.isPublic) {
+    if (this.group().isPublic) {
       this.groupRefreshRequired.emit();
       return;
     }

--- a/src/app/groups/containers/group-permissions/group-permissions.component.html
+++ b/src/app/groups/containers/group-permissions/group-permissions.component.html
@@ -1,16 +1,14 @@
-@if (permissions) {
-  <ul class="captions">
-    <li class="caption-item">
-      <div class="caption">Can View: {{ permissions.canView | groupPermissionCaption }}</div>
-    </li>
-    <li class="caption-item">
-      <div class="caption">Can Grant View: {{ permissions.canGrantView | groupPermissionCaption }}</div>
-    </li>
-    <li class="caption-item">
-      <div class="caption">Can Enter From: {{ permissions.canEnterFrom | date:'d/MM/y' }}</div>
-    </li>
-    <li class="caption-item">
-      <div class="caption">Until: {{ permissions.canEnterUntil | date:'d/MM/y' }}</div>
-    </li>
-  </ul>
-}
+<ul class="captions">
+  <li class="caption-item">
+    <div class="caption">Can View: {{ permissions().canView | groupPermissionCaption }}</div>
+  </li>
+  <li class="caption-item">
+    <div class="caption">Can Grant View: {{ permissions().canGrantView | groupPermissionCaption }}</div>
+  </li>
+  <li class="caption-item">
+    <div class="caption">Can Enter From: {{ permissions().canEnterFrom | date:'d/MM/y' }}</div>
+  </li>
+  <li class="caption-item">
+    <div class="caption">Until: {{ permissions().canEnterUntil | date:'d/MM/y' }}</div>
+  </li>
+</ul>

--- a/src/app/groups/containers/group-permissions/group-permissions.component.ts
+++ b/src/app/groups/containers/group-permissions/group-permissions.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { GrantedPermissions } from '../../data-access/granted-permissions.service';
 import { GroupPermissionCaptionPipe } from 'src/app/pipes/groupPermissionCaption';
 import { DatePipe } from '@angular/common';
@@ -7,12 +7,11 @@ import { DatePipe } from '@angular/common';
   selector: 'alg-group-permissions',
   templateUrl: './group-permissions.component.html',
   styleUrls: [ './group-permissions.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     DatePipe,
     GroupPermissionCaptionPipe,
   ]
 })
 export class GroupPermissionsComponent {
-  @Input() permissions?: GrantedPermissions['permissions'];
+  permissions = input.required<GrantedPermissions['permissions']>();
 }

--- a/src/app/groups/containers/user-indicator/user-indicator.component.html
+++ b/src/app/groups/containers/user-indicator/user-indicator.component.html
@@ -1,7 +1,7 @@
-@if (user) {
+@if (user()) {
   <div class="container">
     <div class="content" i18n>
-      You are manager of <alg-group-links class="links" [items]="user.ancestorsCurrentUserIsManagerOf"></alg-group-links>
+      You are manager of <alg-group-links class="links" [items]="user().ancestorsCurrentUserIsManagerOf"></alg-group-links>
       of which this user is member.
     </div>
   </div>

--- a/src/app/groups/containers/user-indicator/user-indicator.component.html
+++ b/src/app/groups/containers/user-indicator/user-indicator.component.html
@@ -1,8 +1,6 @@
-@if (user()) {
-  <div class="container">
-    <div class="content" i18n>
-      You are manager of <alg-group-links class="links" [items]="user().ancestorsCurrentUserIsManagerOf"></alg-group-links>
-      of which this user is member.
-    </div>
+<div class="container">
+  <div class="content" i18n>
+    You are manager of <alg-group-links class="links" [items]="user().ancestorsCurrentUserIsManagerOf"></alg-group-links>
+    of which this user is member.
   </div>
-}
+</div>

--- a/src/app/groups/containers/user-indicator/user-indicator.component.ts
+++ b/src/app/groups/containers/user-indicator/user-indicator.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { User } from '../../models/user';
 import { GroupLinksComponent } from '../group-links/group-links.component';
 
@@ -7,9 +7,8 @@ import { GroupLinksComponent } from '../group-links/group-links.component';
   selector: 'alg-user-indicator',
   templateUrl: './user-indicator.component.html',
   styleUrls: [ './user-indicator.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ GroupLinksComponent ]
 })
 export class UserIndicatorComponent {
-  @Input() user?: User;
+  user = input.required<User>();
 }


### PR DESCRIPTION
## Summary
- Modernize six groups leaf components to Angular 22 patterns (signal inputs/outputs, OnPush-safe signal state).
- Batch 8 from `.cursor/plans/modernize-batch-8-groups-leaves.md`.
- `group-composition-filter` now emits fresh filter objects; `setFilter()` public API preserved for `member-list`.

## Scope
- **user-indicator**, **group-permissions**, **group-overview**, **group-leave** — `@Input`/`@Output` → `input()`/`output()`, drop `Eager`
- **group-composition-filter** — internal state → signals, fresh `{ ...value() }` on emit
- **group-manager-add** — `state` → signal for subscribe-mutated loading state

## Risks / manual checks
- **group-composition-filter** ⇄ **member-list** contract (`setFilter` + `change` payload) — highest risk area
- No unit specs for any of the six; e2e coverage is indirect
- Manual smoke: user indicator, group access permissions, leave group, members filter tabs/descendant toggle, add manager by login

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-8/en/

## Verification
- [x] `npm run lint`
- [x] `rg 'alg-user-indicator|…' src e2e`
- [x] `ng build --configuration=e2e`
- [x] Manual smoke (use URL above)