### PR TITLE
Modernize Angular components (batch 11).

### DIFF
--- a/src/app/containers/access-code-view/access-code-view.component.html
+++ b/src/app/containers/access-code-view/access-code-view.component.html
@@ -5,16 +5,17 @@
     type="text"
     i18n-placeholder placeholder="Group code"
     (keyup)="0"
-    [(ngModel)]="code"
-    [disabled]="state === 'loading'"
+    [ngModel]="code()"
+    (ngModelChange)="code.set($event)"
+    [disabled]="state() === 'loading'"
   >
   <div class="button-section">
     <button
       class="size-l"
       icon="ph-bold ph-check"
-      [disabled]="input.value.trim() === '' || state === 'loading'"
+      [disabled]="input.value.trim() === '' || state() === 'loading'"
       (click)="checkCodeValidity()"
       alg-button
-    >{{ buttonLabel }}</button>
+    >{{ buttonLabel() }}</button>
   </div>
 </div>

--- a/src/app/containers/access-code-view/access-code-view.component.ts
+++ b/src/app/containers/access-code-view/access-code-view.component.ts
@@ -1,8 +1,7 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, EventEmitter, inject, Input, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output, signal } from '@angular/core';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { InvalidCodeReason, JoinByCodeService } from '../../data-access/join-by-code.service';
-import { ItemData } from 'src/app/items/models/item-data';
 import { FormsModule } from '@angular/forms';
 import {
   JoinGroupConfirmationDialogComponent, JoinGroupConfirmationDialogResult
@@ -17,27 +16,25 @@ import { EMPTY, Observable, throwError } from 'rxjs';
   selector: 'alg-access-code-view',
   templateUrl: './access-code-view.component.html',
   styleUrls: [ './access-code-view.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ FormsModule, ButtonComponent ]
 })
 export class AccessCodeViewComponent {
   private joinByCodeService = inject(JoinByCodeService);
   private actionFeedbackService = inject(ActionFeedbackService);
 
-  @Input() sectionLabel = '';
-  @Input() buttonLabel = '';
-  @Input() itemData?: ItemData;
-  @Output() groupJoined = new EventEmitter<void>();
+  buttonLabel = input.required<string>();
+  groupJoined = output<void>();
 
   private dialogService = inject(Dialog);
 
-  code = '';
-  state: 'ready'|'loading' = 'ready';
+  code = signal('');
+  state = signal<'ready'|'loading'>('ready');
 
   checkCodeValidity(): void {
-    this.code = this.code.trim();
-    this.state = 'loading';
-    this.joinByCodeService.checkCodeValidity(this.code).pipe(
+    const trimmedCode = this.code().trim();
+    this.code.set(trimmedCode);
+    this.state.set('loading');
+    this.joinByCodeService.checkCodeValidity(trimmedCode).pipe(
       catchError(() =>
         throwError(() => new Error($localize`Failed to check code validity, please retry. If the problem persists, contact us.`))
       ),
@@ -58,17 +55,17 @@ export class AccessCodeViewComponent {
             disableClose: true,
           },
         ).closed.pipe(
-          switchMap(result => (result?.confirmed ? this.joinGroup(this.code, group) : EMPTY))
+          switchMap(result => (result?.confirmed ? this.joinGroup(trimmedCode, group) : EMPTY))
         );
       }),
     ).subscribe({
       next: () => {
-        this.code = '';
+        this.code.set('');
         this.actionFeedbackService.success($localize`Changes successfully saved.`);
         this.groupJoined.emit();
       },
       error: (error: unknown) => {
-        this.state = 'ready';
+        this.state.set('ready');
         if (error instanceof Error) {
           this.actionFeedbackService.error(error.message);
         } else if (error instanceof HttpErrorResponse) {
@@ -78,7 +75,7 @@ export class AccessCodeViewComponent {
         }
       },
       complete: () => {
-        this.state = 'ready';
+        this.state.set('ready');
       }
     });
   }

