### PR TITLE
Modernize Angular components (batch 12).

### DIFF
--- a/src/app/items/containers/chapter-children/chapter-children.component.html
+++ b/src/app/items/containers/chapter-children/chapter-children.component.html
@@ -23,17 +23,17 @@
         i18n-message message="This chapter has no content visible to you, so you can't validate it for now."
       ></alg-error>
     }
-    @if (itemData && itemData.item.displaySettings.childrenLayout === 'Grid') {
+    @if (itemData().item.displaySettings.childrenLayout === 'Grid') {
       @if (data.children.length > 0) {
         <div
           class="grid-container"
-          [ngClass]="{ 'left-menu-shown': leftMenuShown() }"
+          [class.left-menu-shown]="leftMenuShown()"
         >
           @for (item of data.children; track item; let i = $index) {
             <div class="grid-item">
-              @if (itemData && itemData.currentResult?.attemptId; as attemptId) {
+              @if (itemData().currentResult?.attemptId; as attemptId) {
                 <a class="grid-card"
-                  [routerLink]="item | itemRoute: { path: itemData.route.path.concat([ itemData.item.id ]) } |
+                  [routerLink]="item | itemRoute: { path: itemData().route.path.concat([ itemData().item.id ]) } |
                     with: (item.result && item.result.attemptId ? { attemptId : item.result.attemptId } : { parentAttemptId: attemptId }) |
                     url"
                 >
@@ -77,14 +77,14 @@
           }
         </div>
       }
-    } @else if (itemData && itemData.item.displaySettings.childrenLayout === 'List') {
-      @if (itemData && itemData.currentResult?.attemptId; as attemptId) {
+    } @else if (itemData().item.displaySettings.childrenLayout === 'List') {
+      @if (itemData().currentResult?.attemptId; as attemptId) {
         <alg-item-children-list
           [children]="data.children"
-          [routeParams]="{ parentAttemptId: attemptId, path: itemData.route.path.concat([ itemData.item.id ]) }"
+          [routeParams]="{ parentAttemptId: attemptId, path: itemData().route.path.concat([ itemData().item.id ]) }"
         ></alg-item-children-list>
       }
-    } @else if (itemData && itemData.item.displaySettings.childrenLayout === 'Hide') {
+    } @else if (itemData().item.displaySettings.childrenLayout === 'Hide') {
       @if (!leftMenuShown()) {
         <div class="hidden-children-hint">
           <i class="hidden-children-hint-icon ph ph-sidebar-simple"></i>

--- a/src/app/items/containers/chapter-children/chapter-children.component.ts
+++ b/src/app/items/containers/chapter-children/chapter-children.component.ts
@@ -1,11 +1,13 @@
-import { combineLatest, ReplaySubject, Subject } from 'rxjs';
-import { Component, inject, Input, OnChanges, OnDestroy, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
+import { combineLatest, Subject } from 'rxjs';
+import { Component, inject, input, DestroyRef } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { GetItemChildrenService, ItemChildren } from '../../../data-access/get-item-children.service';
 import { ItemData } from '../../models/item-data';
 import { bestAttemptFromResults } from 'src/app/items/models/attempts';
-import { distinctUntilChanged, map } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 import { switchMapToFetchState } from 'src/app/utils/operators/state';
 import { canCurrentUserViewContent } from 'src/app/items/models/item-view-permission';
+import { isNotUndefined } from 'src/app/utils/null-undefined-predicates';
 import { ItemChildWithAdditions } from '../item-children-list/item-children';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
 import { ItemRoutePipe, ItemRouteWithExtraPipe } from 'src/app/pipes/itemRoute';
@@ -14,18 +16,16 @@ import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.
 import { RouterLink } from '@angular/router';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
-import { AsyncPipe, NgClass } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store/observation';
 import { LayoutService } from 'src/app/services/layout.service';
-import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'alg-chapter-children',
   templateUrl: './chapter-children.component.html',
   styleUrls: [ './chapter-children.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -36,26 +36,42 @@ import { toSignal } from '@angular/core/rxjs-interop';
     ItemRoutePipe,
     ItemRouteWithExtraPipe,
     RouteUrlPipe,
-    NgClass,
     ButtonComponent,
   ]
 })
-export class ChapterChildrenComponent implements OnChanges, OnDestroy {
+export class ChapterChildrenComponent {
   private store = inject(Store);
   private getItemChildrenService = inject(GetItemChildrenService);
 
-  @Input() itemData?: ItemData;
+  readonly itemData = input.required<ItemData>();
 
   layoutService = inject(LayoutService);
 
-  private readonly params$ = new ReplaySubject<{ id: string, attemptId: string }>(1);
-  private refresh$ = new Subject<void>();
+  private readonly refresh$ = new Subject<void>();
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.refresh$.complete());
+  }
+
+  private readonly params$ = toObservable(this.itemData).pipe(
+    map(itemData => (itemData.currentResult
+      ? {
+        id: itemData.item.id,
+        attemptId: itemData.currentResult.attemptId,
+        currentResultValidated: itemData.currentResult.validated,
+      }
+      : undefined)),
+    filter(isNotUndefined),
+    distinctUntilChanged((a, b) =>
+      a.id === b.id && a.attemptId === b.attemptId && a.currentResultValidated === b.currentResultValidated),
+  );
+
   readonly state$ = combineLatest([
-    this.params$.pipe(distinctUntilChanged((a, b) => a.id === b.id && a.attemptId === b.attemptId)),
+    this.params$,
     this.store.select(fromObservation.selectObservedGroupId),
   ]).pipe(
     switchMapToFetchState(
-      ([{ id, attemptId }, observedGroupId ]) =>
+      ([{ id, attemptId, currentResultValidated }, observedGroupId ]) =>
         this.getItemChildrenService.get(id, attemptId, { watchedGroupId: observedGroupId ?? undefined }).pipe(
           map<ItemChildren, ItemChildWithAdditions[]>(itemChildren => itemChildren.map(child => {
             const res = bestAttemptFromResults(child.results);
@@ -71,28 +87,15 @@ export class ChapterChildrenComponent implements OnChanges, OnDestroy {
           })),
           map(children => ({
             children,
-            missingValidation: !(this.itemData?.currentResult?.validated || children.filter(item => item.category === 'Validation')
+            missingValidation: !(currentResultValidated || children.filter(item => item.category === 'Validation')
               .every(item => item.result && item.result.validated)),
           })),
         ),
       { resetter: this.refresh$ },
     ),
   );
+
   leftMenuShown = toSignal(this.layoutService.leftMenu$.pipe(map(({ shown }) => shown)), { initialValue: true });
-
-  ngOnChanges(_changes: SimpleChanges): void {
-    if (this.itemData?.currentResult) {
-      this.params$.next({
-        id: this.itemData.item.id,
-        attemptId: this.itemData.currentResult.attemptId,
-      });
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.params$.complete();
-    this.refresh$.complete();
-  }
 
   refresh(): void {
     this.refresh$.next();

--- a/src/app/items/containers/item-unlock-access/item-unlock-access.component.ts
+++ b/src/app/items/containers/item-unlock-access/item-unlock-access.component.ts
@@ -1,9 +1,7 @@
-import {
-  ChangeDetectionStrategy, Component, ElementRef, Input, OnChanges, OnDestroy, QueryList, signal, ViewChildren,
-  inject,
-} from '@angular/core';
+import { Component, DestroyRef, inject, input, signal } from '@angular/core';
+import { outputFromObservable, toObservable } from '@angular/core/rxjs-interop';
 import { ItemData } from '../../models/item-data';
-import { ReplaySubject, Subject, switchMap } from 'rxjs';
+import { Subject, switchMap } from 'rxjs';
 import { map, share } from 'rxjs/operators';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { GetItemPrerequisitesService } from '../../data-access/get-item-prerequisites.service';
@@ -18,13 +16,11 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
 import { AsyncPipe } from '@angular/common';
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
-import { outputFromObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'alg-item-unlock-access',
   templateUrl: './item-unlock-access.component.html',
   styleUrls: [ './item-unlock-access.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -38,15 +34,20 @@ import { outputFromObservable } from '@angular/core/rxjs-interop';
     ShowOverlayHoverTargetDirective,
   ]
 })
-export class ItemUnlockAccessComponent implements OnChanges, OnDestroy {
+export class ItemUnlockAccessComponent {
   private getItemPrerequisitesService = inject(GetItemPrerequisitesService);
 
-  @Input() itemData?: ItemData;
+  readonly itemData = input.required<ItemData>();
 
-  @ViewChildren('contentRef') contentRef?: QueryList<ElementRef<HTMLElement>>;
-
-  private readonly itemId$ = new ReplaySubject<string>(1);
   private readonly refresh$ = new Subject<void>();
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.refresh$.complete());
+  }
+
+  private readonly itemId$ = toObservable(this.itemData).pipe(
+    map(itemData => itemData.item.id),
+  );
 
   state$ = this.itemId$.pipe(
     switchMap(itemId => this.getItemPrerequisitesService.get(itemId)),
@@ -64,17 +65,6 @@ export class ItemUnlockAccessComponent implements OnChanges, OnDestroy {
   ));
 
   itemId = signal<string | undefined>(undefined);
-
-  ngOnChanges(): void {
-    if (this.itemData) {
-      this.itemId$.next(this.itemData.item.id);
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.itemId$.complete();
-    this.refresh$.complete();
-  }
 
   refresh(): void {
     this.refresh$.next();

--- a/src/app/items/containers/parent-skills/parent-skills.component.html
+++ b/src/app/items/containers/parent-skills/parent-skills.component.html
@@ -14,12 +14,12 @@
     ></alg-error>
   }
   @if (state.isReady && state.data; as parents) {
-    @if (itemData && itemData.currentResult?.attemptId; as attemptId) {
+    @if (itemData().currentResult?.attemptId; as attemptId) {
       <alg-item-children-list
         type="skill"
         i18n-emptyMessage emptyMessage="This skill does not have parent skills."
         [children]="parents"
-        [routeParams]="{ parentAttemptId: attemptId, path: itemData.route.path | slice :0 : -1 }"
+        [routeParams]="{ parentAttemptId: attemptId, path: itemData().route.path | slice :0 : -1 }"
       ></alg-item-children-list>
     }
   }

--- a/src/app/items/containers/parent-skills/parent-skills.component.ts
+++ b/src/app/items/containers/parent-skills/parent-skills.component.ts
@@ -1,10 +1,12 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges, inject, ChangeDetectionStrategy } from '@angular/core';
-import { ReplaySubject, Subject } from 'rxjs';
-import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
+import { Component, DestroyRef, inject, input } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
 import { GetItemParentsService } from '../../data-access/get-item-parents.service';
 import { ItemData } from '../../models/item-data';
 import { mapToFetchState } from 'src/app/utils/operators/state';
 import { canCurrentUserViewContent } from 'src/app/items/models/item-view-permission';
+import { isNotUndefined } from 'src/app/utils/null-undefined-predicates';
 import { ItemChildrenListComponent } from '../item-children-list/item-children-list.component';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
@@ -14,18 +16,28 @@ import { AsyncPipe, SlicePipe } from '@angular/common';
   selector: 'alg-parent-skills',
   templateUrl: './parent-skills.component.html',
   styleUrls: [ './parent-skills.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ LoadingComponent, ErrorComponent, ItemChildrenListComponent, AsyncPipe, SlicePipe ]
 })
-export class ParentSkillsComponent implements OnChanges, OnDestroy {
+export class ParentSkillsComponent {
   private getItemParentsService = inject(GetItemParentsService);
 
-  @Input() itemData?: ItemData;
+  readonly itemData = input.required<ItemData>();
 
-  private readonly params$ = new ReplaySubject<{ id: string, attemptId: string }>(1);
-  private refresh$ = new Subject<void>();
-  readonly state$ = this.params$.pipe(
+  private readonly refresh$ = new Subject<void>();
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.refresh$.complete());
+  }
+
+  private readonly params$ = toObservable(this.itemData).pipe(
+    map(itemData => (itemData.currentResult
+      ? { id: itemData.item.id, attemptId: itemData.currentResult.attemptId }
+      : undefined)),
+    filter(isNotUndefined),
     distinctUntilChanged((a, b) => a.id === b.id && a.attemptId === b.attemptId),
+  );
+
+  readonly state$ = this.params$.pipe(
     switchMap(({ id, attemptId }) => this.getItemParentsService.get(id, attemptId)),
     map(parents => parents.map(parent => ({
       ...parent,
@@ -38,20 +50,6 @@ export class ParentSkillsComponent implements OnChanges, OnDestroy {
     }))),
     mapToFetchState({ resetter: this.refresh$ }),
   );
-
-  ngOnChanges(_changes: SimpleChanges): void {
-    if (this.itemData?.currentResult) {
-      this.params$.next({
-        id: this.itemData.item.id,
-        attemptId: this.itemData.currentResult.attemptId,
-      });
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.params$.complete();
-    this.refresh$.complete();
-  }
 
   refresh(): void {
     this.refresh$.next();

--- a/src/app/items/containers/sub-skills/sub-skills.component.html
+++ b/src/app/items/containers/sub-skills/sub-skills.component.html
@@ -14,22 +14,22 @@
     <h2 class="alg-h2 alg-text-normal alg-base-title-primary-space" i18n>
       Sub-skills
     </h2>
-    @if (itemData && itemData.currentResult?.attemptId; as attemptId) {
+    @if (itemData().currentResult?.attemptId; as attemptId) {
       <alg-item-children-list
         type="skill"
         i18n-emptyMessage emptyMessage="This skill does not have subskills."
         [children]="data.skills"
-        [routeParams]="{ parentAttemptId: attemptId, path: itemData.route.path.concat([ itemData.item.id ]) }"
+        [routeParams]="{ parentAttemptId: attemptId, path: itemData().route.path.concat([ itemData().item.id ]) }"
       ></alg-item-children-list>
     }
     <div class="section-title alg-h2" i18n>
       Activities to learn or reinforce this skill
     </div>
-    @if (itemData && itemData.currentResult?.attemptId; as attemptId) {
+    @if (itemData().currentResult?.attemptId; as attemptId) {
       <alg-item-children-list
         i18n-emptyMessage emptyMessage="This skill does not have related activities."
         [children]="data.activities"
-        [routeParams]="{ parentAttemptId: attemptId, path: itemData.route.path.concat([ itemData.item.id ]) }"
+        [routeParams]="{ parentAttemptId: attemptId, path: itemData().route.path.concat([ itemData().item.id ]) }"
       ></alg-item-children-list>
     }
   }

--- a/src/app/items/containers/sub-skills/sub-skills.component.ts
+++ b/src/app/items/containers/sub-skills/sub-skills.component.ts
@@ -1,12 +1,14 @@
-import { Component, Input, OnChanges, OnDestroy, SimpleChanges, inject, ChangeDetectionStrategy } from '@angular/core';
-import { ReplaySubject, Subject } from 'rxjs';
-import { distinctUntilChanged, map, switchMap } from 'rxjs/operators';
+import { Component, DestroyRef, inject, input } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { Subject } from 'rxjs';
+import { distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
 import { bestAttemptFromResults } from 'src/app/items/models/attempts';
 import { isASkill } from 'src/app/items/models/item-type';
 import { GetItemChildrenService } from '../../../data-access/get-item-children.service';
 import { ItemData } from '../../models/item-data';
 import { mapToFetchState } from 'src/app/utils/operators/state';
 import { canCurrentUserViewContent } from 'src/app/items/models/item-view-permission';
+import { isNotUndefined } from 'src/app/utils/null-undefined-predicates';
 import { ItemChildrenListComponent } from '../item-children-list/item-children-list.component';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
@@ -16,18 +18,28 @@ import { AsyncPipe } from '@angular/common';
   selector: 'alg-sub-skills',
   templateUrl: './sub-skills.component.html',
   styleUrls: [ './sub-skills.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ LoadingComponent, ErrorComponent, ItemChildrenListComponent, AsyncPipe ]
 })
-export class SubSkillsComponent implements OnChanges, OnDestroy {
+export class SubSkillsComponent {
   private getItemChildrenService = inject(GetItemChildrenService);
 
-  @Input() itemData?: ItemData;
+  readonly itemData = input.required<ItemData>();
 
-  private readonly params$ = new ReplaySubject<{ id: string, attemptId: string }>(1);
-  private refresh$ = new Subject<void>();
-  readonly state$ = this.params$.pipe(
+  private readonly refresh$ = new Subject<void>();
+
+  constructor() {
+    inject(DestroyRef).onDestroy(() => this.refresh$.complete());
+  }
+
+  private readonly params$ = toObservable(this.itemData).pipe(
+    map(itemData => (itemData.currentResult
+      ? { id: itemData.item.id, attemptId: itemData.currentResult.attemptId }
+      : undefined)),
+    filter(isNotUndefined),
     distinctUntilChanged((a, b) => a.id === b.id && a.attemptId === b.attemptId),
+  );
+
+  readonly state$ = this.params$.pipe(
     switchMap(({ id, attemptId }) => this.getItemChildrenService.get(id, attemptId)),
     map(children => {
       const newChildren = children
@@ -50,20 +62,6 @@ export class SubSkillsComponent implements OnChanges, OnDestroy {
     }),
     mapToFetchState({ resetter: this.refresh$ }),
   );
-
-  ngOnChanges(_changes: SimpleChanges): void {
-    if (this.itemData?.currentResult) {
-      this.params$.next({
-        id: this.itemData.item.id,
-        attemptId: this.itemData.currentResult.attemptId,
-      });
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.params$.complete();
-    this.refresh$.complete();
-  }
 
   refresh(): void {
     this.refresh$.next();


### PR DESCRIPTION
## Summary
- Modernize `sub-skills`, `parent-skills`, `item-unlock-access`, and `chapter-children` to Angular 22 patterns: `input.required<ItemData>()`, `toObservable()` fetch pipelines, async-pipe-driven templates.
- Batch 12 from `.cursor/plans/modernize-batch-12-items-fetch.md`.

## Scope
- **sub-skills / parent-skills** — replace `ngOnChanges` → `ReplaySubject` with `toObservable(this.itemData)` pipeline; keep `refresh()` + `refresh$`
- **item-unlock-access** — same migration; remove unused `@ViewChildren('contentRef')`; `hasContent` output unchanged
- **chapter-children** — fix stale-closure bug by carrying `currentResultValidated` through pipeline; replace `[ngClass]` with `[class.left-menu-shown]`
- Drop `ChangeDetectionStrategy.Eager` on all four (OnPush default)

## `distinctUntilChanged` decisions
| Component | Comparator | Rationale |
|-----------|------------|-----------|
| **sub-skills / parent-skills** | `(id, attemptId)` | Content depends only on those; suppresses duplicate fetches when parent re-emits same item |
| **item-unlock-access** | *omitted* | Prerequisites must re-fetch after unlock/store refresh (matches old `ngOnChanges` behavior) |
| **chapter-children** | `(id, attemptId, currentResultValidated)` | Fixes stale closure; re-fetches when chapter validation status changes |

## Risks / manual checks
- OnPush switch relies on async-pipe/signal CD — covered by existing E2E (`skill-content.spec.ts`, `chapter-children.spec.ts`, `chapter-children-token-expiration.spec.ts`)
- `chapter-children` now re-fetches when `currentResult.validated` flips (new but correct behavior after stale-closure fix)
- No unit specs for these four components

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-12/en/

## Verification
- [x] `npm run lint`
- [x] `ng build algorea --configuration=en`
- [x] CI E2E (skill-content, chapter-children specs)
- [x] Manual smoke:
  - Open a chapter (children grid/list, left-menu-shown layout shift)
  - Open a skill (sub-skills + parent-skills sections)
  - Open a locked item (prerequisites list + unlock then refresh)