### PR TITLE
on validate, refresh the task token and request task the views (so that 'solutions' tab may appear)

### DIFF
--- a/.cursor/ARCHITECTURE.md
+++ b/.cursor/ARCHITECTURE.md
@@ -393,6 +393,14 @@ Both messages are notifications, not RPC; the helper is ~30 lines and adds no ne
 
 Task API versioning is negotiated at load time via optional `apiVersion` / `minApiVersion` fields returned by `task.getMetaData()`. The platform supports versions 1–2 and picks the highest version in the overlapping range. When the negotiated version is ≥ 2, `Task.reloadAnswer()` dispatches to the v2 wire method `task.reloadAnswerWithOptions`, passing `idUserAnswer` when reloading a submitted answer so the task can fetch submission feedback from its own backend using the signed task token.
 
+#### Showing the solution tab right after validation
+
+Whether a task exposes its `solution` view is decided by the task itself, from the `bAccessSolutions` claim in its signed task token (the backend grants it once the user has validated the item). The platform no longer gates the solution tab in [item-tabs.ts](../src/app/items/item-tabs.ts) — the task is the source of truth. To make the tab appear immediately after a validating submission without a full reload:
+
+- [ItemTaskInitService](../src/app/items/services/item-task-init.service.ts) generates the task token via a `combineLatest` of the generation strategy and a `refreshToken$` subject, so `refreshToken()` re-generates a fresh token even when the strategy is unchanged. Only the **first** token is used for `task.load()` (`take(1)`); later tokens are pushed to the loaded task via `task.updateToken()` and surfaced on `tokenUpdatedOnTask$`. A refresh-path generation failure is swallowed (`retry`/`catchError`) so it never errors the shared `taskToken$` (also consumed by `submitAnswer()`); token-less tasks (`usesTokens: false`) are never pushed a token.
+- [ItemTaskAnswerService](../src/app/items/services/item-task-answer.service.ts) calls `refreshToken()` after a grade is saved when the backend's `save-grade` response reports `validated: true` and the result was not already validated (snapshotted before `patchScore` flips `validated`).
+- [ItemTaskViewsService](../src/app/items/services/item-task-views.service.ts) re-calls `task.getViews()` on each `tokenUpdatedOnTask$` emission, because tasks (e.g. codecast) refetch their content on `task.updateToken` but do not spontaneously re-advertise views. The refreshed view list flows through `tabsChange` → `ItemTabs.setTaskTabs`, and the tab bar recomputes.
+
 #### Test task for platform-task integration
 
 [mocks/test-task/](../mocks/test-task/) is a static jschannel task page used to exercise platform↔task flows without relying on external task content. It is served by the dev mock server (`http://localhost:3000/test-task/`) and never included in Angular production builds. E2E tests intercept the same files via Playwright (`e2e/items/task-platform-interaction.spec.ts`). Update it whenever the task API surface changes.