--- a/src/app/directives/full-height-content.directive.ts
+++ b/src/app/directives/full-height-content.directive.ts
@@ -2,30 +2,45 @@ import {
   AfterViewChecked,
   Directive,
   ElementRef,
-  HostListener,
-  Input,
   NgZone,
   OnInit,
-  OnChanges,
   Renderer2,
-  SimpleChanges,
+  effect,
   inject,
+  input,
 } from '@angular/core';
 
 @Directive({
   selector: '[algFullHeightContent]',
-  standalone: true,
+  host: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    '(window:resize)': 'resize()',
+  },
 })
-export class FullHeightContentDirective implements OnInit, AfterViewChecked, OnChanges {
+export class FullHeightContentDirective implements OnInit, AfterViewChecked {
   private el = inject<ElementRef<HTMLElement>>(ElementRef);
   private renderer = inject(Renderer2);
   private ngZone = inject(NgZone);
 
-  @Input() algFullHeightContent = true;
+  algFullHeightContent = input(true);
 
   mainContainerEl = document.querySelector('#main-container');
 
-  @HostListener('window:resize')
+  private isFirstInputEffect = true;
+
+  constructor() {
+    // ngOnInit handles the initial height; skip the first effect run to preserve that semantic.
+    effect(() => {
+      const enabled = this.algFullHeightContent();
+      if (this.isFirstInputEffect) {
+        this.isFirstInputEffect = false;
+        return;
+      }
+      if (enabled) this.setHeight();
+      else this.unsetHeight();
+    });
+  }
+
   resize(): void {
     this.setHeight();
   }
@@ -34,22 +49,15 @@ export class FullHeightContentDirective implements OnInit, AfterViewChecked, OnC
     if (window.getComputedStyle(this.el.nativeElement).display === 'inline') {
       this.renderer.setStyle(this.el.nativeElement, 'display', 'block');
     }
-    if (this.algFullHeightContent) this.setHeight();
+    if (this.algFullHeightContent()) this.setHeight();
   }
 
   ngAfterViewChecked(): void {
     this.ngZone.runOutsideAngular(() => {
       setTimeout(() => {
-        if (this.algFullHeightContent) this.setHeight();
+        if (this.algFullHeightContent()) this.setHeight();
       });
     });
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.algFullHeightContent && !changes.algFullHeightContent.firstChange) {
-      if (this.algFullHeightContent) this.setHeight();
-      else this.unsetHeight();
-    }
   }
 
   unsetHeight(): void {

--- a/src/app/forum/containers/thread-container/thread-container.component.ts
+++ b/src/app/forum/containers/thread-container/thread-container.component.ts
@@ -1,5 +1,6 @@
-import { AfterViewInit, Component, computed, inject, Input, OnDestroy, ViewChild, ChangeDetectionStrategy } from '@angular/core';
-import { combineLatest, filter, map, of, Subscription, switchMap } from 'rxjs';
+import { AfterViewInit, Component, computed, DestroyRef, inject, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { combineLatest, filter, map, of, switchMap } from 'rxjs';
 import { ThreadComponent } from '../thread/thread.component';
 import { RouterLink } from '@angular/router';
 import { AsyncPipe } from '@angular/common';
@@ -18,7 +19,6 @@ import { catchError } from 'rxjs/operators';
   selector: 'alg-thread-container',
   templateUrl: './thread-container.component.html',
   styleUrls: [ './thread-container.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     RouterLink,
     ThreadComponent,
@@ -27,15 +27,14 @@ import { catchError } from 'rxjs/operators';
     GroupLinkPipe,
   ]
 })
