### PR TITLE
Modernize Angular components (batch 9).

### DIFF
--- a/src/app/containers/content-top-bar/content-top-bar.component.html
+++ b/src/app/containers/content-top-bar/content-top-bar.component.html
@@ -1,6 +1,6 @@
 <div class="content-top-bar">
   <div class="left-pane">
-    @if (showLeftMenuOpener) {
+    @if (showLeftMenuOpener()) {
       <div class="margin-right">
         <button
           class="sidebar-toggle-btn"
@@ -36,7 +36,7 @@
       @if (!behaviourInfo.isNarrowScreen || behaviourInfo.isNarrowScreen && !behaviourInfo.fullFrameContentDisplayed) {
         <div class="left-pane-title margin-right">
           @let titleVal = title();
-          @if (!showBreadcrumbs && titleVal) {
+          @if (!showBreadcrumbs() && titleVal) {
             <p class="left-pane-title-text">{{ titleVal }}</p>
           } @else {
             <alg-breadcrumbs class="breadcrumbs"></alg-breadcrumbs>

--- a/src/app/containers/content-top-bar/content-top-bar.component.ts
+++ b/src/app/containers/content-top-bar/content-top-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { ActivityNavTreeService, SkillNavTreeService } from '../../services/navigation/item-nav-tree.service';
@@ -26,7 +26,6 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
   selector: 'alg-content-top-bar',
   templateUrl: './content-top-bar.component.html',
   styleUrls: [ './content-top-bar.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ScoreRingComponent,
     LetDirective,
@@ -48,8 +47,8 @@ export class ContentTopBarComponent {
   private layoutService = inject(LayoutService);
   private tabService = inject(TabService);
 
-  @Input() showBreadcrumbs = true;
-  @Input() showLeftMenuOpener = false;
+  showBreadcrumbs = input(true);
+  showLeftMenuOpener = input(false);
 
   isItemContentActive = this.store.selectSignal(fromItemContent.selectIsItemContentActive);
   title = this.store.selectSignal(fromCurrentContent.selectTitle);

--- a/src/app/containers/language-picker/language-picker.component.html
+++ b/src/app/containers/language-picker/language-picker.component.html
@@ -1,6 +1,8 @@
-@if (current) {
+@if (current()) {
+  <!-- alg-select CVA reads/writes tag strings via ngModel; (change) emits the full SelectOption. -->
   <alg-select
-    [(ngModel)]="current"
+    [ngModel]="current()"
+    (ngModelChange)="current.set($event)"
     (change)="languageChanged($event)"
   >
     @for (lang of languages; track $index) {
@@ -10,4 +12,3 @@
     }
   </alg-select>
 }
-

--- a/src/app/containers/language-picker/language-picker.component.spec.ts
+++ b/src/app/containers/language-picker/language-picker.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { LanguagePickerComponent } from './language-picker.component';
+import { LocaleService } from '../../services/localeService';
+
+describe('LanguagePickerComponent', () => {
+  let component: LanguagePickerComponent;
+  let fixture: ComponentFixture<LanguagePickerComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ LanguagePickerComponent ],
+      providers: [
+        {
+          provide: LocaleService,
+          useValue: {
+            languages: [ { tag: 'en' }, { tag: 'fr' } ],
+            currentLang: { tag: 'en' },
+            navigateTo: jasmine.createSpy('navigateTo'),
+          },
+        },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LanguagePickerComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize current from localeService when defaultLang is omitted', () => {
+    expect(component.current()).toBe('en');
+  });
+
+  it('should reset current when defaultLang input changes', () => {
+    fixture.componentRef.setInput('defaultLang', 'fr');
+    expect(component.current()).toBe('fr');
+
+    component.current.set('en');
+    expect(component.current()).toBe('en');
+
+    fixture.componentRef.setInput('defaultLang', 'es');
+    expect(component.current()).toBe('es');
+  });
+});

--- a/src/app/containers/language-picker/language-picker.component.ts
+++ b/src/app/containers/language-picker/language-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnChanges, Output, EventEmitter, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, linkedSignal, output } from '@angular/core';
 import { LocaleService } from '../../services/localeService';
 import { FormsModule } from '@angular/forms';
 import { SelectOptionComponent } from 'src/app/ui-components/select/select-option/select-option.component';
@@ -8,37 +8,26 @@ import { SelectComponent } from 'src/app/ui-components/select/select.component';
   selector: 'alg-language-picker',
   templateUrl: './language-picker.component.html',
   styleUrls: [ './language-picker.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ FormsModule, SelectComponent, SelectOptionComponent, SelectOptionComponent ]
+  imports: [ FormsModule, SelectComponent, SelectOptionComponent ]
 })
-export class LanguagePickerComponent implements OnInit, OnChanges {
+export class LanguagePickerComponent {
   private localeService = inject(LocaleService);
 
-  @Input() defaultLang?: string;
-  @Input() redirectOnChange = true;
-  @Output() changeLang = new EventEmitter<string>();
+  defaultLang = input<string>();
+  redirectOnChange = input(true);
+  changeLang = output<string>();
 
   readonly languages = this.localeService.languages.map(({ tag }) => ({ label: tag, value: tag }));
-  current?: string;
-
-  ngOnInit(): void {
-    this.initCurrentLang();
-  }
-
-  ngOnChanges(): void {
-    this.initCurrentLang();
-  }
+  // linkedSignal (not computed): recomputes when defaultLang() changes so platform-settings can
+  // pre-select the user's default language, while user picks via ngModel still persist until then.
+  current = linkedSignal(() => this.defaultLang() ?? this.localeService.currentLang?.tag);
 
   languageChanged(lang: { value: string }): void {
     this.changeLang.emit(lang.value);
 
-    if (this.redirectOnChange) {
+    if (this.redirectOnChange()) {
       this.localeService.navigateTo(lang.value);
     }
-  }
-
-  private initCurrentLang(): void {
-    this.current = this.defaultLang ?? this.localeService.currentLang?.tag;
   }
 
 }

--- a/src/app/containers/observation-bar/observation-bar.component.html
+++ b/src/app/containers/observation-bar/observation-bar.component.html
@@ -1,10 +1,10 @@
 @if (observedGroup$ | async; as observedGroup) {
-  <div class="wrapper" [ngClass]="{ 'only-icon-mode': onlyIcon }">
+  <div class="wrapper" [class.only-icon-mode]="onlyIcon()">
     <div class="left-section alg-flex-1">
       <i
         class="left-icon alg-secondary-color ph-duotone ph-eye"
         [algTooltip]="observationModeTooltip"
-        [tooltipDisabled]="!showTooltip"
+        [tooltipDisabled]="!showTooltip()"
         tooltipPosition="right"
         tooltipStyleClass="observation-mode"
       ></i>
@@ -17,16 +17,16 @@
           Only the content visible by the group you are observing ({{ observedGroup.name }}) is shown.
         }
       </ng-template>
-      @if (!onlyIcon) {
+      @if (!onlyIcon()) {
         <span class="title text-dots">
-          @if(caption) {
-            <span class="alg-secondary-color">{{ caption }}</span>
+          @if (caption()) {
+            <span class="alg-secondary-color">{{ caption() }}</span>
           } @else if(observedGroup.name) {
             <a
               class="link alg-link hover-underline alg-secondary-color"
               [routerLink]="observedGroup.route | groupLink"
             >
-              {{ caption || observedGroup.name }}
+              {{ caption() || observedGroup.name }}
             </a>
           }
         </span>

--- a/src/app/containers/observation-bar/observation-bar.component.spec.ts
+++ b/src/app/containers/observation-bar/observation-bar.component.spec.ts
@@ -1,0 +1,49 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+
+import { ObservationBarComponent } from './observation-bar.component';
+import { fromObservation } from 'src/app/store/observation';
+import { fromItemContent } from 'src/app/items/store';
+import { ItemRouter } from 'src/app/models/routing/item-router';
+
+describe('ObservationBarComponent', () => {
+  let component: ObservationBarComponent;
+  let fixture: ComponentFixture<ObservationBarComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [ ObservationBarComponent ],
+      providers: [
+        provideMockStore({
+          selectors: [
+            { selector: fromObservation.selectObservedGroupInfo, value: null },
+            { selector: fromObservation.selectActiveContentIsBeingObserved, value: false },
+            { selector: fromItemContent.selectActiveContentRoute, value: null },
+          ],
+        }),
+        { provide: ItemRouter, useValue: { navigateTo: jasmine.createSpy('navigateTo') } },
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ObservationBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should accept signal inputs', () => {
+    fixture.componentRef.setInput('caption', 'Watching');
+    fixture.componentRef.setInput('onlyIcon', true);
+    fixture.componentRef.setInput('showTooltip', true);
+    fixture.detectChanges();
+
+    expect(component.caption()).toBe('Watching');
+    expect(component.onlyIcon()).toBeTrue();
+    expect(component.showTooltip()).toBeTrue();
+  });
+});

--- a/src/app/containers/observation-bar/observation-bar.component.ts
+++ b/src/app/containers/observation-bar/observation-bar.component.ts
@@ -1,7 +1,7 @@
-import { Component, EventEmitter, Input, Output, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { GroupLinkPipe } from 'src/app/pipes/groupLink';
 import { RouterLink } from '@angular/router';
-import { NgClass, AsyncPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store/observation';
 import { GroupIsUserPipe } from 'src/app/pipes/groupIsUser';
@@ -17,17 +17,15 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
   selector: 'alg-observation-bar',
   templateUrl: './observation-bar.component.html',
   styleUrls: [ './observation-bar.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ NgClass, RouterLink, AsyncPipe, GroupLinkPipe, GroupIsUserPipe, ButtonIconComponent, TooltipDirective ]
+  imports: [ RouterLink, AsyncPipe, GroupLinkPipe, GroupIsUserPipe, ButtonIconComponent, TooltipDirective ]
 })
 export class ObservationBarComponent {
   private store = inject(Store);
   private itemRouter = inject(ItemRouter);
 
-  @Output() cancel = new EventEmitter<void>();
-  @Input() caption?: string;
-  @Input() onlyIcon = false;
-  @Input() showTooltip = false;
+  caption = input<string>();
+  onlyIcon = input(false);
+  showTooltip = input(false);
 
   observedGroup$ = this.store.select(fromObservation.selectObservedGroupInfo);
   activeContentIsBeingObserved$ = this.store.select(fromObservation.selectActiveContentIsBeingObserved);

--- a/src/app/containers/top-bar/top-bar.component.html
+++ b/src/app/containers/top-bar/top-bar.component.html
@@ -1,10 +1,10 @@
-@if (showLeftMenuOpener) {
+@if (showLeftMenuOpener()) {
   <alg-left-header [compactMode]="true"></alg-left-header>
 }
 <alg-content-top-bar
-  [showBreadcrumbs]="showBreadcrumbs"
-  [showLeftMenuOpener]="showLeftMenuOpener"
+  [showBreadcrumbs]="showBreadcrumbs()"
+  [showLeftMenuOpener]="showLeftMenuOpener()"
 ></alg-content-top-bar>
-@if (showTopRightControls) {
-  <alg-top-right-controls [drawLeftBorder]="!modeBarDisplayed"></alg-top-right-controls>
+@if (showTopRightControls()) {
+  <alg-top-right-controls [drawLeftBorder]="!modeBarDisplayed()"></alg-top-right-controls>
 }

--- a/src/app/containers/top-bar/top-bar.component.ts
+++ b/src/app/containers/top-bar/top-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ElementRef, inject, input } from '@angular/core';
 import { TopRightControlsComponent } from '../top-right-controls/top-right-controls.component';
 import { ContentTopBarComponent } from 'src/app/containers/content-top-bar/content-top-bar.component';
 import { LeftHeaderComponent } from 'src/app/containers/left-header/left-header.component';
@@ -8,7 +8,6 @@ import { LeftHeaderComponent } from 'src/app/containers/left-header/left-header.
   selector: 'alg-top-bar',
   templateUrl: './top-bar.component.html',
   styleUrls: [ './top-bar.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LeftHeaderComponent,
     ContentTopBarComponent,
@@ -18,8 +17,8 @@ import { LeftHeaderComponent } from 'src/app/containers/left-header/left-header.
 export class TopBarComponent {
   elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
-  @Input() showBreadcrumbs = true;
-  @Input() modeBarDisplayed = false;
-  @Input() showTopRightControls = true;
-  @Input() showLeftMenuOpener = true;
+  showBreadcrumbs = input(true);
+  modeBarDisplayed = input(false);
+  showTopRightControls = input(true);
+  showLeftMenuOpener = input(true);
 }

--- a/src/app/containers/top-right-controls/top-right-controls.component.html
+++ b/src/app/containers/top-right-controls/top-right-controls.component.html
@@ -1,9 +1,14 @@
-<div class="controls-zone" [ngClass]="drawLeftBorder ? 'with-left-border' : 'no-left-border'" *ngrxLet="session$ as session">
+<div
+  class="controls-zone"
+  [class.with-left-border]="drawLeftBorder()"
+  [class.no-left-border]="!drawLeftBorder()"
+  *ngrxLet="session$ as session"
+>
   @if (session && !session.tempUser) {
     @if (enableNotifications) {
       <alg-notification-bell></alg-notification-bell>
     }
-    <alg-top-right-menu [styleClass]="topRightMenuStyleClass"></alg-top-right-menu>
+    <alg-top-right-menu [styleClass]="topRightMenuStyleClass()"></alg-top-right-menu>
   } @else {
     @if (languages.length > 1) {
       <alg-language-picker class="lang-button"></alg-language-picker>

--- a/src/app/containers/top-right-controls/top-right-controls.component.ts
+++ b/src/app/containers/top-right-controls/top-right-controls.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, inject, Input, OnInit, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { delay, filter, fromEvent } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { UserSessionService } from '../../services/user-session.service';
@@ -6,7 +6,6 @@ import { LocaleService } from '../../services/localeService';
 import { LanguagePickerComponent } from '../language-picker/language-picker.component';
 import { NotificationBellComponent } from '../notification-bell/notification-bell.component';
 import { TopRightMenuComponent } from '../top-right-menu/top-right-menu.component';
-import { NgClass } from '@angular/common';
 import { LetDirective } from '@ngrx/component';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { APPCONFIG } from 'src/app/config';
@@ -15,8 +14,7 @@ import { APPCONFIG } from 'src/app/config';
   selector: 'alg-top-right-controls',
   templateUrl: './top-right-controls.component.html',
   styleUrls: [ './top-right-controls.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ LetDirective, NgClass, TopRightMenuComponent, LanguagePickerComponent, ButtonComponent, NotificationBellComponent ]
+  imports: [ LetDirective, TopRightMenuComponent, LanguagePickerComponent, ButtonComponent, NotificationBellComponent ]
 })
 export class TopRightControlsComponent implements OnInit {
   private sessionService = inject(UserSessionService);
@@ -24,8 +22,8 @@ export class TopRightControlsComponent implements OnInit {
   private config = inject(APPCONFIG);
   private destroyRef = inject(DestroyRef);
 
-  @Input() drawLeftBorder = true;
-  @Input() topRightMenuStyleClass?: string;
+  drawLeftBorder = input(true);
+  topRightMenuStyleClass = input<string>();
   session$ = this.sessionService.session$.pipe(delay(0));
   readonly languages = this.localeService.languages;
   readonly enableNotifications = this.config.featureFlags.enableNotifications;

--- a/src/app/containers/top-right-menu/top-right-menu.component.html
+++ b/src/app/containers/top-right-menu/top-right-menu.component.html
@@ -14,7 +14,7 @@
 </div>
 
 <ng-template #menu>
-  <div class="menu" [ngClass]="styleClass" cdkMenu>
+  <div class="menu" [class]="styleClass()" cdkMenu>
     @if (isNarrowScreen) {
       <div class="menu-header">
         {{ userLogin }}

--- a/src/app/containers/top-right-menu/top-right-menu.component.ts
+++ b/src/app/containers/top-right-menu/top-right-menu.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, Input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { AuthService } from 'src/app/services/auth/auth.service';
 import { APPCONFIG } from 'src/app/config';
@@ -6,7 +6,7 @@ import { rawGroupRoute } from 'src/app/models/routing/group-route';
 import { GroupRouter } from 'src/app/models/routing/group-router';
 import { UserSessionService } from '../../services/user-session.service';
 import { LayoutService } from '../../services/layout.service';
-import { AsyncPipe, NgClass, NgTemplateOutlet } from '@angular/common';
+import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 import { CdkMenu, CdkMenuItem, CdkMenuTrigger } from '@angular/cdk/menu';
 import { UrlCommand } from 'src/app/utils/url';
@@ -24,14 +24,12 @@ export interface MenuItem {
   selector: 'alg-top-right-menu',
   templateUrl: './top-right-menu.component.html',
   styleUrls: [ './top-right-menu.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     AsyncPipe,
     ButtonIconComponent,
     CdkMenuTrigger,
     CdkMenu,
     CdkMenuItem,
-    NgClass,
     NgTemplateOutlet,
     RouterLink,
   ]
@@ -42,7 +40,7 @@ export class TopRightMenuComponent {
   private groupRouter = inject(GroupRouter);
   private layoutService = inject(LayoutService);
   private config = inject(APPCONFIG);
-  @Input() styleClass?: string;
+  styleClass = input<string>();
 
   isNarrowScreen$ = this.layoutService.isNarrowScreen$;
 


### PR DESCRIPTION
## Summary
- Modernize top-bar app-shell slice (6 components) to Angular 22 signal inputs/outputs.
- Batch 9 from `.cursor/plans/modernize-batch-9-top-bar.md`.
- `language-picker` uses `linkedSignal` for two-way select state; removed dead `observation-bar` `cancel` output.

## Scope
- **top-bar**, **content-top-bar**, **top-right-controls**, **top-right-menu**, **observation-bar**, **language-picker**
- `NgClass` → class bindings; drop `Eager` everywhere
- Minimal specs: `language-picker`, `observation-bar`

## Risks / manual checks
- App shell CD regression is highly visible — smoke login/logout, breadcrumbs, narrow-screen controls
- Group observation bar (top bar + left nav caption/tooltip)
- Language picker: top bar redirect vs platform-settings no-redirect + `defaultLang` pre-selection

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-9/en/

## Verification
- [x] `npm run lint`
- [x] `rg 'alg-top-bar|…' src e2e`
- [x] `ng build --configuration=e2e`
- [x] Unit tests (language-picker, observation-bar)
- [x] Manual smoke (use URL above)
- [x] E2E: `e2e/app.spec.ts`, `e2e/groups/group-observing.spec.ts`