### PR TITLE
Modernize ng comp 13

### DIFF
--- a/src/app/groups/containers/group-access/group-access.component.html
+++ b/src/app/groups/containers/group-access/group-access.component.html
@@ -1,5 +1,5 @@
-@if (group?.currentUserCanGrantGroupAccess) {
-  <h2 class="alg-h2 alg-text-normal alg-base-title-space" i18n>Activity associated to {{ group?.name }}</h2>
+@if (group().currentUserCanGrantGroupAccess) {
+  <h2 class="alg-h2 alg-text-normal alg-base-title-space" i18n>Activity associated to {{ group().name }}</h2>
   @if (rootActivityState$ | async; as rootActivityState) {
     @if (rootActivityState.isFetching) {
       <div class="spinner">
@@ -53,7 +53,7 @@
               <strong>
                 {{ grantedPermission.item.title }}.
               </strong>
-              @if (grantedPermission.sourceGroup.id !== group?.id && grantedPermission.group.id !== group?.id) {
+              @if (grantedPermission.sourceGroup.id !== group().id && grantedPermission.group.id !== group().id) {
                 <span i18n>Given by</span>
                 <a
                   class="alg-link"

--- a/src/app/groups/containers/group-access/group-access.component.ts
+++ b/src/app/groups/containers/group-access/group-access.component.ts
@@ -1,7 +1,7 @@
-import { Component, Input, OnChanges, OnDestroy, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, inject, input } from '@angular/core';
 import { Group } from '../../models/group';
 import { GetItemByIdService } from 'src/app/data-access/get-item-by-id.service';
-import { ReplaySubject, of, Subject } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { mapToFetchState } from 'src/app/utils/operators/state';
 import { GrantedPermissionsService } from '../../data-access/granted-permissions.service';
@@ -11,12 +11,12 @@ import { RouterLink } from '@angular/router';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
 import { AsyncPipe } from '@angular/common';
+import { toObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'alg-group-access',
   templateUrl: './group-access.component.html',
   styleUrls: [ './group-access.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -26,15 +26,18 @@ import { AsyncPipe } from '@angular/common';
     GroupLinkPipe,
   ]
 })
-export class GroupAccessComponent implements OnChanges, OnDestroy {
+export class GroupAccessComponent {
   private getItemByIdService = inject(GetItemByIdService);
   private grantedPermissionsService = inject(GrantedPermissionsService);
+  private destroyRef = inject(DestroyRef);
 
-  @Input() group?: Group;
-
-  private readonly group$ = new ReplaySubject<Group>(1);
+  group = input.required<Group>();
 
   private refresh$ = new Subject<void>();
+  private permissionsRefresh$ = new Subject<void>();
+
+  private group$ = toObservable(this.group);
+
   rootActivityState$ = this.group$.pipe(
     switchMap(({ rootActivityId }) => {
       if (!rootActivityId) {
@@ -45,21 +48,16 @@ export class GroupAccessComponent implements OnChanges, OnDestroy {
     mapToFetchState({ resetter: this.refresh$ }),
   );
 
-  private permissionsRefresh$ = new Subject<void>();
   permissionState$ = this.group$.pipe(
     switchMap(group => this.grantedPermissionsService.get(group.id)),
     mapToFetchState({ resetter: this.permissionsRefresh$ }),
   );
 
-  ngOnChanges(): void {
-    if (this.group) {
-      this.group$.next(this.group);
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.group$.complete();
-    this.refresh$.complete();
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.refresh$.complete();
+      this.permissionsRefresh$.complete();
+    });
   }
 
   refresh(): void {

--- a/src/app/groups/containers/group-log-view/group-log-view.component.html
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.html
@@ -71,7 +71,7 @@
             >
               <a
                 class="alg-link"
-                [ngClass]="{'disabled': !rowData.item}"
+                [class.disabled]="!rowData.item"
                 [routerLink]="rowData.item | itemRoute | url"
                 algShowOverlayHoverTarget
               >

--- a/src/app/groups/containers/group-log-view/group-log-view.component.ts
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input, Input, OnChanges, signal, SimpleChanges, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, effect, inject, input, signal } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map, withLatestFrom } from 'rxjs/operators';
 import { ActivityLogs, ActivityLogService } from 'src/app/data-access/activity-log.service';
@@ -14,7 +14,7 @@ import { Router, RouterLink } from '@angular/router';
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
-import { NgClass, AsyncPipe, DatePipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { UserSessionService } from '../../../services/user-session.service';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
@@ -42,12 +42,10 @@ const logsLimit = 20;
   selector: 'alg-group-log-view',
   templateUrl: './group-log-view.component.html',
   styleUrls: [ './group-log-view.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
     ScoreRingComponent,
-    NgClass,
     RouterLink,
     PathSuggestionComponent,
     AsyncPipe,
@@ -74,14 +72,15 @@ const logsLimit = 20;
     CdkNoDataRow,
   ]
 })
-export class GroupLogViewComponent implements OnChanges {
+export class GroupLogViewComponent {
   private activityLogService = inject(ActivityLogService);
   private actionFeedbackService = inject(ActionFeedbackService);
   private sessionService = inject(UserSessionService);
   private store = inject(Store);
   private router = inject(Router);
 
-  @Input() groupId?: string;
+  /** Undefined means "my own log" (see user.component). Must not change after init — DataPager's fetch closure captures it. */
+  groupId = input<string>();
   showUserColumn = input(true);
 
   itemId = signal<string | undefined>(undefined);
@@ -102,14 +101,20 @@ export class GroupLogViewComponent implements OnChanges {
 
   readonly state$ = this.datapager.list$;
 
+  private groupIdAtInit: string | undefined | null = null;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if ('groupId' in changes && !changes.groupId?.isFirstChange()) {
-      throw new Error('Unexpected: groupId should not change');
-    }
-    if ('groupId' in changes && changes.groupId?.isFirstChange()) {
-      this.resetRows();
-    }
+  constructor() {
+    effect(() => {
+      const groupId = this.groupId();
+      if (this.groupIdAtInit === null) {
+        this.groupIdAtInit = groupId;
+        this.resetRows();
+        return;
+      }
+      if (groupId !== this.groupIdAtInit) {
+        throw new Error('Unexpected: groupId should not change');
+      }
+    });
   }
 
   refresh(): void {
@@ -126,7 +131,7 @@ export class GroupLogViewComponent implements OnChanges {
     };
 
     return this.activityLogService.getAllActivityLog({
-      watchedGroupId: this.groupId,
+      watchedGroupId: this.groupId(),
       limit: pageSize,
       pagination: paginationParams,
     }).pipe(

--- a/src/app/groups/containers/group-remove-button/group-remove-button.component.ts
+++ b/src/app/groups/containers/group-remove-button/group-remove-button.component.ts
@@ -49,6 +49,7 @@ export class GroupRemoveButtonComponent {
   constructor() {
     this.destroyRef.onDestroy(() => {
       this.refresh$.complete();
+      this.deletionInProgress$.complete();
     });
   }
 

--- a/src/app/groups/containers/group-remove-button/group-remove-button.component.ts
+++ b/src/app/groups/containers/group-remove-button/group-remove-button.component.ts
@@ -1,7 +1,7 @@
-import { Component, EventEmitter, Input, OnChanges, OnDestroy, Output, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, inject, input, output } from '@angular/core';
 import { Group } from '../../models/group';
 import { distinctUntilChanged, switchMap, map, filter } from 'rxjs/operators';
-import { Observable, ReplaySubject, Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { GetGroupChildrenService, GroupChild } from '../../data-access/get-group-children.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { GroupDeleteService } from '../../data-access/group-delete.service';
@@ -12,44 +12,44 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
 import { AsyncPipe } from '@angular/common';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { ConfirmationModalService } from 'src/app/services/confirmation-modal.service';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'alg-group-remove-button',
   templateUrl: './group-remove-button.component.html',
   styleUrls: [ './group-remove-button.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ LoadingComponent, ErrorComponent, AsyncPipe, ButtonComponent ]
 })
-export class GroupRemoveButtonComponent implements OnChanges, OnDestroy {
+export class GroupRemoveButtonComponent {
   private actionFeedbackService = inject(ActionFeedbackService);
   private confirmationModalService = inject(ConfirmationModalService);
   private getGroupChildrenService = inject(GetGroupChildrenService);
   private groupDeleteService = inject(GroupDeleteService);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
-  @Input() group?: Group;
+  group = input.required<Group>();
 
-  @Output() groupDeleted = new EventEmitter<void>();
+  groupDeleted = output<void>();
 
   deletionInProgress$ = new Subject<boolean>();
 
-  private readonly id$ = new ReplaySubject<string>(1);
   private refresh$ = new Subject<void>();
-  readonly state$ = this.id$.pipe(
+
+  private id$ = toObservable(this.group).pipe(
+    map(g => g.id),
     distinctUntilChanged(),
+  );
+
+  readonly state$ = this.id$.pipe(
     switchMap(id => this.hasGroupChildren$(id)),
     mapToFetchState({ resetter: this.refresh$ }),
   );
 
-  ngOnChanges(): void {
-    if (this.group) {
-      this.id$.next(this.group.id);
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.id$.complete();
-    this.refresh$.complete();
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.refresh$.complete();
+    });
   }
 
   hasGroupChildren$(groupId: string): Observable<boolean> {
@@ -59,9 +59,8 @@ export class GroupRemoveButtonComponent implements OnChanges, OnDestroy {
   }
 
   onDeleteGroup(): void {
-    if (!this.group) throw new Error('Unexpected: Missed group');
-    const id = this.group.id;
-    const groupName = this.group.name;
+    const id = this.group().id;
+    const groupName = this.group().name;
 
     this.deletionInProgress$.next(true);
     this.confirmationModalService.open({
@@ -74,7 +73,8 @@ export class GroupRemoveButtonComponent implements OnChanges, OnDestroy {
       rejectButtonIcon: 'ph-bold ph-x',
     }).pipe(
       filter(accepted => !!accepted),
-      switchMap(() => this.groupDeleteService.delete(id))
+      switchMap(() => this.groupDeleteService.delete(id)),
+      takeUntilDestroyed(this.destroyRef),
     ).subscribe({
       next: () => {
         this.actionFeedbackService.success($localize`You have deleted "${groupName}"`);


### PR DESCRIPTION
## Summary
- Modernize `group-access`, `group-remove-button`, and `group-log-view` to Angular 22 patterns: signal inputs/outputs, `toObservable()` fetch pipelines, async-pipe-driven templates.
- Batch 13 from `.cursor/plans/modernize-batch-13-groups-fetch.md`.

## Scope
- **group-access** — `input.required<Group>()`, `toObservable(this.group)` for both pipelines; fix `permissionsRefresh$` leak via `DestroyRef.onDestroy()`
- **group-remove-button** — `input.required<Group>()`, `output<void>()`, `toObservable` + `distinctUntilChanged()` on group id; `takeUntilDestroyed()` on delete subscription
- **group-log-view** — optional `input<string>()` for `groupId`; immutability guard moved to constructor `effect()`; `[class.disabled]` replaces `NgClass`
- Drop `ChangeDetectionStrategy.Eager` on all three

## Risks / manual checks
- **group-log-view** — e2e coverage in `group-history-page.ts`, `user-page.ts`, `show-path-suggestion-overflow.spec.ts` (rely on CI)
- **group-access / group-remove-button** — no direct e2e; manual smoke required for access tab and delete flow
- `groupId` immutability guard preserved (belt-and-braces; route change recreates component)

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-13/en/

## Verification
- [x] `npm run lint`
- [x] `ng build algorea --configuration=e2e`
- [x] CI E2E (group history, user page, path-suggestion overflow)
- [x] Manual smoke:
  - Group access tab (root activity + permissions list, error/retry)
  - Group settings → delete button (with/without children, confirm dialog, redirect)
  - Group history table + user history (own + observed user)
  - Path-suggestion overlay from a log row