-export class ThreadContainerComponent implements AfterViewInit, OnDestroy {
+export class ThreadContainerComponent implements AfterViewInit {
 
   private store = inject(Store);
   private userSessionService = inject(UserSessionService);
   private userService = inject(GetUserService);
+  private destroyRef = inject(DestroyRef);
 
-  @ViewChild(ThreadComponent) threadComponent?: ThreadComponent;
-
-  @Input() topCompensation = 0;
+  threadComponent = viewChild(ThreadComponent);
 
   visible$ = this.store.select(fromForum.selectVisible);
   threadHydratedId = this.store.selectSignal(fromForum.selectThreadHydratedId);
@@ -68,17 +67,14 @@ export class ThreadContainerComponent implements AfterViewInit, OnDestroy {
   /** The participant id, for linking to their profile. */
   participantId = computed(() => this.threadHydratedId()?.id.participantId ?? null);
 
-  private subscription?: Subscription;
-
   ngAfterViewInit(): void {
-    this.subscription = this.visible$.pipe(filter(visible => visible)).subscribe(() => {
-      this.threadComponent?.scrollDown();
-      this.threadComponent?.focusOnInput();
+    this.visible$.pipe(
+      filter(visible => visible),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(() => {
+      this.threadComponent()?.scrollDown();
+      this.threadComponent()?.focusOnInput();
     });
-  }
-
-  ngOnDestroy(): void {
-    this.subscription?.unsubscribe();
   }
 
   onClose(): void {

--- a/src/app/groups/containers/my-groups/my-groups.component.html
+++ b/src/app/groups/containers/my-groups/my-groups.component.html
@@ -8,7 +8,6 @@
 @if ((currentUser$ | async)?.tempUser === false) {
   <h2 class="alg-h2 alg-text-normal" i18n>Join a group by code</h2>
   <alg-access-code-view
-    i18n-sectionLabel sectionLabel="Join a group by code"
     i18n-buttonLabel="Button label for joining a group" buttonLabel="Join"
     (groupJoined)="onGroupJoined()"
   ></alg-access-code-view>

--- a/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.html
+++ b/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.html
@@ -29,11 +29,11 @@
               </div>
             </div>
             <div class="buttons">
-              @if (!info.isObserving && author.groupId === info.currentUserId && itemData()) {
+              @if (!info.isObserving && author.groupId === info.currentUserId) {
                 <a
                   class="size-xs button"
                   alg-button
-                  [routerLink]="itemData()!.item | itemRoute | url"
+                  [routerLink]="itemData().item | itemRoute | url"
                   [algLoadAnswerAsCurrent]="answer.id"
                   i18n
                 >
@@ -42,7 +42,7 @@
                 <a
                   class="size-xs button"
                   alg-button
-                  [routerLink]="itemData()!.item | itemRoute | url"
+                  [routerLink]="itemData().item | itemRoute | url"
                   i18n
                 >
                   View your current answer

--- a/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.html
+++ b/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.html
@@ -29,11 +29,11 @@
               </div>
             </div>
             <div class="buttons">
-              @if (!info.isObserving && author.groupId === info.currentUserId && itemData) {
+              @if (!info.isObserving && author.groupId === info.currentUserId && itemData()) {
                 <a
                   class="size-xs button"
                   alg-button
-                  [routerLink]="itemData.item | itemRoute | url"
+                  [routerLink]="itemData()!.item | itemRoute | url"
                   [algLoadAnswerAsCurrent]="answer.id"
                   i18n
                 >
@@ -42,7 +42,7 @@
                 <a
                   class="size-xs button"
                   alg-button
-                  [routerLink]="itemData.item | itemRoute | url"
+                  [routerLink]="itemData()!.item | itemRoute | url"
                   i18n
                 >
                   View your current answer

--- a/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.ts
+++ b/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.ts
@@ -1,5 +1,5 @@
-import { Component, DestroyRef, input, Input, OnChanges, OnDestroy, SimpleChanges, inject, ChangeDetectionStrategy } from '@angular/core';
-import { ReplaySubject } from 'rxjs';
+import { Component, DestroyRef, input, inject } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { map, shareReplay, switchMap } from 'rxjs/operators';
 import { GetUserService } from 'src/app/groups/data-access/get-user.service';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
@@ -27,7 +27,6 @@ import { fromItemContent } from 'src/app/items/store';
   selector: 'alg-answer-author-indicator',
   templateUrl: './answer-author-indicator.component.html',
   styleUrls: [ './answer-author-indicator.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -43,7 +42,7 @@ import { fromItemContent } from 'src/app/items/store';
     ButtonComponent,
   ]
 })
-export class AnswerAuthorIndicatorComponent implements OnChanges, OnDestroy {
+export class AnswerAuthorIndicatorComponent {
   private store = inject(Store);
   private router = inject(Router);
   private groupRouter = inject(GroupRouter);
@@ -61,9 +60,9 @@ export class AnswerAuthorIndicatorComponent implements OnChanges, OnDestroy {
   }
 
   answer = input.required<Answer>();
-  @Input() itemData?: ItemData;
+  itemData = input<ItemData>();
 
-  answer$ = new ReplaySubject<Answer>(1);
+  readonly answer$ = toObservable(this.answer);
   readonly author$ = this.answer$.pipe(
     switchMap(answer => this.getUserService.getForId(answer.authorId)),
     mapToFetchState(),
@@ -78,14 +77,6 @@ export class AnswerAuthorIndicatorComponent implements OnChanges, OnDestroy {
   );
   readonly isObserving$ = this.store.select(fromObservation.selectIsObserving);
   readonly backLink = this.store.selectSignal(fromItemContent.selectBackLink);
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.answer) this.answer$.next(this.answer());
-  }
-
-  ngOnDestroy(): void {
-    this.answer$.complete();
-  }
 
   onBackLinkClick(url: string): void {
     void this.router.navigateByUrl(url);

--- a/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.ts
+++ b/src/app/items/containers/answer-author-indicator/answer-author-indicator.component.ts
@@ -60,7 +60,7 @@ export class AnswerAuthorIndicatorComponent {
   }
 
   answer = input.required<Answer>();
-  itemData = input<ItemData>();
+  itemData = input.required<ItemData>();
 
   readonly answer$ = toObservable(this.answer);
   readonly author$ = this.answer$.pipe(

--- a/src/app/items/containers/item-task-edit/item-task-edit.component.html
+++ b/src/app/items/containers/item-task-edit/item-task-edit.component.html
@@ -1,11 +1,11 @@
 
-@if (!!sanitizedUrl) {
+@if (!!sanitizedUrl()) {
   <div
     class="iframe-container"
     [algFullHeightContent]="true"
   >
     <iframe
-      [src]="sanitizedUrl"
+      [src]="sanitizedUrl()"
       [algFullHeightContent]="true"
       allowfullscreen
     ></iframe>

--- a/src/app/items/containers/item-task-edit/item-task-edit.component.ts
+++ b/src/app/items/containers/item-task-edit/item-task-edit.component.ts
@@ -1,5 +1,5 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, inject, ChangeDetectionStrategy } from '@angular/core';
-import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { Component, computed, effect, inject, input, output } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 import { FullHeightContentDirective } from 'src/app/directives/full-height-content.directive';
 
 
@@ -7,22 +7,24 @@ import { FullHeightContentDirective } from 'src/app/directives/full-height-conte
   selector: 'alg-item-task-edit',
   templateUrl: './item-task-edit.component.html',
   styleUrls: [ './item-task-edit.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ FullHeightContentDirective ]
 })
-export class ItemTaskEditComponent implements OnChanges {
+export class ItemTaskEditComponent {
   private sanitizer = inject(DomSanitizer);
 
-  @Input() editorUrl?: string;
-  @Output() redirectToDefaultTab = new EventEmitter<void>();
+  editorUrl = input<string>();
+  redirectToDefaultTab = output<void>();
 
-  sanitizedUrl?: SafeResourceUrl;
+  sanitizedUrl = computed(() => {
+    const url = this.editorUrl();
+    return url ? this.sanitizer.bypassSecurityTrustResourceUrl(url) : undefined;
+  });
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.editorUrl) {
-      this.sanitizedUrl = this.editorUrl ? this.sanitizer.bypassSecurityTrustResourceUrl(this.editorUrl) : undefined;
-      if (!this.sanitizedUrl) this.redirectToDefaultTab.emit();
-    }
+  constructor() {
+    // Output emission from an effect is a deliberate exception: redirect when no editor URL is provided.
+    effect(() => {
+      if (!this.editorUrl()) this.redirectToDefaultTab.emit();
+    });
   }
 
 }

--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -8,9 +8,7 @@
         @if (showAccessCodeField$ | async) {
           <div class="access-code-view">
             <alg-access-code-view
-              i18n-sectionLabel sectionLabel="Access to activity"
               i18n-buttonLabel="Button label for joining an item by (group) code" buttonLabel="Access"
-              [itemData]="itemData"
               (groupJoined)="reloadItem()"
             ></alg-access-code-view>
           </div>

--- a/src/app/models/routing/item-navigation-state.ts
+++ b/src/app/models/routing/item-navigation-state.ts
@@ -1,6 +1,6 @@
 
 import { AnswerId } from 'src/app/models/ids';
-import { Directive, inject, Input, OnChanges } from '@angular/core';
+import { Directive, effect, inject, input } from '@angular/core';
 import { isString } from 'src/app/utils/type-checkers';
 import { RouterLink } from '@angular/router';
 
@@ -12,14 +12,17 @@ export interface ItemNavigationState {
 /**
  * Set the `loadAnswerIdAsCurrent` property in the router state
  */
-@Directive({ selector: '[algLoadAnswerAsCurrent]', standalone: true })
-export class LoadAnswerAsCurrentDirective implements OnChanges {
-  @Input('algLoadAnswerAsCurrent') answerId?: AnswerId;
+@Directive({ selector: '[algLoadAnswerAsCurrent]' })
+export class LoadAnswerAsCurrentDirective {
+  answerId = input<AnswerId | undefined>(undefined, { alias: 'algLoadAnswerAsCurrent' });
   private routerLink = inject(RouterLink);
 
-  ngOnChanges(): void {
-    const routerLinkState = this.routerLink.state || {};
-    this.routerLink.state = { ...routerLinkState, loadAnswerIdAsCurrent: this.answerId };
+  constructor() {
+    effect(() => {
+      const routerLinkState = this.routerLink.state || {};
+      // Intentionally mutates RouterLink state so navigation carries loadAnswerIdAsCurrent.
+      this.routerLink.state = { ...routerLinkState, loadAnswerIdAsCurrent: this.answerId() };
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Modernize `full-height-content`, `LoadAnswerAsCurrentDirective`, `item-task-edit`, `answer-author-indicator`, `thread-container`, and `access-code-view` to Angular 22 patterns (signal inputs/outputs, computed(), effect(), template cleanup).
- Batch 11 from `.cursor/plans/modernize-batch-11-directives-misc.md`.

## Scope
- **`full-height-content` directive** — signal input, host `(window:resize)`, `effect()` instead of `ngOnChanges`
- **`LoadAnswerAsCurrentDirective`** — signal input with alias, `effect()` for RouterLink state
- **`item-task-edit`** — signal input/output, `computed()` for sanitized URL, redirect `effect()`
- **`answer-author-indicator`** — fix broken hybrid: `toObservable(this.answer)` replaces stale `ngOnChanges` bridge
- **`thread-container`** — remove dead `topCompensation` input; `viewChild()`; `takeUntilDestroyed()`
- **`access-code-view`** — remove dead `sectionLabel` and `itemData` inputs (+ parent bindings in `item-by-id`, `my-groups`); signals for `state` and `code`
- Drop `Eager` change detection on all four components

## Risks / manual checks
- **`full-height-content`** — task display height and window resize (no direct e2e)
- **`answer-author-indicator`** — fixes previously broken author banner; verify observer answer load shows banner and "Edit it" / back-link buttons
- **`access-code-view`** — dead-input removal drops two unused i18n source strings (`sectionLabel` on parents); no visible regression (parents render their own headers)
- No unit specs for any of these components; manual smoke required

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-11/en/

## Verification
- [x] `npm run lint`
- [x] Targeted unit tests from plan (none exist for these components)
- [x] `ng build algorea --configuration=en`
- [x] Manual smoke:
  - Open a task (full height + window resize)
  - Task editor tab with/without editor URL (redirect when absent)
  - Load an answer via activity log (author indicator)
  - Open forum thread panel (scroll/focus)
  - Join a group by code from my-groups and from an item requiring entry