### PR TITLE
Modernize Angular components (batch 10).

### DIFF
--- a/src/app/containers/left-nav-tree/left-nav-tree.component.html
+++ b/src/app/containers/left-nav-tree/left-nav-tree.component.html
@@ -6,7 +6,7 @@
       [title]="parent.title"
     ></alg-left-menu-back-button>
   </div>
-} @else if (elementType === 'group') {
+} @else if (elementType() === 'group') {
   <div class="container buttons-section" data-testid="group-left-menu">
     <a
       class="size-l stroke left-menu alg-flex-1"
@@ -106,7 +106,7 @@
             >
               <ng-container *ngTemplateOutlet="navLeft; context: { $implicit: node }"></ng-container>
               <div class="tree-nav-right">
-                @if (elementType === 'skill' && node.data.score) {
+                @if (elementType() === 'skill' && node.data.score) {
                   <div class="tree-nav-skill-progress">
                     <alg-skill-progress
                       [bestScore]="node.data.score.bestScore"
@@ -127,7 +127,7 @@
             >
               <ng-container *ngTemplateOutlet="navLeft; context: { $implicit: node }"></ng-container>
               <div class="tree-nav-right">
-                @if (elementType === 'skill' && node.data.score) {
+                @if (elementType() === 'skill' && node.data.score) {
                   <alg-skill-progress
                     [bestScore]="node.data.score.bestScore"
                     [currentScore]="node.data.score.currentScore"
@@ -198,7 +198,7 @@
   </div>
 } @else {
   <div class="empty-message">
-    {elementType, select,
+    {elementType(), select,
       group {You are not a member or manager of any group}
       other {There is no content to display}
     }

--- a/src/app/containers/left-nav-tree/left-nav-tree.component.ts
+++ b/src/app/containers/left-nav-tree/left-nav-tree.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, input, Input, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, effect, input, signal } from '@angular/core';
 import { isAChapter, isASkill, ItemTypeCategory } from 'src/app/items/models/item-type';
 import { areSameElements } from '../../models/routing/entity-route';
 import { NavTreeData, NavTreeElement } from '../../models/left-nav-loading/nav-tree-data';
@@ -46,7 +46,6 @@ export const SELECTED_NAV_NODE_SELECTOR = '.tree-nav-wrapper[data-selected="true
   selector: 'alg-left-nav-tree',
   templateUrl: './left-nav-tree.component.html',
   styleUrls: [ './left-nav-tree.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LeftMenuBackButtonComponent,
     RouterLink,
@@ -66,7 +65,7 @@ export const SELECTED_NAV_NODE_SELECTOR = '.tree-nav-wrapper[data-selected="true
 })
 export class LeftNavTreeComponent {
   data = input.required<NavTreeData>();
-  @Input() elementType: ItemTypeCategory | 'group' = 'activity';
+  elementType = input<ItemTypeCategory | 'group'>('activity');
 
   nodes = signal<TreeNode<NavTreeElement>[]>([]);
   treeControl = new NestedTreeControl<TreeNode<NavTreeElement>>(node => node.children);
@@ -148,7 +147,7 @@ export class LeftNavTreeComponent {
   }
 
   private typeForElement(e: NavTreeElement): string {
-    switch (this.elementType) {
+    switch (this.elementType()) {
       case 'activity':
         if (e.itemType) {
           return isAChapter({ type: e.itemType }) ? 'chapter' : 'task';

--- a/src/app/containers/left-search-result/left-search-result.component.html
+++ b/src/app/containers/left-search-result/left-search-result.component.html
@@ -1,16 +1,16 @@
-@if (data !== undefined) {
+@if (data() !== undefined) {
   <div class="container result-caption">
-    @if (data.length < 10) {
+    @if (data()!.length < 10) {
       <ng-container i18n>
-      {data.length, plural, =0 {No result found} =1 {{{ data.length }} result found} other {{{ data.length }} results found}}
+      {data()!.length, plural, =0 {No result found} =1 {{{ data()!.length }} result found} other {{{ data()!.length }} results found}}
     </ng-container>
     } @else {
-      <span i18n>First {{ data.length }} results</span>
+      <span i18n>First {{ data()!.length }} results</span>
     }
   </div>
 }
 
-@if (data === undefined) {
+@if (data() === undefined) {
   <div class="container">
     <alg-message-info class="search" icon="ph-duotone ph-warning-circle" i18n>
       Type at least 3 letters to search content
@@ -18,7 +18,7 @@
   </div>
 }
 
-@if (data !== undefined && data.length === 0) {
+@if (data() !== undefined && data()!.length === 0) {
   <div class="container">
     <alg-message-info icon="ph-duotone ph-warning-circle" i18n>
       No results
@@ -26,7 +26,7 @@
   </div>
 }
 
-@for (item of data; track item) {
+@for (item of data(); track item) {
   <div class="container">
     <ul class="result-list alg-search-result">
       <li
@@ -39,10 +39,8 @@
         <a class="result-list-link" [routerLink]="item | itemRoute | url" routerLinkActive="selected">
           <i
             class="result-list-icon ph-duotone"
-            [ngClass]="{
-            'ph-files': item.type === 'Task',
-            'ph-folders': item.type === 'Chapter'
-          }"
+            [class.ph-files]="item.type === 'Task'"
+            [class.ph-folders]="item.type === 'Chapter'"
           ></i>
           <span class="result-list-link-caption" algShowOverlayHoverTarget>
             @if (item.titleHighlight; as titleHighlight) {
@@ -66,4 +64,3 @@
     </ul>
   </div>
 }
-

--- a/src/app/containers/left-search-result/left-search-result.component.html
+++ b/src/app/containers/left-search-result/left-search-result.component.html
@@ -1,66 +1,64 @@
-@if (data() !== undefined) {
+@if (data(); as searchResults) {
   <div class="container result-caption">
-    @if (data()!.length < 10) {
-      <ng-container i18n>
-      {data()!.length, plural, =0 {No result found} =1 {{{ data()!.length }} result found} other {{{ data()!.length }} results found}}
-    </ng-container>
+    @if (searchResults.length < 10) {
+      <span i18n>
+        {searchResults.length, plural, =0 {No result found} =1 {{{ searchResults.length }} result found} other {{{ searchResults.length }} results found}}
+      </span>
     } @else {
-      <span i18n>First {{ data()!.length }} results</span>
+      <span i18n>First {{ searchResults.length }} results</span>
     }
   </div>
-}
 
-@if (data() === undefined) {
+  @if (searchResults.length === 0) {
+    <div class="container">
+      <alg-message-info icon="ph-duotone ph-warning-circle" i18n>
+        No results
+      </alg-message-info>
+    </div>
+  }
+
+  @for (item of searchResults; track item) {
+    <div class="container">
+      <ul class="result-list alg-search-result">
+        <li
+          class="result-list-item"
+          [algShowOverlay]="op"
+          (overlayOpenEvent)="itemId.set(item.id)"
+          (overlayCloseEvent)="itemId.set(undefined)"
+          #overlay="algShowOverlay"
+        >
+          <a class="result-list-link" [routerLink]="item | itemRoute | url" routerLinkActive="selected">
+            <i
+              class="result-list-icon ph-duotone"
+              [class.ph-files]="item.type === 'Task'"
+              [class.ph-folders]="item.type === 'Chapter'"
+            ></i>
+            <span class="result-list-link-caption" algShowOverlayHoverTarget>
+              @if (item.titleHighlight; as titleHighlight) {
+                <span [innerHTML]="titleHighlight"></span>
+              } @else {
+                {{ item.title }}
+              }
+            </span>
+          </a>
+          @if (item.highlights.length > 0) {
+            <div class="result-list-description-wrapper">
+              @for (highlight of item.highlights; track highlight) {
+                <p class="result-list-description" [innerHTML]="highlight"></p>
+              }
+            </div>
+          }
+          <ng-template #op>
+            <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+          </ng-template>
+        </li>
+      </ul>
+    </div>
+  }
+} @else {
   <div class="container">
     <alg-message-info class="search" icon="ph-duotone ph-warning-circle" i18n>
       Type at least 3 letters to search content
     </alg-message-info>
-  </div>
-}
-
-@if (data() !== undefined && data()!.length === 0) {
-  <div class="container">
-    <alg-message-info icon="ph-duotone ph-warning-circle" i18n>
-      No results
-    </alg-message-info>
-  </div>
-}
-
-@for (item of data(); track item) {
-  <div class="container">
-    <ul class="result-list alg-search-result">
-      <li
-        class="result-list-item"
-        [algShowOverlay]="op"
-        (overlayOpenEvent)="itemId.set(item.id)"
-        (overlayCloseEvent)="itemId.set(undefined)"
-        #overlay="algShowOverlay"
-      >
-        <a class="result-list-link" [routerLink]="item | itemRoute | url" routerLinkActive="selected">
-          <i
-            class="result-list-icon ph-duotone"
-            [class.ph-files]="item.type === 'Task'"
-            [class.ph-folders]="item.type === 'Chapter'"
-          ></i>
-          <span class="result-list-link-caption" algShowOverlayHoverTarget>
-            @if (item.titleHighlight; as titleHighlight) {
-              <span [innerHTML]="titleHighlight"></span>
-            } @else {
-              {{ item.title }}
-            }
-          </span>
-        </a>
-        @if (item.highlights.length > 0) {
-          <div class="result-list-description-wrapper">
-            @for (highlight of item.highlights; track highlight) {
-              <p class="result-list-description" [innerHTML]="highlight"></p>
-            }
-          </div>
-        }
-        <ng-template #op>
-          <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
-        </ng-template>
-      </li>
-    </ul>
   </div>
 }

--- a/src/app/containers/left-search-result/left-search-result.component.ts
+++ b/src/app/containers/left-search-result/left-search-result.component.ts
@@ -1,11 +1,10 @@
-import { Component, Input, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { SearchResponse } from '../../data-access/search.service';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
 import { ItemRoutePipe } from 'src/app/pipes/itemRoute';
 import { PathSuggestionComponent } from '../path-suggestion/path-suggestion.component';
 import { RouterLinkActive, RouterLink } from '@angular/router';
 import { MessageInfoComponent } from '../../ui-components/message-info/message-info.component';
-import { NgClass } from '@angular/common';
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
 
@@ -13,12 +12,10 @@ import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/s
   selector: 'alg-left-search-result',
   templateUrl: './left-search-result.component.html',
   styleUrls: [ './left-search-result.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     MessageInfoComponent,
     RouterLinkActive,
     RouterLink,
-    NgClass,
     PathSuggestionComponent,
     ItemRoutePipe,
     RouteUrlPipe,
@@ -27,7 +24,8 @@ import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/s
   ],
 })
 export class LeftSearchResultComponent {
-  @Input() data?: SearchResponse['searchResults'];
+  // Parent always binds [data]; undefined value means search has not run yet.
+  data = input.required<SearchResponse['searchResults'] | undefined>();
 
   itemId = signal<string | undefined>(undefined);
 }

--- a/src/app/containers/path-suggestion/path-suggestion.component.ts
+++ b/src/app/containers/path-suggestion/path-suggestion.component.ts
@@ -1,11 +1,11 @@
 import {
-  AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, Output,
-  inject,
+  AfterViewInit, Component, ElementRef, inject, input, OnDestroy, output,
 } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { GetBreadcrumbsFromRootsService } from '../../data-access/get-breadcrumbs-from-roots.service';
-import { ReplaySubject, Subject, switchMap } from 'rxjs';
+import { Subject, switchMap } from 'rxjs';
 import { mapToFetchState } from '../../utils/operators/state';
-import { map } from 'rxjs/operators';
+import { filter, map } from 'rxjs/operators';
 import { RouterLink } from '@angular/router';
 import { ErrorComponent } from '../../ui-components/error/error.component';
 import { LoadingComponent } from '../../ui-components/loading/loading.component';
@@ -18,7 +18,6 @@ import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
   selector: 'alg-path-suggestion',
   templateUrl: './path-suggestion.component.html',
   styleUrls: [ './path-suggestion.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -28,18 +27,18 @@ import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
     RouteUrlPipe,
   ]
 })
-export class PathSuggestionComponent implements AfterViewInit, OnDestroy, OnChanges {
+export class PathSuggestionComponent implements AfterViewInit, OnDestroy {
   private getBreadcrumbsFromRootsService = inject(GetBreadcrumbsFromRootsService);
   private elementRef = inject<ElementRef<HTMLDivElement>>(ElementRef);
 
-  @Output() resize = new EventEmitter<void>();
-  @Input() itemId?: string;
+  itemId = input<string>();
+  resize = output<void>();
 
   resizeObserver = new ResizeObserver(() =>
     this.resize.emit()
   );
 
-  private readonly itemId$ = new ReplaySubject<string>(1);
+  private readonly itemId$ = toObservable(this.itemId).pipe(filter((id): id is string => !!id));
   private readonly refresh$ = new Subject<void>();
 
   state$ = this.itemId$.pipe(
@@ -53,14 +52,7 @@ export class PathSuggestionComponent implements AfterViewInit, OnDestroy, OnChan
     this.resizeObserver.observe(this.elementRef.nativeElement);
   }
 
-  ngOnChanges(): void {
-    if (this.itemId) {
-      this.itemId$.next(this.itemId);
-    }
-  }
-
   ngOnDestroy(): void {
-    this.itemId$.complete();
     this.refresh$.complete();
     this.resizeObserver.unobserve(this.elementRef.nativeElement);
   }

--- a/src/app/containers/preview-html/preview-html.component.html
+++ b/src/app/containers/preview-html/preview-html.component.html
@@ -1,7 +1,7 @@
 <div class="wrapper">
-  @if ((textContent() ?? '').trim() !== '') {
+  @if (textContent().trim() !== '') {
     <alg-description-iframe
-      [content]="textContent() ?? ''"
+      [content]="textContent()"
       (navigationRequested)="onPreviewNavigate($event)"
     ></alg-description-iframe>
   } @else {

--- a/src/app/containers/preview-html/preview-html.component.html
+++ b/src/app/containers/preview-html/preview-html.component.html
@@ -1,7 +1,7 @@
 <div class="wrapper">
-  @if (textContent.trim() !== '') {
+  @if ((textContent() ?? '').trim() !== '') {
     <alg-description-iframe
-      [content]="textContent"
+      [content]="textContent() ?? ''"
       (navigationRequested)="onPreviewNavigate($event)"
     ></alg-description-iframe>
   } @else {

--- a/src/app/containers/preview-html/preview-html.component.spec.ts
+++ b/src/app/containers/preview-html/preview-html.component.spec.ts
@@ -23,7 +23,7 @@ describe('PreviewHtmlComponent', () => {
   });
 
   it('should render description iframe when there is HTML content', () => {
-    component.textContent = '<p>preview</p>';
+    fixture.componentRef.setInput('textContent', '<p>preview</p>');
     fixture.detectChanges();
 
     const iframe = fixture.debugElement.query(By.css('alg-description-iframe iframe'));
@@ -32,7 +32,7 @@ describe('PreviewHtmlComponent', () => {
   });
 
   it('should show empty state when there is nothing to preview', () => {
-    component.textContent = '   ';
+    fixture.componentRef.setInput('textContent', '   ');
     fixture.detectChanges();
 
     expect(fixture.debugElement.query(By.css('alg-description-iframe'))).toBeFalsy();

--- a/src/app/containers/preview-html/preview-html.component.ts
+++ b/src/app/containers/preview-html/preview-html.component.ts
@@ -12,7 +12,7 @@ import { MessageService } from 'src/app/services/message.service';
 export class PreviewHtmlComponent {
   private messageService = inject(MessageService);
 
-  textContent = input<string | undefined>('');
+  textContent = input('');
 
   /**
    * Preview is for editing a (possibly unsaved) item — we never actually navigate. Surface the

--- a/src/app/containers/preview-html/preview-html.component.ts
+++ b/src/app/containers/preview-html/preview-html.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { DescriptionIframeComponent } from 'src/app/ui-components/description-iframe/description-iframe.component';
 import { DescriptionIframeNavigationRequest } from 'src/app/ui-components/description-iframe/description-iframe.messages';
 import { MessageService } from 'src/app/services/message.service';
@@ -7,13 +7,12 @@ import { MessageService } from 'src/app/services/message.service';
   selector: 'alg-preview-html',
   templateUrl: './preview-html.component.html',
   styleUrls: [ './preview-html.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ DescriptionIframeComponent ],
 })
 export class PreviewHtmlComponent {
   private messageService = inject(MessageService);
 
-  @Input() textContent = '';
+  textContent = input<string | undefined>('');
 
   /**
    * Preview is for editing a (possibly unsaved) item — we never actually navigate. Surface the


### PR DESCRIPTION
## Summary
- Modernize left-menu slice + `preview-html` to Angular 22 patterns.
- Batch 10 from `.cursor/plans/modernize-batch-10-left-menu.md`.
- `path-suggestion`: `toObservable` + `output()`; dropped `Eager` on `left-nav-tree` (highest-risk change).

## Scope
- **path-suggestion** — `itemId` → `input()`, `resize` → `output()`, `ngOnChanges` → `toObservable`
- **left-nav-tree** — finish `elementType` signal, drop `Eager`
- **left-search-result** — `data` → `input.required()`, `NgClass` → class bindings
- **preview-html** — `textContent` → `input()`, spec uses `setInput`

## Risks / manual checks
- **left-nav-tree** dropping `Eager` — heavy e2e coverage; verify expand/collapse, tab switching, selection
- **path-suggestion** overlay reopen relies on parents clearing `itemId` to `undefined`
- Manual smoke: left menu navigation, search + path overlay, description preview tab

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-10/en/

## Verification
- [x] `npm run lint`
- [x] preview-html unit tests
- [x] `ng build --configuration=e2e`
- [x] Manual smoke + e2e left-menu specs (use URL above)