### PR TITLE
Modernize Angular components (batch 15).

### DIFF
--- a/src/app/groups/containers/member-list/member-list-columns.ts
+++ b/src/app/groups/containers/member-list/member-list-columns.ts
@@ -1,0 +1,43 @@
+import { Filter, TypeFilter } from '../group-composition-filter/group-composition-filter.component';
+
+export interface Column {
+  sortable?: boolean,
+  field: string,
+  header: string,
+}
+
+const usersColumns: Column[] = [
+  { field: 'user.login', header: $localize`Name`, sortable: true },
+  { field: 'member_since', header: $localize`Member Since`, sortable: true },
+];
+
+const groupsColumns: Column[] = [
+  { field: 'name', header: $localize`Name`, sortable: true },
+  { field: 'type', header: $localize`Type` },
+  { field: 'userCount', header: $localize`User Count` },
+];
+
+const nameUserCountColumns: Column[] = [
+  { field: 'name', header: $localize`Name`, sortable: true },
+  { field: 'userCount', header: $localize`User Count` },
+];
+
+const descendantUsersColumns: Column[] = [
+  { field: 'user.login', header: $localize`Name` },
+  { field: 'parentGroups', header: $localize`Parent group(s)` },
+];
+
+const descendantTeamsColumns: Column[] = [
+  { field: 'name', header: $localize`Name`, sortable: true },
+  { field: 'parentGroups', header: $localize`Parent group(s)` },
+  { field: 'members', header: $localize`Member(s)` },
+];
+
+export function getColumns(filter: Filter): Column[] {
+  switch (filter.type) {
+    case TypeFilter.Groups: return groupsColumns;
+    case TypeFilter.Sessions: return nameUserCountColumns;
+    case TypeFilter.Teams: return filter.directChildren ? nameUserCountColumns : descendantTeamsColumns;
+    case TypeFilter.Users: return filter.directChildren ? usersColumns : descendantUsersColumns;
+  }
+}

--- a/src/app/groups/containers/member-list/member-list-removal.service.ts
+++ b/src/app/groups/containers/member-list/member-list-removal.service.ts
@@ -1,0 +1,127 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { defer, Observable, of, ReplaySubject } from 'rxjs';
+import { filter, switchMap } from 'rxjs/operators';
+import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
+import { ConfirmationModalService } from 'src/app/services/confirmation-modal.service';
+import { GroupUsersService, parseResults } from '../../data-access/group-users.service';
+import { RemoveGroupService } from '../../data-access/remove-group.service';
+import { RemoveSubgroupService } from '../../data-access/remove-subgroup.service';
+import { GroupChild } from '../../data-access/get-group-children.service';
+import { GroupMembers } from '../../data-access/get-group-members.service';
+import { displayResponseToast } from './user-removal-response-handling';
+import { displayGroupRemovalResponseToast } from './group-removal-response-handling';
+
+type Member = GroupMembers[number];
+
+function getSelectedGroupChildCaptions(selection: GroupChild[]): string {
+  return selection.map(selected => selected.name).join(', ');
+}
+
+export interface MemberListRemovalCallbacks {
+  unselectAll: () => void,
+  fetchRows: () => void,
+  onRemovedGroup: () => void,
+}
+
+@Injectable()
+export class MemberListRemovalService {
+  private groupUsersService = inject(GroupUsersService);
+  private actionFeedbackService = inject(ActionFeedbackService);
+  private confirmationModalService = inject(ConfirmationModalService);
+  private removeGroupService = inject(RemoveGroupService);
+  private removeSubgroupService = inject(RemoveSubgroupService);
+  private destroyRef = inject(DestroyRef);
+
+  removeUsers(
+    groupId: string,
+    selection: Member[],
+    removalInProgress$: ReplaySubject<boolean>,
+    callbacks: MemberListRemovalCallbacks,
+  ): void {
+    if (selection.length === 0) {
+      throw new Error('Unexpected: Missed selected members');
+    }
+
+    const selectedMemberIds = selection.map(member => member.id);
+
+    removalInProgress$.next(true);
+    this.groupUsersService.removeUsers(groupId, selectedMemberIds)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: result => {
+          displayResponseToast(this.actionFeedbackService, parseResults(result));
+          callbacks.unselectAll();
+          callbacks.fetchRows();
+          removalInProgress$.next(false);
+        },
+        error: err => {
+          removalInProgress$.next(false);
+          this.actionFeedbackService.unexpectedError();
+          if (!(err instanceof HttpErrorResponse)) throw err;
+        }
+      });
+  }
+
+  removeGroupsOrSubgroups(
+    selectedGroupChildren: GroupChild[],
+    groupId: string,
+    removalInProgress$: ReplaySubject<boolean>,
+    callbacks: MemberListRemovalCallbacks,
+  ): void {
+    const selectedGroupChildIds = selectedGroupChildren.map(g => g.id);
+    const isSubgroupsEmpty = selectedGroupChildren.every(g => g.isEmpty);
+    const selectedCaptions = getSelectedGroupChildCaptions(selectedGroupChildren);
+
+    removalInProgress$.next(true);
+
+    const confirmRemoveGroup$ = defer(() => this.confirmationModalService.open({
+      message: $localize`Are you sure you want to permanently delete ${selectedCaptions}?
+        This operation cannot be undone.`,
+      acceptIcon: 'ph-bold ph-check',
+      acceptButtonStyleClass: 'danger',
+      messageIconStyleClass: 'ph-duotone ph-warning-circle alg-validation-error',
+    }, { maxWidth: '37.5rem' }).pipe(filter(accepted => !!accepted)));
+
+    const confirmRemoveSubgroups$ = defer(() => this.confirmationModalService.open({
+      message: $localize`By removing ${selectedCaptions} from the group, you may lose
+        manager access to them (if no explicit permission or through other parent group). Are you sure you want to proceed?`,
+      acceptIcon: 'ph-bold ph-check',
+      acceptButtonStyleClass: 'danger',
+      messageIconStyleClass: 'ph-duotone ph-warning-circle alg-validation-error',
+    }, { maxWidth: '37.5rem' }).pipe(filter(accepted => !!accepted)));
+
+    const proceedRemoving$: Observable<boolean | undefined> = isSubgroupsEmpty ? this.confirmationModalService.open({
+      message: selectedGroupChildren.length === 1 ?
+        $localize`Do you also want to delete the group?` :
+        $localize`These groups are all empty. Do you also want to delete them?`,
+      acceptIcon: 'ph-bold ph-check',
+      acceptButtonStyleClass: 'danger',
+      messageIconStyleClass: 'ph-duotone ph-warning-circle alg-validation-error',
+    }).pipe(filter(accepted => accepted !== undefined)) : of(undefined);
+
+    proceedRemoving$.pipe(
+      switchMap(allowToRemoveGroup => (
+        allowToRemoveGroup === true
+          ? confirmRemoveGroup$.pipe(switchMap(() => this.removeGroupService.removeBatch(selectedGroupChildIds)))
+          : confirmRemoveSubgroups$.pipe(switchMap(() => this.removeSubgroupService.removeBatch(groupId, selectedGroupChildIds)))
+      )),
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe({
+      next: response => {
+        displayGroupRemovalResponseToast(this.actionFeedbackService, response);
+        callbacks.unselectAll();
+        callbacks.fetchRows();
+        removalInProgress$.next(false);
+        callbacks.onRemovedGroup();
+      },
+      error: err => {
+        removalInProgress$.next(false);
+        this.actionFeedbackService.unexpectedError();
+        if (!(err instanceof HttpErrorResponse)) throw err;
+      },
+      complete: () => removalInProgress$.next(false)
+    });
+  }
+}

