### PR TITLE
Modernize Angular components (batch 14).

### DIFF
--- a/src/app/groups/containers/add-sub-group/add-sub-group.component.html
+++ b/src/app/groups/containers/add-sub-group/add-sub-group.component.html
@@ -7,7 +7,7 @@
     [allowedTypesForNewContent]="allowedNewGroupTypes"
     [searchFunction]="searchFunction"
     (contentAdded)="addChild($event)"
-    [loading]="loading"
+    [loading]="loading()"
     #addContentComponent
   ></alg-add-content>
 </alg-sub-section>

--- a/src/app/groups/containers/add-sub-group/add-sub-group.component.ts
+++ b/src/app/groups/containers/add-sub-group/add-sub-group.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output, ViewChild, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output, viewChild } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import {
@@ -6,7 +6,6 @@ import {
   AddedContent,
   NewContentType
 } from 'src/app/ui-components/add-content/add-content.component';
-import { Group } from '../../models/group';
 import { SearchGroupService } from '../../data-access/search-group.service';
 import { AddContentComponent as AddContentComponent_1 } from 'src/app/ui-components/add-content/add-content.component';
 import { SubSectionComponent } from 'src/app/ui-components/sub-section/sub-section.component';
@@ -17,24 +16,16 @@ type GroupType = 'Class'|'Team'|'Club'|'Friends'|'Other';
   selector: 'alg-add-sub-group',
   templateUrl: './add-sub-group.component.html',
   styleUrls: [ './add-sub-group.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ SubSectionComponent, AddContentComponent_1 ]
 })
 export class AddSubGroupComponent {
   private searchGroupService = inject(SearchGroupService);
 
-  @ViewChild('addContentComponent') addContentComponent?: AddContentComponent<GroupType>;
+  addContentComponent = viewChild<AddContentComponent<GroupType>>('addContentComponent');
 
-  @Input() group?: Group;
-  @Input() loading = false;
+  loading = input(false);
 
-  @Output() addGroup = new EventEmitter<AddedContent<GroupType>>();
-
-  groupsFound: {
-    type: GroupType,
-    title: string,
-    description: string|null,
-  }[] = [];
+  addGroup = output<AddedContent<GroupType>>();
 
   allowedNewGroupTypes: NewContentType<GroupType>[] = [
     {

--- a/src/app/groups/containers/group-composition/group-composition.component.html
+++ b/src/app/groups/containers/group-composition/group-composition.component.html
@@ -1,23 +1,21 @@
-@if (groupData) {
-  @let group = groupData.group;
-  @if (group | isCurrentUserManager) {
-    <alg-member-list class="member-list" #memberList [groupData]="groupData" (removedGroup)="removedGroup.emit()"></alg-member-list>
-    @if (group.currentUserCanManage !== 'none') {
-      <alg-add-sub-group
-        [loading]="state === 'addingGroup'"
-        (addGroup)="addGroup($event)"
-        #addSubGroupComponent
-      ></alg-add-sub-group>
-    }
-    @if (group.currentUserCanManage !== 'none') {
-      <alg-group-join-by-code [group]="group" (refreshRequired)="refreshGroupInfo()">
-      </alg-group-join-by-code>
-    }
-    @if (group.currentUserCanManage !== 'none') {
-      <alg-group-invite-users [group]="group" (refreshRequired)="refreshGroupInfo()">
-      </alg-group-invite-users>
-    }
-  } @else {
-    <alg-group-no-permission></alg-group-no-permission>
+@let group = groupData().group;
+@if (group | isCurrentUserManager) {
+  <alg-member-list class="member-list" #memberList [groupData]="groupData()" (removedGroup)="removedGroup.emit()"></alg-member-list>
+  @if (group.currentUserCanManage !== 'none') {
+    <alg-add-sub-group
+      [loading]="state() === 'addingGroup'"
+      (addGroup)="addGroup($event)"
+      #addSubGroupComponent
+    ></alg-add-sub-group>
   }
+  @if (group.currentUserCanManage !== 'none') {
+    <alg-group-join-by-code [group]="group" (refreshRequired)="refreshGroupInfo()">
+    </alg-group-join-by-code>
+  }
+  @if (group.currentUserCanManage !== 'none') {
+    <alg-group-invite-users [group]="group">
+    </alg-group-invite-users>
+  }
+} @else {
+  <alg-group-no-permission></alg-group-no-permission>
 }

--- a/src/app/groups/containers/group-composition/group-composition.component.ts
+++ b/src/app/groups/containers/group-composition/group-composition.component.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, EventEmitter, Input, Output, ViewChild, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output, signal, viewChild } from '@angular/core';
 import { forkJoin, of } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
@@ -24,7 +24,6 @@ export interface GroupChildData {
   selector: 'alg-group-composition',
   templateUrl: './group-composition.component.html',
   styleUrls: [ './group-composition.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     MemberListComponent,
     AddSubGroupComponent,
@@ -38,40 +37,38 @@ export class GroupCompositionComponent {
   private groupCreationService = inject(GroupCreationService);
   private actionFeedbackService = inject(ActionFeedbackService);
 
-  @ViewChild('addSubGroupComponent') addSubGroupComponent?: AddSubGroupComponent;
+  addSubGroupComponent = viewChild<AddSubGroupComponent>('addSubGroupComponent');
 
-  @Input() groupData?: GroupData;
+  groupData = input.required<GroupData>();
 
-  @Output() groupRefreshRequired = new EventEmitter<void>();
-  @Output() addedGroup = new EventEmitter<void>();
-  @Output() removedGroup = new EventEmitter<void>();
+  groupRefreshRequired = output<void>();
+  addedGroup = output<void>();
+  removedGroup = output<void>();
 
-  @ViewChild('memberList') private memberList?: MemberListComponent;
+  private memberList = viewChild<MemberListComponent>('memberList');
 
-  state: 'addingGroup' | 'ready' = 'ready';
+  state = signal<'addingGroup' | 'ready'>('ready');
 
   refreshGroupInfo(): void {
     this.groupRefreshRequired.emit();
   }
 
   addGroup(group: GroupChildData): void {
-    if (!this.groupData) throw Error('Tried to add a subgroup to an undefined group');
-
-    this.state = 'addingGroup';
+    this.state.set('addingGroup');
 
     forkJoin({
-      parentGroupId: of(this.groupData.group.id),
+      parentGroupId: of(this.groupData().group.id),
       childGroupId: group.id ? of(group.id) : this.groupCreationService.create(group.title, group.type),
     }).pipe(switchMap(ids => this.groupCreationService.addSubgroup(ids.parentGroupId, ids.childGroupId))).subscribe({
       next: _ => {
         this.actionFeedbackService.success($localize`Group successfully added as child group`);
-        this.memberList?.setFilter({ directChildren: true, type: TypeFilter.Groups });
-        this.state = 'ready';
+        this.memberList()?.setFilter({ directChildren: true, type: TypeFilter.Groups });
+        this.state.set('ready');
         this.addedGroup.emit();
-        this.addSubGroupComponent?.addContentComponent?.reset();
+        this.addSubGroupComponent()?.addContentComponent()?.reset();
       },
       error: err => {
-        this.state = 'ready';
+        this.state.set('ready');
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       }

--- a/src/app/groups/containers/group-invite-users/group-invite-users.component.html
+++ b/src/app/groups/containers/group-invite-users/group-invite-users.component.html
@@ -7,7 +7,7 @@
     i18n-placeholder placeholder="login_1, login_2..."
   ></alg-textarea>
 
-  @if (state === 'too_many') {
+  @if (state() === 'too_many') {
     <div class="too-many-message">
       <alg-message-info class="danger">
         <ng-container i18n>You cannot invite more than 100 users at once</ng-container>
@@ -19,21 +19,19 @@
     <button
       class="size-l"
       (click)="onInviteClicked()"
-      [disabled]="state !== 'ready'"
+      [disabled]="state() !== 'ready'"
       alg-button
       i18n
     >Invite</button>
   </div>
 
-  @for (message of messages; track $index) {
+  @for (message of messages(); track $index) {
     <div class="message-container">
       <alg-message-info
         class="message"
-        [ngClass]="{
-          'info': message.type === 'info',
-          'success': message.type === 'success',
-          'danger': message.type === 'error'
-        }"
+        [class.info]="message.type === 'info'"
+        [class.success]="message.type === 'success'"
+        [class.danger]="message.type === 'error'"
         [icon]="message.icon"
         [closable]="true"
         (closeEvent)="onCloseMessage(message)"

--- a/src/app/groups/containers/group-invite-users/group-invite-users.component.ts
+++ b/src/app/groups/containers/group-invite-users/group-invite-users.component.ts
@@ -1,11 +1,10 @@
-import { Component, Input, Output, EventEmitter, OnDestroy, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CreateGroupInvitationsService, InvitationResult } from '../../data-access/create-group-invitations.service';
 import { Group } from '../../models/group';
 import { UntypedFormBuilder } from '@angular/forms';
-import { Subscription } from 'rxjs';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { HttpErrorResponse } from '@angular/common/http';
-import { NgClass } from '@angular/common';
 import { TextareaComponent } from 'src/app/ui-components/textarea/textarea.component';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { MessageInfoComponent } from 'src/app/ui-components/message-info/message-info.component';
@@ -23,45 +22,39 @@ type GroupInviteState = 'empty'|'too_many'|'loading'|'ready';
   selector: 'alg-group-invite-users',
   templateUrl: './group-invite-users.component.html',
   styleUrls: [ './group-invite-users.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     TextareaComponent,
     ButtonComponent,
     MessageInfoComponent,
-    NgClass,
   ]
 })
-export class GroupInviteUsersComponent implements OnInit, OnDestroy {
+export class GroupInviteUsersComponent {
   private createGroupInvitationsService = inject(CreateGroupInvitationsService);
   private actionFeedbackService = inject(ActionFeedbackService);
   private formBuilder = inject(UntypedFormBuilder);
 
-  @Input() group?: Group;
-  @Output() refreshRequired = new EventEmitter<void>();
+  group = input.required<Group>();
 
   inviteForm = this.formBuilder.group({ logins: '' });
-  state: GroupInviteState = 'empty';
+  state = signal<GroupInviteState>('empty');
 
-  messages: Message[] = [];
-  subscription?: Subscription;
+  messages = signal<Message[]>([]);
 
-  ngOnInit(): void {
-    this.subscription = this.inviteForm.get('logins')?.valueChanges.subscribe((change: string) => this.loginListChanged(change));
-  }
-
-  ngOnDestroy(): void {
-    this.subscription?.unsubscribe();
+  constructor() {
+    this.inviteForm.get('logins')?.valueChanges
+      .pipe(takeUntilDestroyed())
+      .subscribe((change: string) => this.loginListChanged(change));
   }
 
   setState(newState: GroupInviteState): void {
-    if (this.state === newState) return;
-    if (this.state === 'loading') this.inviteForm.enable(); // enable the form only if the previous state was disabled
+    if (this.state() === newState) return;
+    if (this.state() === 'loading') this.inviteForm.enable(); // enable the form only if the previous state was disabled
     if (newState === 'loading') this.inviteForm.disable();
-    this.state = newState;
+    this.state.set(newState);
   }
 
   loginListChanged(newValue: string): void {
-    if (this.state === 'loading') return;
+    if (this.state() === 'loading') return;
     this.setState('ready');
 
     const logins = newValue.split(',').filter(login => login.length > 0);
@@ -80,8 +73,10 @@ export class GroupInviteUsersComponent implements OnInit, OnDestroy {
     const notFoundUsers: string[] = Array.from(response.entries()).filter(e => e[1] === InvitationResult.NotFound).map(e => e[0]);
     const invalidInvites: string[] = Array.from(response.entries()).filter(e => e[1] === InvitationResult.Error).map(e => e[0]);
 
+    const newMessages: Message[] = [];
+
     if (successInvites.length > 0)
-      this.messages.push({
+      newMessages.push({
         type: 'success',
         summary: $localize`${successInvites.length} user(s) invited successfully: `,
         detail: `${successInvites.join(', ')}`,
@@ -89,7 +84,7 @@ export class GroupInviteUsersComponent implements OnInit, OnDestroy {
       });
 
     if (alreadyInvited.length > 0)
-      this.messages.push({
+      newMessages.push({
         type: 'info',
         summary: $localize`${alreadyInvited.length} user(s) have already been invited: `,
         detail: `${alreadyInvited.join(', ')}`,
@@ -97,7 +92,7 @@ export class GroupInviteUsersComponent implements OnInit, OnDestroy {
       });
 
     if (notFoundUsers.length > 0)
-      this.messages.push({
+      newMessages.push({
         type: 'error',
         summary: $localize`${notFoundUsers.length} user login(s) not found: `,
         detail: `${notFoundUsers.join(', ')}`,
@@ -105,20 +100,22 @@ export class GroupInviteUsersComponent implements OnInit, OnDestroy {
       });
 
     if (invalidInvites.length > 0)
-      this.messages.push({
+      newMessages.push({
         type: 'error',
         summary: $localize`${invalidInvites.length} user login(s) could not be invited: `,
         detail: `${invalidInvites.join(', ')}`,
         icon: 'ph-duotone ph-x-circle',
       });
+
+    this.messages.update(messages => [ ...messages, ...newMessages ]);
   }
 
   /* events */
   onInviteClicked(): void {
-    if (!this.group || this.state !== 'ready') return;
+    if (this.state() !== 'ready') return;
 
     // clear the messages
-    this.messages = [];
+    this.messages.set([]);
 
     // remove empty logins and duplicates
     const control = this.inviteForm.get('logins');
@@ -133,7 +130,7 @@ export class GroupInviteUsersComponent implements OnInit, OnDestroy {
     // disable UI
     this.setState('loading');
 
-    this.createGroupInvitationsService.createInvitations(this.group.id, logins).subscribe({
+    this.createGroupInvitationsService.createInvitations(this.group().id, logins).subscribe({
       next: res => {
         this.displayResponse(res);
 
@@ -151,6 +148,6 @@ export class GroupInviteUsersComponent implements OnInit, OnDestroy {
   }
 
   onCloseMessage(message: Message): void {
-    this.messages = this.messages.filter(m => m !== message);
+    this.messages.update(messages => messages.filter(m => m !== message));
   }
 }

--- a/src/app/groups/containers/group-join-by-code/group-join-by-code.component.html
+++ b/src/app/groups/containers/group-join-by-code/group-join-by-code.component.html
@@ -2,11 +2,11 @@
   Let users join using a code
 </h2>
 
-@if (processing) {
+@if (processing()) {
   <alg-loading></alg-loading>
 } @else {
   <p class="alg-text-secondary" i18n>Let users access this group using a password you send them.</p>
-  @if (codeInfo) {
+  @if (codeInfo(); as codeInfo) {
     @if (codeInfo.hasCodeNotSet) {
       <p class="alg-text-small" i18n>There is currently no code set.</p>
     }
@@ -38,19 +38,19 @@
         class="size-l"
         icon="ph-bold ph-plus"
         (click)="generateNewCode()"
-        [disabled]="processing"
+        [disabled]="processing()"
         i18n
         alg-button
       >Generate a code</button>
     }
   }
-  @if (group && group.code) {
+  @if (group().code; as code) {
     <div>
       <div class="field">
         <span class="field-name" i18n>Code</span>
         <div class="field-value">
           <alg-code-token
-            [code]="group.code"
+            [code]="code"
             [showRefresh]="true"
             [showRemove]="true"
             (refresh)="generateNewCode()"
@@ -63,10 +63,10 @@
         <div class="field-value">
           <alg-selection
             [items]="codeLifetimeOptions"
-            [selected]="selectedCodeLifetimeOption"
+            [selected]="selectedCodeLifetimeOption()"
             (change)="changeCodeLifetime($event)"
           ></alg-selection>
-          @if (selectedCodeLifetimeOption === customCodeLifetimeOption) {
+          @if (selectedCodeLifetimeOption() === customCodeLifetimeOption) {
             <div class="duration-form-group">
               <alg-duration
                 class="alg-duration"
@@ -86,7 +86,7 @@
                   class="size-l stroke"
                   icon="ph-bold ph-check"
                   (click)="codeLifetimeControlValue && submitCodeLifetime(codeLifetimeControlValue.ms)"
-                  [disabled]="processing || !codeLifetimeControlValue || !control.dirty || codeLifetimeControlValue.ms === group.codeLifetime?.ms"
+                  [disabled]="processing() || !codeLifetimeControlValue || !control.dirty || codeLifetimeControlValue.ms === group().codeLifetime?.ms"
                   alg-button-icon
                 ></button>
               </span>
@@ -97,4 +97,3 @@
     </div>
   }
 }
-

--- a/src/app/groups/containers/group-join-by-code/group-join-by-code.component.ts
+++ b/src/app/groups/containers/group-join-by-code/group-join-by-code.component.ts
@@ -1,8 +1,8 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, effect, inject, input, output, signal } from '@angular/core';
 import { switchMap } from 'rxjs/operators';
 import { Duration } from 'src/app/utils/duration';
 import { Group } from '../../models/group';
-import { codeInfo, CodeInfo } from '../../models/group-code';
+import { codeInfo } from '../../models/group-code';
 import { GroupActionsService } from '../../data-access/group-actions.service';
 import { CodeActionsService } from '../../data-access/code-actions.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
@@ -24,7 +24,6 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
   selector: 'alg-group-join-by-code',
   templateUrl: './group-join-by-code.component.html',
   styleUrls: [ './group-join-by-code.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     CodeTokenComponent,
     SelectionComponent,
@@ -39,18 +38,17 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
     TooltipDirective,
   ]
 })
-
-export class GroupJoinByCodeComponent implements OnChanges {
+export class GroupJoinByCodeComponent {
   private groupActionsService = inject(GroupActionsService);
   private codeActionsService = inject(CodeActionsService);
   private actionFeedbackService = inject(ActionFeedbackService);
 
-  @Input() group?: Group;
-  @Output() refreshRequired = new EventEmitter<void>();
+  group = input.required<Group>();
+  refreshRequired = output<void>();
 
-  codeInfo?: CodeInfo;
+  codeInfo = computed(() => codeInfo(this.group()));
   codeLifetimeControlValue?: Duration;
-  processing = false;
+  processing = signal(false);
 
   codeLifetimeOptions = [
     {
@@ -71,35 +69,36 @@ export class GroupJoinByCodeComponent implements OnChanges {
     },
   ];
   customCodeLifetimeOption = this.codeLifetimeOptions.findIndex(({ value }) => value === 'custom');
-  selectedCodeLifetimeOption = 0;
+  selectedCodeLifetimeOption = signal(0);
   durationTooltip = $localize`:@@expireDuration:This code will expire after the given duration ` +
     $localize`:@@resetCurrentExpiration:(reset current expiration)`;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.group && !this.group) this.codeInfo = undefined;
-    if (changes.group && this.group) {
-      this.codeInfo = codeInfo(this.group);
+  // Only reset the user-editable duration controls when the server-side lifetime actually changed,
+  // so unrelated group refreshes don't clobber in-progress edits.
+  // `null` is included because CodeLifetime.valueInSeconds returns number | null.
+  private previousCodeLifetimeSeconds: number | null | undefined;
 
-      const codeLifetimeHasChanged = (changes.group.previousValue as Group | undefined)?.codeLifetime?.valueInSeconds !==
-        (changes.group.currentValue as Group | undefined)?.codeLifetime?.valueInSeconds;
-
-      if (codeLifetimeHasChanged) {
-        this.codeLifetimeControlValue = this.group.codeLifetime?.asDuration;
-        this.selectedCodeLifetimeOption = this.getSelectedCodeLifetimeOption(this.group.codeLifetime);
+  constructor() {
+    effect(() => {
+      const group = this.group();
+      const seconds = group.codeLifetime?.valueInSeconds;
+      if (seconds !== this.previousCodeLifetimeSeconds) {
+        this.previousCodeLifetimeSeconds = seconds;
+        this.codeLifetimeControlValue = group.codeLifetime?.asDuration;
+        this.selectedCodeLifetimeOption.set(this.getSelectedCodeLifetimeOption(group.codeLifetime));
       }
-    }
+    });
   }
 
   /* events */
 
   generateNewCode(): void {
-    if (!this.group) return;
-
     // disable UI
-    this.processing = true;
+    this.processing.set(true);
 
-    const groupId = this.group.id;
-    const expiresAt = this.group.codeExpiresAt;
+    const group = this.group();
+    const groupId = group.id;
+    const expiresAt = group.codeExpiresAt;
     // call code refresh service, then group refresh data
     this.codeActionsService.createNewCode(groupId)
       .pipe(
@@ -111,11 +110,11 @@ export class GroupJoinByCodeComponent implements OnChanges {
       .subscribe({
         next: () => {
           this.actionFeedbackService.success($localize`A new code has been generated`);
-          this.processing = false;
+          this.processing.set(false);
           this.refreshRequired.emit();
         },
         error: err => {
-          this.processing = false;
+          this.processing.set(false);
           this.actionFeedbackService.unexpectedError();
           if (!(err instanceof HttpErrorResponse)) throw err;
         },
@@ -123,26 +122,27 @@ export class GroupJoinByCodeComponent implements OnChanges {
   }
 
   submitCodeLifetime(ms: number): void {
-    if (!this.group || !this.codeInfo) throw new Error('cannot submit new code lifetime when group is undefined');
-    if (this.codeInfo.hasCodeNotSet) throw new Error('cannot submit code lifetime when no code is set');
+    const info = this.codeInfo();
+    if (info.hasCodeNotSet) throw new Error('cannot submit code lifetime when no code is set');
+    const group = this.group();
     const newCodeLifetime = new CodeLifetime(ms);
-    if (this.group.codeLifetime?.valueInSeconds === newCodeLifetime.valueInSeconds) return;
+    if (group.codeLifetime?.valueInSeconds === newCodeLifetime.valueInSeconds) return;
 
     // disable UI
-    this.processing = true;
+    this.processing.set(true);
 
     // call code refresh service, then group refresh data
-    this.groupActionsService.updateGroup(this.group.id, {
+    this.groupActionsService.updateGroup(group.id, {
       code_lifetime: newCodeLifetime.valueInSeconds,
       code_expires_at: null,
     }).subscribe({
       next: () => {
         this.actionFeedbackService.success($localize`The validity has been changed`);
-        this.processing = false;
+        this.processing.set(false);
         this.refreshRequired.emit();
       },
       error: err => {
-        this.processing = false;
+        this.processing.set(false);
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       },
@@ -150,13 +150,12 @@ export class GroupJoinByCodeComponent implements OnChanges {
   }
 
   removeCode(): void {
-    if (!this.group) throw new Error('cannot remove code when group is undefined');
-
     // disable UI
-    this.processing = true;
+    this.processing.set(true);
 
-    const groupId = this.group.id;
-    const expiresAt = this.group.codeExpiresAt;
+    const group = this.group();
+    const groupId = group.id;
+    const expiresAt = group.codeExpiresAt;
     // call code refresh service, then group refresh data
     this.codeActionsService.removeCode(groupId)
       .pipe(
@@ -168,11 +167,11 @@ export class GroupJoinByCodeComponent implements OnChanges {
       .subscribe({
         next: () => {
           this.actionFeedbackService.success($localize`Users will not be able to join with the former code.`);
-          this.processing = false;
+          this.processing.set(false);
           this.refreshRequired.emit();
         },
         error: err => {
-          this.processing = false;
+          this.processing.set(false);
           this.actionFeedbackService.unexpectedError();
           if (!(err instanceof HttpErrorResponse)) throw err;
         },
@@ -184,7 +183,7 @@ export class GroupJoinByCodeComponent implements OnChanges {
     if (optionValue === 'infinite') this.submitCodeLifetime(CodeLifetime.infiniteValue);
     if (optionValue === 'usable_once') this.submitCodeLifetime(CodeLifetime.usableOnceValue);
 
-    this.selectedCodeLifetimeOption = selected;
+    this.selectedCodeLifetimeOption.set(selected);
   }
 
   private getSelectedCodeLifetimeOption(codeLifetime?: CodeLifetime): number {


### PR DESCRIPTION
## Summary
- Modernize `group-composition`, `add-sub-group`, `group-join-by-code`, and `group-invite-users` to Angular 22 patterns (signal inputs/outputs, `viewChild()` chains, signals for OnPush-mutated state, `takeUntilDestroyed()`).
- Batch 14 from `.cursor/plans/modernize-batch-14-group-composition.md`.

## Scope
- **add-sub-group** — remove dead `group` input + `groupsFound`; public `viewChild()` for add-content reset chain
- **group-join-by-code** — `computed()` + `effect()` preserves lifetime-edit semantics (only reset controls when server-side lifetime changes); `processing` / `selectedCodeLifetimeOption` → signals
- **group-invite-users** — remove dead `refreshRequired` output + parent binding; `state` / `messages` → signals; `[class.*]` replaces `NgClass`
- **group-composition** — `viewChild()` chain `addContentComponent()?.reset()`; `state` → signal

## Removed dead API
- `add-sub-group`: unused `group` input, `groupsFound` field
- `group-invite-users`: never-emitted `refreshRequired` output
- `group-composition`: `(refreshRequired)="refreshGroupInfo()"` binding on invite-users

## Risks / manual checks
- **group-join-by-code** lifetime effect: test all 3 options; refresh group mid-edit — in-progress custom duration must not be clobbered; server-side change must apply. E2E: `group-join-code-duration.spec.ts`
- **group-composition** viewChild chain: add existing subgroup → add-content field resets
- **group-invite-users** (no e2e): valid/invalid login parsing; success/partial/failure messages

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-14/en/

## Verification
- [x] `npm run lint`
- [x] `ng build --localize=false` (template type-checking)
- [x] CI E2E (`group-join-code-duration.spec.ts`)
- [ ] Manual smoke: create subgroup, add existing subgroup (reset check), generate/remove join code, change code lifetime (all 3 options), invite users by login list