--- a/e2e/items/pages/test-task-page.ts
+++ b/e2e/items/pages/test-task-page.ts
@@ -159,9 +159,13 @@ export async function mockTestTaskItemApi(page: Page, options: TestTaskApiOption
   await page.route(`${apiUrl}/answers`, route => route.fulfill({
     json: { ...actionSuccess, data: { answer_token: 'mock-answer-token' } },
   }));
-  await page.route(`${apiUrl}/items/save-grade`, route => route.fulfill({
-    json: { ...actionSuccess, data: { validated: false, unlocked_items: [] } },
-  }));
+  await page.route(`${apiUrl}/items/save-grade`, route => {
+    // mirror the backend: a submission validates the item once it reaches the max score
+    const score = (route.request().postDataJSON() as { score?: number } | null)?.score ?? 0;
+    route.fulfill({
+      json: { ...actionSuccess, data: { validated: score >= 100, unlocked_items: [] } },
+    });
+  });
 }
 
 export class TestTaskPage {
@@ -243,6 +247,10 @@ export class TestTaskPage {
   activeTab() {
     return this.page.locator('alg-tab-bar li.alg-tab-bar-active');
   }
+
+  tabByName(name: string) {
+    return this.page.locator('alg-tab-bar li', { hasText: name });
+  }
 }
 
 declare global {
@@ -254,6 +262,7 @@ declare global {
       token: string,
       shownViews: Record<string, boolean>,
       loaded: boolean,
+      solutionGranted: boolean,
     },
     invokePlatform?: (method: string, params: unknown) => Promise<unknown>,
   }

--- a/e2e/items/task-platform-interaction.spec.ts
+++ b/e2e/items/task-platform-interaction.spec.ts
@@ -82,6 +82,42 @@ test.describe('platform-task interaction', () => {
     await expect(testTaskPage.taskFrame.getByTestId('task-params-result')).toContainText('randomSeed');
   });
 
+  test('shows the solution tab after a validating grade without reloading the task', async ({ page }) => {
+    // task that only exposes the 'solution' view once it receives a token *after* being loaded
+    await mockTestTaskItemApi(page, { taskQuery: 'usesTokens=1&solutionOnTokenUpdate=1' });
+    await testTaskPage.gotoItem();
+    await testTaskPage.waitForLoaded();
+
+    // before validation: no solution access, so no solution tab
+    await expect(testTaskPage.taskFrame.getByTestId('solution-granted')).toHaveText('no');
+    await expect(testTaskPage.tabByName('Solution')).toHaveCount(0);
+
+    // register the request listener before triggering, so a fast save-grade cannot fire before we await it
+    const saveGradeRequest = page.waitForRequest(
+      request => request.url().includes('/items/save-grade') && request.method() === 'POST',
+    );
+
+    // validate with a passing score -> backend grants solution access on a freshly generated token
+    await testTaskPage.setAnswer('100');
+    await testTaskPage.clickValidate('done');
+
+    await saveGradeRequest;
+
+    // the platform regenerates the token and pushes it to the task (a 2nd updateToken, after the load-time one)
+    await expect.poll(async () => {
+      const calls = await testTaskPage.getCalls();
+      return calls.filter(entry => entry.method === 'task.updateToken').length;
+    }).toBeGreaterThanOrEqual(2);
+
+    // the task now grants the solution and the platform re-queries the views, so the solution tab appears
+    await expect(testTaskPage.taskFrame.getByTestId('solution-granted')).toHaveText('yes');
+    await expect(testTaskPage.tabByName('Solution')).toBeVisible();
+
+    // the task must NOT have been reloaded (no second task.load)
+    const calls = await testTaskPage.getCalls();
+    expect(calls.filter(entry => entry.method === 'task.load').length).toBe(1);
+  });
+
   test('reloads an existing answer and state on load', async ({ page }) => {
     await mockTestTaskItemApi(page, {
       taskQuery: 'apiVersion=1&minApiVersion=1',

--- a/mocks/test-task/README.md
+++ b/mocks/test-task/README.md
@@ -78,6 +78,7 @@ npm run e2e -- e2e/items/task-platform-interaction.spec.ts
 | `gradeDelay=ms` | Delay `task.gradeAnswer` completion |
 | `failGrade=1` | Make `task.gradeAnswer` fail |
 | `score=N` | Fixed grade score instead of parsing the answer |
+| `solutionOnTokenUpdate=1` | Hide the `solution` view until a token is pushed *after* load (simulates solution access granted on validation). Combine with `usesTokens=1`. |
 
 ## API coverage
 
@@ -94,7 +95,7 @@ npm run e2e -- e2e/items/task-platform-interaction.spec.ts
 Inside the iframe:
 
 - `window.testTaskCalls` — array of `{ method, params, timestamp }`
-- `window.testTaskState` — `{ answer, state, token, shownViews, loaded }`
+- `window.testTaskState` — `{ answer, state, token, shownViews, loaded, solutionGranted }`
 - `window.testTask` — helpers (`setAnswer`, `getCalls`, …)
 
 ## Keeping in sync

--- a/mocks/test-task/index.html
+++ b/mocks/test-task/index.html
@@ -24,6 +24,7 @@
     </label>
     <p>Last token: <span id="last-token" data-testid="last-token">—</span></p>
     <p>Shown views: <span id="shown-views" data-testid="shown-views">—</span></p>
+    <p>Solution granted: <span id="solution-granted" data-testid="solution-granted">—</span></p>
   </section>
 
   <section class="panel">

--- a/mocks/test-task/test-task.js
+++ b/mocks/test-task/test-task.js
@@ -12,6 +12,9 @@
     gradeDelay: Number(params.get('gradeDelay') || '0'),
     failGrade: params.get('failGrade') === '1',
     fixedScore: params.get('score'),
+    // when set, the 'solution' view is hidden until the task receives a token update *after* being loaded
+    // (simulates a task whose token grants solution access only once the item has been validated)
+    solutionOnTokenUpdate: params.get('solutionOnTokenUpdate') === '1',
   };
 
   var calls = [];
@@ -21,6 +24,8 @@
     token: '',
     shownViews: {},
     loaded: false,
+    // solution is granted up-front unless the scenario defers it to a post-load token update
+    solutionGranted: !config.solutionOnTokenUpdate,
   };
 
   var statusEl = document.getElementById('status');
@@ -29,16 +34,22 @@
   var stateInput = document.getElementById('state-input');
   var lastTokenEl = document.getElementById('last-token');
   var shownViewsEl = document.getElementById('shown-views');
+  var solutionGrantedEl = document.getElementById('solution-granted');
   var loadedMarker = document.getElementById('loaded-marker');
 
-  var views = {
+  var baseViews = {
     task: { includes: ['editor'] },
     editor: {},
-    solution: {},
     hints: {},
     grader: {},
     metadata: {},
   };
+
+  function getCurrentViews() {
+    var currentViews = Object.assign({}, baseViews);
+    if (state.solutionGranted) currentViews.solution = {};
+    return currentViews;
+  }
 
   function logCall(method, callParams) {
     var entry = { method: method, params: callParams, timestamp: Date.now() };
@@ -58,6 +69,7 @@
       token: state.token,
       shownViews: state.shownViews,
       loaded: state.loaded,
+      solutionGranted: state.solutionGranted,
     };
   }
 
@@ -66,6 +78,7 @@
     stateInput.value = state.taskState;
     lastTokenEl.textContent = state.token || '—';
     shownViewsEl.textContent = Object.keys(state.shownViews).length ? JSON.stringify(state.shownViews) : '—';
+    if (solutionGrantedEl) solutionGrantedEl.textContent = state.solutionGranted ? 'yes' : 'no';
   }
 
   function parseGradeScore(answer) {
@@ -136,6 +149,9 @@
   chan.bind('task.updateToken', function (trans, token) {
     logCall('task.updateToken', token);
     state.token = String(token);
+    // a token received after the task is loaded (i.e. not the initial load token) may grant new permissions,
+    // such as access to the solution once the item has been validated
+    if (config.solutionOnTokenUpdate && state.loaded) state.solutionGranted = true;
     syncInputsFromState();
     return delayedComplete(trans, true, 0);
   });
@@ -179,7 +195,7 @@
 
   chan.bind('task.getViews', function () {
     logCall('task.getViews', []);
-    return views;
+    return getCurrentViews();
   });
 
   chan.bind('task.showViews', function (trans, shown) {
@@ -350,5 +366,6 @@
     window.testTaskState = getPublicState();
   });
 
+  syncInputsFromState();
   statusEl.textContent = 'Waiting for platform…';
 })();

--- a/src/app/items/item-tabs.ts
+++ b/src/app/items/item-tabs.ts
@@ -6,7 +6,7 @@ import { TaskTab } from './containers/item-display/item-display.component';
 import { APPCONFIG } from 'src/app/config';
 import { isAChapter, isATask } from 'src/app/items/models/item-type';
 import { allowsWatchingResults } from 'src/app/items/models/item-watch-permission';
-import { canCurrentUserViewContent, canCurrentUserViewSolution } from 'src/app/items/models/item-view-permission';
+import { canCurrentUserViewContent } from 'src/app/items/models/item-view-permission';
 import { allowsEditingAll } from 'src/app/items/models/item-edit-permission';
 import { isNotNull, isNotUndefined } from 'src/app/utils/null-undefined-predicates';
 import { NavigationEnd, Router } from '@angular/router';
@@ -29,8 +29,6 @@ const parametersTab = { title: $localize`Parameters`, routerLink: [ 'parameters'
 const forumTab = { title: $localize`Forum`, routerLink: [ 'forum' ], tag: 'alg-forum' };
 // Task and chapter stats share the same route and component (alg-item-stats); only the tab title differs by item type.
 const itemStatsTab = { routerLink: [ 'item-stats' ], tag: 'alg-item-stats' };
-
-const solutionTabView = 'solution'; // 'view' name used by tasks for the solution tab
 
 /**
  * Service for letting item-by-id component know what tabs and active tab to be displayed
@@ -76,7 +74,6 @@ export class ItemTabs implements OnDestroy {
 
       const hasEditionPerm = state.isReady ? allowsEditingAll(state.data.item.permissions) : false;
       const canViewContent = state.isReady ? canCurrentUserViewContent(state.data.item) : false;
-      const canViewSolution = state.isReady ? canCurrentUserViewSolution(state.data.item, state.data.currentResult) : false;
       const canWatchResults = state.isReady ? allowsWatchingResults(state.data.item.permissions) : false;
       const isTask = state.isReady ? isATask(state.data.item) : undefined;
       const isChapter = state.isReady ? isAChapter(state.data.item) : undefined;
@@ -85,12 +82,16 @@ export class ItemTabs implements OnDestroy {
       const canSetExtraTime = state.isReady ? isTimeLimitedActivity(state.data.item) && canCurrentUserSetExtraTime(state.data.item) : false;
 
       const shouldHideTab = (v: string): boolean => this.config.featureFlags.hideTaskTabs.includes(v);
-      const filteredTaskTabs = taskTabs.filter(({ view }) => !shouldHideTab(view) && (canViewSolution || view !== solutionTabView));
+      // The solution tab is gated by the task itself (it advertises the 'solution' view based on its token, which the
+      // backend fills according to the user's permissions/validation), so no platform-side solution filtering is needed
+      // here. Only feature-flag-hidden views are dropped, and the result drives both the content-tab fallback and the
+      // displayed task tabs.
+      const visibleTaskTabs = taskTabs.filter(({ view }) => !shouldHideTab(view));
 
       return [
-        filteredTaskTabs.length === 0 && !this.isCurrentTab(childrenEditTab) ? contentTab : null,
-        filteredTaskTabs.length === 0 && this.isCurrentTab(childrenEditTab) ? childrenEditTab : null,
-        ...taskTabs.map(t => ({ title: t.name, routerLink: [ 'task', t.view ], tag: t.view, exactpathMatch: true })),
+        visibleTaskTabs.length === 0 && !this.isCurrentTab(childrenEditTab) ? contentTab : null,
+        visibleTaskTabs.length === 0 && this.isCurrentTab(childrenEditTab) ? childrenEditTab : null,
+        ...visibleTaskTabs.map(t => ({ title: t.name, routerLink: [ 'task', t.view ], tag: t.view, exactpathMatch: true })),
         this.isCurrentTab(editTab) || (editTabEnabled && hasEditionPerm) ? editTab : null,
         this.isCurrentTab(statsTab) || (canViewStats && !isTask && isObserving) ? statsTab : null,
         this.isCurrentTab(historyTab) || (showProgress && (isObserving || isTask)) ? historyTab : null,
@@ -103,7 +104,7 @@ export class ItemTabs implements OnDestroy {
           : null,
       ]
         .filter(isNotNull)
-        .filter(t => !shouldHideTab(t.tag))
+        .filter(t => !shouldHideTab(t.tag)) // uniform safety net (also lets a feature flag hide a non-task tab by tag)
         .map(t => ({ ...t, command: itemRouteAsUrlCommand(state.data.route, this.config.redirects, t.routerLink) }))
       ;
     }),

--- a/src/app/items/models/item-view-permission.ts
+++ b/src/app/items/models/item-view-permission.ts
@@ -33,15 +33,6 @@ export function allowsViewingContent(p: ItemPermWithView): boolean {
   return [ P.Content, P.ContentWithDescendants, P.Solution ].includes(p.canView);
 }
 
-/**
- * Permission required for viewing content + children (under propagation conditions) + view item solution
- * Note that users are also allowed to view solution if they have validated the item
- * (more info in devdoc)
- */
-export function allowsViewingSolution(p: ItemPermWithView): boolean {
-  return p.canView === P.Solution;
-}
-
 // ********************************************
 // Shortcut/helper functions on items directly
 // ********************************************
@@ -52,10 +43,6 @@ export function canCurrentUserViewInfo(i: ItemWithViewPerm): boolean {
 
 export function canCurrentUserViewContent(i: ItemWithViewPerm): boolean {
   return allowsViewingContent(i.permissions);
-}
-
-export function canCurrentUserViewSolution(i: ItemWithViewPerm, result?: { validated: boolean }): boolean {
-  return allowsViewingSolution(i.permissions) || (canCurrentUserViewContent(i) && !!result?.validated);
 }
 
 // ********************************************

--- a/src/app/items/services/item-task-answer.service.spec.ts
+++ b/src/app/items/services/item-task-answer.service.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { provideMockStore } from '@ngrx/store/testing';
+import { ItemTaskAnswerService } from './item-task-answer.service';
+import { ItemTaskInitService } from './item-task-init.service';
+import { CurrentAnswerService } from '../data-access/current-answer.service';
+import { AnswerTokenService } from '../data-access/answer-token.service';
+import { GradeService } from '../data-access/grade.service';
+import { Task } from '../api/task-proxy';
+import { itemRoute } from 'src/app/models/routing/item-route';
+import { fromItemContent } from '../store';
+
+const route = itemRoute('activity', '1', { attemptId: '0', path: [] });
+
+function createMockTask(): jasmine.SpyObj<Task> {
+  const task = jasmine.createSpyObj<Task>('Task', [ 'getAnswer', 'getState', 'gradeAnswer', 'reloadAnswer', 'reloadState' ]);
+  task.getAnswer.and.returnValue(of('100'));
+  task.getState.and.returnValue(of('task-state'));
+  task.gradeAnswer.and.returnValue(of({ score: 100, message: 'ok', scoreToken: null }));
+  return task;
+}
+
+interface SetupOptions {
+  validated?: boolean, // value returned by save-grade
+  alreadyValidated?: boolean, // current result validation state before submitting
+}
+
+function setup(options: SetupOptions = {}): { service: ItemTaskAnswerService, refreshToken: jasmine.Spy } {
+  const mockTask = createMockTask();
+  const refreshToken = jasmine.createSpy('refreshToken');
+
+  const initServiceMock = {
+    loadedTask$: of(mockTask),
+    config$: of({ route, url: 'http://example.com/task', attemptId: '0', initialAnswer: null, readOnly: false }),
+    taskToken$: of('task-token'),
+    refreshToken,
+  };
+
+  TestBed.configureTestingModule({
+    providers: [
+      ItemTaskAnswerService,
+      provideMockStore({
+        selectors: [
+          { selector: fromItemContent.selectActiveContentCurrentResult, value: { validated: options.alreadyValidated ?? false } },
+        ],
+      }),
+      { provide: ItemTaskInitService, useValue: initServiceMock },
+      { provide: CurrentAnswerService, useValue: { update: (): ReturnType<CurrentAnswerService['update']> => of(undefined) } },
+      { provide: AnswerTokenService, useValue: { generate: (): ReturnType<AnswerTokenService['generate']> => of('answer-token') } },
+      {
+        provide: GradeService,
+        useValue: {
+          save: (): ReturnType<GradeService['save']> => of({ validated: options.validated ?? false, unlockedItems: [] }),
+        },
+      },
+    ],
+  });
+
+  return { service: TestBed.inject(ItemTaskAnswerService), refreshToken };
+}
+
+describe('ItemTaskAnswerService – refresh token on validation', () => {
+  afterEach(() => {
+    TestBed.inject(ItemTaskAnswerService).ngOnDestroy();
+  });
+
+  it('refreshes the token when the submission newly validates the item', () => {
+    const { service, refreshToken } = setup({ validated: true, alreadyValidated: false });
+
+    service.submitAnswer().subscribe();
+
+    expect(refreshToken).toHaveBeenCalled();
+  });
+
+  it('does NOT refresh the token when the item was already validated', () => {
+    const { service, refreshToken } = setup({ validated: true, alreadyValidated: true });
+
+    service.submitAnswer().subscribe();
+
+    expect(refreshToken).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refresh the token when the submission does not validate the item', () => {
+    const { service, refreshToken } = setup({ validated: false, alreadyValidated: false });
+
+    service.submitAnswer().subscribe();
+
+    expect(refreshToken).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/items/services/item-task-answer.service.ts
+++ b/src/app/items/services/item-task-answer.service.ts
@@ -14,6 +14,7 @@ import {
   tap,
   timeout,
 } from 'rxjs/operators';
+import { createSelector, Store } from '@ngrx/store';
 import { SECONDS } from 'src/app/utils/duration';
 import { AnswerTokenService } from '../data-access/answer-token.service';
 import { CurrentAnswerService } from '../data-access/current-answer.service';
@@ -23,8 +24,14 @@ import { Answer } from './item-task.service';
 import { areStateAnswerEqual } from '../models/answers';
 import { mapToFetchState } from 'src/app/utils/operators/state';
 import { FetchState } from 'src/app/utils/state';
+import { fromItemContent } from '../store';
 
 const answerAndStateSaveInterval = 60*SECONDS;
+
+const selectIsCurrentResultValidated = createSelector(
+  fromItemContent.selectActiveContentCurrentResult,
+  result => !!result?.validated,
+);
 
 /** config of a task which has been started, so which has an attempt id set */
 type RunningItemTaskConfig = ItemTaskConfig & { attemptId: string };
@@ -35,6 +42,7 @@ export class ItemTaskAnswerService implements OnDestroy {
   private currentAnswerService = inject(CurrentAnswerService);
   private answerTokenService = inject(AnswerTokenService);
   private gradeService = inject(GradeService);
+  private store = inject(Store);
 
   private destroyed$ = new Subject<void>();
 
@@ -148,6 +156,10 @@ export class ItemTaskAnswerService implements OnDestroy {
   }
 
   submitAnswer(): Observable<void> {
+    // snapshot the validation state *before* grading: a grade triggers `patchScore` which may flip `validated` to true.
+    // We only want to refresh the token (to grant solution access) on the transition to validated, not on every submit.
+    const wasValidated$ = this.store.select(selectIsCurrentResultValidated).pipe(take(1));
+
     // Step 1: get answer from task
     const answer$ = this.loadedTask$.pipe(take(1), switchMap(task => task.getAnswer()), takeUntil(this.destroyed$), shareReplay(1));
 
@@ -179,11 +191,15 @@ export class ItemTaskAnswerService implements OnDestroy {
       takeUntil(this.destroyed$),
       shareReplay(1),
     );
-    combineLatest([ grade$, saveGrade$, this.saveTaskStateAnswerAsCurrent() ])
+    combineLatest([ grade$, saveGrade$, this.saveTaskStateAnswerAsCurrent(), wasValidated$ ])
       .pipe(catchError(() => EMPTY)) // error is handled elsewhere by returning saveGrade$
-      .subscribe(([ grade, saveGradeResult ]) => {
+      .subscribe(([ grade, saveGradeResult, , wasValidated ]) => {
         if (grade.score !== undefined) this.scoreChange.next(grade.score);
         if (saveGradeResult.unlockedItems.length > 0) this.unlockedItems.next(saveGradeResult.unlockedItems);
+        // a newly-validated task grants solution access: regenerate the token so the task can expose the solution view
+        // without a full reload. Use the backend's authoritative `validated` flag, and skip if it was already
+        // validated (the previous token already granted access).
+        if (saveGradeResult.validated && !wasValidated) this.taskInitService.refreshToken();
       });
     return saveGrade$.pipe(map(() => undefined));
   }

--- a/src/app/items/services/item-task-init.service.spec.ts
+++ b/src/app/items/services/item-task-init.service.spec.ts
@@ -1,6 +1,7 @@
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { EMPTY, merge, of, Subject, TimeoutError } from 'rxjs';
+import { EMPTY, merge, Observable, of, Subject, throwError, TimeoutError } from 'rxjs';
 import { map, startWith } from 'rxjs/operators';
+import { TaskToken } from '../data-access/task-token.service';
 import { ItemTaskInitService, IncompatibleTaskApiVersionError, LOAD_TASK_TIMEOUT, TASK_PROXY_FROM_IFRAME } from './item-task-init.service';
 import { TaskTokenService } from '../data-access/task-token.service';
 import { itemRoute } from 'src/app/models/routing/item-route';
@@ -228,5 +229,128 @@ describe('ItemTaskInitService – API version negotiation', () => {
 
     expect(apiVersionError).withContext('apiVersionError$ should have emitted').toBeInstanceOf(IncompatibleTaskApiVersionError);
     expect(loadedTaskEmitted).withContext('loadedTask$ should not have emitted successfully').toBeFalse();
+  }));
+});
+
+describe('ItemTaskInitService – token refresh', () => {
+  let service: ItemTaskInitService;
+  let iframe: HTMLIFrameElement;
+  let taskProxy$: Subject<Task>;
+  let generatedTokenCount: number;
+  // overridable per test so failure / sequencing scenarios can be exercised
+  let generateFn: () => Observable<TaskToken>;
+
+  function createTokenMockTask(usesTokens = true): jasmine.SpyObj<Task> {
+    const task = jasmine.createSpyObj<Task>('Task', [ 'getMetaData', 'load', 'updateToken', 'getViews', 'destroy', 'bindPlatform' ]);
+    task.getMetaData.and.returnValue(of({ usesTokens }));
+    task.load.and.returnValue(of(undefined));
+    task.updateToken.and.returnValue(of(undefined));
+    task.getViews.and.returnValue(of({ task: {} }));
+    return task;
+  }
+
+  function loadTask(mockTask: Task): void {
+    iframe.dispatchEvent(new Event('load'));
+    tick(0);
+    taskProxy$.next(mockTask);
+    taskProxy$.complete();
+    tick(0);
+  }
+
+  beforeEach(() => {
+    taskProxy$ = new Subject<Task>();
+    generatedTokenCount = 0;
+    generateFn = (): Observable<TaskToken> => of(`token${++generatedTokenCount}`);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ItemTaskInitService,
+        { provide: LOAD_TASK_TIMEOUT, useValue: testTimeout },
+        { provide: TASK_PROXY_FROM_IFRAME, useFactory: () => () => taskProxy$.asObservable() },
+        {
+          provide: TaskTokenService,
+          useValue: { generate: () => generateFn(), generateForAnswer: () => EMPTY },
+        },
+      ],
+    });
+
+    service = TestBed.inject(ItemTaskInitService);
+    iframe = document.createElement('iframe');
+
+    service.configure(route, 'http://example.com/task', '0', null, undefined, false);
+    service.initTask(iframe, () => {});
+  });
+
+  afterEach(() => {
+    service.ngOnDestroy();
+  });
+
+  it('should load the task once with the first token and apply it via updateToken', fakeAsync(() => {
+    const mockTask = createTokenMockTask();
+    service.loadedTask$.subscribe();
+
+    loadTask(mockTask);
+
+    expect(mockTask.load).withContext('task.load should be called once').toHaveBeenCalledTimes(1);
+    expect(mockTask.updateToken).withContext('first token should be applied').toHaveBeenCalledWith('token1');
+  }));
+
+  it('should push a new token to the task and emit tokenUpdatedOnTask$ without reloading on refreshToken()', fakeAsync(() => {
+    const mockTask = createTokenMockTask();
+    let tokenUpdatedCount = 0;
+    service.loadedTask$.subscribe();
+    service.tokenUpdatedOnTask$.subscribe(() => tokenUpdatedCount++);
+
+    loadTask(mockTask);
+
+    expect(tokenUpdatedCount).withContext('no post-load token push before refresh').toBe(0);
+    const updateTokenCallsAfterLoad = mockTask.updateToken.calls.count();
+
+    service.refreshToken();
+    tick(0);
+
+    expect(mockTask.load).withContext('task.load should NOT be called again').toHaveBeenCalledTimes(1);
+    expect(mockTask.updateToken.calls.count()).withContext('a new token should be pushed').toBe(updateTokenCallsAfterLoad + 1);
+    expect(mockTask.updateToken).withContext('the refreshed token should be applied').toHaveBeenCalledWith('token2');
+    expect(tokenUpdatedCount).withContext('tokenUpdatedOnTask$ should emit once after refresh').toBe(1);
+  }));
+
+  it('should never push a token to a token-less task, even on refreshToken()', fakeAsync(() => {
+    const mockTask = createTokenMockTask(false);
+    let tokenUpdatedCount = 0;
+    service.loadedTask$.subscribe();
+    service.tokenUpdatedOnTask$.subscribe(() => tokenUpdatedCount++);
+
+    loadTask(mockTask);
+
+    service.refreshToken();
+    tick(0);
+
+    expect(mockTask.updateToken).withContext('token-less task must not receive updateToken').not.toHaveBeenCalled();
+    expect(tokenUpdatedCount).withContext('tokenUpdatedOnTask$ must not emit for a token-less task').toBe(0);
+  }));
+
+  it('should keep serving the previous token (not error the shared stream) when a refresh generation fails', fakeAsync(() => {
+    const mockTask = createTokenMockTask();
+    const emittedTokens: TaskToken[] = [];
+    let errored = false;
+    service.loadedTask$.subscribe();
+    service.taskToken$.subscribe({ next: token => emittedTokens.push(token), error: () => errored = true });
+
+    loadTask(mockTask);
+    expect(emittedTokens).withContext('initial token should be generated').toEqual([ 'token1' ]);
+
+    // make the refresh-triggered generation fail
+    generateFn = (): Observable<TaskToken> => throwError(() => new Error('network blip'));
+    service.refreshToken();
+    tick(0);
+
+    expect(errored).withContext('taskToken$ must not error on a failed refresh').toBeFalse();
+    expect(emittedTokens).withContext('no new token emitted; previous one is kept').toEqual([ 'token1' ]);
+
+    // a later successful submission can still obtain a token
+    let latestToken: TaskToken | undefined;
+    service.taskToken$.subscribe(token => latestToken = token);
+    expect(latestToken).withContext('previous token still available to consumers').toBe('token1');
   }));
 });

--- a/src/app/items/services/item-task-init.service.ts
+++ b/src/app/items/services/item-task-init.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, InjectionToken, OnDestroy, inject } from '@angular/core';
-import { EMPTY, fromEvent, Observable, of, ReplaySubject, Subject, TimeoutError } from 'rxjs';
+import { EMPTY, fromEvent, merge, Observable, of, ReplaySubject, Subject, TimeoutError } from 'rxjs';
 import {
   catchError,
   delayWhen,
@@ -7,11 +7,15 @@ import {
   filter,
   map,
   pairwise,
+  retry,
   shareReplay,
+  skip,
   switchMap,
+  take,
   takeUntil,
   tap,
   timeout,
+  withLatestFrom,
 } from 'rxjs/operators';
 import { APPCONFIG } from 'src/app/config';
 import { SECONDS } from 'src/app/utils/duration';
@@ -56,6 +60,9 @@ export class ItemTaskInitService implements OnDestroy {
   private destroyed$ = new Subject<void>();
   private configFromItem$ = new ReplaySubject<ItemTaskConfig>(1);
   private configFromIframe$ = new ReplaySubject<{ iframe: HTMLIFrameElement, bindPlatform(task: Task): void }>(1);
+  // forces `taskToken$` to re-generate a token even when the generation strategy is unchanged (e.g. after a validating
+  // grade, so that the new token grants solution access)
+  private refreshToken$ = new Subject<void>();
 
   readonly config$ = this.configFromItem$.asObservable();
   readonly iframe$ = this.configFromIframe$.pipe(map(config => config.iframe));
@@ -75,8 +82,8 @@ export class ItemTaskInitService implements OnDestroy {
     shareReplay(1),
   );
 
-  // task token generation (possibly after some delay) (may fail!)
-  readonly taskToken$: Observable<TaskToken> = this.config$.pipe(
+  // generation strategy, recomputed on config changes only
+  private tokenStrategy$ = this.config$.pipe(
     // build strategy separately from switchMap to prevent cancellation of the request
     map(({ readOnly, initialAnswer, attemptId, route }) => {
       if (readOnly) {
@@ -92,17 +99,33 @@ export class ItemTaskInitService implements OnDestroy {
       return { strategy: 'regularToken' as const, itemId: route.id, attemptId };
     }),
     distinctUntilChanged((prev, cur) => prev.strategy === cur.strategy),
-    switchMap(s => {
-      if (s.strategy === 'answerToken') return this.taskTokenService.generateForAnswer(s.answerId);
-      if (s.strategy === 'regularToken') return this.taskTokenService.generate(s.itemId, s.attemptId);
-      return EMPTY; // s.strategy === 'wait'
+  );
+
+  // task token generation (possibly after some delay) (may fail!)
+  // re-emits a freshly generated token whenever the strategy changes or `refreshToken()` is called. Each emission is
+  // tagged with whether it was triggered by a refresh (vs a strategy change) so that ONLY refresh-triggered generations
+  // swallow errors — using which source emitted (not a sticky combineLatest flag), so a strategy change after a refresh
+  // still propagates its errors.
+  readonly taskToken$: Observable<TaskToken> = merge(
+    this.tokenStrategy$.pipe(map(strategy => ({ strategy, isRefresh: false }))),
+    this.refreshToken$.pipe(withLatestFrom(this.tokenStrategy$), map(([ , strategy ]) => ({ strategy, isRefresh: true }))),
+  ).pipe(
+    switchMap(({ strategy: s, isRefresh }) => {
+      let generate$: Observable<TaskToken> = EMPTY; // s.strategy === 'wait'
+      if (s.strategy === 'answerToken') generate$ = this.taskTokenService.generateForAnswer(s.answerId);
+      if (s.strategy === 'regularToken') generate$ = this.taskTokenService.generate(s.itemId, s.attemptId);
+      // A refresh failure must NOT error `taskToken$`: it is a shared stream also consumed by `submitAnswer()`
+      // (answer-token + save-grade), so erroring it would break every later submission. Keep the previous token
+      // instead. Initial-load / strategy-change generation keeps propagating errors (handled by load timeout / consumers).
+      return isRefresh ? generate$.pipe(retry(2), catchError(() => EMPTY)) : generate$;
     }),
     takeUntil(this.destroyed$),
     shareReplay(1),
   );
 
-  // the task (i.e., a client to the task in the iframe) which has been loaded (may fail!)
-  readonly loadedTask$ = this.task$.pipe(
+  // the loaded task together with whether it consumes task tokens (kept internally so `tokenUpdatedOnTask$` can gate on
+  // it without re-fetching the metadata). May fail!
+  private loadedTaskWithTokenUse$ = this.task$.pipe(
     switchMap(task => task.getMetaData().pipe(map(metadata => {
       const negotiated = negotiateApiVersion(metadata.minApiVersion, metadata.apiVersion);
       if (negotiated === null) throw new IncompatibleTaskApiVersionError();
@@ -110,12 +133,36 @@ export class ItemTaskInitService implements OnDestroy {
       return { usesTokens: metadata.usesTokens ?? true, task };
     }))),
     switchMap(({ usesTokens, task }) => (usesTokens ? this.taskToken$.pipe(
+      take(1), // only the first token is used to load the task; later tokens are pushed via `tokenUpdatedOnTask$`
       switchMap(token => task.updateToken(token)),
-      map(() => task)
-    ): of(task))),
-    switchMap(task => task.load(
+      map(() => ({ usesTokens, task })),
+    ): of({ usesTokens, task }))),
+    switchMap(({ usesTokens, task }) => task.load(
       { task: true, solution: true, editor: true, hints: true, grader: true, metadata: true }
-    ).pipe(map(() => task))),
+    ).pipe(map(() => ({ usesTokens, task })))),
+    takeUntil(this.destroyed$),
+    shareReplay(1),
+  );
+
+  // the task (i.e., a client to the task in the iframe) which has been loaded (may fail!)
+  // no shareReplay here: the source is already multicast+replayed; this is just a pure projection of it
+  readonly loadedTask$ = this.loadedTaskWithTokenUse$.pipe(map(({ task }) => task));
+
+  // pushes tokens generated after the initial load to the task (e.g. after a refresh), so the task can re-evaluate what
+  // it is allowed to show (such as the solution view). Emits the task each time a new token has been applied.
+  // No-op for token-less tasks: they ignore tokens and pushing one could error their (unimplemented) `updateToken`.
+  readonly tokenUpdatedOnTask$: Observable<Task> = this.loadedTaskWithTokenUse$.pipe(
+    // INVARIANT: `refreshToken()` is only ever called after the task is loaded (its single caller, submitAnswer(),
+    // structurally requires a loaded task). This lets `skip(1)` reliably drop the load-time token replayed by
+    // `taskToken$` (shareReplay(1)). If a future caller refreshes *before* load completes, that token would be the
+    // value replayed here and `skip(1)` would silently discard the refresh — keep the invariant or revisit this.
+    switchMap(({ usesTokens, task }) => (usesTokens ? this.taskToken$.pipe(
+      skip(1), // skip the token already applied during load (token-less tasks never reach this branch)
+      switchMap(token => task.updateToken(token).pipe(
+        map(() => task),
+        catchError(() => EMPTY), // a single failed push must not kill future view re-queries
+      )),
+    ) : EMPTY)),
     takeUntil(this.destroyed$),
     shareReplay(1),
   );
@@ -152,6 +199,8 @@ export class ItemTaskInitService implements OnDestroy {
 
   // subscribe to the task token so that it is requested even before it is needed (so ready more quickly)
   tokenSubscription = this.taskToken$.pipe(catchError(() => EMPTY)).subscribe();
+  // keep the token pushed to the task even if no other consumer subscribes to `tokenUpdatedOnTask$`
+  tokenPushSubscription = this.tokenUpdatedOnTask$.pipe(catchError(() => EMPTY)).subscribe();
 
   ngOnDestroy(): void {
     // task is a one replayed value observable. If a task has been emitted, destroy it ; else nothing to do.
@@ -160,8 +209,21 @@ export class ItemTaskInitService implements OnDestroy {
     if (!this.configFromIframe$.closed) this.configFromIframe$.complete();
     this.guardSubscription.unsubscribe();
     this.tokenSubscription.unsubscribe();
+    this.tokenPushSubscription.unsubscribe();
+    this.refreshToken$.complete();
     this.destroyed$.next();
     this.destroyed$.complete();
+  }
+
+  /**
+   * Request a fresh task token to be generated and pushed to the loaded task.
+   * Useful after an event that changes the user's permissions on the task (e.g. validating it grants solution access).
+   *
+   * MUST be called only after the task has been loaded (see the `skip(1)` invariant on `tokenUpdatedOnTask$`): a refresh
+   * triggered before load completes would be swallowed and silently lost.
+   */
+  refreshToken(): void {
+    this.refreshToken$.next();
   }
 
   configure(

--- a/src/app/items/services/item-task-views.service.ts
+++ b/src/app/items/services/item-task-views.service.ts
@@ -15,9 +15,13 @@ export class ItemTaskViewsService implements OnDestroy {
   private displaySubject = new ReplaySubject<UpdateDisplayParams>(1);
   readonly display$ = this.displaySubject.asObservable().pipe(takeUntil(this.error$));
   private loadedTask$ = this.initService.loadedTask$.pipe(catchError(() => EMPTY), takeUntil(this.error$));
+  // when a new token has been pushed to the task (e.g. after validation), re-query its views as the task may now expose
+  // additional views (such as the solution). Tasks do not spontaneously re-advertise views on token update.
+  private tokenUpdatedOnTask$ = this.initService.tokenUpdatedOnTask$.pipe(catchError(() => EMPTY), takeUntil(this.error$));
 
   private readonly views = merge(
     this.loadedTask$.pipe(switchMap(task => task.getViews())),
+    this.tokenUpdatedOnTask$.pipe(switchMap(task => task.getViews())),
     this.display$.pipe(map(({ views }) => views), filter(isNotUndefined)),
   ).pipe(
     map(views => this.getAvailableViews(views)),


### PR DESCRIPTION
Code written with the help of AI, already reviewed locally.