### PR TITLE
Modernize ng comp 17

### DIFF
--- a/src/app/items/containers/chapter-group-progress/chapter-group-progress.component.html
+++ b/src/app/items/containers/chapter-group-progress/chapter-group-progress.component.html
@@ -1,7 +1,7 @@
 @if (state$ | async; as state) {
   @if (state.isReady) {
     <alg-group-progress-grid
-      [itemData]="itemData"
+      [itemData]="itemData()"
       [group]="state.data"
     >
     </alg-group-progress-grid>

--- a/src/app/items/containers/chapter-group-progress/chapter-group-progress.component.ts
+++ b/src/app/items/containers/chapter-group-progress/chapter-group-progress.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, inject, input } from '@angular/core';
 import { switchMap, filter } from 'rxjs/operators';
 import { GetGroupByIdService } from 'src/app/groups/data-access/get-group-by-id.service';
 import { ItemData } from '../../models/item-data';
@@ -16,14 +16,14 @@ import { fromObservation } from 'src/app/store/observation';
   selector: 'alg-chapter-group-progress',
   templateUrl: './chapter-group-progress.component.html',
   styleUrls: [ './chapter-group-progress.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ GroupProgressGridComponent, LoadingComponent, ErrorComponent, AsyncPipe ]
 })
-export class ChapterGroupProgressComponent implements OnDestroy {
+export class ChapterGroupProgressComponent {
   private store = inject(Store);
   private getGroupByIdService = inject(GetGroupByIdService);
+  private destroyRef = inject(DestroyRef);
 
-  @Input() itemData?: ItemData;
+  readonly itemData = input.required<ItemData>();
 
   private refresh$ = new Subject<void>();
   state$ = this.store.select(fromObservation.selectObservedGroupId).pipe(
@@ -32,8 +32,8 @@ export class ChapterGroupProgressComponent implements OnDestroy {
     mapToFetchState({ resetter: this.refresh$ }),
   );
 
-  ngOnDestroy(): void {
-    this.refresh$.complete();
+  constructor() {
+    this.destroyRef.onDestroy(() => this.refresh$.complete());
   }
 
   refresh(): void {

--- a/src/app/items/containers/group-progress-grid/group-progress-grid-columns.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid-columns.ts
@@ -1,0 +1,30 @@
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { GetItemChildrenService } from '../../../data-access/get-item-children.service';
+import { ItemData } from '../../models/item-data';
+import { DataColumn } from './group-progress-grid.types';
+
+export function getGroupProgressGridColumns(
+  getItemChildrenService: GetItemChildrenService,
+  itemData: ItemData,
+): Observable<DataColumn[]> {
+  if (!itemData.currentResult?.attemptId) throw new Error('unexpected');
+  return getItemChildrenService.get(itemData.item.id, itemData.currentResult.attemptId).pipe(
+    map(items => [
+      {
+        id: itemData.item.id,
+        requiresExplicitEntry: itemData.item.requiresExplicitEntry,
+        title: itemData.item.string.title,
+        type: itemData.item.type,
+        permissions: itemData.item.permissions,
+      },
+      ...items.map(item => ({
+        id: item.id,
+        requiresExplicitEntry: !!item.requiresExplicitEntry,
+        title: item.string.title,
+        type: item.type,
+        permissions: item.permissions,
+      }))
+    ]),
+  );
+}

--- a/src/app/items/containers/group-progress-grid/group-progress-grid-csv-export.service.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid-csv-export.service.ts
@@ -1,0 +1,44 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { inject, Injectable, signal } from '@angular/core';
+import { ProgressCSVService } from 'src/app/data-access/progress-csv.service';
+import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
+import { downloadFile } from 'src/app/utils/download-file';
+import { TypeFilter } from '../../models/composition-filter';
+
+@Injectable()
+export class GroupProgressGridCsvExportService {
+  private progressCSVService = inject(ProgressCSVService);
+  private actionFeedbackService = inject(ActionFeedbackService);
+
+  readonly isFetching = signal(false);
+
+  export(groupId: string, parentItemId: string, filter: TypeFilter): void {
+    const downloadDataType = this.getDownloadTypeByFilter(filter);
+
+    this.isFetching.set(true);
+    this.progressCSVService
+      .getCSVData(groupId, downloadDataType, [ parentItemId ])
+      .subscribe({
+        next: data => {
+          this.isFetching.set(false);
+          downloadFile([ data ], `${parentItemId}-${new Date().toDateString()}.csv`, 'text/csv');
+        },
+        error: err => {
+          this.isFetching.set(false);
+          this.actionFeedbackService.unexpectedError();
+          if (!(err instanceof HttpErrorResponse)) throw err;
+        },
+      });
+  }
+
+  private getDownloadTypeByFilter(filter: TypeFilter): 'group' | 'team' | 'user' {
+    switch (filter) {
+      case 'Groups':
+        return 'group';
+      case 'Users':
+        return 'user';
+      case 'Teams':
+        return 'team';
+    }
+  }
+}

--- a/src/app/items/containers/group-progress-grid/group-progress-grid-data.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid-data.ts
@@ -1,0 +1,81 @@
+import { forkJoin, Observable } from 'rxjs';
+import { combineLatestWith, map } from 'rxjs/operators';
+import { GetGroupChildrenService } from 'src/app/groups/data-access/get-group-children.service';
+import { formatUser } from 'src/app/groups/models/user';
+import { GetGroupDescendantsService } from 'src/app/data-access/get-group-descendants.service';
+import { GetGroupProgressService } from 'src/app/data-access/get-group-progress.service';
+import { DataColumn, DataFetching, DataRow, Progress } from './group-progress-grid.types';
+
+function getGroupProgressRows(
+  getGroupDescendantsService: GetGroupDescendantsService,
+  getGroupChildrenService: GetGroupChildrenService,
+  { groupId, filter, pageSize, fromId }: Omit<DataFetching, 'itemId'>,
+): Observable<{ id: string, value: string, user?: DataRow['user'] }[]> {
+  switch (filter) {
+    case 'Users':
+      return getGroupDescendantsService.getUserDescendants(groupId, { limit: pageSize, fromId })
+        .pipe(map(users => users.map(user => ({ id: user.id, value: formatUser(user.user), user: { ...user.user, id: user.id } }))));
+    case 'Teams':
+      return getGroupDescendantsService.getTeamDescendants(groupId, { limit: pageSize, fromId })
+        .pipe(map(teams => teams.map(team => ({ id: team.id, value: team.name }))));
+    case 'Groups':
+      return getGroupChildrenService.getGroupChildren(groupId, [], [], [ 'Team', 'User' ], { limit: pageSize, fromId })
+        .pipe(map(groups => groups.map(group => ({ id: group.id, value: group.name }))));
+  }
+}
+
+function getGroupProgress(
+  getGroupUsersProgressService: GetGroupProgressService,
+  { itemId, groupId, filter, pageSize, fromId }: DataFetching,
+): Observable<Progress[]> {
+  switch (filter) {
+    case 'Users':
+      return getGroupUsersProgressService.getUsersProgress(groupId, [ itemId ], { limit: pageSize, fromId }).pipe(
+        map(progress => progress.map(p => ({ ...p, type: 'user' }))),
+      );
+    case 'Teams':
+      return getGroupUsersProgressService.getTeamsProgress(groupId, [ itemId ], { limit: pageSize, fromId }).pipe(
+        map(progress => progress.map(p => ({ ...p, type: 'user' }))),
+      );
+    case 'Groups':
+      return getGroupUsersProgressService.getGroupsProgress(groupId, [ itemId ], { limit: pageSize, fromId })
+        .pipe(map(groupsProgress => groupsProgress.map(p => ({
+          type: 'group',
+          groupId: p.groupId,
+          itemId: p.itemId,
+          validationRate: p.validationRate,
+          score: p.averageScore,
+          timeSpent: p.avgTimeSpent,
+          hintsRequested: p.avgHintsRequested,
+          submissions: p.avgSubmissions,
+          latestActivityAt: null,
+        }))));
+  }
+}
+
+export function getRowsWithProgress(
+  getGroupDescendantsService: GetGroupDescendantsService,
+  getGroupChildrenService: GetGroupChildrenService,
+  getGroupUsersProgressService: GetGroupProgressService,
+  columns$: Observable<DataColumn[]>,
+  fetching: DataFetching,
+): Observable<DataRow[]> {
+  return forkJoin({
+    rows: getGroupProgressRows(getGroupDescendantsService, getGroupChildrenService, fetching),
+    progress: getGroupProgress(getGroupUsersProgressService, fetching),
+  }).pipe(
+    combineLatestWith(columns$),
+    map(([{ rows, progress }, items ]) =>
+      rows
+        .filter(row => progress.find(p => p.groupId === row.id))
+        .map(row => ({
+          header: row.value,
+          id: row.id,
+          user: row.user,
+          data: items.map(item =>
+            progress.find(p => p.itemId === item.id && p.groupId === row.id)
+          ),
+        })),
+    )
+  );
+}

--- a/src/app/items/containers/group-progress-grid/group-progress-grid-menu-positions.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid-menu-positions.ts
@@ -1,0 +1,28 @@
+import { ConnectedPosition } from '@angular/cdk/overlay';
+
+export const groupProgressDetailMenuPositions: ConnectedPosition[] = [
+  {
+    originX: 'center',
+    originY: 'bottom',
+    overlayX: 'center',
+    overlayY: 'top',
+    offsetY: 10,
+    panelClass: [ 'alg-top-center-triangle', 'grey' ],
+  },
+  {
+    originX: 'center',
+    originY: 'top',
+    overlayX: 'center',
+    overlayY: 'bottom',
+    offsetY: -40,
+    panelClass: [ 'alg-bottom-center-triangle', 'grey' ],
+  },
+  {
+    originX: 'start',
+    originY: 'center',
+    overlayX: 'end',
+    overlayY: 'center',
+    offsetX: -10,
+    panelClass: [ 'alg-left-center-triangle', 'grey' ],
+  },
+];

--- a/src/app/items/containers/group-progress-grid/group-progress-grid.component.html
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid.component.html
@@ -27,15 +27,15 @@
             (refresh)="fetchRows()"
             i18n
           >
-          This group has no {currentFilter, select, Users {users} Teams {teams} other {sub-groups}}
+          This group has no {currentFilter(), select, Users {users} Teams {teams} other {sub-groups}}
         </alg-error>
         </p>
       }
       <ng-template #menu>
         <div class="menu" cdkMenu (closed)="hideProgressDetail()">
           <alg-user-progress-details
-            [canEditPermissions]="canAccess"
-            [progressData]="progressOverlay"
+            [canEditPermissions]="canAccess()"
+            [progressData]="progressOverlay()"
             (editPermissions)="onAccessPermissions()"
           ></alg-user-progress-details>
         </div>
@@ -48,7 +48,7 @@
             type="button"
             icon="ph ph-file-arrow-down"
             (click)="onCSVExport()"
-            [disabled]="isCSVDataFetching"
+            [disabled]="isCSVDataFetching()"
             i18n
           >Export as CSV</button>
         </div>
@@ -78,11 +78,11 @@
                         tooltipStyleClass="secondary"
                         [tooltipDelay]="100"
                       >
-                        @if (itemData && itemData.currentResult && itemData.currentResult.attemptId; as attemptId) {
+                        @if (itemData().currentResult?.attemptId; as attemptId) {
                           <a
                             class="alg-link cursor-pointer alg-text-bold"
-                            [routerLink]="col | itemRoute: { path: itemData.item.id === col.id ? itemData.route.path : itemData.route.path.concat([ itemData.item.id ]) } |
-                              with: (itemData.item.id === col.id ? { attemptId } : { parentAttemptId: attemptId }) |
+                            [routerLink]="col | itemRoute: { path: itemData().item.id === col.id ? itemData().route.path : itemData().route.path.concat([ itemData().item.id ]) } |
+                              with: (itemData().item.id === col.id ? { attemptId } : { parentAttemptId: attemptId }) |
                               url : [ 'progress', 'chapter' ]"
                           >{{ col.title }}</a>
                         }
@@ -121,7 +121,7 @@
                         [class.active-cell]="activeCell()?.rowId === row.id && activeCell()?.colIndex === colIndex"
                         (click)="showProgressDetail(row, col, colIndex)"
                         [cdkMenuTriggerFor]="menu"
-                        [cdkMenuPosition]="progressDetailMenuPositions()"
+                        [cdkMenuPosition]="progressDetailMenuPositions"
                         data-testid="user-progress-tooltip-target"
                       >
                         @if (rowData.type === 'user') {

--- a/src/app/items/containers/group-progress-grid/group-progress-grid.component.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid.component.ts
@@ -1,26 +1,21 @@
-import { Component, inject, Input, OnChanges, OnDestroy, signal, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
-import { forkJoin, Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
-import { combineLatestWith, filter, map, shareReplay, switchMap } from 'rxjs/operators';
+import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
+import { combineLatest, Observable, Subject } from 'rxjs';
+import { filter, shareReplay, switchMap } from 'rxjs/operators';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { canCurrentUserGrantGroupAccess } from 'src/app/groups/models/group-management';
 import { Group } from 'src/app/groups/models/group';
 import { GetGroupChildrenService } from 'src/app/groups/data-access/get-group-children.service';
-import { formatUser, UserBaseWithId } from 'src/app/groups/models/user';
 import { GetGroupDescendantsService } from 'src/app/data-access/get-group-descendants.service';
 import { GetGroupProgressService } from 'src/app/data-access/get-group-progress.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { TypeFilter } from '../../models/composition-filter';
 import { GetItemChildrenService } from '../../../data-access/get-item-children.service';
 import { ItemData } from '../../models/item-data';
-import { ProgressCSVService } from 'src/app/data-access/progress-csv.service';
-import { downloadFile } from 'src/app/utils/download-file';
-import { ItemType, typeCategoryOfItem } from 'src/app/items/models/item-type';
-import { RawGroupRoute, rawGroupRoute } from 'src/app/models/routing/group-route';
 import { ProgressData, UserProgressDetailsComponent } from '../../containers/user-progress-details/user-progress-details.component';
 import { DataPager } from 'src/app/utils/data-pager';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { FetchState } from 'src/app/utils/state';
-import { HttpErrorResponse } from '@angular/common/http';
-import { allowsGivingPermToItem, ItemCorePerm } from 'src/app/items/models/item-permissions';
+import { allowsGivingPermToItem } from 'src/app/items/models/item-permissions';
 import { itemRoute, itemRouteWith } from 'src/app/models/routing/item-route';
 import { selectObservedGroupRouteAsItemRouteParameter } from 'src/app/models/routing/item-route-observation-selector';
 import { Store } from '@ngrx/store';
@@ -41,68 +36,29 @@ import { CompositionFilterComponent } from '../../containers/composition-filter/
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 import { CdkMenu, CdkMenuTrigger } from '@angular/cdk/menu';
-import { ConnectedPosition } from '@angular/cdk/overlay';
 import { Dialog } from '@angular/cdk/dialog';
 import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directive';
 import { UserLinkWithActionsComponent } from 'src/app/ui-components/user-link-with-actions/user-link-with-actions.component';
 import { UrlTree } from '@angular/router';
+import { typeCategoryOfItem } from 'src/app/items/models/item-type';
+import { RawGroupRoute, rawGroupRoute } from 'src/app/models/routing/group-route';
+import { getGroupProgressGridColumns } from './group-progress-grid-columns';
+import { groupProgressDetailMenuPositions } from './group-progress-grid-menu-positions';
+import { getRowsWithProgress } from './group-progress-grid-data';
+import { GroupProgressGridCsvExportService } from './group-progress-grid-csv-export.service';
+import {
+  DataColumn,
+  DataRow,
+  ProgressDataDialog,
+} from './group-progress-grid.types';
 
-export type Progress = {
-  groupId: string,
-  itemId: string,
-  score: number,
-  timeSpent: number,
-  hintsRequested: number,
-  submissions: number,
-  latestActivityAt: Date | null,
-} & ({
-  type: 'user',
-  validated: boolean,
-} | {
-  type: 'group',
-  validationRate: number,
-});
-
-
-interface DataRow {
-  header: string,
-  id: string,
-  user?: UserBaseWithId,
-  data: (Progress|undefined)[],
-}
-interface DataColumn {
-  id: string,
-  requiresExplicitEntry: boolean,
-  title: string|null,
-  type: ItemType,
-  permissions: ItemCorePerm,
-}
-interface DataFetching {
-  groupId: string,
-  itemId: string,
-  filter: TypeFilter,
-  fromId?: string,
-  pageSize: number,
-}
-
-interface ProgressDataDialog {
-  item: {
-    id: string,
-    requiresExplicitEntry: boolean,
-    string: {
-      title: string | null,
-    },
-  },
-  group: RawGroupRoute,
-  groupName: string,
-  sourceGroupName: string,
-}
+export type { Progress } from './group-progress-grid.types';
 
 @Component({
   selector: 'alg-group-progress-grid',
   templateUrl: './group-progress-grid.component.html',
   styleUrls: [ './group-progress-grid.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  providers: [ GroupProgressGridCsvExportService ],
   imports: [
     CompositionFilterComponent,
     ErrorComponent,
@@ -123,40 +79,42 @@ interface ProgressDataDialog {
     UserLinkWithActionsComponent,
   ]
 })
-export class GroupProgressGridComponent implements OnChanges, OnDestroy {
+export class GroupProgressGridComponent {
   private getItemChildrenService = inject(GetItemChildrenService);
   private getGroupDescendantsService = inject(GetGroupDescendantsService);
   private getGroupUsersProgressService = inject(GetGroupProgressService);
   private getGroupChildrenService = inject(GetGroupChildrenService);
   private actionFeedbackService = inject(ActionFeedbackService);
-  private progressCSVService = inject(ProgressCSVService);
+  private csvExportService = inject(GroupProgressGridCsvExportService);
   private store = inject(Store);
   private observedGroupRouteParam = this.store.selectSignal(selectObservedGroupRouteAsItemRouteParameter);
   private itemRouter = inject(ItemRouter);
-
-  @Input() group?: Group;
-  @Input() itemData?: ItemData;
-
   private dialogService = inject(Dialog);
+  private destroyRef = inject(DestroyRef);
+
+  readonly group = input.required<Group>();
+  readonly itemData = input.required<ItemData>();
 
   defaultFilter: TypeFilter = 'Users';
 
-  currentFilter = this.defaultFilter;
+  readonly currentFilter = signal<TypeFilter>(this.defaultFilter);
+  readonly progressOverlay = signal<ProgressData | undefined>(undefined);
+  readonly activeCell = signal<{ rowId: string, colIndex: number } | null>(null);
+  readonly progressDataDialog = signal<ProgressDataDialog | undefined>(undefined);
+  readonly sourceGroup = signal<RawGroupRoute | undefined>(undefined);
+  private readonly isRefreshing = signal(false);
 
-  progressOverlay?: ProgressData;
-  activeCell = signal<{ rowId: string, colIndex: number } | null>(null);
-  progressDataDialog?: ProgressDataDialog;
-  sourceGroup?: RawGroupRoute;
+  readonly canAccess = computed(() =>
+    canCurrentUserGrantGroupAccess(this.group())
+    && allowsGivingPermToItem(this.itemData().item.permissions)
+  );
 
-  isCSVDataFetching = false;
-  canAccess = false;
-  private isRefreshing = signal(false);
+  readonly isCSVDataFetching = this.csvExportService.isFetching;
 
-  private itemData$ = new ReplaySubject<ItemData>(1);
-  private refresh$ = new Subject<void>();
+  private readonly refresh$ = new Subject<void>();
   // columns containing results, including the first "chapter summary" one
-  readonly columns$: Observable<FetchState<DataColumn[]>> = this.itemData$.pipe(
-    switchMap(itemData => this.getColumns(itemData)),
+  readonly columns$: Observable<FetchState<DataColumn[]>> = toObservable(this.itemData).pipe(
+    switchMap(itemData => getGroupProgressGridColumns(this.getItemChildrenService, itemData)),
     mapToFetchState({ resetter: this.refresh$ }),
     shareReplay(1),
   );
@@ -169,14 +127,21 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
     pageSize: this.pageSizesForFilter(this.defaultFilter).default,
     maxPageSize: this.pageSizesForFilter(this.defaultFilter).max,
     fetch: (pageSize, latestRow?: DataRow): Observable<DataRow[]> => {
-      if (!this.group || !this.itemData) throw new Error('properties are missing');
-      return this.getRowsWithProgress({
-        groupId: this.group.id,
-        itemId: this.itemData.item.id,
-        filter: this.currentFilter,
-        fromId: latestRow?.id,
-        pageSize,
-      });
+      const group = this.group();
+      const itemData = this.itemData();
+      return getRowsWithProgress(
+        this.getGroupDescendantsService,
+        this.getGroupChildrenService,
+        this.getGroupUsersProgressService,
+        this.columns$.pipe(readyData()),
+        {
+          groupId: group.id,
+          itemId: itemData.item.id,
+          filter: this.currentFilter(),
+          fromId: latestRow?.id,
+          pageSize,
+        },
+      );
     },
     onLoadMoreError: (): void => {
       this.actionFeedbackService.error($localize`Could not load more results, are you connected to the internet?`);
@@ -185,72 +150,41 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
 
   rows$ = this.datapager.list$;
 
-  private refreshSubscription: Subscription = this.rows$.pipe(
-    filter(() => this.isRefreshing()),
-    filter(state => state.isReady || state.isError),
-  ).subscribe(state => {
-    this.isRefreshing.set(false);
-    if (state.isReady) {
-      this.actionFeedbackService.success($localize`Data refreshed successfully`);
-    }
-  });
+  readonly progressDetailMenuPositions = groupProgressDetailMenuPositions;
 
-  progressDetailMenuPositions = signal<ConnectedPosition[]>([
-    {
-      originX: 'center',
-      originY: 'bottom',
-      overlayX: 'center',
-      overlayY: 'top',
-      offsetY: 10,
-      panelClass: [ 'alg-top-center-triangle', 'grey' ],
-    },
-    {
-      originX: 'center',
-      originY: 'top',
-      overlayX: 'center',
-      overlayY: 'bottom',
-      offsetY: -40,
-      panelClass: [ 'alg-bottom-center-triangle', 'grey' ],
-    },
-    {
-      originX: 'start',
-      originY: 'center',
-      overlayX: 'end',
-      overlayY: 'center',
-      offsetX: -10,
-      panelClass: [ 'alg-left-center-triangle', 'grey' ],
-    },
-  ]);
+  constructor() {
+    combineLatest([
+      toObservable(this.group),
+      toObservable(this.itemData),
+    ]).pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([ group ]) => {
+        this.fetchRows();
+        this.sourceGroup.set(rawGroupRoute(group));
+      });
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.itemData && this.itemData) this.itemData$.next(this.itemData);
-    if (this.group) {
-      this.fetchRows();
-      this.sourceGroup = rawGroupRoute(this.group);
-    }
-    this.canAccess = !!(this.group && canCurrentUserGrantGroupAccess(this.group)
-      && this.itemData && allowsGivingPermToItem(this.itemData.item.permissions));
-  }
+    this.rows$.pipe(
+      filter(() => this.isRefreshing()),
+      filter(state => state.isReady || state.isError),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(state => {
+      this.isRefreshing.set(false);
+      if (state.isReady) {
+        this.actionFeedbackService.success($localize`Data refreshed successfully`);
+      }
+    });
 
-  ngOnDestroy(): void {
-    this.itemData$.complete();
-    this.refresh$.complete();
-    this.refreshSubscription.unsubscribe();
+    this.destroyRef.onDestroy(() => this.refresh$.complete());
   }
 
   showProgressDetail(row: DataRow, col: DataColumn, colIndex: number): void {
     const progress = row.data[colIndex];
     if (!progress) throw new Error('Unexpected: progress data is missing');
     this.activeCell.set({ rowId: row.id, colIndex });
-    if (!this.itemData) {
-      throw new Error('Unexpected: Missed item data');
-    }
-    if (!this.group) {
-      throw new Error('Unexpected: Missed group');
-    }
-    const attemptId = this.itemData.currentResult?.attemptId;
+    const itemData = this.itemData();
+    const group = this.group();
+    const attemptId = itemData.currentResult?.attemptId;
     if (!attemptId) throw new Error('Unexpected: Children have been loaded, so we are sure this item has an attempt');
-    this.progressOverlay = {
+    this.progressOverlay.set({
       progress,
       colItem: {
         type: col.type,
@@ -258,8 +192,8 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
           typeCategoryOfItem(col),
           col.id,
           {
-            path: [ ...this.itemData.route.path, ...(col.id !== this.itemData.route.id ? [ this.itemData.route.id ] : []) ],
-            ...col.id === this.itemData.route.id ? {
+            path: [ ...itemData.route.path, ...(col.id !== itemData.route.id ? [ itemData.route.id ] : []) ],
+            ...col.id === itemData.route.id ? {
               attemptId,
             } : {
               parentAttemptId: attemptId,
@@ -271,10 +205,10 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
       },
       rowGroup: {
         id: row.id,
-        isUser: this.currentFilter === 'Users',
+        isUser: this.currentFilter() === 'Users',
       },
-    };
-    this.progressDataDialog = {
+    });
+    this.progressDataDialog.set({
       item: {
         id: col.id,
         requiresExplicitEntry: col.requiresExplicitEntry,
@@ -282,14 +216,14 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
           title: col.title,
         },
       },
-      group: rawGroupRoute({ id: row.id, isUser: this.currentFilter === 'Users' }),
+      group: rawGroupRoute({ id: row.id, isUser: this.currentFilter() === 'Users' }),
       groupName: row.header,
-      sourceGroupName: this.group.name,
-    };
+      sourceGroupName: group.name,
+    });
   }
 
   hideProgressDetail(): void {
-    this.progressOverlay = undefined;
+    this.progressOverlay.set(undefined);
     this.activeCell.set(null);
   }
 
@@ -299,72 +233,9 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
     this.fetchMoreRows();
   }
 
-  private getProgress({ itemId, groupId, filter, pageSize, fromId }: DataFetching): Observable<Progress[]> {
-    switch (filter) {
-      case 'Users':
-        return this.getGroupUsersProgressService.getUsersProgress(groupId, [ itemId ], { limit: pageSize, fromId }).pipe(
-          map(progress => progress.map(p => ({ ...p, type: 'user' }))),
-        );
-      case 'Teams':
-        return this.getGroupUsersProgressService.getTeamsProgress(groupId, [ itemId ], { limit: pageSize, fromId }).pipe(
-          map(progress => progress.map(p => ({ ...p, type: 'user' }))),
-        );
-      case 'Groups':
-        return this.getGroupUsersProgressService.getGroupsProgress(groupId, [ itemId ], { limit: pageSize, fromId })
-          .pipe(map(groupsProgress => groupsProgress.map(p => ({
-            type: 'group',
-            groupId: p.groupId,
-            itemId: p.itemId,
-            validationRate: p.validationRate,
-            score: p.averageScore,
-            timeSpent: p.avgTimeSpent,
-            hintsRequested: p.avgHintsRequested,
-            submissions: p.avgSubmissions,
-            latestActivityAt: null,
-          }))));
-    }
-  }
-
-  private getRows(
-    { groupId, filter, pageSize, fromId }: Omit<DataFetching, 'itemId'>,
-  ): Observable<{ id: string, value: string, user?: UserBaseWithId }[]> {
-    switch (filter) {
-      case 'Users':
-        return this.getGroupDescendantsService.getUserDescendants(groupId, { limit: pageSize, fromId })
-          .pipe(map(users => users.map(user => ({ id: user.id, value: formatUser(user.user), user: { ...user.user, id: user.id } }))));
-      case 'Teams':
-        return this.getGroupDescendantsService.getTeamDescendants(groupId, { limit: pageSize, fromId })
-          .pipe(map(teams => teams.map(team => ({ id: team.id, value: team.name }))));
-      case 'Groups':
-        return this.getGroupChildrenService.getGroupChildren(groupId, [], [], [ 'Team', 'User' ], { limit: pageSize, fromId })
-          .pipe(map(groups => groups.map(group => ({ id: group.id, value: group.name }))));
-    }
-  }
-
-  private getRowsWithProgress({ itemId, groupId, filter, fromId, pageSize }: DataFetching): Observable<DataRow[]> {
-    return forkJoin({
-      rows: this.getRows({ groupId, filter, pageSize, fromId }),
-      progress: this.getProgress({ itemId, groupId, filter, pageSize, fromId }),
-    }).pipe(
-      combineLatestWith(this.columns$.pipe(readyData())),
-      map(([{ rows, progress }, items ]) =>
-        rows
-          .filter(row => progress.find(progress => progress.groupId === row.id)) // only keep rows with a defined progress
-          .map(row => ({
-            header: row.value,
-            id: row.id,
-            user: row.user,
-            data: items.map(item =>
-              progress.find(progress => progress.itemId === item.id && progress.groupId === row.id)
-            ),
-          })),
-      )
-    );
-  }
-
   onFilterChange(typeFilter: TypeFilter): void {
-    if (typeFilter !== this.currentFilter) {
-      this.currentFilter = typeFilter;
+    if (typeFilter !== this.currentFilter()) {
+      this.currentFilter.set(typeFilter);
       const sizes = this.pageSizesForFilter(typeFilter);
       this.datapager.setPageSize(sizes.default, sizes.max);
       this.fetchRows();
@@ -383,83 +254,33 @@ export class GroupProgressGridComponent implements OnChanges, OnDestroy {
 
   onAccessPermissions(): void {
     this.hideProgressDetail();
-    if (!this.progressDataDialog) throw new Error('Unexpected: progress data dialog');
-    if (!this.itemData) throw new Error('Unexpected: missed item data');
-    if (!this.sourceGroup) throw new Error('Unexpected: missed source group');
+    const progressDataDialog = this.progressDataDialog();
+    if (!progressDataDialog) throw new Error('Unexpected: progress data dialog');
+    const sourceGroup = this.sourceGroup();
+    if (!sourceGroup) throw new Error('Unexpected: missed source group');
     this.dialogService.open<boolean, PermissionsEditDialogParams>(PermissionsEditDialogComponent, {
       data: {
-        currentUserPermissions: this.itemData.item.permissions,
-        item: this.progressDataDialog.item,
-        group: this.progressDataDialog.group,
-        sourceGroup: this.sourceGroup,
-        permReceiverName: this.progressDataDialog.groupName,
-        permGiverName: this.progressDataDialog.sourceGroupName,
+        currentUserPermissions: this.itemData().item.permissions,
+        item: progressDataDialog.item,
+        group: progressDataDialog.group,
+        sourceGroup,
+        permReceiverName: progressDataDialog.groupName,
+        permGiverName: progressDataDialog.sourceGroupName,
       },
       disableClose: true,
     }).closed.subscribe(() => {
-      this.progressDataDialog = undefined;
+      this.progressDataDialog.set(undefined);
     });
   }
 
   getObserveLink(row: DataRow): UrlTree | undefined {
-    if (!row.user || !this.itemData) return undefined;
-    return this.itemRouter.url(itemRouteWith(this.itemData.route, { observedGroup: { id: row.id, isUser: true } }));
-  }
-
-  getCSVDownloadTypeByFilter(): 'group' | 'team' | 'user' {
-    switch (this.currentFilter) {
-      case 'Groups':
-        return 'group';
-      case 'Users':
-        return 'user';
-      case 'Teams':
-        return 'team';
-    }
+    if (!row.user) return undefined;
+    return this.itemRouter.url(itemRouteWith(this.itemData().route, { observedGroup: { id: row.id, isUser: true } }));
   }
 
   onCSVExport(): void {
-    if (!this.group || !this.itemData) {
-      throw new Error('Unexpected: input component params is required');
-    }
-
-    const parentItemId = this.itemData.item.id;
-    const downloadDataType = this.getCSVDownloadTypeByFilter();
-
-    this.isCSVDataFetching = true;
-    this.progressCSVService
-      .getCSVData(this.group.id, downloadDataType, [ parentItemId ])
-      .subscribe({
-        next: data => {
-          this.isCSVDataFetching = false;
-          downloadFile([ data ], `${parentItemId}-${new Date().toDateString()}.csv`, 'text/csv');
-        },
-        error: err => {
-          this.isCSVDataFetching = false;
-          this.actionFeedbackService.unexpectedError();
-          if (!(err instanceof HttpErrorResponse)) throw err;
-        },
-      });
-  }
-
-  private getColumns(itemData: ItemData): Observable<DataColumn[]> {
-    if (!itemData.currentResult?.attemptId) throw new Error('unexpected');
-    return this.getItemChildrenService.get(itemData.item.id, itemData.currentResult.attemptId).pipe(
-      map(items => [
-        {
-          id: itemData.item.id,
-          requiresExplicitEntry: itemData.item.requiresExplicitEntry,
-          title: itemData.item.string.title,
-          type: itemData.item.type,
-          permissions: itemData.item.permissions,
-        },
-        ...items.map(item => ({
-          id: item.id,
-          requiresExplicitEntry: !!item.requiresExplicitEntry,
-          title: item.string.title,
-          type: item.type,
-          permissions: item.permissions,
-        }))
-      ]),
-    );
+    const group = this.group();
+    const itemData = this.itemData();
+    this.csvExportService.export(group.id, itemData.item.id, this.currentFilter());
   }
 }

--- a/src/app/items/containers/group-progress-grid/group-progress-grid.types.ts
+++ b/src/app/items/containers/group-progress-grid/group-progress-grid.types.ts
@@ -1,0 +1,57 @@
+import { UserBaseWithId } from 'src/app/groups/models/user';
+import { ItemType } from 'src/app/items/models/item-type';
+import { ItemCorePerm } from 'src/app/items/models/item-permissions';
+import { RawGroupRoute } from 'src/app/models/routing/group-route';
+import { TypeFilter } from '../../models/composition-filter';
+
+export type Progress = {
+  groupId: string,
+  itemId: string,
+  score: number,
+  timeSpent: number,
+  hintsRequested: number,
+  submissions: number,
+  latestActivityAt: Date | null,
+} & ({
+  type: 'user',
+  validated: boolean,
+} | {
+  type: 'group',
+  validationRate: number,
+});
+
+export interface DataRow {
+  header: string,
+  id: string,
+  user?: UserBaseWithId,
+  data: (Progress|undefined)[],
+}
+
+export interface DataColumn {
+  id: string,
+  requiresExplicitEntry: boolean,
+  title: string|null,
+  type: ItemType,
+  permissions: ItemCorePerm,
+}
+
+export interface DataFetching {
+  groupId: string,
+  itemId: string,
+  filter: TypeFilter,
+  fromId?: string,
+  pageSize: number,
+}
+
+export interface ProgressDataDialog {
+  item: {
+    id: string,
+    requiresExplicitEntry: boolean,
+    string: {
+      title: string | null,
+    },
+  },
+  group: RawGroupRoute,
+  groupName: string,
+  sourceGroupName: string,
+}

--- a/src/app/items/containers/user-progress-details/user-progress-details.component.html
+++ b/src/app/items/containers/user-progress-details/user-progress-details.component.html
@@ -1,96 +1,100 @@
 <div class="container">
-  @if (progress && (progress.latestActivityAt !== null || progress.score > 0)) {
-    <div class="value-section">
-      <i class="ph ph-clock icon"></i>
-      <span class="label" i18n>
-        @if (progress.type === 'group') { avg } time spent:
-      </span>
-      <span class="value">{{ progress.timeSpent | secToDuration | readable }}</span>
-    </div>
-
-    <div class="value-section">
-      <i class="ph ph-lightbulb icon"></i>
-      <span class="label" i18n>
-        @if (progress.type === 'group') { avg } hints requested:
-      </span>
-      <span class="value">{{ progress.hintsRequested }}</span>
-    </div>
-
-    <div class="value-section">
-      <i class="ph ph-hash icon"></i>
-      <span class="label" i18n>
-        @if (progress.type === 'group') { avg } submissions:
-      </span>
-      <span class="value">{{ progress.submissions }}</span>
-    </div>
-
-    @if (progress.latestActivityAt !== null) {
+  @if (progress(); as progress) {
+    @if (progress.latestActivityAt !== null || progress.score > 0) {
       <div class="value-section">
-        <i class="ph ph-person-arms-spread icon"></i>
-        <span class="label" i18n>last activity:</span>
-        <span class="value"><alg-relative-time [value]="progress.latestActivityAt!" /></span>
-      </div>
-    }
-
-    @if (progress.type === 'group') {
-      <div class="value-section">
-        <i class="ph ph-star icon"></i>
-        <span class="label" i18n>validation rate:</span>
-        <span class="value">{{ progress.validationRate * 100 }}%</span>
+        <i class="ph ph-clock icon"></i>
+        <span class="label" i18n>
+          @if (progress.type === 'group') { avg } time spent:
+        </span>
+        <span class="value">{{ progress.timeSpent | secToDuration | readable }}</span>
       </div>
 
       <div class="value-section">
-        <i class="ph ph-gauge icon"></i>
-        <span class="label" i18n>average score:</span>
-        <span class="value">{{ progress.score | number:'1.0-0' }}</span>
+        <i class="ph ph-lightbulb icon"></i>
+        <span class="label" i18n>
+          @if (progress.type === 'group') { avg } hints requested:
+        </span>
+        <span class="value">{{ progress.hintsRequested }}</span>
       </div>
-    }
 
-    @if (progress.type === 'user') {
-      <span class="score-section">
-        <alg-score-ring
-          [currentScore]="progress.score"
-          [diameter]="32"
-          [isValidated]="progress.validated"
-        ></alg-score-ring>
-      </span>
-    }
-    @if (progressData && progress.type === 'user' && progressData.colItem.type === 'Task' && progressData.progress.submissions > 0) {
-      @if (currentUser$ | async; as currentUser) {
-        <div
-          class="view-answer-section"
-          i18n-algTooltip algTooltip="You cannot view answers for this content."
-          tooltipStyleClass="secondary"
-          [tooltipDisabled]="(progressData.colItem.permissions | allowsWatchingAnswers) || progressData.progress.groupId === currentUser.groupId"
-        >
-          <a
-            [ngClass]="{ 'disabled': !(progressData.colItem.permissions | allowsWatchingAnswers) && progressData.progress.groupId !== currentUser.groupId }"
-            [routerLink]="progressData.colItem.fullRoute | with: { answer: { best: { id: progress.groupId }}} | url: ['task', 'editor']"
-            icon="ph ph-code-simple"
-            alg-button
-            (click)="onViewAnswer()"
-            i18n
-          >
-            View answer
-          </a>
+      <div class="value-section">
+        <i class="ph ph-hash icon"></i>
+        <span class="label" i18n>
+          @if (progress.type === 'group') { avg } submissions:
+        </span>
+        <span class="value">{{ progress.submissions }}</span>
+      </div>
+
+      @if (progress.latestActivityAt !== null) {
+        <div class="value-section">
+          <i class="ph ph-person-arms-spread icon"></i>
+          <span class="label" i18n>last activity:</span>
+          <span class="value"><alg-relative-time [value]="progress.latestActivityAt!" /></span>
         </div>
       }
-    }
-    @if (progressData) {
-      <div class="button-section">
-        <a
-          alg-button
-          icon="ph ph-clock-counter-clockwise"
-          [routerLink]="progressData.colItem.fullRoute | with: { observedGroup: progressData.rowGroup } | url: ['progress', 'history']"
-          (click)="onViewHistory()"
-          i18n
-        >History</a>
-      </div>
+
+      @if (progress.type === 'group') {
+        <div class="value-section">
+          <i class="ph ph-star icon"></i>
+          <span class="label" i18n>validation rate:</span>
+          <span class="value">{{ progress.validationRate * 100 }}%</span>
+        </div>
+
+        <div class="value-section">
+          <i class="ph ph-gauge icon"></i>
+          <span class="label" i18n>average score:</span>
+          <span class="value">{{ progress.score | number:'1.0-0' }}</span>
+        </div>
+      }
+
+      @if (progress.type === 'user') {
+        <span class="score-section">
+          <alg-score-ring
+            [currentScore]="progress.score"
+            [diameter]="32"
+            [isValidated]="progress.validated"
+          ></alg-score-ring>
+        </span>
+      }
+      @if (progressData(); as progressData) {
+        @if (progress.type === 'user' && progressData.colItem.type === 'Task' && progressData.progress.submissions > 0) {
+          @if (currentUser$ | async; as currentUser) {
+            <div
+              class="view-answer-section"
+              i18n-algTooltip algTooltip="You cannot view answers for this content."
+              tooltipStyleClass="secondary"
+              [tooltipDisabled]="(progressData.colItem.permissions | allowsWatchingAnswers) || progressData.progress.groupId === currentUser.groupId"
+            >
+              <a
+                [class.disabled]="!(progressData.colItem.permissions | allowsWatchingAnswers) && progressData.progress.groupId !== currentUser.groupId"
+                [routerLink]="progressData.colItem.fullRoute | with: { answer: { best: { id: progress.groupId }}} | url: ['task', 'editor']"
+                icon="ph ph-code-simple"
+                alg-button
+                (click)="onViewAnswer()"
+                i18n
+              >
+                View answer
+              </a>
+            </div>
+          }
+        }
+        <div class="button-section">
+          <a
+            alg-button
+            icon="ph ph-clock-counter-clockwise"
+            [routerLink]="progressData.colItem.fullRoute | with: { observedGroup: progressData.rowGroup } | url: ['progress', 'history']"
+            (click)="onViewHistory()"
+            i18n
+          >History</a>
+        </div>
+      }
+    } @else {
+      <span class="not-started" i18n="In progress matrix, explanation when cell is empty">Not started</span>
     }
   } @else {
     <span class="not-started" i18n="In progress matrix, explanation when cell is empty">Not started</span>
   }
-  @if (canEditPermissions) {
+  @if (canEditPermissions()) {
     <div class="button-section">
       <button
         icon="ph-duotone ph-lock"

--- a/src/app/items/containers/user-progress-details/user-progress-details.component.spec.ts
+++ b/src/app/items/containers/user-progress-details/user-progress-details.component.spec.ts
@@ -67,7 +67,7 @@ describe('UserProgressDetailsComponent.onViewHistory', () => {
   });
 
   it('does not dispatch when progressData is missing', () => {
-    component.progressData = undefined;
+    fixture.componentRef.setInput('progressData', undefined);
     store.overrideSelector(fromObservation.selectObservedGroupInfo, observedGroup);
     store.refreshState();
 
@@ -77,7 +77,7 @@ describe('UserProgressDetailsComponent.onViewHistory', () => {
   });
 
   it('dispatches with a generic fallback label when observedGroupInfo is null', () => {
-    component.progressData = fakeProgressData;
+    fixture.componentRef.setInput('progressData', fakeProgressData);
     store.overrideSelector(fromObservation.selectObservedGroupInfo, null);
     store.refreshState();
     fixture.detectChanges();
@@ -95,7 +95,7 @@ describe('UserProgressDetailsComponent.onViewHistory', () => {
   });
 
   it('dispatches registerBackLink with router.url and the observed group name', () => {
-    component.progressData = fakeProgressData;
+    fixture.componentRef.setInput('progressData', fakeProgressData);
     store.overrideSelector(fromObservation.selectObservedGroupInfo, observedGroup);
     store.refreshState();
     fixture.detectChanges();

--- a/src/app/items/containers/user-progress-details/user-progress-details.component.ts
+++ b/src/app/items/containers/user-progress-details/user-progress-details.component.ts
@@ -1,5 +1,4 @@
-import { SimpleChanges, inject, ChangeDetectionStrategy } from '@angular/core';
-import { Component, EventEmitter, Input, Output, OnChanges } from '@angular/core';
+import { Component, computed, inject, input, output } from '@angular/core';
 import { FullItemRoute } from 'src/app/models/routing/item-route';
 import { ItemPermWithWatch } from 'src/app/items/models/item-watch-permission';
 import { UserSessionService } from 'src/app/services/user-session.service';
@@ -9,10 +8,10 @@ import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
 import { ItemRouteWithExtraPipe } from 'src/app/pipes/itemRoute';
 import { Router, RouterLink } from '@angular/router';
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
-import { NgClass, AsyncPipe, DecimalPipe } from '@angular/common';
+import { AsyncPipe, DecimalPipe } from '@angular/common';
 import { ItemType } from 'src/app/items/models/item-type';
 import { RelativeTimeComponent } from 'src/app/ui-components/relative-time/relative-time.component';
-import { Progress } from 'src/app/items/containers/group-progress-grid/group-progress-grid.component';
+import { Progress } from 'src/app/items/containers/group-progress-grid/group-progress-grid.types';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directive';
 import { Store } from '@ngrx/store';
@@ -36,10 +35,8 @@ export interface ProgressData {
   selector: 'alg-user-progress-details',
   templateUrl: './user-progress-details.component.html',
   styleUrls: [ './user-progress-details.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ScoreRingComponent,
-    NgClass,
     RouterLink,
     AsyncPipe,
     ItemRouteWithExtraPipe,
@@ -53,26 +50,19 @@ export interface ProgressData {
     TooltipDirective,
   ]
 })
-export class UserProgressDetailsComponent implements OnChanges {
+export class UserProgressDetailsComponent {
   private userSessionService = inject(UserSessionService);
   private store = inject(Store);
   private router = inject(Router);
 
-  @Input() progressData?: ProgressData;
-  @Input() canEditPermissions?: boolean;
+  readonly progressData = input<ProgressData>();
+  readonly canEditPermissions = input<boolean>();
+  readonly editPermissions = output<void>();
 
-  @Output() editPermissions = new EventEmitter<void>();
-
-  progress?: ProgressData['progress'];
+  readonly progress = computed(() => this.progressData()?.progress);
 
   currentUser$ = this.userSessionService.userProfile$;
   private readonly observedGroupInfo = this.store.selectSignal(fromObservation.selectObservedGroupInfo);
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.progressData && !changes.progressData.firstChange) {
-      this.progress = this.progressData?.progress;
-    }
-  }
 
   onViewAnswer(): void {
     this.store.dispatch(fromItemContent.sourcePageActions.registerBackLink({
@@ -84,7 +74,8 @@ export class UserProgressDetailsComponent implements OnChanges {
   }
 
   onViewHistory(): void {
-    if (!this.progressData) return;
+    const progressData = this.progressData();
+    if (!progressData) return;
     const observedGroup = this.observedGroupInfo();
     // Always register, even when observation info hasn't resolved yet: the History link's
     // routerLink navigates regardless of this dispatch, so silently skipping registration


### PR DESCRIPTION
## Summary
- Modernize `chapter-group-progress`, `group-progress-grid`, and `user-progress-details` to Angular 22 patterns (signal inputs/outputs, `toObservable`, `computed()`, split helpers).
- Batch 17 from `.cursor/plans/modernize-batch-17-progress-grid.md`.
- Two commits: migrate leaf components first, then grid split.

## Scope
- **chapter-group-progress** — `input.required<ItemData>()`, `DestroyRef` teardown
- **user-progress-details** — fix `firstChange` quirk: `progress = computed(() => progressData()?.progress)`; spec uses `setInput`
- **group-progress-grid** — signals for filter/overlay/CSV state; split into `group-progress-grid-columns.ts`, `-data.ts`, `-csv-export.service.ts`, `-menu-positions.ts`, `-types.ts` (286-line component)

## Risks / manual checks
- Overlay on first **and** subsequent cell clicks must show correct data (replaces old `firstChange` skip)
- Strong e2e: `group-progress-grid.spec.ts`, `user-progress-tooltip.spec.ts`, `progress-history-back-link.spec.ts`
- Manual smoke: filter Users/Teams/Groups, cell overlay, load more, refresh, CSV export

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-17/en/

## Verification
- [x] `npm run lint`
- [x] `user-progress-details` unit tests (3/3)
- [x] `ng build algorea --configuration=en`
- [x] CI E2E (progress grid, tooltip, back-link)
- [x] Manual smoke (see above)