### PR TITLE
Modernize Angular components (batch 20).

### DIFF
--- a/e2e/items/item-parameters-validation-criteria.spec.ts
+++ b/e2e/items/item-parameters-validation-criteria.spec.ts
@@ -17,8 +17,8 @@ test('checks edit parameters - validation criteria', async ({ page, createItem, 
     page.goto(`a/${createItem.itemId};p=${rootItemId};pa=0/parameters`),
     itemContentPage.waitForItemResponse(createItem.itemId),
   ]);
-  // `<alg-item-edit-wrapper>` calls `itemForm.disable()` on first change-detection (in `ngOnChanges`)
-  // and only re-enables it once `fetchOtherLanguages` resolves. While the form is disabled the
+  // `<alg-item-edit-wrapper>` disables the form on initial item load and only re-enables it once
+  // `fetchOtherLanguages` resolves. While the form is disabled the floating save button stays
   // floating save button stays disabled even though the form is dirty, and on a slow CI runner the
   // pending `?language_tag=…` request can keep the form disabled longer than the test budget. Wait
   // for that secondary fetch (best-effort) so the form is guaranteed to be enabled before we

--- a/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.html
+++ b/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.html
@@ -1,30 +1,28 @@
-@if (itemData) {
-  @if (itemData.item.permissions | allowsEditingAll) {
-    <form [formGroup]="itemForm">
-      @let defaultLanguageTagValue = itemForm.controls.defaultLanguageTag.getRawValue();
-      <alg-item-all-strings-form
-        [defaultLanguageTag]="defaultLanguageTagValue"
-        [supportedLanguages]="supportedLanguages()"
-        [itemId]="itemData.item.id"
-        [itemSupportedLanguageTags]="itemData.item.supportedLanguageTags"
-        [loadedLanguageTags]="loadedLanguageTags()"
-        [showDescription]="itemData.item.type !== 'Task' && itemData.currentResult !== undefined"
-        formControlName="allStrings"
-        (defaultLanguageEvent)="onDefaultLanguageChange($event)"
-        (languageValueLoaded)="onLanguageValueLoaded($event)"
-      ></alg-item-all-strings-form>
-      <alg-item-parameters-form
-        formControlName="parameters"
-        [itemData]="itemData"
-        [textIdError]="textIdError()"
-        (confirmRemoval)="onConfirmRemoval()"
-      ></alg-item-parameters-form>
-    </form>
+@if (itemData().item.permissions | allowsEditingAll) {
+  <form [formGroup]="itemForm">
+    @let defaultLanguageTagValue = itemForm.controls.defaultLanguageTag.getRawValue();
+    <alg-item-all-strings-form
+      [defaultLanguageTag]="defaultLanguageTagValue"
+      [supportedLanguages]="supportedLanguages()"
+      [itemId]="itemData().item.id"
+      [itemSupportedLanguageTags]="itemData().item.supportedLanguageTags"
+      [loadedLanguageTags]="loadedLanguageTags()"
+      [showDescription]="itemData().item.type !== 'Task' && itemData().currentResult !== undefined"
+      formControlName="allStrings"
+      (defaultLanguageEvent)="onDefaultLanguageChange($event)"
+      (languageValueLoaded)="onLanguageValueLoaded($event)"
+    ></alg-item-all-strings-form>
+    <alg-item-parameters-form
+      formControlName="parameters"
+      [itemData]="itemData()"
+      [textIdError]="textIdError()"
+      (confirmRemoval)="onConfirmRemoval()"
+    ></alg-item-parameters-form>
+  </form>
 
-    @if (itemForm.dirty) {
-      <alg-floating-save [saving]="itemForm.disabled" (save)="save()" (cancel)="onCancel()"></alg-floating-save>
-    }
-  } @else {
-    <alg-error i18n-message message="You do not have the permissions to edit this content."></alg-error>
+  @if (itemForm.dirty) {
+    <alg-floating-save [saving]="itemForm.disabled" (save)="save()" (cancel)="onCancel()"></alg-floating-save>
   }
+} @else {
+  <alg-error i18n-message message="You do not have the permissions to edit this content."></alg-error>
 }

--- a/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.spec.ts
+++ b/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.spec.ts
@@ -186,5 +186,35 @@ describe('ItemEditWrapperComponent – form pristine on load', () => {
       expect(component.itemForm.dirty).toBeTrue();
       expect(component.isDirty()).toBeTrue();
     });
+
+    it('preserves user edits on partial server baseline resync', async () => {
+      const initialItem = buildItem();
+      await loadItem(initialItem);
+      await new Promise(resolve => setTimeout(resolve, 0));
+      fixture.detectChanges();
+      const stringsForm = fixture.debugElement.query(By.directive(ItemAllStringsFormComponent))
+        .componentInstance as ItemAllStringsFormComponent;
+      stringsForm.allStrings.at(0).patchValue({
+        languageTag: 'en',
+        title: 'Changed title',
+        subtitle: 'Sub',
+        description: 'Desc',
+      });
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const serverRefreshedItem = buildItem({
+        string: {
+          ...initialItem.string,
+          description: 'Server updated description',
+        },
+      });
+      fixture.componentRef.setInput('itemData', buildItemData(serverRefreshedItem));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(stringsForm.allStrings.at(0).getRawValue().title).toBe('Changed title');
+      expect(component.itemForm.dirty).toBeTrue();
+    });
   });
 });

