### PR TITLE
Modernize Angular components (batch 16).

### DIFF
--- a/src/app/items/containers/add-dependency/add-dependency.component.html
+++ b/src/app/items/containers/add-dependency/add-dependency.component.html
@@ -1,8 +1,8 @@
 <h2 class="alg-h2 alg-text-normal title" i18n>Add a new prerequisite</h2>
 <alg-add-content
-  [allowedTypesForNewContent]="allowedNewItemTypes"
+  [allowedTypesForNewContent]="allowedNewItemTypes()"
   [searchFunction]="searchFunction"
-  [addedIds]="addedIds"
+  [addedIds]="addedIds()"
   [loading]="false"
   [showCreateUI]="false"
   (contentAdded)="onAdd($event)"

--- a/src/app/items/containers/add-dependency/add-dependency.component.ts
+++ b/src/app/items/containers/add-dependency/add-dependency.component.ts
@@ -1,10 +1,9 @@
 import {
-  ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild, inject,
+  Component, computed, input, output, viewChild, inject,
 } from '@angular/core';
 import {
   AddContentComponent,
   AddedContent,
-  NewContentType
 } from 'src/app/ui-components/add-content/add-content.component';
 import { getAllowedNewItemTypes } from 'src/app/items/models/new-item-types';
 import { ItemType } from 'src/app/items/models/item-type';
@@ -15,27 +14,26 @@ import { SearchItemService } from 'src/app/data-access/search-item.service';
   selector: 'alg-add-dependency',
   templateUrl: './add-dependency.component.html',
   styleUrls: [ './add-dependency.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ AddContentComponent ]
 })
