### PR TITLE
add a way to test the 'task API' both with E2E and for manual testing (task served locally)

### DIFF
--- a/.cursor/ARCHITECTURE.md
+++ b/.cursor/ARCHITECTURE.md
@@ -393,6 +393,10 @@ Both messages are notifications, not RPC; the helper is ~30 lines and adds no ne
 
 Task API versioning is negotiated at load time via optional `apiVersion` / `minApiVersion` fields returned by `task.getMetaData()`. The platform supports versions 1–2 and picks the highest version in the overlapping range. When the negotiated version is ≥ 2, `Task.reloadAnswer()` dispatches to the v2 wire method `task.reloadAnswerWithOptions`, passing `idUserAnswer` when reloading a submitted answer so the task can fetch submission feedback from its own backend using the signed task token.
 
+#### Test task for platform-task integration
+
+[mocks/test-task/](../mocks/test-task/) is a static jschannel task page used to exercise platform↔task flows without relying on external task content. It is served by the dev mock server (`http://localhost:3000/test-task/`) and never included in Angular production builds. E2E tests intercept the same files via Playwright (`e2e/items/task-platform-interaction.spec.ts`). Update it whenever the task API surface changes.
+
 ## Testing
 
 - **Unit tests**: Jasmine + Karma (`ng test`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,16 @@ Make sure after each modification that:
 - Set the user token in `.e2e.env` (start from `.e2e.env.sample`)
 - Launch web server (`ng serve`) before running tests
 
+## Testing platform-task interaction
+
+When changing code under `src/app/items/api/` or the `item-task-*` services:
+
+1. Keep [mocks/test-task/](mocks/test-task/) in sync with the Bebras task API (add bindings and control-panel buttons for new methods).
+2. For manual checks, run `npm start` and set a dev task URL to `http://localhost:3000/test-task/index.html`.
+3. Add or update coverage in [e2e/items/task-platform-interaction.spec.ts](e2e/items/task-platform-interaction.spec.ts).
+
+See [mocks/test-task/README.md](mocks/test-task/README.md) for scenario query params and API coverage.
+
 ## Internationalization
 
 - All English strings in templates and code must be internationalized

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app w
 
 If you use the mock server - via `npm start`, copy mocks/environment.dev.ts to mocks/enviromnent.ts and update the dev token value.
 
+### Testing platform-task interaction locally
+
+A local test task (a static page implementing the Bebras task API) is served by the mock server at `http://localhost:3000/test-task/index.html`. Point a dev Task item at this URL to exercise platform↔task communication manually. See [mocks/test-task/README.md](mocks/test-task/README.md) for launch instructions, scenarios, and API coverage.
+
 ## Code Style
 
 Run `npm run lint` to launch the linter checks on the code.

--- a/e2e/items/pages/test-task-page.ts
+++ b/e2e/items/pages/test-task-page.ts
@@ -1,0 +1,256 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { expect, FrameLocator, Page } from '@playwright/test';
+import { apiUrl } from 'e2e/helpers/e2e_http';
+
+export const TEST_TASK_ITEM_ID = '9999999999999999001';
+export const TEST_TASK_URL = 'http://localhost:4200/test-task/index.html';
+
+export interface TestTaskApiOptions {
+  itemId?: string,
+  taskUrl?: string,
+  taskQuery?: string,
+  currentAnswer?: { answer: string, state: string } | null,
+}
+
+interface TaskCallLogEntry {
+  method: string,
+  params: unknown,
+  timestamp: number,
+}
+
+const actionSuccess = { success: true as const, message: 'ok' };
+
+function buildTaskResponse(itemId: string, taskUrl: string): object {
+  return {
+    id: itemId,
+    type: 'Task',
+    validation_type: 'All',
+    requires_explicit_entry: false,
+    allows_multiple_attempts: true,
+    entry_participant_type: 'User',
+    duration: null,
+    no_score: false,
+    default_language_tag: 'en',
+    permissions: {
+      can_view: 'content',
+      can_grant_view: 'none',
+      can_watch: 'none',
+      can_edit: 'none',
+      is_owner: true,
+      can_request_help: true,
+    },
+    entry_min_admitted_members_ratio: 'None',
+    entry_frozen_teams: false,
+    entry_max_team_size: 0,
+    prompt_to_join_group_by_code: false,
+    text_id: null,
+    read_only: false,
+    children_layout: 'List',
+    entering_time_min: '1000-01-01T00:00:00Z',
+    entering_time_max: '9999-12-31T23:59:59Z',
+    supported_language_tags: ['en'],
+    best_score: 0,
+    display_settings: {},
+    string: {
+      language_tag: 'en',
+      title: 'Platform-task test task',
+      image_url: null,
+      subtitle: null,
+      description: null,
+      edu_comment: null,
+    },
+    url: taskUrl,
+    options: '',
+    uses_api: true,
+    hints_allowed: false,
+  };
+}
+
+export async function routeTestTaskAssets(page: Page): Promise<void> {
+  const testTaskDir = path.join(__dirname, '../../../mocks/test-task');
+  const jschannelPath = path.join(__dirname, '../../../node_modules/jschannel/src/jschannel.js');
+  const contentTypes: Record<string, string> = {
+    '.html': 'text/html',
+    '.css': 'text/css',
+    '.js': 'application/javascript',
+  };
+
+  await page.route('**/test-task/**', async route => {
+    const url = new URL(route.request().url());
+    const relativePath = url.pathname.replace(/^.*\/test-task\//, '') || 'index.html';
+    if (relativePath === 'jschannel.js') {
+      await route.fulfill({
+        body: fs.readFileSync(jschannelPath),
+        contentType: 'application/javascript',
+        headers: { 'Cache-Control': 'no-cache, no-store, must-revalidate' },
+      });
+      return;
+    }
+    const filePath = path.join(testTaskDir, relativePath);
+    const extension = path.extname(filePath);
+    await route.fulfill({
+      body: fs.readFileSync(filePath),
+      contentType: contentTypes[extension] ?? 'text/plain',
+      headers: { 'Cache-Control': 'no-cache, no-store, must-revalidate' },
+    });
+  });
+}
+
+export async function mockTestTaskItemApi(page: Page, options: TestTaskApiOptions = {}): Promise<void> {
+  const itemId = options.itemId ?? TEST_TASK_ITEM_ID;
+  const taskUrl = options.taskUrl ?? (
+    options.taskQuery ? `${TEST_TASK_URL}?${options.taskQuery}` : TEST_TASK_URL
+  );
+  const taskResponse = buildTaskResponse(itemId, taskUrl);
+  const breadcrumbs = [{
+    item_id: itemId,
+    language_tag: 'en',
+    title: 'Platform-task test task',
+    type: 'Task',
+  }];
+  const attempts = [{
+    id: '0',
+    created_at: '2024-01-01T00:00:00Z',
+    score_computed: 0,
+    validated: false,
+    started_at: '2024-01-01T00:00:00Z',
+    ended_at: null,
+    allows_submissions_until: '9999-12-31T23:59:59Z',
+    latest_activity_at: '2024-01-01T00:00:00Z',
+    help_requested: false,
+    user_creator: {
+      login: 'test-user',
+      first_name: null,
+      last_name: null,
+      group_id: '1',
+    },
+  }];
+
+  await page.route(`${apiUrl}/items/${itemId}`, route => route.fulfill({ json: taskResponse }));
+  await page.route(`${apiUrl}/items/${itemId}/breadcrumbs*`, route => route.fulfill({ json: breadcrumbs }));
+  await page.route(`${apiUrl}/items/${itemId}/attempts*`, route => route.fulfill({ json: attempts }));
+  await page.route(`${apiUrl}/items/${itemId}/current-answer*`, route => {
+    if (route.request().method() === 'PUT') {
+      route.fulfill({ json: actionSuccess });
+      return;
+    }
+    if (options.currentAnswer) {
+      route.fulfill({
+        json: {
+          answer: options.currentAnswer.answer,
+          state: options.currentAnswer.state,
+          attempt_id: '0',
+          author_id: '1',
+          participant_id: '1',
+          id: 'answer-1',
+          item_id: itemId,
+          score: null,
+          type: 'Current',
+        },
+      });
+      return;
+    }
+    route.fulfill({ json: { type: null } });
+  });
+  await page.route(`${apiUrl}/items/${itemId}/attempts/*/generate-task-token`, route => route.fulfill({
+    json: { ...actionSuccess, data: { task_token: 'mock-task-token' } },
+  }));
+  await page.route(`${apiUrl}/answers`, route => route.fulfill({
+    json: { ...actionSuccess, data: { answer_token: 'mock-answer-token' } },
+  }));
+  await page.route(`${apiUrl}/items/save-grade`, route => route.fulfill({
+    json: { ...actionSuccess, data: { validated: false, unlocked_items: [] } },
+  }));
+}
+
+export class TestTaskPage {
+  readonly taskFrame: FrameLocator = this.page.locator('alg-item-display iframe').contentFrame();
+
+  constructor(private readonly page: Page) {}
+
+  async gotoItem(itemId = TEST_TASK_ITEM_ID): Promise<void> {
+    await this.page.goto(`/a/${itemId};p=;a=0`);
+  }
+
+  async waitForLoaded(): Promise<void> {
+    await expect(this.page.getByText('Loading the content')).not.toBeVisible({ timeout: 30000 });
+    await expect(this.taskFrame.getByTestId('test-task-status')).toHaveText('Ready', { timeout: 30000 });
+    // Guard against the task script having crashed partway through setup (e.g. a missing DOM element):
+    // the channel binds happen early, so the status can be "Ready" even if button handlers were never attached.
+    const setupComplete = await this.taskFrame.locator('body')
+      .evaluate(() => typeof window.invokePlatform === 'function');
+    expect(setupComplete).toBe(true);
+  }
+
+  async getCalls(): Promise<TaskCallLogEntry[]> {
+    return this.taskFrame.locator('body').evaluate(() => window.testTaskCalls ?? []);
+  }
+
+  async waitForCall(method: string, matches?: (entry: TaskCallLogEntry) => boolean): Promise<TaskCallLogEntry> {
+    const isMatch = (entry: TaskCallLogEntry): boolean => entry.method === method && (!matches || matches(entry));
+    await expect.poll(async () => {
+      const calls = await this.getCalls();
+      return calls.some(isMatch);
+    }).toBe(true);
+    const calls = await this.getCalls();
+    return calls.find(isMatch)!;
+  }
+
+  async waitForPlatformCall(method: string): Promise<TaskCallLogEntry> {
+    const outboundMethod = '→ ' + method;
+    await expect.poll(async () => {
+      const calls = await this.getCalls();
+      return calls.some(entry => entry.method === outboundMethod || entry.method === '_outgoing.' + method);
+    }, { timeout: 15000 }).toBe(true);
+    const calls = await this.getCalls();
+    return calls.find(entry => entry.method === outboundMethod)
+      ?? calls.find(entry => entry.method === '_outgoing.' + method)!;
+  }
+
+  async setAnswer(value: string): Promise<void> {
+    await this.taskFrame.getByTestId('answer-input').fill(value);
+  }
+
+  async clickValidate(mode = 'top'): Promise<void> {
+    await this.taskFrame.getByTestId('validate-mode').selectOption(mode);
+    await this.taskFrame.getByTestId('validate-btn').click();
+  }
+
+  async clickShowView(view: string): Promise<void> {
+    await this.taskFrame.getByTestId('show-view').selectOption(view);
+    await this.taskFrame.getByTestId('show-view-btn').click();
+  }
+
+  async invokeGetTaskParams(): Promise<void> {
+    await this.taskFrame.getByTestId('get-task-params-btn').click();
+  }
+
+  async clickUpdateDisplay(height: number): Promise<void> {
+    await this.taskFrame.getByTestId('display-height').fill(String(height));
+    await this.taskFrame.getByTestId('update-display-btn').click();
+  }
+
+  async clickOpenUrl(itemId: string): Promise<void> {
+    await this.taskFrame.getByTestId('open-url-target').fill(itemId);
+    await this.taskFrame.getByTestId('open-url-btn').click();
+  }
+
+  taskIframeLocator() {
+    return this.page.locator('alg-item-display iframe.iframe-element');
+  }
+}
+
+declare global {
+  interface Window {
+    testTaskCalls?: TaskCallLogEntry[],
+    testTaskState?: {
+      answer: string,
+      state: string,
+      token: string,
+      shownViews: Record<string, boolean>,
+      loaded: boolean,
+    },
+    invokePlatform?: (method: string, params: unknown) => Promise<unknown>,
+  }
+}

--- a/e2e/items/task-platform-interaction.spec.ts
+++ b/e2e/items/task-platform-interaction.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from 'e2e/items/fixture';
+import { initAsUsualUser } from 'e2e/helpers/e2e_auth';
+import {
+  mockTestTaskItemApi,
+  routeTestTaskAssets,
+  TestTaskPage,
+} from 'e2e/items/pages/test-task-page';
+
+test.describe('platform-task interaction', () => {
+  let testTaskPage: TestTaskPage;
+
+  test.beforeEach(async ({ page }) => {
+    await initAsUsualUser(page);
+    await routeTestTaskAssets(page);
+    await mockTestTaskItemApi(page);
+    testTaskPage = new TestTaskPage(page);
+  });
+
+  test('loads the task and completes the jschannel handshake', async () => {
+    await testTaskPage.gotoItem();
+    await testTaskPage.waitForLoaded();
+
+    await testTaskPage.waitForCall('task.getMetaData');
+    const loadCall = await testTaskPage.waitForCall('task.load');
+    expect(loadCall.params).toMatchObject({
+      task: true,
+      solution: true,
+      editor: true,
+      hints: true,
+      grader: true,
+      metadata: true,
+    });
+  });
+
+  test('validate top triggers getAnswer, gradeAnswer, and save-grade', async ({ page }) => {
+    await testTaskPage.gotoItem();
+    await testTaskPage.waitForLoaded();
+
+    const saveGradeRequest = page.waitForRequest(
+      request => request.url().includes('/items/save-grade') && request.method() === 'POST',
+    );
+
+    await testTaskPage.setAnswer('80');
+    await testTaskPage.clickValidate('top');
+
+    await testTaskPage.waitForPlatformCall('platform.validate');
+    await testTaskPage.waitForCall('task.getAnswer');
+    const gradeCall = await testTaskPage.waitForCall('task.gradeAnswer');
+    expect(gradeCall.params).toEqual(['80', 'mock-answer-token']);
+
+    const request = await saveGradeRequest;
+    const body = request.postDataJSON() as { score: number };
+    expect(body.score).toBe(80);
+  });
+
+  test('showView asks the platform to switch tabs and reload task views', async () => {
+    await testTaskPage.gotoItem();
+    await testTaskPage.waitForLoaded();
+
+    await testTaskPage.clickShowView('solution');
+
+    await testTaskPage.waitForPlatformCall('platform.showView');
+    // skip the initial showViews({ task: true }) emitted on load
+    const showViewsCall = await testTaskPage.waitForCall(
+      'task.showViews',
+      entry => (entry.params as { solution?: boolean }).solution === true,
+    );
+    expect(showViewsCall.params).toMatchObject({ solution: true });
+  });
+
+  test('getTaskParams returns platform parameters to the task', async () => {
+    await testTaskPage.gotoItem();
+    await testTaskPage.waitForLoaded();
+
+    await testTaskPage.invokeGetTaskParams();
+
+    await testTaskPage.waitForPlatformCall('platform.getTaskParams');
+    await expect(testTaskPage.taskFrame.getByTestId('task-params-result')).toContainText('randomSeed');
+  });
+
+  test('reloads an existing answer and state on load', async ({ page }) => {
+    await mockTestTaskItemApi(page, {
+      taskQuery: 'apiVersion=1&minApiVersion=1',
+      currentAnswer: { answer: '42', state: 'saved-state' },
+    });
+    await testTaskPage.gotoItem();
+    await testTaskPage.waitForLoaded();
+
+    const reloadAnswerCall = await testTaskPage.waitForCall('task.reloadAnswer');
+    expect(reloadAnswerCall.params).toBe('42');
+    const reloadStateCall = await testTaskPage.waitForCall('task.reloadState');
+    expect(reloadStateCall.params).toBe('saved-state');
+    await expect(testTaskPage.taskFrame.getByTestId('answer-input')).toHaveValue('42');
+    await expect(testTaskPage.taskFrame.getByTestId('state-input')).toHaveValue('saved-state');
+  });
+});

--- a/mocks/server.ts
+++ b/mocks/server.ts
@@ -1,18 +1,42 @@
-import express from 'express';
+import express, { RequestHandler } from 'express';
+import path from 'path';
 import { json as bodyParserJson } from 'body-parser';
 import cors from 'cors';
-import * as handlers from './handlers';
 import { errorHandler } from './handlers/error';
-import { auth, operation, proxy } from './middlewares';
+import { auth } from './middlewares/auth';
+import { proxy } from './middlewares/proxy';
 
 const app = express();
+const projectRoot = path.join(__dirname, '..');
+const testTaskDir = path.join(__dirname, 'test-task');
+
+app.get('/test-task/jschannel.js', (_req, res) => {
+  res.sendFile(path.join(projectRoot, 'node_modules/jschannel/src/jschannel.js'));
+});
+app.use('/test-task', express.static(testTaskDir));
 
 app.use(cors({ credentials: true, origin: 'http://localhost:4200' }));
 app.use(bodyParserJson());
 app.use(auth());
-app.use(operation());
 
-Object.values(handlers).forEach(handler => app.use(handler));
+// The API mock handlers (and the `operation` middleware they rely on) depend on mocks/types/schema.ts,
+// which is generated from the backend swagger spec (`npm run generate-types-from-swagger`) and not
+// committed. Static features like the test task do not need it, so when the file is missing we only
+// disable the API mocks (requests fall through to the proxy) instead of crashing the whole server.
+try {
+  /* eslint-disable @typescript-eslint/no-var-requires */
+  const { operation } = require('./middlewares/operation') as typeof import('./middlewares/operation');
+  const handlers = require('./handlers') as Record<string, RequestHandler>;
+  /* eslint-enable @typescript-eslint/no-var-requires */
+  app.use(operation());
+  Object.values(handlers).forEach(handler => app.use(handler));
+} catch {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'API mocks disabled: mocks/types/schema.ts is missing. ' +
+    'Run `npm run generate-types-from-swagger` if you need them. All /api requests are proxied to the dev backend.'
+  );
+}
 
 app.use(proxy());
 app.use(errorHandler());

--- a/mocks/test-task/README.md
+++ b/mocks/test-task/README.md
@@ -1,0 +1,102 @@
+# Test task (platform-task interaction)
+
+Static page implementing the Bebras task API over jschannel. It is **not** part of the Angular build and is never deployed to production.
+
+## Launch (manual testing)
+
+You need **two local servers**:
+
+| Server | Port | Role |
+|--------|------|------|
+| Mock server | `3000` | Serves this test task at `/test-task/` |
+| Angular dev server | `4200` | The Algorea platform (`ng serve`) |
+
+### 1. Start the servers
+
+**Option A — both at once** (when port 4200 is free):
+
+```bash
+npm start
+```
+
+**Option B — mock only** (when `ng serve` is already running in another terminal):
+
+```bash
+npm run mock
+```
+
+If `npm start` fails with *“Port 4200 is already in use”*, you already have the platform running: keep it and use option B.
+
+No backend or API setup is required: the test task is plain static files. If the mock server prints *“API mocks disabled: mocks/types/schema.ts is missing”*, you can ignore it — that only affects the API mocking feature (see [mocks/README.md](../README.md)), not the test task.
+
+### 2. Task URL
+
+Set the **task URL** of a dev Task item to:
+
+```
+http://localhost:3000/test-task/index.html
+```
+
+Add query parameters for scenarios if needed (see [Scenario query parameters](#scenario-query-parameters) below). The platform adds `channelId` and other params automatically when it loads the iframe — do not add them yourself.
+
+Examples:
+
+```
+http://localhost:3000/test-task/index.html?usesTokens=1
+http://localhost:3000/test-task/index.html?apiVersion=1&minApiVersion=1
+```
+
+### 3. Open the item in the platform
+
+1. Go to [http://localhost:4200/](http://localhost:4200/) and open the Task item you configured.
+2. Wait for the iframe status to show **Ready**.
+3. Use the **Platform calls** buttons inside the iframe to trigger `platform.*` methods.
+4. Read the **Platform → task call log** to see what the platform sent (`task.load`, `task.getAnswer`, …).
+
+Opening `http://localhost:3000/test-task/index.html` directly in a browser tab is only useful to check that the mock server is up; jschannel needs the platform parent frame, so the page will stay on *“Waiting for platform…”*.
+
+**Known limitation (manual mode):** the task cannot produce a signed `score_token` (that requires the task platform's private key), so it returns a null token and the raw score is sent to `/items/save-grade`. The backend accepts that only when the item's task platform is not configured to require tokens; otherwise `platform.validate` fails at the save-grade step (earlier steps — answer saving, answer token, `task.gradeAnswer` — can still be observed). In e2e this is not an issue since the backend endpoints are mocked.
+
+## E2E testing
+
+Playwright serves the same files from disk via route interception (`routeTestTaskAssets` in `e2e/items/pages/test-task-page.ts`). Specs live in `e2e/items/task-platform-interaction.spec.ts`.
+
+Run:
+
+```bash
+npm run e2e -- e2e/items/task-platform-interaction.spec.ts
+```
+
+## Scenario query parameters
+
+| Parameter | Effect |
+|-----------|--------|
+| `apiVersion` / `minApiVersion` | Negotiated task API version (default 2 / 1) |
+| `usesTokens=1` | Task metadata requests token flow (`task.updateToken`) |
+| `autoHeight=1` | Metadata `autoHeight: true` |
+| `loadDelay=ms` | Delay `task.load` completion |
+| `gradeDelay=ms` | Delay `task.gradeAnswer` completion |
+| `failGrade=1` | Make `task.gradeAnswer` fail |
+| `score=N` | Fixed grade score instead of parsing the answer |
+
+## API coverage
+
+### Platform → task (logged automatically)
+
+`task.getMetaData`, `task.load`, `task.unload`, `task.getHeight`, `task.updateToken`, `task.getAnswer`, `task.reloadAnswer`, `task.reloadAnswerWithOptions`, `task.getState`, `task.reloadState`, `task.getViews`, `task.showViews`, `task.gradeAnswer`, `task.getResources`
+
+### Task → platform (buttons in the page)
+
+`platform.validate`, `platform.updateDisplay`, `platform.updateHeight`, `platform.openUrl`, `platform.showView`, `platform.getTaskParams`, `platform.askHint`, `platform.log`
+
+## Programmatic access (e2e / debugging)
+
+Inside the iframe:
+
+- `window.testTaskCalls` — array of `{ method, params, timestamp }`
+- `window.testTaskState` — `{ answer, state, token, shownViews, loaded }`
+- `window.testTask` — helpers (`setAnswer`, `getCalls`, …)
+
+## Keeping in sync
+
+When changing [task-proxy.ts](../../src/app/items/api/task-proxy.ts) or `item-task-*` services, update this page and `e2e/items/task-platform-interaction.spec.ts` in the same change.

--- a/mocks/test-task/index.html
+++ b/mocks/test-task/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Algorea test task</title>
+  <link rel="stylesheet" href="test-task.css">
+  <script src="jschannel.js"></script>
+</head>
+<body>
+  <header>
+    <h1>Algorea test task</h1>
+    <p id="status" data-testid="test-task-status">Connecting…</p>
+  </header>
+
+  <section class="panel">
+    <h2>Task data</h2>
+    <label>
+      Answer
+      <input id="answer-input" data-testid="answer-input" type="text" value="">
+    </label>
+    <label>
+      State
+      <input id="state-input" data-testid="state-input" type="text" value="">
+    </label>
+    <p>Last token: <span id="last-token" data-testid="last-token">—</span></p>
+    <p>Shown views: <span id="shown-views" data-testid="shown-views">—</span></p>
+  </section>
+
+  <section class="panel">
+    <h2>Platform calls</h2>
+    <div class="controls">
+      <label>
+        Validate mode
+        <select id="validate-mode" data-testid="validate-mode">
+          <option value="done">done (plain submit)</option>
+          <option value="cancel">cancel</option>
+          <option value="next">next</option>
+          <option value="nextImmediate">nextImmediate</option>
+          <option value="top">top</option>
+        </select>
+      </label>
+      <button type="button" id="validate-btn" data-testid="validate-btn">platform.validate</button>
+    </div>
+    <div class="controls">
+      <label>
+        Height
+        <input id="display-height" data-testid="display-height" type="number" value="420">
+      </label>
+      <button type="button" id="update-display-btn" data-testid="update-display-btn">platform.updateDisplay</button>
+      <button type="button" id="update-height-btn" data-testid="update-height-btn">platform.updateHeight</button>
+    </div>
+    <div class="controls">
+      <label>
+        openUrl target
+        <input id="open-url-target" data-testid="open-url-target" type="text" value="4702">
+      </label>
+      <button type="button" id="open-url-btn" data-testid="open-url-btn">platform.openUrl (path)</button>
+    </div>
+    <div class="controls">
+      <label>
+        View
+        <select id="show-view" data-testid="show-view">
+          <option value="task">task</option>
+          <option value="editor">editor</option>
+          <option value="solution">solution</option>
+          <option value="hints">hints</option>
+        </select>
+      </label>
+      <button type="button" id="show-view-btn" data-testid="show-view-btn">platform.showView</button>
+    </div>
+    <div class="controls">
+      <button type="button" id="get-task-params-btn" data-testid="get-task-params-btn">platform.getTaskParams</button>
+      <span id="task-params-result" data-testid="task-params-result"></span>
+    </div>
+    <div class="controls">
+      <button type="button" id="ask-hint-btn" data-testid="ask-hint-btn">platform.askHint</button>
+      <button type="button" id="log-btn" data-testid="log-btn">platform.log</button>
+    </div>
+  </section>
+
+  <section class="panel">
+    <h2>Platform → task call log</h2>
+    <ol id="call-log" data-testid="call-log"></ol>
+  </section>
+
+  <div id="loaded-marker" data-testid="test-task-loaded" hidden>loaded</div>
+  <script src="test-task.js"></script>
+</body>
+</html>

--- a/mocks/test-task/test-task.css
+++ b/mocks/test-task/test-task.css
@@ -1,0 +1,72 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  font-size: 0.875rem;
+  color: #1a1a1a;
+  background: #f5f7fa;
+}
+
+header {
+  padding: 0.75rem 1rem;
+  background: #fff;
+  border-bottom: 1px solid #d8dee9;
+}
+
+h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.125rem;
+}
+
+.panel {
+  margin: 0.75rem;
+  padding: 0.75rem;
+  background: #fff;
+  border: 1px solid #d8dee9;
+  border-radius: 0.375rem;
+}
+
+.panel h2 {
+  margin: 0 0 0.5rem;
+  font-size: 0.9375rem;
+}
+
+label {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-right: 0.5rem;
+}
+
+input,
+select,
+button {
+  font: inherit;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+#call-log {
+  max-height: 15rem;
+  overflow: auto;
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+#call-log li {
+  margin-bottom: 0.25rem;
+  word-break: break-word;
+}
+
+#status.ready {
+  color: #0a7a3e;
+}
+
+#status.error {
+  color: #b00020;
+}

--- a/mocks/test-task/test-task.js
+++ b/mocks/test-task/test-task.js
@@ -1,0 +1,354 @@
+/* eslint-disable no-var, vars-on-top, no-console */
+(function () {
+  'use strict';
+
+  var params = new URLSearchParams(window.location.search);
+  var config = {
+    apiVersion: Number(params.get('apiVersion') || '2'),
+    minApiVersion: Number(params.get('minApiVersion') || '1'),
+    usesTokens: params.get('usesTokens') === '1',
+    autoHeight: params.get('autoHeight') === '1',
+    loadDelay: Number(params.get('loadDelay') || '0'),
+    gradeDelay: Number(params.get('gradeDelay') || '0'),
+    failGrade: params.get('failGrade') === '1',
+    fixedScore: params.get('score'),
+  };
+
+  var calls = [];
+  var state = {
+    answer: '',
+    taskState: '',
+    token: '',
+    shownViews: {},
+    loaded: false,
+  };
+
+  var statusEl = document.getElementById('status');
+  var callLogEl = document.getElementById('call-log');
+  var answerInput = document.getElementById('answer-input');
+  var stateInput = document.getElementById('state-input');
+  var lastTokenEl = document.getElementById('last-token');
+  var shownViewsEl = document.getElementById('shown-views');
+  var loadedMarker = document.getElementById('loaded-marker');
+
+  var views = {
+    task: { includes: ['editor'] },
+    editor: {},
+    solution: {},
+    hints: {},
+    grader: {},
+    metadata: {},
+  };
+
+  function logCall(method, callParams) {
+    var entry = { method: method, params: callParams, timestamp: Date.now() };
+    calls.push(entry);
+    var item = document.createElement('li');
+    item.dataset.method = method;
+    item.textContent = method + ' ' + JSON.stringify(callParams);
+    callLogEl.appendChild(item);
+    window.testTaskCalls = calls;
+    window.testTaskState = getPublicState();
+  }
+
+  function getPublicState() {
+    return {
+      answer: state.answer,
+      state: state.taskState,
+      token: state.token,
+      shownViews: state.shownViews,
+      loaded: state.loaded,
+    };
+  }
+
+  function syncInputsFromState() {
+    answerInput.value = state.answer;
+    stateInput.value = state.taskState;
+    lastTokenEl.textContent = state.token || '—';
+    shownViewsEl.textContent = Object.keys(state.shownViews).length ? JSON.stringify(state.shownViews) : '—';
+  }
+
+  function parseGradeScore(answer) {
+    if (config.fixedScore !== null && config.fixedScore !== '') return Number(config.fixedScore);
+    var parsed = Number(answer);
+    if (Number.isFinite(parsed)) return Math.max(0, Math.min(100, parsed));
+    return 0;
+  }
+
+  function delayedComplete(trans, value, delayMs) {
+    if (delayMs > 0) {
+      trans.delayReturn(true);
+      window.setTimeout(function () { trans.complete(value); }, delayMs);
+      return;
+    }
+    return value;
+  }
+
+  function getScope() {
+    var scope = params.get('channelId');
+    if (!scope) throw new Error('Missing channelId query parameter');
+    return scope;
+  }
+
+  var chan = Channel.build({
+    window: window.parent,
+    origin: '*',
+    scope: getScope(),
+    onReady: function () {
+      statusEl.textContent = 'Channel ready';
+    },
+  });
+
+  chan.bind('task.getMetaData', function () {
+    logCall('task.getMetaData', []);
+    return {
+      autoHeight: config.autoHeight,
+      usesTokens: config.usesTokens,
+      apiVersion: config.apiVersion,
+      minApiVersion: config.minApiVersion,
+      fullFeedback: true,
+      minWidth: 'auto',
+    };
+  });
+
+  chan.bind('task.load', function (trans, loadViews) {
+    logCall('task.load', loadViews);
+    state.loaded = true;
+    loadedMarker.hidden = false;
+    loadedMarker.setAttribute('aria-hidden', 'false');
+    statusEl.textContent = 'Ready';
+    statusEl.className = 'ready';
+    return delayedComplete(trans, true, config.loadDelay);
+  });
+
+  chan.bind('task.unload', function () {
+    logCall('task.unload', []);
+    state.loaded = false;
+    loadedMarker.hidden = true;
+    loadedMarker.setAttribute('aria-hidden', 'true');
+  });
+
+  chan.bind('task.getHeight', function () {
+    logCall('task.getHeight', []);
+    return document.body.scrollHeight;
+  });
+
+  chan.bind('task.updateToken', function (trans, token) {
+    logCall('task.updateToken', token);
+    state.token = String(token);
+    syncInputsFromState();
+    return delayedComplete(trans, true, 0);
+  });
+
+  chan.bind('task.getAnswer', function () {
+    logCall('task.getAnswer', []);
+    state.answer = answerInput.value;
+    syncInputsFromState();
+    return state.answer;
+  });
+
+  chan.bind('task.reloadAnswer', function (trans, answer) {
+    logCall('task.reloadAnswer', answer);
+    state.answer = String(answer);
+    syncInputsFromState();
+    return delayedComplete(trans, true, 0);
+  });
+
+  chan.bind('task.reloadAnswerWithOptions', function (trans, callParams) {
+    var answer = Array.isArray(callParams) ? callParams[0] : callParams;
+    var options = Array.isArray(callParams) ? callParams[1] : {};
+    logCall('task.reloadAnswerWithOptions', [answer, options]);
+    state.answer = String(answer);
+    syncInputsFromState();
+    return delayedComplete(trans, true, 0);
+  });
+
+  chan.bind('task.getState', function () {
+    logCall('task.getState', []);
+    state.taskState = stateInput.value;
+    syncInputsFromState();
+    return state.taskState;
+  });
+
+  chan.bind('task.reloadState', function (trans, taskState) {
+    logCall('task.reloadState', taskState);
+    state.taskState = String(taskState);
+    syncInputsFromState();
+    return delayedComplete(trans, true, 0);
+  });
+
+  chan.bind('task.getViews', function () {
+    logCall('task.getViews', []);
+    return views;
+  });
+
+  chan.bind('task.showViews', function (trans, shown) {
+    logCall('task.showViews', shown);
+    state.shownViews = shown || {};
+    syncInputsFromState();
+    return delayedComplete(trans, true, 0);
+  });
+
+  chan.bind('task.gradeAnswer', function (trans, callParams) {
+    var answer = Array.isArray(callParams) ? callParams[0] : '';
+    var answerToken = Array.isArray(callParams) ? callParams[1] : '';
+    logCall('task.gradeAnswer', [answer, answerToken]);
+    if (config.failGrade) {
+      trans.delayReturn(true);
+      window.setTimeout(function () {
+        trans.error('runtime_error', 'Simulated grade failure');
+      }, config.gradeDelay);
+      return;
+    }
+    var score = parseGradeScore(answer);
+    // scoreToken is null: a real token is a JWS signed with the task platform's private key,
+    // which this static page cannot produce. The platform then sends the raw score to save-grade;
+    // the backend accepts it only for items whose platform does not require tokens.
+    var result = [score, 'Graded by test task', null];
+    return delayedComplete(trans, result, config.gradeDelay);
+  });
+
+  chan.bind('task.getResources', function () {
+    logCall('task.getResources', []);
+    return {};
+  });
+
+  function logPlatformCall(method, callParams, status, detail) {
+    var entry = {
+      method: '→ ' + method,
+      params: { request: callParams, status: status, detail: detail },
+      timestamp: Date.now(),
+    };
+    calls.push(entry);
+    var item = document.createElement('li');
+    item.dataset.method = method;
+    item.dataset.direction = 'out';
+    item.textContent = entry.method + ' ' + JSON.stringify(entry.params);
+    callLogEl.appendChild(item);
+    window.testTaskCalls = calls;
+  }
+
+  function formatError(err, message) {
+    if (message && typeof message === 'string') return message;
+    if (typeof err === 'string') return err;
+    try {
+      return JSON.stringify(err);
+    } catch (jsonError) {
+      return String(err);
+    }
+  }
+
+  function platformCall(method, callParams) {
+    logCall('_outgoing.' + method, callParams);
+    chan.call({
+      method: method,
+      params: callParams,
+      timeout: 5000,
+      success: function (result) {
+        logPlatformCall(method, callParams, 'ok', result);
+      },
+      error: function (err, message) {
+        var detail = formatError(err, message);
+        logPlatformCall(method, callParams, 'error', detail);
+        statusEl.textContent = method + ' failed: ' + detail;
+        statusEl.className = 'error';
+      },
+    });
+  }
+
+  function invokePlatform(method, callParams) {
+    return new Promise(function (resolve, reject) {
+      chan.call({
+        method: method,
+        params: callParams,
+        timeout: 5000,
+        success: function (result) {
+          logPlatformCall(method, callParams, 'ok', result);
+          resolve(result);
+        },
+        error: function (err, message) {
+          var detail = formatError(err, message);
+          logPlatformCall(method, callParams, 'error', detail);
+          reject(new Error(detail));
+        },
+      });
+    });
+  }
+
+  // Exposed before the button wiring below so test instrumentation is available
+  // even if a DOM lookup fails; e2e uses this to detect partial setup.
+  window.testTaskCalls = calls;
+  window.testTaskState = getPublicState();
+  window.invokePlatform = invokePlatform;
+  window.testTask = {
+    getCalls: function () { return calls.slice(); },
+    setAnswer: function (value) {
+      state.answer = String(value);
+      answerInput.value = state.answer;
+      window.testTaskState = getPublicState();
+    },
+    setState: function (value) {
+      state.taskState = String(value);
+      stateInput.value = state.taskState;
+      window.testTaskState = getPublicState();
+    },
+    waitForCall: function (method) {
+      return calls.some(function (entry) { return entry.method === method; });
+    },
+    invokePlatform: invokePlatform,
+  };
+
+  document.getElementById('validate-btn').addEventListener('click', function () {
+    // The platform requires a string mode (zod-validated); calling without one is rejected.
+    var mode = document.getElementById('validate-mode').value;
+    platformCall('platform.validate', mode);
+  });
+
+  document.getElementById('update-display-btn').addEventListener('click', function () {
+    var height = Number(document.getElementById('display-height').value);
+    platformCall('platform.updateDisplay', { height: height });
+  });
+
+  document.getElementById('update-height-btn').addEventListener('click', function () {
+    var height = Number(document.getElementById('display-height').value);
+    platformCall('platform.updateHeight', height);
+  });
+
+  document.getElementById('open-url-btn').addEventListener('click', function () {
+    var target = document.getElementById('open-url-target').value;
+    platformCall('platform.openUrl', { path: target });
+  });
+
+  document.getElementById('show-view-btn').addEventListener('click', function () {
+    var view = document.getElementById('show-view').value;
+    platformCall('platform.showView', view);
+  });
+
+  document.getElementById('get-task-params-btn').addEventListener('click', function () {
+    invokePlatform('platform.getTaskParams', []).then(function (result) {
+      document.getElementById('task-params-result').textContent = JSON.stringify(result);
+    }).catch(function (error) {
+      document.getElementById('task-params-result').textContent = 'Error: ' + error.message;
+    });
+  });
+
+  document.getElementById('ask-hint-btn').addEventListener('click', function () {
+    platformCall('platform.askHint', 'test-hint-token');
+  });
+
+  document.getElementById('log-btn').addEventListener('click', function () {
+    platformCall('platform.log', ['test-task log message']);
+  });
+
+  answerInput.addEventListener('input', function () {
+    state.answer = answerInput.value;
+    window.testTaskState = getPublicState();
+  });
+
+  stateInput.addEventListener('input', function () {
+    state.taskState = stateInput.value;
+    window.testTaskState = getPublicState();
+  });
+
+  statusEl.textContent = 'Waiting for platform…';
+})();


### PR DESCRIPTION
add a way to test the 'task API' both with E2E and for manual testing (task served locally)
Code written with the help of AI, already reviewed locally.