--- a/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.ts
+++ b/src/app/items/containers/item-edit-wrapper/item-edit-wrapper.component.ts
@@ -2,14 +2,12 @@ import {
   Component,
   computed,
   inject,
-  Input,
-  OnChanges,
+  input,
   OnDestroy,
   OnInit,
   signal,
-  SimpleChanges,
-  ChangeDetectionStrategy
 } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ItemData } from '../../models/item-data';
 import {
   ValidationErrors,
@@ -24,7 +22,6 @@ import { UpdateItemStringService } from '../../data-access/update-item-string.se
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { Item } from 'src/app/data-access/get-item-by-id.service';
 import { distinctUntilChanged, map, Observable, of, throwError } from 'rxjs';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { HttpErrorResponse } from '@angular/common/http';
 import { PendingChangesComponent } from 'src/app/guards/pending-changes-guard';
 import { PendingChangesService } from 'src/app/services/pending-changes-service';
@@ -57,7 +54,6 @@ import { runItemEditSave } from './item-edit-wrapper-save-flow';
   selector: 'alg-item-edit-wrapper',
   templateUrl: './item-edit-wrapper.component.html',
   styleUrls: [ './item-edit-wrapper.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     FormsModule,
     ReactiveFormsModule,
@@ -68,8 +64,8 @@ import { runItemEditSave } from './item-edit-wrapper-save-flow';
     ItemAllStringsFormComponent,
   ]
 })
-export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, PendingChangesComponent {
-  @Input() itemData?: ItemData;
+export class ItemEditWrapperComponent implements OnInit, OnDestroy, PendingChangesComponent {
+  readonly itemData = input.required<ItemData>();
 
   private store = inject(Store);
   private currentContentService = inject(CurrentContentService);
@@ -99,6 +95,8 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
 
   textIdError = signal<string | null>(null);
 
+  private previousItemData?: ItemData;
+
   constructor() {
     this.itemForm.controls.parameters.valueChanges
       .pipe(
@@ -107,29 +105,26 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
         takeUntilDestroyed(),
       )
       .subscribe(() => this.textIdError.set(null));
+
+    // Full snapshot on item change, partial resync on server-baseline change of the same item,
+    // preserving in-progress user edits (same semantics as the former ngOnChanges).
+    toObservable(this.itemData).pipe(takeUntilDestroyed()).subscribe(itemData => {
+      const prevItem = this.previousItemData?.item;
+      const currItem = itemData.item;
+      const idChanged = prevItem?.id !== currItem.id;
+
+      if (idChanged) {
+        this.applyFullItemSnapshot(currItem);
+      } else if (shouldResyncStringsBaseline(prevItem, currItem)) {
+        this.resyncServerBaseline(currItem);
+      }
+
+      this.previousItemData = itemData;
+    });
   }
 
   ngOnInit(): void {
     this.pendingChangesService.set(this);
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (!this.itemData) return;
-    const itemChange = changes.itemData;
-    if (!itemChange) return;
-
-    const prevItem = (itemChange.previousValue as ItemData | undefined)?.item;
-    const currItem = (itemChange.currentValue as ItemData).item;
-    const idChanged = prevItem?.id !== currItem.id;
-
-    if (idChanged) {
-      this.applyFullItemSnapshot(currItem);
-      return;
-    }
-
-    if (shouldResyncStringsBaseline(prevItem, currItem)) {
-      this.resyncServerBaseline(currItem);
-    }
   }
 
   ngOnDestroy(): void {
@@ -153,15 +148,14 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
     }
     const itemChanges = this.buildItemChanges();
     if (itemChanges === null) return;
-    const id = this.itemData?.item.id;
-    if (!id) throw new Error('Missing ID form');
+    const id = this.itemData().item.id;
 
     runItemEditSave({
       itemId: id,
       initialItem: this.initialItem,
       getAllStrings: () => this.itemForm.controls.allStrings.getRawValue(),
       initialLanguageValues: this.initialLanguageValues(),
-      serverSupportedLanguageTags: this.itemData?.item.supportedLanguageTags ?? [],
+      serverSupportedLanguageTags: this.itemData().item.supportedLanguageTags,
       itemChanges,
       updateItem: changes => this.updateItem(changes),
       updateItemStringService: this.updateItemStringService,
@@ -266,7 +260,7 @@ export class ItemEditWrapperComponent implements OnInit, OnChanges, OnDestroy, P
   private syncFormStateAfterSave(): void {
     syncFormStateAfterSave(
       { itemForm: this.itemForm },
-      this.itemData?.item.supportedLanguageTags ?? [],
+      this.itemData().item.supportedLanguageTags,
       values => this.initialLanguageValues.set(values),
     );
   }


### PR DESCRIPTION
## Summary
- Modernize `item-edit-wrapper` to Angular 22 patterns: `input.required<ItemData>()`, `toObservable()` form sync preserving full-snapshot vs partial-resync semantics.
- Batch 20 from `.cursor/plans/modernize-batch-20-item-edit-wrapper.md`.

## Scope
- Replace `ngOnChanges` with `toObservable(this.itemData)` + `previousItemData` tracking (verbatim hook body)
- Keep `isDirty()` as method for `item-by-id` `@ViewChild` contract
- Keep `PendingChangesService` register/clear and save flow unchanged
- Added unit test for partial server-baseline resync preserving user edits
- Drop `ChangeDetectionStrategy.Eager`

## Risks / manual checks
- **Data-loss risk** if sync semantics drift — e2e: `lost-changes-confirmation.spec.ts`, `item-parameters-validation-criteria.spec.ts`
- Manual smoke: edit parameters, floating save, save → pristine, navigate away (pending changes), partial resync after save, language strings

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-20/en/

## Verification
- [x] `npm run lint`
- [x] `item-edit-wrapper` unit tests (4/4)
- [x] `ng build algorea --configuration=en`
- [x] CI E2E (lost-changes, validation-criteria)
- [x] Manual smoke (see above)