-export class AddDependencyComponent implements OnChanges {
+export class AddDependencyComponent {
   private searchItemService = inject(SearchItemService);
 
-  @ViewChild('addContentComponent') addContentComponent?: AddContentComponent<ItemType>;
-  @Input() allowSkills = false;
-  @Input() addedIds: string[] = [];
-  @Output() contentAdded = new EventEmitter<AddedContent<ItemType>>();
+  /** Kept for API symmetry; not bound at any call site today. */
+  allowSkills = input(false);
+  addedIds = input.required<string[]>();
+  contentAdded = output<AddedContent<ItemType>>();
 
-  allowedNewItemTypes: NewContentType<ItemType>[] = [];
+  addContentComponent = viewChild<AddContentComponent<ItemType>>('addContentComponent');
+
+  allowedNewItemTypes = computed(() =>
+    getAllowedNewItemTypes({ allowActivities: true, allowSkills: this.allowSkills() })
+  );
 
   searchFunction = (value: string): Observable<AddedContent<ItemType>[]> =>
     this.searchItemService.search(
-      value, getAllowedNewItemTypes({ allowActivities: true, allowSkills: this.allowSkills }).map(item => item.type)
+      value, getAllowedNewItemTypes({ allowActivities: true, allowSkills: this.allowSkills() }).map(item => item.type)
     );
-
-  ngOnChanges(_changes: SimpleChanges): void {
-    this.allowedNewItemTypes = getAllowedNewItemTypes({ allowActivities: true, allowSkills: this.allowSkills });
-  }
 
   onAdd(item: AddedContent<ItemType>): void {
     this.contentAdded.emit(item);

--- a/src/app/items/containers/add-item/add-item.component.html
+++ b/src/app/items/containers/add-item/add-item.component.html
@@ -1,9 +1,9 @@
 <alg-sub-section i18n-label label="Add a content">
   <alg-add-content
     [isLight]="true"
-    [allowedTypesForNewContent]="allowedNewItemTypes"
+    [allowedTypesForNewContent]="allowedNewItemTypes()"
     [searchFunction]="searchFunction"
-    [addedIds]="addedItemIds"
+    [addedIds]="addedItemIds()"
     (contentAdded)="addChild($event)"
     #addContentComponent
   ></alg-add-content>

--- a/src/app/items/containers/add-item/add-item.component.ts
+++ b/src/app/items/containers/add-item/add-item.component.ts
@@ -1,50 +1,44 @@
 import {
-  ChangeDetectionStrategy, Component, computed, EventEmitter, input, Input, OnChanges, Output, SimpleChanges,
-  ViewChild, inject,
+  Component, computed, input, output, viewChild, inject,
 } from '@angular/core';
 import { Observable } from 'rxjs';
 import {
-  NewContentType,
   AddedContent,
-  AddContentComponent
+  AddContentComponent,
 } from 'src/app/ui-components/add-content/add-content.component';
 import { ItemType, ItemTypeCategory, itemTypeCategoryEnum } from 'src/app/items/models/item-type';
 import { getAllowedNewItemTypes } from 'src/app/items/models/new-item-types';
 import { SearchItemService } from 'src/app/data-access/search-item.service';
-import { AddContentComponent as AddContentComponent_1 } from 'src/app/ui-components/add-content/add-content.component';
 import { SubSectionComponent } from 'src/app/ui-components/sub-section/sub-section.component';
 
 @Component({
   selector: 'alg-add-item',
   templateUrl: './add-item.component.html',
   styleUrls: [ './add-item.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ SubSectionComponent, AddContentComponent_1 ]
+  imports: [ SubSectionComponent, AddContentComponent ]
 })
-export class AddItemComponent implements OnChanges {
+export class AddItemComponent {
   private searchItemService = inject(SearchItemService);
 
-  @ViewChild('addContentComponent') addContentComponent?: AddContentComponent<ItemType>;
+  addContentComponent = viewChild<AddContentComponent<ItemType>>('addContentComponent');
 
   type = input<ItemTypeCategory>('activity');
   isSkill = computed(() => this.type() === itemTypeCategoryEnum.skill);
 
-  @Input() addedItemIds: string[] = [];
-  @Output() contentAdded = new EventEmitter<AddedContent<ItemType>>();
+  addedItemIds = input.required<string[]>();
+  contentAdded = output<AddedContent<ItemType>>();
 
-  allowedNewItemTypes: NewContentType<ItemType>[] = [];
+  allowedNewItemTypes = computed(() =>
+    getAllowedNewItemTypes({ allowActivities: !this.isSkill(), allowSkills: this.isSkill() })
+  );
 
   searchFunction = (value: string): Observable<AddedContent<ItemType>[]> =>
     this.searchItemService.search(
       value, getAllowedNewItemTypes({ allowActivities: !this.isSkill(), allowSkills: this.isSkill() }).map(item => item.type)
     );
 
-  ngOnChanges(_changes: SimpleChanges): void {
-    this.allowedNewItemTypes = getAllowedNewItemTypes({ allowActivities: !this.isSkill(), allowSkills: this.isSkill() });
-  }
-
   addChild(item: AddedContent<ItemType>): void {
     this.contentAdded.emit(item);
-    this.addContentComponent?.reset();
+    this.addContentComponent()?.reset();
   }
 }

--- a/src/app/items/containers/item-dependencies/item-dependencies.component.html
+++ b/src/app/items/containers/item-dependencies/item-dependencies.component.html
@@ -1,99 +1,24 @@
-@if (itemData) {
-  <h2 class="alg-h2 alg-text-normal alg-base-title-primary-space" i18n>Prerequisites</h2>
-  @if (['all','all_with_grant'].includes(itemData.item.permissions.canEdit)) {
-    @if (state$ | async; as state) {
-      <div>
-        @if (state.isFetching || changeInProgress) {
-          <alg-loading class="loading" size="medium"></alg-loading>
-        }
-        @if (state.isError) {
-          <alg-error
-            icon="ph-duotone ph-warning-circle"
-            i18n-message message="Unable to load the prerequisites"
-            i18n-buttonCaption buttonCaption="Retry to load prerequisites"
-            [showRefreshButton]="true"
-            (refresh)="refresh()"
-          ></alg-error>
-        }
-        @if (!state.isFetching && !changeInProgress && state.data) {
-          @if (state.data.length > 0) {
-            <p class="explanation" i18n>
-              Users will unlock access to this content if they solve <strong>at least one</strong> of the content below.
-            </p>
-            <ul class="list">
-              @for (item of state.data; track item; let i = $index) {
-                <li
-                  class="list-item"
-                  [algShowOverlay]="op"
-                  (overlayOpenEvent)="itemId.set(item.id)"
-                  (overlayCloseEvent)="itemId.set(undefined)"
-                  #overlay="algShowOverlay"
-                >
-                  <a
-                    class="alg-link"
-                    [routerLink]="item | itemRoute | url"
-                    algShowOverlayHoverTarget
-                  >
-                    {{ item.string.title }}
-                  </a>
-                  <button
-                    class="size-s"
-                    type="button"
-                    icon="ph-duotone ph-trash"
-                    (click)="onRemove(item.id)"
-                    alg-button-icon
-                  ></button>
-                  <ng-template #op>
-                    <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
-                  </ng-template>
-                </li>
-              }
-            </ul>
-            <p class="note-caption" i18n>
-            Users will see the list of dependencies on the "content" tab and only when they do not have access to the content yet.
-            They will only see dependencies they are allowed to view already.
-          </p>
-          } @else {
-            <alg-error i18n>
-              There are no prerequisites for this
-              {itemData.item.type, select, Skill {skill} other {activity}}.
-              Users will have access to it only if they are given access manually or if the "default access" is configured as
-              "open" in its parent {itemData.item.type, select, Skill {skill} Chapter {chapter} other {activity}}.
-            </alg-error>
-          }
-        }
-      </div>
-    }
-  } @else {
-    <alg-error icon="ph ph-prohibit" i18n>You are not allowed to view dependencies for this content</alg-error>
-  }
-  @if (addedIds$ | async; as addedIds) {
-    @if (['all','all_with_grant'].includes(itemData.item.permissions.canEdit)) {
-      <alg-add-dependency
-        class="add-dependency"
-        (contentAdded)="onAdd($event)"
-        [addedIds]="addedIds"
-        #addDependencyComponent
-      ></alg-add-dependency>
-    }
-  }
-  <h2 class="alg-h2 alg-text-normal depending-content-title" i18n>Content depending on this one</h2>
-  @if (dependenciesState$ | async; as state) {
+<h2 class="alg-h2 alg-text-normal alg-base-title-primary-space" i18n>Prerequisites</h2>
+@if (['all','all_with_grant'].includes(itemData().item.permissions.canEdit)) {
+  @if (state$ | async; as state) {
     <div>
-      @if (state.isFetching || changeInProgress) {
-        <alg-loading size="medium"></alg-loading>
+      @if (state.isFetching || changeInProgress()) {
+        <alg-loading class="loading" size="medium"></alg-loading>
       }
       @if (state.isError) {
         <alg-error
           icon="ph-duotone ph-warning-circle"
-          i18n-message message="Unable to load the dependencies"
-          i18n-buttonCaption buttonCaption="Retry to load dependencies"
+          i18n-message message="Unable to load the prerequisites"
+          i18n-buttonCaption buttonCaption="Retry to load prerequisites"
           [showRefreshButton]="true"
           (refresh)="refresh()"
         ></alg-error>
       }
-      @if (!state.isFetching && !changeInProgress && state.data) {
+      @if (!state.isFetching && !changeInProgress() && state.data) {
         @if (state.data.length > 0) {
+          <p class="explanation" i18n>
+            Users will unlock access to this content if they solve <strong>at least one</strong> of the content below.
+          </p>
           <ul class="list">
             @for (item of state.data; track item; let i = $index) {
               <li
@@ -104,12 +29,21 @@
                 #overlay="algShowOverlay"
               >
                 <a
-                  class="alg-link list-item-link"
+                  class="alg-link"
                   [routerLink]="item | itemRoute | url"
                   algShowOverlayHoverTarget
                 >
                   {{ item.string.title }}
                 </a>
+                <button
+                  class="size-s"
+                  type="button"
+                  icon="ph-duotone ph-trash"
+                  aria-label="Remove prerequisite"
+                  i18n-aria-label
+                  (click)="onRemove(item.id)"
+                  alg-button-icon
+                ></button>
                 <ng-template #op>
                   <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
                 </ng-template>
@@ -117,14 +51,80 @@
             }
           </ul>
           <p class="note-caption" i18n>
-          Only the content that is visible to you is listed. Other content may depend on it.
+          Users will see the list of dependencies on the "content" tab and only when they do not have access to the content yet.
+          They will only see dependencies they are allowed to view already.
         </p>
         } @else {
           <alg-error i18n>
-            There are no other content (visible to you) which depends on this one to unlock. To add some, visit this same tab on the content you want to grant access to.
+            There are no prerequisites for this
+            {itemData().item.type, select, Skill {skill} other {activity}}.
+            Users will have access to it only if they are given access manually or if the "default access" is configured as
+            "open" in its parent {itemData().item.type, select, Skill {skill} Chapter {chapter} other {activity}}.
           </alg-error>
         }
       }
     </div>
   }
+} @else {
+  <alg-error icon="ph ph-prohibit" i18n>You are not allowed to view dependencies for this content</alg-error>
+}
+@if (addedIds$ | async; as addedIds) {
+  @if (['all','all_with_grant'].includes(itemData().item.permissions.canEdit)) {
+    <alg-add-dependency
+      class="add-dependency"
+      (contentAdded)="onAdd($event)"
+      [addedIds]="addedIds"
+      #addDependencyComponent
+    ></alg-add-dependency>
+  }
+}
+<h2 class="alg-h2 alg-text-normal depending-content-title" i18n>Content depending on this one</h2>
+@if (dependenciesState$ | async; as state) {
+  <div>
+    @if (state.isFetching || changeInProgress()) {
+      <alg-loading size="medium"></alg-loading>
+    }
+    @if (state.isError) {
+      <alg-error
+        icon="ph-duotone ph-warning-circle"
+        i18n-message message="Unable to load the dependencies"
+        i18n-buttonCaption buttonCaption="Retry to load dependencies"
+        [showRefreshButton]="true"
+        (refresh)="refresh()"
+      ></alg-error>
+    }
+    @if (!state.isFetching && !changeInProgress() && state.data) {
+      @if (state.data.length > 0) {
+        <ul class="list">
+          @for (item of state.data; track item; let i = $index) {
+            <li
+              class="list-item"
+              [algShowOverlay]="op"
+              (overlayOpenEvent)="itemId.set(item.id)"
+              (overlayCloseEvent)="itemId.set(undefined)"
+              #overlay="algShowOverlay"
+            >
+              <a
+                class="alg-link list-item-link"
+                [routerLink]="item | itemRoute | url"
+                algShowOverlayHoverTarget
+              >
+                {{ item.string.title }}
+              </a>
+              <ng-template #op>
+                <alg-path-suggestion [itemId]="itemId()" (resize)="overlay.updatePosition()"></alg-path-suggestion>
+              </ng-template>
+            </li>
+          }
+        </ul>
+        <p class="note-caption" i18n>
+        Only the content that is visible to you is listed. Other content may depend on it.
+      </p>
+      } @else {
+        <alg-error i18n>
+          There are no other content (visible to you) which depends on this one to unlock. To add some, visit this same tab on the content you want to grant access to.
+        </alg-error>
+      }
+    }
+  </div>
 }

--- a/src/app/items/containers/item-dependencies/item-dependencies.component.ts
+++ b/src/app/items/containers/item-dependencies/item-dependencies.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, OnChanges, OnDestroy, signal, ViewChild, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, input, signal, viewChild, inject } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { GetItemPrerequisitesService } from '../../data-access/get-item-prerequisites.service';
-import { ReplaySubject, Subject, switchMap } from 'rxjs';
+import { Subject, switchMap } from 'rxjs';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { map, share } from 'rxjs/operators';
 import { ItemData } from '../../models/item-data';
@@ -27,7 +28,6 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
   selector: 'alg-item-dependencies',
   templateUrl: './item-dependencies.component.html',
   styleUrls: [ './item-dependencies.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -42,19 +42,21 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
     ButtonIconComponent,
   ]
 })
-export class ItemDependenciesComponent implements OnChanges, OnDestroy {
+export class ItemDependenciesComponent {
   private getItemPrerequisitesService = inject(GetItemPrerequisitesService);
   private addItemPrerequisiteService = inject(AddItemPrerequisiteService);
   private removeItemPrerequisiteService = inject(RemoveItemPrerequisiteService);
   private actionFeedbackService = inject(ActionFeedbackService);
   private getItemDependenciesService = inject(GetItemDependenciesService);
+  private readonly destroyRef = inject(DestroyRef);
 
-  @Input() itemData?: ItemData;
+  itemData = input.required<ItemData>();
 
-  @ViewChild('addDependencyComponent') addDependencyComponent?: AddDependencyComponent;
+  addDependencyComponent = viewChild('addDependencyComponent', { read: AddDependencyComponent });
 
-  private readonly itemId$ = new ReplaySubject<string>(1);
   private readonly refresh$ = new Subject<void>();
+
+  private readonly itemId$ = toObservable(this.itemData).pipe(map(itemData => itemData.item.id));
 
   state$ = this.itemId$.pipe(
     switchMap(itemId => this.getItemPrerequisitesService.get(itemId)),
@@ -70,18 +72,11 @@ export class ItemDependenciesComponent implements OnChanges, OnDestroy {
   );
   addedIds$ = this.state$.pipe(readyData(), map(data => data.map(dependency => dependency.id)));
 
-  changeInProgress = false;
+  changeInProgress = signal(false);
   itemId = signal<string | undefined>(undefined);
 
-  ngOnChanges(): void {
-    if (this.itemData) {
-      this.itemId$.next(this.itemData.item.id);
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.itemId$.complete();
-    this.refresh$.complete();
+  constructor() {
+    this.destroyRef.onDestroy(() => this.refresh$.complete());
   }
 
   refresh(): void {
@@ -92,20 +87,19 @@ export class ItemDependenciesComponent implements OnChanges, OnDestroy {
     if (!item.id) {
       throw new Error('Unexpected: item id is missing');
     }
-    const dependentItemId = this.itemData?.item.id;
-    if (!dependentItemId) {
-      throw new Error('Unexpected: dependent item id is missing');
-    }
-    this.changeInProgress = true;
-    this.addItemPrerequisiteService.create(dependentItemId, item.id).subscribe({
+    const dependentItemId = this.itemData().item.id;
+    this.changeInProgress.set(true);
+    this.addItemPrerequisiteService.create(dependentItemId, item.id).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
       next: () => {
-        this.changeInProgress = false;
+        this.changeInProgress.set(false);
         this.actionFeedbackService.success('The new dependency has been added');
-        this.addDependencyComponent?.addContentComponent?.reset();
+        this.addDependencyComponent()?.addContentComponent()?.reset();
         this.refresh();
       },
       error: err => {
-        this.changeInProgress = false;
+        this.changeInProgress.set(false);
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       }
@@ -113,19 +107,18 @@ export class ItemDependenciesComponent implements OnChanges, OnDestroy {
   }
 
   onRemove(id: string): void {
-    const dependentItemId = this.itemData?.item.id;
-    if (!dependentItemId) {
-      throw new Error('Unexpected: Missed dependent item id');
-    }
-    this.changeInProgress = true;
-    this.removeItemPrerequisiteService.delete(dependentItemId, id).subscribe({
+    const dependentItemId = this.itemData().item.id;
+    this.changeInProgress.set(true);
+    this.removeItemPrerequisiteService.delete(dependentItemId, id).pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
       next: () => {
-        this.changeInProgress = false;
+        this.changeInProgress.set(false);
         this.actionFeedbackService.success('The dependency has been removed');
         this.refresh();
       },
       error: err => {
-        this.changeInProgress = false;
+        this.changeInProgress.set(false);
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       }

--- a/src/app/items/containers/item-log-view/item-log-view.component.html
+++ b/src/app/items/containers/item-log-view/item-log-view.component.html
@@ -30,10 +30,10 @@
   @if (state.data) {
     <div class="operation-buttons">
       <div>
-        @if (itemData && itemData.currentResult?.attemptId; as parentAttemptId) {
-          @if (itemData && itemData.item.type === 'Task') {
+        @if (itemData().currentResult?.attemptId; as parentAttemptId) {
+          @if (itemData().item.type === 'Task') {
             <a class="size-s stroke" alg-button icon="ph-duotone ph-arrows-clockwise"
-              [routerLink]="itemData.route | with: {
+              [routerLink]="itemData().route | with: {
                   parentAttemptId,
                   answer: { best: { id: observedGroupId ? observedGroupId : undefined }}
                 } | url"
@@ -73,10 +73,10 @@
                       </div>
                       <div class="item-title">
                         <p class="item-title-caption">{{ rowData.activityType | logActionDisplay }}</p>
-                        @if (itemData && rowData.answerId) {
-                          @let path = rowData.item.id === itemData.item.id ? itemData.route.path : undefined;
-                          @let attemptId = rowData.item.id === itemData.item.id ? itemData.route.attemptId : undefined;
-                          @let parentAttemptId = rowData.item.id === itemData.item.id ? itemData.route.parentAttemptId : undefined;
+                        @if (rowData.answerId) {
+                          @let path = rowData.item.id === itemData().item.id ? itemData().route.path : undefined;
+                          @let attemptId = rowData.item.id === itemData().item.id ? itemData().route.attemptId : undefined;
+                          @let parentAttemptId = rowData.item.id === itemData().item.id ? itemData().route.parentAttemptId : undefined;
                           @let route = rowData.item | itemRoute: { path, attemptId, parentAttemptId };
                           @if (!isObserving || !!rowData.canWatchAnswer) {
                             <a
@@ -93,7 +93,7 @@
                     </div>
                   }
                   @case ('item.string.title') {
-                    <a class="alg-link" [ngClass]="{'disabled': !rowData.item}" [routerLink]="rowData.item | itemRoute | url">
+                    <a class="alg-link" [class.disabled]="!rowData.item" [routerLink]="rowData.item | itemRoute | url">
                       {{ rowData.item.string.title }}
                     </a>
                   }

--- a/src/app/items/containers/item-log-view/item-log-view.component.spec.ts
+++ b/src/app/items/containers/item-log-view/item-log-view.component.spec.ts
@@ -10,6 +10,55 @@ import { ActionFeedbackService } from 'src/app/services/action-feedback.service'
 import { ItemRouter } from 'src/app/models/routing/item-router';
 import { rawGroupRoute } from 'src/app/models/routing/group-route';
 import { ObservationInfo } from 'src/app/store/observation/models';
+import { ItemData } from '../../models/item-data';
+import { itemRoute } from 'src/app/models/routing/item-route';
+import { Item } from 'src/app/data-access/get-item-by-id.service';
+import { displaySettingsSchema } from 'src/app/items/models/display-settings';
+import { ItemViewPerm } from '../../models/item-view-permission';
+import { ItemGrantViewPerm } from '../../models/item-grant-view-permission';
+import { ItemEditPerm } from '../../models/item-edit-permission';
+import { ItemWatchPerm } from '../../models/item-watch-permission';
+
+const mockItem: Item = {
+  id: '1',
+  requiresExplicitEntry: false,
+  string: { title: 'Test', description: null, imageUrl: null, subtitle: null, languageTag: 'en' },
+  bestScore: 0,
+  permissions: {
+    canView: ItemViewPerm.Content,
+    canGrantView: ItemGrantViewPerm.None,
+    canEdit: ItemEditPerm.None,
+    canWatch: ItemWatchPerm.None,
+    isOwner: false,
+    canRequestHelp: false,
+  },
+  type: 'Task',
+  displaySettings: displaySettingsSchema.parse({}),
+  textId: null,
+  validationType: 'None',
+  noScore: false,
+  allowsMultipleAttempts: false,
+  duration: null,
+  enteringTimeMin: new Date(),
+  enteringTimeMax: new Date(),
+  entryParticipantType: 'User',
+  entryFrozenTeams: false,
+  entryMaxTeamSize: 0,
+  entryMinAdmittedMembersRatio: 'None',
+  url: 'http://example.com/task',
+  usesApi: false,
+  defaultLanguageTag: 'en',
+  supportedLanguageTags: [ 'en' ],
+};
+
+const mockItemData: ItemData = {
+  route: itemRoute('activity', '1', { attemptId: '0', path: [] }),
+  item: mockItem,
+  breadcrumbs: [],
+  currentResult: {
+    attemptId: '0', latestActivityAt: new Date(), score: 0, validated: false, startedAt: new Date(), allowsSubmissionsUntil: new Date(),
+  },
+};
 
 describe('ItemLogViewComponent.backLinkHeading', () => {
   let component: ItemLogViewComponent;
@@ -56,6 +105,7 @@ describe('ItemLogViewComponent.backLinkHeading', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ItemLogViewComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('itemData', mockItemData);
   });
 
   it('returns an empty string when observedGroupInfo is null', () => {

--- a/src/app/items/containers/item-log-view/item-log-view.component.ts
+++ b/src/app/items/containers/item-log-view/item-log-view.component.ts
@@ -1,10 +1,10 @@
-import { Component, computed, DestroyRef, Input, OnChanges, OnDestroy, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, DestroyRef, input, OnInit, inject } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ItemData } from '../../models/item-data';
 import { ActivityLogs, ActivityLogService } from 'src/app/data-access/activity-log.service';
-import { combineLatest, Observable, ReplaySubject } from 'rxjs';
+import { combineLatest, Observable } from 'rxjs';
 import { distinctUntilChanged, switchMap, map } from 'rxjs/operators';
 import { ItemType } from 'src/app/items/models/item-type';
-import { Item } from 'src/app/data-access/get-item-by-id.service';
 import { UserSessionService } from 'src/app/services/user-session.service';
 import { DataPager } from 'src/app/utils/data-pager';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
@@ -17,7 +17,7 @@ import { Router, RouterLink } from '@angular/router';
 import { LetDirective } from '@ngrx/component';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
-import { NgClass, AsyncPipe } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { RelativeTimeComponent } from '../../../ui-components/relative-time/relative-time.component';
 import { Store } from '@ngrx/store';
 import { fromObservation } from 'src/app/store/observation';
@@ -42,7 +42,6 @@ import {
   CdkRowDef,
   CdkTable,
 } from '@angular/cdk/table';
-import { toSignal } from '@angular/core/rxjs-interop';
 interface Column {
   field: string,
   header: string,
@@ -54,14 +53,12 @@ const logsLimit = 20;
   selector: 'alg-item-log-view',
   templateUrl: './item-log-view.component.html',
   styleUrls: [ './item-log-view.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
     LetDirective,
     RouterLink,
     ScoreRingComponent,
-    NgClass,
     AsyncPipe,
     ItemRoutePipe,
     ItemRouteWithExtraPipe,
@@ -85,7 +82,7 @@ const logsLimit = 20;
     CdkNoDataRow,
   ]
 })
-export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
+export class ItemLogViewComponent implements OnInit {
   private store = inject(Store);
   private activityLogService = inject(ActivityLogService);
   private sessionService = inject(UserSessionService);
@@ -103,7 +100,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
     });
   }
 
-  @Input() itemData?: ItemData;
+  itemData = input.required<ItemData>();
 
   observedGroupId$ = this.store.select(fromObservation.selectObservedGroupId);
   isObserving$ = this.store.select(fromObservation.selectIsObserving);
@@ -129,7 +126,8 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
     },
   });
 
-  private readonly item$ = new ReplaySubject<Item>(1);
+  private readonly item$ = toObservable(this.itemData).pipe(map(itemData => itemData.item));
+
   readonly state$ = combineLatest([
     this.datapager.list$,
     this.sessionService.userProfile$,
@@ -154,18 +152,6 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
     this.resetRows();
   }
 
-  ngOnChanges(): void {
-    if (!this.itemData) {
-      return;
-    }
-
-    this.item$.next(this.itemData.item);
-  }
-
-  ngOnDestroy(): void {
-    this.item$.complete();
-  }
-
   refresh(): void {
     this.resetRows();
   }
@@ -183,7 +169,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
         };
 
         return this.activityLogService.getActivityLog(
-          this.itemData?.item.id ?? '', {
+          this.itemData().item.id, {
             limit: pageSize,
             pagination: paginationParams,
             watchedGroupId: observedGroupId ?? undefined,
@@ -215,8 +201,7 @@ export class ItemLogViewComponent implements OnChanges, OnDestroy, OnInit {
   }
 
   getObserveLink(user: { id: string }): UrlTree | undefined {
-    if (!this.itemData) return undefined;
-    return this.itemRouter.url(itemRouteWith(this.itemData.route, { observedGroup: { id: user.id, isUser: true } }));
+    return this.itemRouter.url(itemRouteWith(this.itemData().route, { observedGroup: { id: user.id, isUser: true } }));
   }
 
   private isSelfCurrentAnswer(log: ActivityLogs[number], profileId: string): boolean {


### PR DESCRIPTION
## Summary
- Modernize `add-item`, `add-dependency`, `item-dependencies`, and `item-log-view` to Angular 22 patterns (signal inputs/outputs, `computed()`, `viewChild()` chains, `takeUntilDestroyed()`).
- Batch 16 from `.cursor/plans/modernize-batch-16-add-wrappers.md`.

## Scope
- **add-item** — fix stale `allowedNewItemTypes` bug (`computed()` reacts to `type` changes, not just `addedItemIds`)
- **add-dependency** — `computed()` for allowed types; public `viewChild` for parent reset chain
- **item-dependencies** — `toObservable(itemData)` fetch pipelines; `changeInProgress` → signal; `takeUntilDestroyed` on HTTP subscribes
- **item-log-view** — `toObservable(itemData)`; spec updated with `setInput`; `[class.disabled]` replaces `NgClass`
- **A11y fix:** i18n `aria-label` on icon-only prerequisite delete button

## Risks / manual checks
- **item-dependencies** add/remove → list refresh chain — e2e: `dependencies.spec.ts`, `show-path-suggestion-overflow.spec.ts`
- **item-log-view** back-link — e2e: `progress-history-back-link.spec.ts`
- Manual smoke: chapter children edit (add by search/title); dependencies tab add/remove + overlay; log tab rows + back-link

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-16/en/

## Verification
- [x] `npm run lint`
- [x] `item-log-view` unit tests (3/3)
- [x] `ng build algorea -c en`
- [x] CI E2E (dependencies, path-suggestion, progress-history-back-link)
- [x] Manual smoke (see above)