--- a/src/app/groups/containers/member-list/member-list.component.html
+++ b/src/app/groups/containers/member-list/member-list.component.html
@@ -15,7 +15,7 @@
           <ng-container cdkColumnDef="checkbox">
             <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef></th>
             <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
-              @let isSelected = !!(selection | findInArray: rowData);
+              @let isSelected = !!(selection() | findInArray: rowData);
               <input type="checkbox" [checked]="isSelected" (change)="onSelect(rowData)" />
             </td>
           </ng-container>
@@ -62,7 +62,7 @@
           }
           <tr
             class="alg-table-header-tr"
-            [ngClass]="{ 'alg-display-none': !state.isReady || state.data.length === 0 }"
+            [class.alg-display-none]="!state.isReady || state.data.length === 0"
             cdk-header-row
             *cdkHeaderRowDef="displayedColumns()"
           ></tr>
@@ -89,7 +89,7 @@
                 id="select-all-checkbox"
                 data-testid="member-list-select-all"
                 (change)="onSelectAll(data)"
-                [checked]="data.length === selection.length"
+                [checked]="data.length === selection().length"
               />
               <span class="alg-table-footer-select-all" i18n>
               Select all
@@ -101,9 +101,9 @@
             type="button"
             icon="ph ph-trash"
             (click)="onRemove()"
-            [disabled]="(removalInProgress$ | async) || !state.isReady || selection.length === 0"
+            [disabled]="(removalInProgress$ | async) || !state.isReady || selection().length === 0"
           >
-            {currentFilter.type, select, users {Remove} other {Remove from group}}
+            {currentFilter().type, select, users {Remove} other {Remove from group}}
           </button>
         </div>
       }

--- a/src/app/groups/containers/member-list/member-list.component.ts
+++ b/src/app/groups/containers/member-list/member-list.component.ts
@@ -1,41 +1,31 @@
 import {
   Component,
   computed,
-  EventEmitter,
-  Input,
-  OnChanges,
-  OnDestroy,
-  Output,
-  signal,
-  SimpleChanges,
-  ViewChild,
+  DestroyRef,
   inject,
-  ChangeDetectionStrategy
+  input,
+  output,
+  signal,
+  viewChild,
 } from '@angular/core';
-import { defer, Observable, of, ReplaySubject } from 'rxjs';
-import { filter, map, switchMap } from 'rxjs/operators';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { Observable, ReplaySubject } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { GetGroupDescendantsService } from 'src/app/data-access/get-group-descendants.service';
 import { groupRoute, rawGroupRoute, RawGroupRoute } from 'src/app/models/routing/group-route';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { GetGroupChildrenService, GroupChild } from '../../data-access/get-group-children.service';
 import { GetGroupMembersService, GroupMembers } from '../../data-access/get-group-members.service';
-import { GroupUsersService, parseResults } from '../../data-access/group-users.service';
 import { GroupData } from '../../models/group-data';
 import { Filter, GroupCompositionFilterComponent, TypeFilter } from '../group-composition-filter/group-composition-filter.component';
