### PR TITLE
Modernize Angular components (batch 18).

### DIFF
--- a/src/app/items/containers/item-permissions/item-permissions.component.html
+++ b/src/app/items/containers/item-permissions/item-permissions.component.html
@@ -1,167 +1,167 @@
-@if (observedGroup) {
-  @if (itemData) {
-    <div class="header" (click)="collapsed = !collapsed">
-      <i class="header-icon ph-duotone ph-lock-open"></i>
-      <div class="header-title">
-        @if (watchedGroupPermissions) {
-          <ng-container label-section i18n>
-            «{{ observedGroup.name }}»
-            {(watchedGroupPermissions | allowsViewingContent).toString(), select, true {can} other {may not be able to}}
-            access this
-            {itemData.item.type, select, Skill {skill} other {activity}}
-          </ng-container>
-        } @else {
-          <ng-container i18n>
-            You cannot watch other users progress on this {itemData.item.type, select, Skill {skill} other {activity}}
-          </ng-container>
-        }
-      </div>
-      <i class="header-arrow-icon ph" [ngClass]="{ 'ph-caret-down': collapsed, 'ph-caret-up': !collapsed }"></i>
-    </div>
+<div class="header" (click)="collapsed.set(!collapsed())">
+  <i class="header-icon ph-duotone ph-lock-open"></i>
+  <div class="header-title">
+    @if (watchedGroupPermissions(); as permissions) {
+      <ng-container label-section i18n>
+        «{{ observedGroup().name }}»
+        {(permissions | allowsViewingContent).toString(), select, true {can} other {may not be able to}}
+        access this
+        {itemData().item.type, select, Skill {skill} other {activity}}
+      </ng-container>
+    } @else {
+      <ng-container i18n>
+        You cannot watch other users progress on this {itemData().item.type, select, Skill {skill} other {activity}}
+      </ng-container>
+    }
+  </div>
+  <i
+    class="header-arrow-icon ph"
+    [class.ph-caret-down]="collapsed()"
+    [class.ph-caret-up]="!collapsed()"
+  ></i>
+</div>
 
-    @if (!collapsed) {
-      <div class="content">
-        @if (watchedGroupPermissions) {
-          @if (!(watchedGroupPermissions | allowsViewingInfo)) {
-            <div class="no-access" i18n>
-              This {(observedGroup.route | isUser).toString(), select, true {user} other {group}} didn't directly obtain rights to view this content.
-            </div>
-          }
-          @if ((watchedGroupPermissions | allowsViewingInfo) && !(watchedGroupPermissions | allowsViewingContent)) {
-            <div class="no-access" i18n>
-              This {(observedGroup.route | isUser).toString(), select, true {user} other {group}}
-              can view the title, subtitle and description of this {itemData.item.type, select, Skill {skill} other {activity}}
-              but may not be able to {itemData.item.type, select, Task {view its content} other {view what it contains}}.
-            </div>
-          }
-        } @else {
-          <div class="no-access" i18n>
-            You cannot watch other users' activity on this content
-          </div>
-        }
-        @if (watchedGroupPermissions) {
-          @if (watchedGroupPermissions.isOwner) {
-            <div class="permission-indicator-section">
-              <alg-section-header
-                i18n-caption caption="Is owner"
-                icon="ph-duotone ph-user"
-                theme="warning"
-              >
-                <ng-template #content>
-                  <span class="alg-text-small alg-text-secondary" i18n>Yes</span>
-                </ng-template>
-              </alg-section-header>
-            </div>
-          } @else {
-            <div class="permission-indicator-section">
-              <alg-section-header
-                i18n-caption caption="Can view"
-                icon="ph-duotone ph-eyeglasses"
-                theme="warning"
-              >
-                <ng-template #content>
-                  <alg-progress-select
-                    [collapsed]="true"
-                    [(ngModel)]="watchedGroupPermissions.canView"
-                    [values]="canViewValues"
-                    theme="warning"
-                  >
-                    @if (observedGroup.currentUserCanGrantAccess && (itemData.item.permissions | allowsGrantingContentView) && !(watchedGroupPermissions | allowsViewingInfo)) {
-                      <span header-section>
-                        <button
-                          class="size-s stroke accent-dark grant-access-button"
-                          type="button"
-                          icon="ph ph-plus"
-                          (click)="grantViewContentAccess()"
-                          [disabled]="updateInProcess"
-                          alg-button
-                          i18n
-                        >Grant content access</button>
-                      </span>
-                    }
-                  </alg-progress-select>
-                </ng-template>
-              </alg-section-header>
-            </div>
-            @if (watchedGroupPermissions | allowsViewingInfo) {
-              <div class="permission-indicator-section">
-                <alg-section-header
-                  i18n-caption caption="Can grant view"
-                  icon="ph-duotone ph-key"
-                  theme="warning"
-                >
-                  <ng-template #content>
-                    <alg-progress-select
-                      [collapsed]="true"
-                      [(ngModel)]="watchedGroupPermissions.canGrantView"
-                      [values]="canGrantViewValues"
-                      theme="warning"
-                    ></alg-progress-select>
-                  </ng-template>
-                </alg-section-header>
-              </div>
-            }
-            @if (watchedGroupPermissions | allowsViewingContent) {
-              <div class="permission-indicator-section">
-                <alg-section-header
-                  i18n-caption caption="Can watch"
-                  icon="ph-duotone ph-binoculars"
-                  theme="warning"
-                >
-                  <ng-template #content>
-                    <alg-progress-select
-                      [collapsed]="true"
-                      [(ngModel)]="watchedGroupPermissions.canWatch"
-                      [values]="canWatchValues"
-                      theme="warning"
-                    ></alg-progress-select>
-                  </ng-template>
-                </alg-section-header>
-              </div>
-              <div class="permission-indicator-section">
-                <alg-section-header
-                  i18n-caption caption="Can edit"
-                  icon="ph-duotone ph-pencil"
-                  theme="warning"
-                >
-                  <ng-template #content>
-                    <alg-progress-select
-                      [collapsed]="true"
-                      [(ngModel)]="watchedGroupPermissions.canEdit"
-                      [values]="canEditValues"
-                      theme="warning"
-                    ></alg-progress-select>
-                  </ng-template>
-                </alg-section-header>
-              </div>
-            }
-          }
-        }
-      </div>
-      <div class="footer">
-        @if (!(observedGroup.route | isUser)) {
-          <div class="footer-caption" i18n>
-            Note that some members or sub-groups of this group may have obtained additional access rights on this {itemData.item.type, select, Skill {skill} other {activity}}.
-          </div>
-        }
-        @if (itemData.item.permissions) {
-          <span
-            class="give-access-button"
-            [algTooltip]="lockEdit | i18nSelect : lockEditTooltipCaptions"
-            tooltipPosition="bottom"
-            [tooltipDisabled]="!lockEdit"
-          >
-            <button
-              alg-button
-              type="button"
-              class="only-caption accent-dark"
-              [disabled]="lockEdit"
-              (click)="openPermissionsDialog()"
-              i18n
-            >Edit permissions</button>
-          </span>
-        }
+@if (!collapsed()) {
+  <div class="content">
+    @if (watchedGroupPermissions(); as permissions) {
+      @if (!(permissions | allowsViewingInfo)) {
+        <div class="no-access" i18n>
+          This {(observedGroup().route | isUser).toString(), select, true {user} other {group}} didn't directly obtain rights to view this content.
+        </div>
+      }
+      @if ((permissions | allowsViewingInfo) && !(permissions | allowsViewingContent)) {
+        <div class="no-access" i18n>
+          This {(observedGroup().route | isUser).toString(), select, true {user} other {group}}
+          can view the title, subtitle and description of this {itemData().item.type, select, Skill {skill} other {activity}}
+          but may not be able to {itemData().item.type, select, Task {view its content} other {view what it contains}}.
+        </div>
+      }
+    } @else {
+      <div class="no-access" i18n>
+        You cannot watch other users' activity on this content
       </div>
     }
-  }
+    @if (watchedGroupPermissions(); as permissions) {
+      @if (permissions.isOwner) {
+        <div class="permission-indicator-section">
+          <alg-section-header
+            i18n-caption caption="Is owner"
+            icon="ph-duotone ph-user"
+            theme="warning"
+          >
+            <ng-template #content>
+              <span class="alg-text-small alg-text-secondary" i18n>Yes</span>
+            </ng-template>
+          </alg-section-header>
+        </div>
+      } @else {
+        <div class="permission-indicator-section">
+          <alg-section-header
+            i18n-caption caption="Can view"
+            icon="ph-duotone ph-eyeglasses"
+            theme="warning"
+          >
+            <ng-template #content>
+              <alg-progress-select
+                [collapsed]="true"
+                [ngModel]="permissions.canView"
+                [values]="canViewValues"
+                theme="warning"
+              >
+                @if (observedGroup().currentUserCanGrantAccess && (itemData().item.permissions | allowsGrantingContentView) && !(permissions | allowsViewingInfo)) {
+                  <span header-section>
+                    <button
+                      class="size-s stroke accent-dark grant-access-button"
+                      type="button"
+                      icon="ph ph-plus"
+                      (click)="grantViewContentAccess()"
+                      [disabled]="updateInProcess()"
+                      alg-button
+                      i18n
+                    >Grant content access</button>
+                  </span>
+                }
+              </alg-progress-select>
+            </ng-template>
+          </alg-section-header>
+        </div>
+        @if (permissions | allowsViewingInfo) {
+          <div class="permission-indicator-section">
+            <alg-section-header
+              i18n-caption caption="Can grant view"
+              icon="ph-duotone ph-key"
+              theme="warning"
+            >
+              <ng-template #content>
+                <alg-progress-select
+                  [collapsed]="true"
+                  [ngModel]="permissions.canGrantView"
+                  [values]="canGrantViewValues"
+                  theme="warning"
+                ></alg-progress-select>
+              </ng-template>
+            </alg-section-header>
+          </div>
+        }
+        @if (permissions | allowsViewingContent) {
+          <div class="permission-indicator-section">
+            <alg-section-header
+              i18n-caption caption="Can watch"
+              icon="ph-duotone ph-binoculars"
+              theme="warning"
+            >
+              <ng-template #content>
+                <alg-progress-select
+                  [collapsed]="true"
+                  [ngModel]="permissions.canWatch"
+                  [values]="canWatchValues"
+                  theme="warning"
+                ></alg-progress-select>
+              </ng-template>
+            </alg-section-header>
+          </div>
+          <div class="permission-indicator-section">
+            <alg-section-header
+              i18n-caption caption="Can edit"
+              icon="ph-duotone ph-pencil"
+              theme="warning"
+            >
+              <ng-template #content>
+                <alg-progress-select
+                  [collapsed]="true"
+                  [ngModel]="permissions.canEdit"
+                  [values]="canEditValues"
+                  theme="warning"
+                ></alg-progress-select>
+              </ng-template>
+            </alg-section-header>
+          </div>
+        }
+      }
+    }
+  </div>
+  <div class="footer">
+    @if (!(observedGroup().route | isUser)) {
+      <div class="footer-caption" i18n>
+        Note that some members or sub-groups of this group may have obtained additional access rights on this {itemData().item.type, select, Skill {skill} other {activity}}.
+      </div>
+    }
+    @if (itemData().item.permissions) {
+      <span
+        class="give-access-button"
+        [algTooltip]="lockEdit() | i18nSelect : lockEditTooltipCaptions"
+        tooltipPosition="bottom"
+        [tooltipDisabled]="!lockEdit()"
+      >
+        <button
+          alg-button
+          type="button"
+          class="only-caption accent-dark"
+          [disabled]="lockEdit()"
+          (click)="openPermissionsDialog()"
+          i18n
+        >Edit permissions</button>
+      </span>
+    }
+  </div>
 }

--- a/src/app/items/containers/item-permissions/item-permissions.component.ts
+++ b/src/app/items/containers/item-permissions/item-permissions.component.ts
@@ -1,4 +1,5 @@
-import { Component, EventEmitter, inject, Input, OnChanges, Output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ItemData } from '../../models/item-data';
 import {
   ProgressSelectValue,
@@ -18,7 +19,7 @@ import {
 } from '../permissions-edit-dialog/permissions-edit-dialog.component';
 import { FormsModule } from '@angular/forms';
 import { SectionHeaderComponent } from 'src/app/ui-components/section-header/section-header.component';
-import { I18nSelectPipe, NgClass } from '@angular/common';
+import { I18nSelectPipe } from '@angular/common';
 import { RawGroupRoute } from 'src/app/models/routing/group-route';
 import { GroupIsUserPipe } from 'src/app/pipes/groupIsUser';
 import { AllowsGrantingContentViewItemPipe } from 'src/app/items/models/item-grant-view-permission';
@@ -34,7 +35,6 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
   selector: 'alg-item-permissions',
   templateUrl: './item-permissions.component.html',
   styleUrls: [ './item-permissions.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     SectionHeaderComponent,
     ProgressSelectComponent,
@@ -42,65 +42,67 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
     I18nSelectPipe,
     AllowsViewingItemContentPipe,
     AllowsViewingItemInfoPipe,
-    NgClass,
     GroupIsUserPipe,
     AllowsGrantingContentViewItemPipe,
     ButtonComponent,
     TooltipDirective,
   ]
 })
-export class ItemPermissionsComponent implements OnChanges {
+export class ItemPermissionsComponent {
   private groupPermissionsService = inject(GroupPermissionsService);
   private actionFeedbackService = inject(ActionFeedbackService);
   private currentContentService = inject(CurrentContentService);
-
-  @Output() changed = new EventEmitter<void>();
-
-  @Input() itemData?: ItemData;
-  @Input() observedGroup?: { route: RawGroupRoute, name: string, currentUserCanGrantAccess: boolean };
-
   private dialogService = inject(Dialog);
+  private destroyRef = inject(DestroyRef);
+
+  itemData = input.required<ItemData>();
+  observedGroup = input.required<{ route: RawGroupRoute, name: string, currentUserCanGrantAccess: boolean }>();
+  changed = output<void>();
 
   canViewValues: ProgressSelectValue<string>[] = generateCanViewValues('Groups');
   canGrantViewValues: ProgressSelectValue<string>[] = generateCanGrantViewValues('Groups');
   canWatchValues: ProgressSelectValue<string>[] = generateCanWatchValues('Groups');
   canEditValues: ProgressSelectValue<string>[] = generateCanEditValues('Groups');
-  watchedGroupPermissions?: ItemCorePerm & ItemOwnerPerm & ItemSessionPerm;
-  lockEdit?: 'content' | 'group' | 'contentGroup';
-  collapsed = true;
+  collapsed = signal(true);
+  updateInProcess = signal(false);
   lockEditTooltipCaptions = {
     content: $localize`You are not allowed to give permissions on this content`,
     group: $localize`You are not allowed to give permissions to this group`,
     contentGroup: $localize`You are not allowed to give permissions on this content and to this group`,
   };
-  updateInProcess = false;
 
-  ngOnChanges(): void {
-    this.watchedGroupPermissions = this.itemData?.item?.watchedGroup?.permissions ? {
-      ...this.itemData.item.watchedGroup.permissions,
+  protected readonly watchedGroupPermissions = computed((): (ItemCorePerm & ItemOwnerPerm & ItemSessionPerm) | undefined => {
+    const itemData = this.itemData();
+    return itemData.item?.watchedGroup?.permissions ? {
+      ...itemData.item.watchedGroup.permissions,
       canMakeSessionOfficial: false,
     } : undefined;
+  });
 
-    const currentUserCanGrantAccess = this.observedGroup?.currentUserCanGrantAccess;
-    const currentUserCanGivePermissions = this.itemData && allowsGivingPermToItem(this.itemData.item.permissions);
+  protected readonly lockEdit = computed((): 'content' | 'group' | 'contentGroup' | undefined => {
+    const observedGroup = this.observedGroup();
+    const itemData = this.itemData();
+    const currentUserCanGrantAccess = observedGroup.currentUserCanGrantAccess;
+    const currentUserCanGivePermissions = allowsGivingPermToItem(itemData.item.permissions);
 
-    this.lockEdit = currentUserCanGrantAccess && !currentUserCanGivePermissions ? 'content' :
-      !currentUserCanGrantAccess && currentUserCanGivePermissions ? 'group' :
-        !currentUserCanGrantAccess && !currentUserCanGivePermissions ? 'contentGroup' : undefined;
-  }
+    if (currentUserCanGrantAccess && !currentUserCanGivePermissions) return 'content';
+    if (!currentUserCanGrantAccess && currentUserCanGivePermissions) return 'group';
+    if (!currentUserCanGrantAccess && !currentUserCanGivePermissions) return 'contentGroup';
+    return undefined;
+  });
 
   openPermissionsDialog(): void {
-    if (!this.itemData) throw new Error('Unexpected: missed item data');
-    if (!this.observedGroup) throw new Error('Unexpected: missed observed group');
     this.dialogService.open<boolean, PermissionsEditDialogParams>(PermissionsEditDialogComponent, {
       data: {
-        currentUserPermissions: this.itemData.item.permissions,
-        item: this.itemData.item,
-        group: this.observedGroup.route,
-        permReceiverName: this.observedGroup.name,
+        currentUserPermissions: this.itemData().item.permissions,
+        item: this.itemData().item,
+        group: this.observedGroup().route,
+        permReceiverName: this.observedGroup().name,
       },
       disableClose: true,
-    }).closed.subscribe(changed => {
+    }).closed.pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(changed => {
       if (changed) {
         this.changed.emit();
       }
@@ -108,12 +110,10 @@ export class ItemPermissionsComponent implements OnChanges {
   }
 
   grantViewContentAccess(): void {
-    const groupId = this.observedGroup?.route.id;
-    if (!groupId) throw new Error('Unexpected: The group id is not provided');
-    const itemId = this.itemData?.item.id;
-    if (!itemId) throw new Error('Unexpected: The item id is not provided');
+    const groupId = this.observedGroup().route.id;
+    const itemId = this.itemData().item.id;
 
-    this.updateInProcess = true;
+    this.updateInProcess.set(true);
     this.groupPermissionsService.updatePermissions(
       groupId,
       groupId,
@@ -122,13 +122,13 @@ export class ItemPermissionsComponent implements OnChanges {
     )
       .subscribe({
         next: () => {
-          this.updateInProcess = false;
+          this.updateInProcess.set(false);
           this.actionFeedbackService.success($localize`:@@permissionsUpdated:Permissions successfully updated.`);
           this.changed.emit();
           this.currentContentService.forceNavMenuReload();
         },
         error: err => {
-          this.updateInProcess = false;
+          this.updateInProcess.set(false);
           this.actionFeedbackService.unexpectedError();
           this.currentContentService.forceNavMenuReload();
           if (!(err instanceof HttpErrorResponse)) throw err;

--- a/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.html
+++ b/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.html
@@ -2,13 +2,13 @@
   <form [formGroup]="form">
     <div class="container">
       <div class="controls-container">
-        @if (requiresExplicitEntry) {
+        @if (requiresExplicitEntry()) {
           <alg-collapsible-section
             class="header-with-padding-left"
             i18n-header header="Can enter"
             icon="ph-duotone ph-door"
-            [collapsible]="!canEnterWarningMessage"
-            [errorMessage]="canEnterWarningMessage"
+            [collapsible]="!canEnterWarningMessage()"
+            [errorMessage]="canEnterWarningMessage()"
             messageStyleClass="warning message-with-bottom-margin"
           >
             <ng-template #content let-collapsed>
@@ -18,7 +18,7 @@
                 icon="fa fa-door-open"
                 formControlName="canEnterEnabled"
                 [collapsed]="collapsed"
-                [disabledTooltip]="permissionsDialogData.canEnterDisabledTooltip ?? []"
+                [disabledTooltip]="permissionsDialogData().canEnterDisabledTooltip ?? []"
               >
                 <ng-template #label i18n>
                   Whether the users with 'info' view permission are allowed to enter this activity.
@@ -49,7 +49,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canView"
-              [values]="permissionsDialogData.canViewValues"
+              [values]="permissionsDialogData().canViewValues"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
@@ -59,7 +59,7 @@
           icon="fa fa-door-open"
           [(value)]="permissions.can_enter_from"
         >
-          <ng-template #label i18n>{{targetTypeString}} may enter this item (a contest or time-limited chapter)</ng-template>
+          <ng-template #label i18n>{{targetTypeString()}} may enter this item (a contest or time-limited chapter)</ng-template>
         </alg-switch-field>-->
 
         <alg-collapsible-section
@@ -72,7 +72,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canGrantView"
-              [values]="permissionsDialogData.canGrantViewValues"
+              [values]="permissionsDialogData().canGrantViewValues"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
@@ -87,7 +87,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canWatch"
-              [values]="permissionsDialogData.canWatchValues"
+              [values]="permissionsDialogData().canWatchValues"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
@@ -102,7 +102,7 @@
             <alg-progress-select
               [collapsed]="collapsed"
               formControlName="canEdit"
-              [values]="permissionsDialogData.canEditValues"
+              [values]="permissionsDialogData().canEditValues"
             ></alg-progress-select>
           </ng-template>
         </alg-collapsible-section>
@@ -117,11 +117,11 @@
             <alg-switch-field
               [collapsed]="collapsed"
               formControlName="canMakeSessionOfficial"
-              [disabledTooltip]="permissionsDialogData.canMakeSessionOfficialDisabledTooltip ?? []"
+              [disabledTooltip]="permissionsDialogData().canMakeSessionOfficialDisabledTooltip ?? []"
             >
               <ng-template #label>
                 <span i18n>
-                  {{ targetTypeString }} may attach official sessions to this item,
+                  {{ targetTypeString() }} may attach official sessions to this item,
                   that will be visible to everyone in the content tab of the item
                 </span>
               </ng-template>
@@ -139,11 +139,11 @@
             <alg-switch-field
               [collapsed]="collapsed"
               formControlName="isOwner"
-              [disabledTooltip]="permissionsDialogData.isOwnerDisabledTooltip ?? []"
+              [disabledTooltip]="permissionsDialogData().isOwnerDisabledTooltip ?? []"
             >
               <ng-template #label>
                 <span i18n>
-                  {{ targetTypeString }} owns this item. This means they get the maximum access in all categories above, and may also delete this item.
+                  {{ targetTypeString() }} owns this item. This means they get the maximum access in all categories above, and may also delete this item.
                 </span>
               </ng-template>
             </alg-switch-field>
@@ -162,7 +162,7 @@
         <button
           icon="ph-bold ph-check"
           (click)="onAccept()"
-          [disabled]="!form.dirty || form.invalid || form.disabled || acceptButtonDisabled"
+          [disabled]="!form.dirty || form.invalid || form.disabled || acceptButtonDisabled()"
           alg-button
           i18n
         >Proceed</button>

--- a/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.ts
+++ b/src/app/items/containers/permissions-edit-dialog-form/permissions-edit-form.component.ts
@@ -1,7 +1,7 @@
 import {
-  ChangeDetectionStrategy, Component, EventEmitter, input, Input, OnChanges, OnDestroy, Output, SimpleChanges,
-  inject,
+  Component, computed, DestroyRef, inject, input, output, signal,
 } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { UntypedFormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { generateValues, getTargetTypeString, PermissionsDialogData } from '../../models/permissions-texts';
 import { GroupComputedPermissions, GroupPermissions } from 'src/app/data-access/group-permissions.service';
@@ -23,13 +23,19 @@ import { CanEnterComponent, CanEnterValue } from 'src/app/ui-components/collapsi
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 
 // eslint-disable-next-line max-len
-const canEnterWarningMessage = $localize`As the group or user has currently "can view >= content" permission, the configured entering times have no effect, the group or user will be able to enter the activity at any time the activity allows it.`;
+const canEnterWarningText = $localize`As the group or user has currently "can view >= content" permission, the configured entering times have no effect, the group or user will be able to enter the activity at any time the activity allows it.`;
+
+const emptyPermissionsDialogData: PermissionsDialogData = {
+  canViewValues: [],
+  canGrantViewValues: [],
+  canEditValues: [],
+  canWatchValues: [],
+};
 
 @Component({
   selector: 'alg-permissions-edit-form',
   templateUrl: 'permissions-edit-form.component.html',
   styleUrls: [ 'permissions-edit-form.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     FormsModule,
     ReactiveFormsModule,
@@ -41,27 +47,22 @@ const canEnterWarningMessage = $localize`As the group or user has currently "can
     ButtonComponent,
   ]
 })
-export class PermissionsEditFormComponent implements OnDestroy, OnChanges {
+export class PermissionsEditFormComponent {
   private fb = inject(UntypedFormBuilder);
+  private destroyRef = inject(DestroyRef);
 
-  @Input() permissions?: GroupPermissions;
-  @Input() computedPermissions?: GroupComputedPermissions;
+  permissions = input<GroupPermissions>();
+  computedPermissions = input<GroupComputedPermissions>();
   giverPermissions = input.required<ItemCorePerm>();
-  @Input() targetType: TypeFilter = 'Users';
-  @Input() acceptButtonDisabled = false;
-  @Input() requiresExplicitEntry = false;
-  @Output() save = new EventEmitter<Partial<GroupPermissions>>();
-  @Output() cancel = new EventEmitter<void>();
+  targetType = input<TypeFilter>('Users');
+  acceptButtonDisabled = input(false);
+  requiresExplicitEntry = input(false);
+  save = output<Partial<GroupPermissions>>();
+  cancel = output<void>();
 
-  targetTypeString = '';
-  canEnterWarningMessage?: string;
-
-  permissionsDialogData: PermissionsDialogData = {
-    canViewValues: [],
-    canGrantViewValues: [],
-    canEditValues: [],
-    canWatchValues: [],
-  };
+  protected readonly targetTypeString = computed(() => getTargetTypeString(this.targetType()));
+  protected readonly canEnterWarningMessage = signal<string | undefined>(undefined);
+  protected readonly permissionsDialogData = signal<PermissionsDialogData>(emptyPermissionsDialogData);
 
   form = this.fb.group({
     canEnterEnabled: [ false ],
@@ -75,54 +76,69 @@ export class PermissionsEditFormComponent implements OnDestroy, OnChanges {
   });
 
   private regenerateValues = new Subject<void>();
-  private subscription = merge(
-    this.form.valueChanges,
-    this.regenerateValues.asObservable()
-  ).subscribe(() => {
-    if (this.permissions) {
-      const receiverPermissions = this.form.value as GroupPermissions & { canEnter: CanEnterValue | null };
-      this.permissionsDialogData = generateValues(this.targetType, receiverPermissions, this.giverPermissions());
 
-      if (this.computedPermissions) {
-        this.permissionsDialogData = withComputePermissions(
-          this.permissionsDialogData,
-          this.permissions,
-          receiverPermissions,
-          this.computedPermissions,
-          this.targetType,
+  constructor() {
+    toObservable(computed(() => ({
+      permissions: this.permissions(),
+      giver: this.giverPermissions(),
+    }))).pipe(takeUntilDestroyed()).subscribe(() => this.resetForm());
+
+    toObservable(this.targetType).pipe(takeUntilDestroyed()).subscribe(() => this.regenerateValues.next());
+
+    merge(
+      this.form.valueChanges,
+      this.regenerateValues.asObservable(),
+    ).pipe(takeUntilDestroyed()).subscribe(() => {
+      const permissions = this.permissions();
+      if (permissions) {
+        const receiverPermissions = this.form.value as GroupPermissions & { canEnter: CanEnterValue | null };
+        let dialogData = generateValues(this.targetType(), receiverPermissions, this.giverPermissions());
+
+        const computedPermissions = this.computedPermissions();
+        if (computedPermissions) {
+          dialogData = withComputePermissions(
+            dialogData,
+            permissions,
+            receiverPermissions,
+            computedPermissions,
+            this.targetType(),
+          );
+        }
+
+        this.permissionsDialogData.set(dialogData);
+
+        const { canEnter, canView } = receiverPermissions;
+        this.canEnterWarningMessage.set(
+          canEnter && computedPermissions
+          && (allowsViewingContent(computedPermissions) || allowsViewingContent({ canView }))
+            ? canEnterWarningText
+            : undefined,
         );
       }
+    });
 
-      const { canEnter, canView } = receiverPermissions;
-      this.canEnterWarningMessage = canEnter && this.computedPermissions
-        && (allowsViewingContent(this.computedPermissions) || allowsViewingContent({ canView }))
-        ? canEnterWarningMessage
-        : undefined;
-    }
-  });
-
-  ngOnDestroy(): void {
-    this.subscription.unsubscribe();
-    this.regenerateValues.complete();
+    this.destroyRef.onDestroy(() => {
+      this.regenerateValues.complete();
+    });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    this.targetTypeString = getTargetTypeString(this.targetType);
-    if ((changes.permissions || changes.giverPermissions) && this.permissions) {
-      this.form.setValidators(permissionsConstraintsValidator(this.giverPermissions(), this.targetType));
-      this.form.updateValueAndValidity();
-      this.form.reset({
-        ...this.permissions,
-        ...(this.requiresExplicitEntry ? {
-          canEnterEnabled: !isInfinite(this.permissions.canEnterFrom),
-          canEnter: {
-            canEnterFrom: isInfinite(this.permissions.canEnterFrom) ? new Date() : this.permissions.canEnterFrom,
-            canEnterUntil: isInfinite(this.permissions.canEnterUntil) ? new Date(farFutureDateString) : this.permissions.canEnterUntil,
-          },
-        } : {}),
-      }, { emitEvent: false });
-    }
-    if (changes.targetType) this.regenerateValues.next();
+  private resetForm(): void {
+    const permissions = this.permissions();
+    if (!permissions) return;
+
+    this.form.reset({
+      ...permissions,
+      ...(this.requiresExplicitEntry() ? {
+        canEnterEnabled: !isInfinite(permissions.canEnterFrom),
+        canEnter: {
+          canEnterFrom: isInfinite(permissions.canEnterFrom) ? new Date() : permissions.canEnterFrom,
+          canEnterUntil: isInfinite(permissions.canEnterUntil) ? new Date(farFutureDateString) : permissions.canEnterUntil,
+        },
+      } : {}),
+    }, { emitEvent: false });
+    this.form.setValidators(permissionsConstraintsValidator(this.giverPermissions(), this.targetType()));
+    this.form.updateValueAndValidity({ emitEvent: false });
+    this.regenerateValues.next();
   }
 
   onAccept(): void {
@@ -137,7 +153,7 @@ export class PermissionsEditFormComponent implements OnDestroy, OnChanges {
       canEdit: this.form.get('canEdit')?.value as GroupPermissions['canEdit'],
       canMakeSessionOfficial: this.form.get('canMakeSessionOfficial')?.value as GroupPermissions['canMakeSessionOfficial'],
       isOwner: this.form.get('isOwner')?.value as GroupPermissions['isOwner'],
-      ...(this.requiresExplicitEntry ? canEnterEnabled && canEnter ? {
+      ...(this.requiresExplicitEntry() ? canEnterEnabled && canEnter ? {
         canEnterFrom: canEnter.canEnterFrom,
         canEnterUntil: canEnter.canEnterUntil,
       } : {


### PR DESCRIPTION
## Summary
- Modernize `item-permissions` and `permissions-edit-form` to Angular 22 patterns (signal inputs/outputs, `computed()`, `takeUntilDestroyed()`).
- Batch 18 from `.cursor/plans/modernize-batch-18-permissions.md`.

## Scope
- **item-permissions** — `computed()` for `watchedGroupPermissions`/`lockEdit`; signals for `collapsed`/`updateInProcess`; CDK dialog subscription managed; one-way `[ngModel]` on read-only selects
- **permissions-edit-form** — fix broken `giverPermissions` hybrid: form resets via `toObservable(computed(...))` when `permissions` or `giverPermissions` change; signals for dialog data/warning messages; tightened `resetForm()` emit handling

## Risks / manual checks
- Permission-granting UI — incorrect form resets can silently grant/revoke wrong permissions
- Test both entry points: item page **and** progress grid (`group-progress-grid`)
- E2E: `item-permissions.spec.ts`, `can-enter-permissions.spec.ts`, `edit-permissions-modal.ts`
- Manual matrix: view/grant/watch/edit levels, constraint messages, can-enter switch + date range, save/cancel/reopen, Grant content access spinner

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-18/en/

## Verification
- [x] `npm run lint`
- [x] `ng build algorea --configuration=en`
- [x] CI E2E (item-permissions, can-enter-permissions)
- [x] Manual smoke (both dialog entry points)