-import { displayResponseToast } from './user-removal-response-handling';
-import { displayGroupRemovalResponseToast } from './group-removal-response-handling';
-import { RemoveSubgroupService } from '../../data-access/remove-subgroup.service';
-import { RemoveGroupService } from '../../data-access/remove-group.service';
 import { FetchState } from 'src/app/utils/state';
 import { DataPager } from 'src/app/utils/data-pager';
-import { HttpErrorResponse } from '@angular/common/http';
 import { UserCaptionPipe } from 'src/app/pipes/userCaption';
 import { GroupLinkPipe } from 'src/app/pipes/groupLink';
 import { RouterLink } from '@angular/router';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
-import { AsyncPipe, DatePipe, NgClass } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
-import { ConfirmationModalService } from 'src/app/services/confirmation-modal.service';
 import {
   CdkCell,
   CdkCellDef,
@@ -53,45 +43,10 @@ import { TableSortDirective } from 'src/app/ui-components/table-sort/table-sort.
 import { SortEvent, TableSortHeaderComponent } from 'src/app/ui-components/table-sort/table-sort-header/table-sort-header.component';
 import { FindInArray } from 'src/app/pipes/findInArray';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
+import { Column, getColumns } from './member-list-columns';
+import { MemberListRemovalService } from './member-list-removal.service';
 
 type Member = GroupMembers[number];
-
-function getSelectedGroupChildCaptions(selection: GroupChild[]): string {
-  return selection.map(selected => selected.name).join(', ');
-}
-
-interface Column {
-  sortable?: boolean,
-  field: string,
-  header: string,
-}
-
-const usersColumns: Column[] = [
-  { field: 'user.login', header: $localize`Name`, sortable: true },
-  { field: 'member_since', header: $localize`Member Since`, sortable: true },
-];
-
-const groupsColumns: Column[] = [
-  { field: 'name', header: $localize`Name`, sortable: true },
-  { field: 'type', header: $localize`Type` },
-  { field: 'userCount', header: $localize`User Count` },
-];
-
-const nameUserCountColumns: Column[] = [
-  { field: 'name', header: $localize`Name`, sortable: true },
-  { field: 'userCount', header: $localize`User Count` },
-];
-
-const descendantUsersColumns: Column[] = [
-  { field: 'user.login', header: $localize`Name` },
-  { field: 'parentGroups', header: $localize`Parent group(s)` },
-];
-
-const descendantTeamsColumns: Column[] = [
-  { field: 'name', header: $localize`Name`, sortable: true },
-  { field: 'parentGroups', header: $localize`Parent group(s)` },
-  { field: 'members', header: $localize`Member(s)` },
-];
 
 const membersLimit = 25;
 
@@ -102,7 +57,7 @@ type Row = (Member|GroupChild|{ login: string, parentGroups: string }|{ name: st
   selector: 'alg-member-list',
   templateUrl: './member-list.component.html',
   styleUrls: [ './member-list.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
+  providers: [ MemberListRemovalService ],
   imports: [
     GroupCompositionFilterComponent,
     ErrorComponent,
@@ -111,7 +66,6 @@ type Row = (Member|GroupChild|{ login: string, parentGroups: string }|{ name: st
     DatePipe,
     GroupLinkPipe,
     UserCaptionPipe,
-    NgClass,
     ButtonComponent,
     CdkTable,
     TableSortDirective,
@@ -130,25 +84,22 @@ type Row = (Member|GroupChild|{ login: string, parentGroups: string }|{ name: st
     LoadingComponent,
   ]
 })
-export class MemberListComponent implements OnChanges, OnDestroy {
+export class MemberListComponent {
   private getGroupMembersService = inject(GetGroupMembersService);
   private getGroupChildrenService = inject(GetGroupChildrenService);
   private getGroupDescendantsService = inject(GetGroupDescendantsService);
-  private groupUsersService = inject(GroupUsersService);
   private actionFeedbackService = inject(ActionFeedbackService);
-  private removeSubgroupService = inject(RemoveSubgroupService);
-  private confirmationModalService = inject(ConfirmationModalService);
-  private removeGroupService = inject(RemoveGroupService);
+  private memberListRemovalService = inject(MemberListRemovalService);
+  private destroyRef = inject(DestroyRef);
 
-  @Input() groupData? : GroupData;
-  @Output() removedGroup = new EventEmitter<void>();
+  groupData = input.required<GroupData>();
+  removedGroup = output<void>();
 
   defaultFilter: Filter = { type: TypeFilter.Users, directChildren: true };
 
-  currentSort: string[] = [];
-  currentFilter: Filter = this.defaultFilter;
-
-  selection: (Member | GroupChild)[] = [];
+  currentSort = signal<string[]>([]);
+  currentFilter = signal<Filter>(this.defaultFilter);
+  selection = signal<(Member | GroupChild)[]>([]);
 
   datapager = new DataPager({
     fetch: (pageSize, latestRow?: Row): Observable<Row[]> => this.getRows(pageSize, latestRow),
@@ -159,7 +110,7 @@ export class MemberListComponent implements OnChanges, OnDestroy {
   });
   rows$: Observable<FetchState<Row[]>> = this.datapager.list$;
 
-  @ViewChild('compositionFilter') private compositionFilter?: GroupCompositionFilterComponent;
+  private compositionFilter = viewChild<GroupCompositionFilterComponent>('compositionFilter');
 
   removalInProgress$ = new ReplaySubject<boolean>();
 
@@ -170,18 +121,26 @@ export class MemberListComponent implements OnChanges, OnDestroy {
     ...this.columns().map(column => column.field),
   ]);
 
-  ngOnDestroy(): void {
-    this.removalInProgress$.complete();
-  }
+  private readonly removalCallbacks = {
+    unselectAll: (): void => this.unselectAll(),
+    fetchRows: (): void => this.fetchRows(),
+    onRemovedGroup: (): void => this.removedGroup.emit(),
+  };
 
-  ngOnChanges(_changes: SimpleChanges): void {
-    if (!this.groupData) return;
+  constructor() {
+    toObservable(this.groupData).pipe(
+      takeUntilDestroyed(),
+    ).subscribe(groupData => {
+      this.currentFilter.set({ ...this.defaultFilter });
+      this.currentUserCanManage.set(groupData.group.currentUserCanManage !== 'none');
+      this.columns.set(getColumns(this.currentFilter()));
+      this.currentSort.set([]);
+      this.fetchRows();
+    });
 
-    this.currentFilter = { ...this.defaultFilter };
-    this.currentUserCanManage.set(this.groupData.group.currentUserCanManage !== 'none');
-    this.columns.set(this.getColumns(this.currentFilter));
-    this.currentSort = [];
-    this.fetchRows();
+    this.destroyRef.onDestroy(() => {
+      this.removalInProgress$.complete();
+    });
   }
 
   fetchRows(): void {
@@ -193,14 +152,16 @@ export class MemberListComponent implements OnChanges, OnDestroy {
   }
 
   getRows(pageSize: number, latestRow?: Row): Observable<Row[]> {
-    if (!this.groupData) throw new Error('group data must be defined to fetch data');
-    const route = this.groupData.route;
+    const groupData = this.groupData();
+    const route = groupData.route;
+    const currentFilter = this.currentFilter();
+    const currentSort = this.currentSort();
 
-    switch (this.currentFilter.type) {
+    switch (currentFilter.type) {
       case TypeFilter.Groups:
         return this.getGroupChildrenService.getGroupChildren(
           route.id,
-          this.currentSort,
+          currentSort,
           [],
           [ 'Team', 'Session', 'User' ],
         ).pipe(map(children => children.map(child => ({
@@ -208,14 +169,14 @@ export class MemberListComponent implements OnChanges, OnDestroy {
           route: groupRoute(child, [ ...route.path, route.id ]),
         }))));
       case TypeFilter.Sessions:
-        return this.getGroupChildrenService.getGroupChildren(route.id, this.currentSort, [ 'Session' ])
+        return this.getGroupChildrenService.getGroupChildren(route.id, currentSort, [ 'Session' ])
           .pipe(map(children => children.map(child => ({
             ...child,
             route: groupRoute(child, [ ...route.path, route.id ]),
           }))));
       case TypeFilter.Teams:
-        if (!this.currentFilter.directChildren) {
-          return this.getGroupDescendantsService.getTeamDescendants(route.id, { sort: this.currentSort })
+        if (!currentFilter.directChildren) {
+          return this.getGroupDescendantsService.getTeamDescendants(route.id, { sort: currentSort })
             .pipe(map(descendantTeams => descendantTeams.map(descendantTeam => ({
               id: descendantTeam.id,
               name: descendantTeam.name,
@@ -224,17 +185,17 @@ export class MemberListComponent implements OnChanges, OnDestroy {
               route: rawGroupRoute({ id: descendantTeam.id, isUser: false }),
             }))));
         } else {
-          return this.getGroupChildrenService.getGroupChildren(route.id, this.currentSort, [ 'Team' ])
+          return this.getGroupChildrenService.getGroupChildren(route.id, currentSort, [ 'Team' ])
             .pipe(map(children => children.map(child => ({
               ...child,
               route: groupRoute(child, [ ...route.path, route.id ]),
             }))));
         }
       case TypeFilter.Users:
-        if (this.currentFilter.directChildren) {
+        if (currentFilter.directChildren) {
           return this.getGroupMembersService.getGroupMembers(
             route.id,
-            this.currentSort,
+            currentSort,
             pageSize,
             (latestRow as Member|undefined)?.id,
           ).pipe(
@@ -244,7 +205,7 @@ export class MemberListComponent implements OnChanges, OnDestroy {
             }))));
         } else {
           return this.getGroupDescendantsService.getUserDescendants(route.id, {
-            sort: this.currentSort,
+            sort: currentSort,
             limit: pageSize,
             fromId: (latestRow as Member|undefined)?.id,
           }).pipe(map(descendantUsers => descendantUsers.map(descendantUser => ({
@@ -259,150 +220,71 @@ export class MemberListComponent implements OnChanges, OnDestroy {
   }
 
   onSortChange(events: SortEvent[]): void {
-    if (!this.groupData) return;
-
     const sortMeta = events.filter(meta => meta.order !== 0).map(meta => (meta.order === -1 ? `-${meta.field}` : meta.field));
 
-    if (sortMeta.length > 0 && JSON.stringify(sortMeta) !== JSON.stringify(this.currentSort)) {
-      this.currentSort = sortMeta;
+    if (sortMeta.length > 0 && JSON.stringify(sortMeta) !== JSON.stringify(this.currentSort())) {
+      this.currentSort.set(sortMeta);
       this.fetchRows();
     }
   }
 
   onFilterChange(filter: Filter): void {
-    if (!this.groupData) return;
-
-    if (filter !== this.currentFilter) {
-      this.currentFilter = { ...filter };
-      this.columns.set(this.getColumns(filter));
-      this.currentSort = [];
+    if (filter !== this.currentFilter()) {
+      this.currentFilter.set({ ...filter });
+      this.columns.set(getColumns(filter));
+      this.currentSort.set([]);
       this.fetchRows();
     }
   }
 
   setFilter(filter: Filter): void {
-    this.compositionFilter?.setFilter(filter);
+    this.compositionFilter()?.setFilter(filter);
     this.onFilterChange(filter);
   }
 
   onSelectAll(rows: Row[]): void {
-    if (this.selection.length === rows.length) {
-      this.selection = [];
+    if (this.selection().length === rows.length) {
+      this.selection.set([]);
     } else {
-      this.selection = rows as (Member | GroupChild)[];
+      this.selection.set(rows as (Member | GroupChild)[]);
     }
   }
 
   unselectAll(): void {
-    this.selection = [];
+    this.selection.set([]);
   }
 
   onSelect(item: (Member | GroupChild)): void {
-    if (this.selection.includes(item)) {
-      const idx = this.selection.indexOf(item);
-      this.selection = [
-        ...this.selection.slice(0, idx),
-        ...this.selection.slice(idx + 1),
-      ];
+    const currentSelection = this.selection();
+    if (currentSelection.includes(item)) {
+      const idx = currentSelection.indexOf(item);
+      this.selection.set([
+        ...currentSelection.slice(0, idx),
+        ...currentSelection.slice(idx + 1),
+      ]);
     } else {
-      this.selection = [ ...this.selection, item ];
+      this.selection.set([ ...currentSelection, item ]);
     }
-  }
-
-  removeUsers(groupId: string): void {
-    if (this.selection.length === 0) {
-      throw new Error('Unexpected: Missed selected members');
-    }
-
-    const selectedMemberIds = this.selection.map(member => member.id);
-
-    this.removalInProgress$.next(true);
-    this.groupUsersService.removeUsers(groupId, selectedMemberIds)
-      .subscribe({
-        next: result => {
-          displayResponseToast(this.actionFeedbackService, parseResults(result));
-          this.unselectAll();
-          this.fetchRows();
-          this.removalInProgress$.next(false);
-        },
-        error: err => {
-          this.removalInProgress$.next(false);
-          this.actionFeedbackService.unexpectedError();
-          if (!(err instanceof HttpErrorResponse)) throw err;
-        }
-      });
-  }
-
-  removeGroupsOrSubgroups(selectedGroupChildren: GroupChild[], groupId: string): void {
-    const selectedGroupChildIds = selectedGroupChildren.map(g => g.id);
-    const isSubgroupsEmpty = selectedGroupChildren.every(g => g.isEmpty);
-
-    this.removalInProgress$.next(true);
-
-    const confirmRemoveGroup$ = defer(() => this.confirmationModalService.open({
-      message: `Are you sure you want to permanently delete ${getSelectedGroupChildCaptions(selectedGroupChildren)}?
-        This operation cannot be undone.`,
-      acceptIcon: 'ph-bold ph-check',
-      acceptButtonStyleClass: 'danger',
-      messageIconStyleClass: 'ph-duotone ph-warning-circle alg-validation-error',
-    }, { maxWidth: '37.5rem' }).pipe(filter(accepted => !!accepted)));
-
-    const confirmRemoveSubgroups$ = defer(() => this.confirmationModalService.open({
-      message: `By removing ${getSelectedGroupChildCaptions(selectedGroupChildren)} from the group, you may loose
-        manager access to them (if no explicit permission or through other parent group). Are you sure you want to proceed?`,
-      acceptIcon: 'ph-bold ph-check',
-      acceptButtonStyleClass: 'danger',
-      messageIconStyleClass: 'ph-duotone ph-warning-circle alg-validation-error',
-    }, { maxWidth: '37.5rem' }).pipe(filter(accepted => !!accepted)));
-
-    const proceedRemoving$: Observable<boolean | undefined> = isSubgroupsEmpty ? this.confirmationModalService.open({
-      message: selectedGroupChildren.length === 1 ?
-        $localize`Do you also want to delete the group?` :
-        $localize`These groups are all empty. Do you also want to delete them?`,
-      acceptIcon: 'ph-bold ph-check',
-      acceptButtonStyleClass: 'danger',
-      messageIconStyleClass: 'ph-duotone ph-warning-circle alg-validation-error',
-    }).pipe(filter(accepted => accepted !== undefined)) : of(undefined);
-
-    proceedRemoving$.pipe(
-      switchMap(allowToRemoveGroup => (
-        allowToRemoveGroup === true
-          ? confirmRemoveGroup$.pipe(switchMap(() => this.removeGroupService.removeBatch(selectedGroupChildIds)))
-          : confirmRemoveSubgroups$.pipe(switchMap(() => this.removeSubgroupService.removeBatch(groupId, selectedGroupChildIds)))
-      ))
-    ).subscribe({
-      next: response => {
-        displayGroupRemovalResponseToast(this.actionFeedbackService, response);
-        this.unselectAll();
-        this.fetchRows();
-        this.removalInProgress$.next(false);
-        this.removedGroup.emit();
-      },
-      error: err => {
-        this.removalInProgress$.next(false);
-        this.actionFeedbackService.unexpectedError();
-        if (!(err instanceof HttpErrorResponse)) throw err;
-      },
-      complete: () => this.removalInProgress$.next(false)
-    });
   }
 
   onRemove(): void {
-    if (this.selection.length === 0 || !this.groupData) throw new Error('Unexpected: Missed group data or selected models');
-    const groupId = this.groupData.group.id;
-    if (this.currentFilter.type === TypeFilter.Users) {
-      this.removeUsers(groupId);
+    const currentSelection = this.selection();
+    if (currentSelection.length === 0) throw new Error('Unexpected: Missed group data or selected models');
+    const groupId = this.groupData().group.id;
+    if (this.currentFilter().type === TypeFilter.Users) {
+      this.memberListRemovalService.removeUsers(
+        groupId,
+        currentSelection as Member[],
+        this.removalInProgress$,
+        this.removalCallbacks,
+      );
     } else {
-      this.removeGroupsOrSubgroups(this.selection as GroupChild[], groupId);
-    }
-  }
-
-  private getColumns(filter: Filter): Column[] {
-    switch (filter.type) {
-      case TypeFilter.Groups: return groupsColumns;
-      case TypeFilter.Sessions: return nameUserCountColumns;
-      case TypeFilter.Teams: return this.currentFilter.directChildren ? nameUserCountColumns : descendantTeamsColumns;
-      case TypeFilter.Users: return this.currentFilter.directChildren ? usersColumns : descendantUsersColumns;
+      this.memberListRemovalService.removeGroupsOrSubgroups(
+        currentSelection as GroupChild[],
+        groupId,
+        this.removalInProgress$,
+        this.removalCallbacks,
+      );
     }
   }
 }

--- a/src/app/groups/containers/pending-join-requests/pending-join-requests.component.spec.ts
+++ b/src/app/groups/containers/pending-join-requests/pending-join-requests.component.spec.ts
@@ -61,18 +61,17 @@ describe('PendingJoinRequestsComponent', () => {
     serviceResponder$ = new Subject<Map<string,any>[]>();
     fixture = TestBed.createComponent(PendingJoinRequestsComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
     requestActionsService = TestBed.inject(RequestActionsService);
     getRequestsService = TestBed.inject(GetRequestsService);
     actionFeedbackService = TestBed.inject(ActionFeedbackService);
-    component.groupId = '99';
     spyOn(actionFeedbackService, 'success').and.callThrough();
     spyOn(actionFeedbackService, 'partial').and.callThrough();
     spyOn(actionFeedbackService, 'error').and.callThrough();
     spyOn(actionFeedbackService, 'unexpectedError').and.callThrough();
     spyOn(getRequestsService, 'getGroupPendingRequests').and.callThrough();
     spyOn(requestActionsService, 'processJoinRequests').and.callThrough();
-    component.ngOnChanges({});
+    fixture.componentRef.setInput('groupId', '99');
+    fixture.detectChanges();
   });
 
   afterEach(() => {
@@ -81,9 +80,9 @@ describe('PendingJoinRequestsComponent', () => {
 
   it('should load requests at init', () => {
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledWith('99', false, []);
-    expect(component.requests).toEqual(MOCK_RESPONSE);
-    expect(component.currentSort).toEqual([]);
-    expect(component.state).toEqual('ready');
+    expect(component.requests()).toEqual(MOCK_RESPONSE);
+    expect(component.currentSort()).toEqual([]);
+    expect(component.state()).toEqual('ready');
   });
 
   it('should, when sorting is changed, call the service with the appropriate attributes,', () => {
@@ -108,7 +107,7 @@ describe('PendingJoinRequestsComponent', () => {
     // step 1: select one and 'accept'
     component.onProcessRequests({ type: Action.Accept, data: [ MOCK_RESPONSE_2 ] });
 
-    expect(component.state).toEqual('processing');
+    expect(component.state()).toEqual('processing');
     expect(requestActionsService.processJoinRequests).toHaveBeenCalledWith(new Map([ [ '50', [ '12' ] ] ]), Action.Accept);
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(1); // the initial one
 
@@ -116,7 +115,7 @@ describe('PendingJoinRequestsComponent', () => {
     serviceResponder$.next([ new Map([ [ '12', 'success' ] ]) ]);
     serviceResponder$.complete();
 
-    expect(component.state).toEqual('ready');
+    expect(component.state()).toEqual('ready');
     expect(actionFeedbackService.success).toHaveBeenCalledTimes(1);
     expect(actionFeedbackService.success).toHaveBeenCalledWith('1 request(s) have been accepted');
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(2);
@@ -127,7 +126,7 @@ describe('PendingJoinRequestsComponent', () => {
     // step 1: select one and 'reject'
     component.onProcessRequests({ type: Action.Reject, data: [ MOCK_RESPONSE_2 ] });
 
-    expect(component.state).toEqual('processing');
+    expect(component.state()).toEqual('processing');
     expect(requestActionsService.processJoinRequests).toHaveBeenCalledWith(new Map([ [ '50', [ '12' ] ] ]), Action.Reject);
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(1); // the initial one
 
@@ -135,7 +134,7 @@ describe('PendingJoinRequestsComponent', () => {
     serviceResponder$.next([ new Map([ [ '12', 'success' ] ]) ]);
     serviceResponder$.complete();
 
-    expect(component.state).toEqual('ready');
+    expect(component.state()).toEqual('ready');
     expect(actionFeedbackService.success).toHaveBeenCalledTimes(1);
     expect(actionFeedbackService.success).toHaveBeenCalledWith('1 request(s) have been declined');
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(2);
@@ -160,7 +159,7 @@ describe('PendingJoinRequestsComponent', () => {
     ]);
     serviceResponder$.complete();
 
-    expect(component.state).toEqual('ready');
+    expect(component.state()).toEqual('ready');
     expect(actionFeedbackService.partial).toHaveBeenCalledTimes(1);
     expect(actionFeedbackService.partial).toHaveBeenCalledWith('2 request(s) have been accepted, 1 could not be executed');
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(2);
@@ -175,7 +174,7 @@ describe('PendingJoinRequestsComponent', () => {
     ]);
     serviceResponder$.complete();
 
-    expect(component.state).toEqual('ready');
+    expect(component.state()).toEqual('ready');
     expect(actionFeedbackService.error).toHaveBeenCalledTimes(1);
     expect(actionFeedbackService.error).toHaveBeenCalledWith('Unable to accept the selected request(s).');
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(2);
@@ -190,7 +189,7 @@ describe('PendingJoinRequestsComponent', () => {
     ]);
     serviceResponder$.complete();
 
-    expect(component.state).toEqual('ready');
+    expect(component.state()).toEqual('ready');
     expect(actionFeedbackService.error).toHaveBeenCalledTimes(1);
     expect(actionFeedbackService.error).toHaveBeenCalledWith('Unable to reject the selected request(s).');
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(2);
@@ -202,7 +201,7 @@ describe('PendingJoinRequestsComponent', () => {
     serviceResponder$.error(new HttpErrorResponse({}));
     serviceResponder$.complete();
 
-    expect(component.state).toEqual('ready');
+    expect(component.state()).toEqual('ready');
     expect(actionFeedbackService.unexpectedError).toHaveBeenCalledTimes(1);
     expect(getRequestsService.getGroupPendingRequests).toHaveBeenCalledTimes(1); // service error does not reload content
   });

--- a/src/app/groups/containers/pending-join-requests/pending-join-requests.component.ts
+++ b/src/app/groups/containers/pending-join-requests/pending-join-requests.component.ts
@@ -1,9 +1,10 @@
-import { Component, Input, OnChanges, SimpleChanges, OnDestroy, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { GetRequestsService, PendingRequest } from '../../data-access/get-requests.service';
 import { Action, parseResults, RequestActionsService } from '../../data-access/request-actions.service';
 import { merge, of, Subject } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
-import { fetchingState, readyState } from 'src/app/utils/state';
+import { catchError, map, switchMap } from 'rxjs/operators';
+import { errorState, fetchingState, readyState } from 'src/app/utils/state';
 import { displayResponseToast } from 'src/app/groups/containers/pending-request/pending-request-response-handling';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { ensureDefined } from 'src/app/utils/assert';
@@ -17,36 +18,44 @@ interface GridColumn {
 
 const groupColumn = { field: 'group.name', header: $localize`GROUP` };
 
+const baseColumns: GridColumn[] = [
+  { field: 'user.login', header: $localize`USER` },
+  { field: 'at', header: $localize`REQUESTED ON` },
+];
+
 @Component({
   selector: 'alg-pending-join-requests',
   templateUrl: './pending-join-requests.component.html',
   styleUrls: [ './pending-join-requests.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  standalone: true,
 })
-export class PendingJoinRequestsComponent implements OnChanges, OnDestroy {
+export class PendingJoinRequestsComponent {
   private getRequestsService = inject(GetRequestsService);
   private requestActionService = inject(RequestActionsService);
   private actionFeedbackService = inject(ActionFeedbackService);
+  private destroyRef = inject(DestroyRef);
 
   // if groupId is undefined, pending join requests from all managed group will be used.
-  @Input() groupId?: string;
-  @Input() showSwitch = true;
+  groupId = input<string>();
+  showSwitch = input(true);
 
-  requests: PendingRequest[] = [];
+  requests = signal<PendingRequest[]>([]);
 
-  columns: GridColumn[] = [
-    { field: 'user.login', header: $localize`USER` },
-    { field: 'at', header: $localize`REQUESTED ON` },
-  ];
+  includeSubgroup = signal(false);
+
+  columns = computed(() => {
+    if (!this.showSwitch() || this.includeSubgroup()) {
+      return [ groupColumn, ...baseColumns ];
+    }
+    return baseColumns;
+  });
+
   readonly subgroupSwitchItems = [
     { label: $localize`This group only`, value: false },
     { label: $localize`All subgroups`, value: true }
   ];
-  includeSubgroup = false;
 
-  state: 'fetching' | 'processing' | 'ready' | 'fetchingError' = 'fetching';
-  currentSort: string[] = [];
+  state = signal<'fetching' | 'processing' | 'ready' | 'fetchingError'>('fetching');
+  currentSort = signal<string[]>([]);
 
   private dataFetching = new Subject<{ groupId?: string, includeSubgroup: boolean, sort: string[] }>();
 
@@ -56,34 +65,43 @@ export class PendingJoinRequestsComponent implements OnChanges, OnDestroy {
         merge(
           of(fetchingState()),
           this.getRequestsService.getGroupPendingRequests(params.groupId, params.includeSubgroup, params.sort)
-            .pipe(map(readyState))
+            .pipe(
+              map(readyState),
+              catchError(err => of(errorState(err))),
+            )
         )
-      )
+      ),
+      takeUntilDestroyed(),
     ).subscribe({
       next: state => {
-        this.state = state.tag;
-        if (state.isReady) {
-          this.requests = state.data;
+        if (state.isError) {
+          this.state.set('fetchingError');
+        } else {
+          this.state.set(state.tag);
+          if (state.isReady) {
+            this.requests.set(state.data);
+          }
         }
       },
-      error: _err => {
-        this.state = 'fetchingError';
-      }
+    });
+
+    toObservable(this.groupId).pipe(
+      takeUntilDestroyed(),
+    ).subscribe(groupId => {
+      this.dataFetching.next({
+        groupId,
+        includeSubgroup: this.includeSubgroup(),
+        sort: this.currentSort(),
+      });
+    });
+
+    this.destroyRef.onDestroy(() => {
+      this.dataFetching.complete();
     });
   }
 
-  ngOnChanges(_changes: SimpleChanges): void {
-    if (!this.showSwitch) this.columns = [ groupColumn ].concat(this.columns);
-    this.dataFetching.next({ groupId: this.groupId, includeSubgroup: this.includeSubgroup, sort: this.currentSort });
-  }
-
-  ngOnDestroy(): void {
-    this.dataFetching.complete();
-  }
-
-
   onProcessRequests(params: { data: PendingRequest[], type: Action }): void {
-    this.state = 'processing';
+    this.state.set('processing');
 
     const requestMap = new Map<string, string[]>();
     params.data.forEach(elm => {
@@ -98,12 +116,16 @@ export class PendingJoinRequestsComponent implements OnChanges, OnDestroy {
     this.requestActionService.processJoinRequests(requestMap, params.type)
       .subscribe({
         next: result => {
-          this.state = 'ready';
+          this.state.set('ready');
           displayResponseToast(this.actionFeedbackService, parseResults(result), params.type);
-          this.dataFetching.next({ groupId: this.groupId, includeSubgroup: this.includeSubgroup, sort: this.currentSort });
+          this.dataFetching.next({
+            groupId: this.groupId(),
+            includeSubgroup: this.includeSubgroup(),
+            sort: this.currentSort(),
+          });
         },
         error: err => {
-          this.state = 'ready';
+          this.state.set('ready');
           this.actionFeedbackService.unexpectedError();
           if (!(err instanceof HttpErrorResponse)) throw err;
         }
@@ -111,18 +133,23 @@ export class PendingJoinRequestsComponent implements OnChanges, OnDestroy {
   }
 
   onSubgroupSwitch(selectedIdx: number): void {
-    this.includeSubgroup = ensureDefined(this.subgroupSwitchItems[selectedIdx]).value;
+    this.includeSubgroup.set(ensureDefined(this.subgroupSwitchItems[selectedIdx]).value);
 
-    this.columns = this.columns.filter(elm => elm !== groupColumn);
-    if (this.includeSubgroup) this.columns = [ groupColumn ].concat(this.columns);
-
-    this.dataFetching.next({ groupId: this.groupId, includeSubgroup: this.includeSubgroup, sort: this.currentSort });
+    this.dataFetching.next({
+      groupId: this.groupId(),
+      includeSubgroup: this.includeSubgroup(),
+      sort: this.currentSort(),
+    });
   }
 
   onFetch(sort: string[]): void {
-    if (JSON.stringify(sort) !== JSON.stringify(this.currentSort)) {
-      this.currentSort = sort;
-      this.dataFetching.next({ groupId: this.groupId, includeSubgroup: this.includeSubgroup, sort: this.currentSort });
+    if (JSON.stringify(sort) !== JSON.stringify(this.currentSort())) {
+      this.currentSort.set(sort);
+      this.dataFetching.next({
+        groupId: this.groupId(),
+        includeSubgroup: this.includeSubgroup(),
+        sort: this.currentSort(),
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Modernize `member-list` and `pending-join-requests` to Angular 22 patterns (signal inputs/outputs, `toObservable`, split helpers).
- Batch 15 from `.cursor/plans/modernize-batch-15-member-list.md`.

## Scope
- **member-list** — split to 290 lines: `member-list-columns.ts`, `member-list-removal.service.ts`; signals for selection/filter/sort; `viewChild`; fix `getColumns()` using `filter` param
- **pending-join-requests** — `computed()` columns fixes duplicate `groupColumn` prepend bug; spec rewritten with `setInput`
- **i18n:** localized removal confirmation strings in removal service
- **Reliability:** `catchError` keeps pending-join-requests fetch stream alive on HTTP errors

## Risks / manual checks
- **member-list** — riskiest groups table (selection + bulk removal + filter). E2E: `group-members-page.ts`, `user-group-invitations.spec.ts`
- Manual smoke: filter users/sub-groups, select all, remove users, remove subgroup (both confirm paths), sort, load more

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-15/en/

## Verification
- [x] `npm run lint`
- [x] `pending-join-requests` unit tests (9/9)
- [x] `ng build algorea --configuration=e2e`
- [x] CI E2E (group members, invitations)
- [ ] Manual smoke (bulk remove paths)