### PR TITLE
Modernize Angular components (batch 19).

### DIFF
--- a/e2e/items/chapter-children-edit-lost-changes.spec.ts
+++ b/e2e/items/chapter-children-edit-lost-changes.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../common/fixture';
+import { initAsTesterUser } from 'e2e/helpers/e2e_auth';
+
+const chapterId = '7523720120450464843';
+const editChildrenUrl = `/a/${chapterId};p=7528142386663912287;a=0/edit-children`;
+
+// Regression test: cancelling the "Confirm Navigation" modal must keep the pending children edits,
+// not silently re-fetch and revert them (see PR #2229 / modernize-ng-comp-19).
+test('keeps pending children edits when navigation is cancelled', async ({
+  page,
+  itemContentPage,
+  itemChildrenEditListComponent,
+  lostChangesConfirmationModal,
+}) => {
+  await initAsTesterUser(page);
+
+  await Promise.all([
+    itemContentPage.goto(editChildrenUrl),
+    itemContentPage.waitForItemResponse(chapterId),
+  ]);
+  await itemContentPage.checksIsItemChildrenEditListVisible();
+
+  const initialRowsCount = await itemChildrenEditListComponent.getRowsCount();
+  expect(initialRowsCount).toBeGreaterThan(0);
+
+  await test.step('removes a child locally', async () => {
+    await itemChildrenEditListComponent.selectChildByIndex(0);
+    await itemChildrenEditListComponent.removeSelected();
+    await expect.poll(() => itemChildrenEditListComponent.getRowsCount()).toBe(initialRowsCount - 1);
+  });
+
+  await test.step('cancels navigation to another tab and keeps the change', async () => {
+    // The "Parameters" tab triggers a new `itemData` emission; before the fix this re-fetched the
+    // children and reverted the pending removal even though the navigation was cancelled.
+    await page.getByRole('link', { name: 'Parameters' }).click();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationVisible();
+    await lostChangesConfirmationModal.cancel();
+    await lostChangesConfirmationModal.checksIsLostChangesConfirmationNotVisible();
+
+    // Still on the children edit tab...
+    await itemContentPage.checksIsItemChildrenEditListVisible();
+    // ...and the removed child must NOT have been reverted by a background re-fetch.
+    await expect.poll(() => itemChildrenEditListComponent.getRowsCount()).toBe(initialRowsCount - 1);
+  });
+});

--- a/e2e/items/pages/item-children-edit-list-component.ts
+++ b/e2e/items/pages/item-children-edit-list-component.ts
@@ -1,11 +1,29 @@
 import { expect, Page } from '@playwright/test';
 
 export class ItemChildrenEditListComponent {
+  private listLocator = this.page.locator('alg-item-children-edit-list');
+  private rowsLocator = this.listLocator.locator('tr.alg-table-body-tr');
+  private removeBtnLocator = this.listLocator.locator('.alg-table-footer button');
   private propagationEditMenuLocator = this.page.locator('alg-propagation-edit-menu');
   private advancedConfigurationBtnLocator = this.propagationEditMenuLocator.getByRole('button', { name: 'Advanced configuration' });
   public enableScoreWeightLocator = this.page.getByTestId('enable-score-weight');
 
   constructor(private readonly page: Page) {
+  }
+
+  async getRowsCount(): Promise<number> {
+    return this.rowsLocator.count();
+  }
+
+  async selectChildByIndex(index: number): Promise<void> {
+    const rowCheckboxLocator = this.rowsLocator.nth(index).getByRole('checkbox');
+    await expect.soft(rowCheckboxLocator).toBeVisible();
+    await rowCheckboxLocator.check();
+  }
+
+  async removeSelected(): Promise<void> {
+    await expect.soft(this.removeBtnLocator).toBeEnabled();
+    await this.removeBtnLocator.click();
   }
 
   async openPropagationMenu(childName: string): Promise<void> {

--- a/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.html
+++ b/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.html
@@ -1,17 +1,15 @@
-@if (itemData(); as itemDataValue) {
-  @if (itemDataValue.item.permissions | allowsEditingChildren) {
-    <alg-item-children-edit
-      #childrenEdit
-      (childrenChanges)="updateItemChanges($event)"
-      [itemData]="itemDataValue"
-      [class.disabled]="disabled()"
-    ></alg-item-children-edit>
-    @if (dirty()) {
-      <alg-floating-save [saving]="disabled()" (save)="save()" (cancel)="onCancel()"></alg-floating-save>
-    }
-  } @else {
-    <p class="validation-text" i18n>
-      You do not have the permissions to edit this content.
-    </p>
+@if (itemData().item.permissions | allowsEditingChildren) {
+  <alg-item-children-edit
+    #childrenEdit
+    (childrenChanges)="updateItemChanges($event)"
+    [itemData]="itemData()"
+    [class.disabled]="disabled()"
+  ></alg-item-children-edit>
+  @if (dirty()) {
+    <alg-floating-save [saving]="disabled()" (save)="save()" (cancel)="onCancel()"></alg-floating-save>
   }
+} @else {
+  <p class="validation-text" i18n>
+    You do not have the permissions to edit this content.
+  </p>
 }

--- a/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.html
+++ b/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.html
@@ -1,13 +1,13 @@
-@if (itemData) {
-  @if (itemData.item.permissions | allowsEditingChildren) {
+@if (itemData(); as itemDataValue) {
+  @if (itemDataValue.item.permissions | allowsEditingChildren) {
     <alg-item-children-edit
       #childrenEdit
       (childrenChanges)="updateItemChanges($event)"
-      [itemData]="itemData"
-      [ngClass]="{disabled: disabled}"
+      [itemData]="itemDataValue"
+      [class.disabled]="disabled()"
     ></alg-item-children-edit>
-    @if (dirty) {
-      <alg-floating-save [saving]="disabled" (save)="save()" (cancel)="onCancel()"></alg-floating-save>
+    @if (dirty()) {
+      <alg-floating-save [saving]="disabled()" (save)="save()" (cancel)="onCancel()"></alg-floating-save>
     }
   } @else {
     <p class="validation-text" i18n>

--- a/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.ts
+++ b/src/app/items/containers/item-children-edit-form/item-children-edit-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit, ViewChild, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, OnDestroy, OnInit, signal, viewChild } from '@angular/core';
 import { ItemData } from '../../models/item-data';
 import {
   ChildDataWithId,
@@ -17,7 +17,6 @@ import { PendingChangesService } from 'src/app/services/pending-changes-service'
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { AllowsEditingChildrenItemPipe } from 'src/app/items/models/item-edit-permission';
 import { FloatingSaveComponent } from 'src/app/ui-components/floating-save/floating-save.component';
-import { NgClass } from '@angular/common';
 import { Store } from '@ngrx/store';
 import { fromItemContent } from '../../store';
 import { LocaleService } from 'src/app/services/localeService';
@@ -26,10 +25,8 @@ import { LocaleService } from 'src/app/services/localeService';
   selector: 'alg-item-children-edit-form',
   templateUrl: './item-children-edit-form.component.html',
   styleUrls: [ './item-children-edit-form.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ItemChildrenEditComponent,
-    NgClass,
     FloatingSaveComponent,
     AllowsEditingChildrenItemPipe,
   ]
@@ -43,16 +40,16 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
   private pendingChangesService = inject(PendingChangesService);
   private currentContentService = inject(CurrentContentService);
 
-  @Input() itemData?: ItemData;
+  itemData = input.required<ItemData>();
 
-  @ViewChild('childrenEdit') private childrenEdit?: ItemChildrenEditComponent;
+  childrenEdit = viewChild<ItemChildrenEditComponent>('childrenEdit');
 
-  disabled = false;
-  dirty = false;
+  disabled = signal(false);
+  dirty = signal(false);
   itemChanges: { children?: PossiblyInvisibleChildData[] } = {};
 
   isDirty(): boolean {
-    return this.dirty;
+    return this.dirty();
   }
 
   ngOnInit(): void {
@@ -64,7 +61,7 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
   }
 
   updateItemChanges(children: PossiblyInvisibleChildData[]): void {
-    this.dirty = true;
+    this.dirty.set(true);
     this.itemChanges.children = children;
   }
 
@@ -80,7 +77,6 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
 
     return forkJoin(
       this.itemChanges.children.map(child => {
-        if (!this.itemData) throw new Error('Missed item data');
         if (hasId(child) || !child.isVisible) return of(child);
         // the child doesn't have an id, so we create it
         if (!child.title) throw new Error('Something went wrong, the new child is missing his title');
@@ -89,7 +85,7 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
           type: child.type,
           url: child.url,
           languageTag,
-          parent: this.itemData.item.id,
+          parent: this.itemData().item.id,
         };
         return this.createItemService
           .create(newChild)
@@ -101,7 +97,6 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
   private updateItem(): Observable<void> {
     return this.createChildren().pipe(
       switchMap(children => {
-        if (!this.itemData) throw new Error('Invalid initial data');
         if (!children) throw new Error('Unexpected: Children list are empty');
         const changes: ItemChanges = { children: [] };
         // @TODO: Avoid affecting component vars in Observable Operator
@@ -117,13 +112,13 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
           upper_view_levels_propagation: child.upperViewLevelsPropagation,
           watch_propagation: child.watchPropagation,
         }));
-        return this.updateItemService.updateItem(this.itemData.item.id, changes);
+        return this.updateItemService.updateItem(this.itemData().item.id, changes);
       }),
     );
   }
 
   save(): void {
-    this.disabled = true;
+    this.disabled.set(true);
     this.updateItem().subscribe({
       next: _status => {
         this.actionFeedbackService.success($localize`Changes successfully saved.`);
@@ -132,7 +127,7 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
         this.currentContentService.forceNavMenuReload();
       },
       error: err => {
-        this.disabled = false;
+        this.disabled.set(false);
         this.actionFeedbackService.unexpectedError();
         this.currentContentService.forceNavMenuReload();
         if (!(err instanceof HttpErrorResponse)) throw err;
@@ -142,8 +137,8 @@ export class ItemChildrenEditFormComponent implements OnInit, PendingChangesComp
 
   onCancel(): void {
     this.itemChanges = {};
-    this.disabled = false;
-    this.dirty = false;
-    this.childrenEdit?.reset();
+    this.disabled.set(false);
+    this.dirty.set(false);
+    this.childrenEdit()?.reset();
   }
 }

--- a/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.html
+++ b/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.html
@@ -10,15 +10,15 @@
     </div>
   </div>
 
-  @if (data.length > 0) {
+  @if (data().length > 0) {
     <div class="alg-table-horizontal-scroll">
       <table
         class="alg-table-v2 editable"
         cdk-table
-        [dataSource]="data"
+        [dataSource]="data()"
         cdkDropList
         (cdkDropListDropped)="orderChanged($event)"
-        [cdkDropListData]="data"
+        [cdkDropListData]="data()"
         [multiTemplateDataRows]="true"
       >
         <ng-container cdkColumnDef="reorder">
@@ -31,7 +31,7 @@
         <ng-container cdkColumnDef="checkbox">
           <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef></th>
           <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
-            @let isSelected = !!(selectedRows | findInArray: rowData);
+            @let isSelected = !!(selectedRows() | findInArray: rowData);
             <input type="checkbox" [checked]="isSelected" (change)="onSelect(rowData)" />
           </td>
         </ng-container>
@@ -43,8 +43,8 @@
               data-testid="edit-score-weight"
               [style.width.rem]="3"
               inputStyleClass="size-s"
-              [(ngModel)]="rowData.scoreWeight"
-              (keyup)="onScoreWeightChange()"
+              [ngModel]="rowData.scoreWeight"
+              (ngModelChange)="onScoreWeightChange(rowData, $event)"
               [min]="0"
               [max]="100"
             ></alg-input-number>
@@ -61,11 +61,11 @@
         <ng-container cdkColumnDef="title">
           <th class="alg-table-th alg-flex-1" cdk-header-cell *cdkHeaderCellDef></th>
           <td class="alg-table-td alg-flex-1" cdk-cell *cdkCellDef="let rowData">
-            @if (itemData && itemData.currentResult?.attemptId; as attemptId) {
+            @if (itemData().currentResult?.attemptId; as attemptId) {
               <a
                 class="main alg-link"
-                [ngClass]="{'disabled': !rowData.id}"
-                [routerLink]="rowData | itemRoute: { path: itemData.route.path.concat([ itemData.item.id ]) } |
+                [class.disabled]="!rowData.id"
+                [routerLink]="rowData | itemRoute: { path: itemData().route.path.concat([ itemData().item.id ]) } |
                 with: (rowData.result?.attemptId ? { attemptId : rowData.result.attemptId } : { parentAttemptId: attemptId }) |
                 url: ['edit-children']"
               >
@@ -130,7 +130,7 @@
             class="alg-table-footer-checkbox"
             id="select-all-checkbox"
             (change)="onSelectAll()"
-            [checked]="data.length === selectedRows.length"
+            [checked]="data().length === selectedRows().length"
           />
           <span class="alg-table-footer-select-all" i18n>
             Select all
@@ -142,7 +142,7 @@
         type="button"
         icon="ph-duotone ph-trash"
         (click)="onRemove()"
-        [disabled]="selectedRows.length === 0"
+        [disabled]="selectedRows().length === 0"
         alg-button-icon
       ></button>
     </div>
@@ -157,21 +157,21 @@
 
 <div class="add-item-container">
   <alg-add-item
-    [type]="type"
-    [addedItemIds]="addedItemIds"
+    [type]="type()"
+    [addedItemIds]="addedItemIds()"
     (contentAdded)="addChild($event)"
   ></alg-add-item>
 </div>
 
 <ng-template #menu>
-  @if (propagationEditItemIdx !== undefined) {
-    @let childData = data[propagationEditItemIdx];
+  @if (propagationEditItemIdx() !== undefined) {
+    @let childData = data()[propagationEditItemIdx()!];
     @if (childData) {
       <div class="menu" cdkMenu>
         <alg-propagation-edit-menu
           [childData]="childData"
-          (clickEvent)="onContentViewPropagationChanged($event, propagationEditItemIdx)"
-          (openAdvancedConfigurationDialogEvent)="openAdvancedPermPropagationConfigurationDialog(childData, propagationEditItemIdx)"
+          (clickEvent)="onContentViewPropagationChanged($event, propagationEditItemIdx()!)"
+          (openAdvancedConfigurationDialogEvent)="openAdvancedPermPropagationConfigurationDialog(childData, propagationEditItemIdx()!)"
         ></alg-propagation-edit-menu>
       </div>
     }

--- a/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.ts
+++ b/src/app/items/containers/item-children-edit-list/item-children-edit-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, EventEmitter, inject, Input, OnChanges, Output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, linkedSignal, output, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DEFAULT_SCORE_WEIGHT, PossiblyInvisibleChildData } from '../item-children-edit/item-children-edit.component';
 import { AddedContent } from 'src/app/ui-components/add-content/add-content.component';
 import { ItemType, ItemTypeCategory } from 'src/app/items/models/item-type';
@@ -14,7 +15,6 @@ import { ItemRoutePipe, ItemRouteWithExtraPipe } from 'src/app/pipes/itemRoute';
 import { PropagationEditMenuComponent } from '../propagation-edit-menu/propagation-edit-menu.component';
 import { AddItemComponent } from '../add-item/add-item.component';
 import { RouterLink } from '@angular/router';
-import { NgClass } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { SwitchComponent } from 'src/app/ui-components/switch/switch.component';
 import { EmptyContentComponent } from 'src/app/ui-components/empty-content/empty-content.component';
@@ -44,11 +44,9 @@ import { Dialog } from '@angular/cdk/dialog';
   selector: 'alg-item-children-edit-list',
   templateUrl: './item-children-edit-list.component.html',
   styleUrls: [ './item-children-edit-list.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     SwitchComponent,
     FormsModule,
-    NgClass,
     RouterLink,
     AddItemComponent,
     PropagationEditMenuComponent,
@@ -73,18 +71,20 @@ import { Dialog } from '@angular/cdk/dialog';
     CdkDrag,
   ]
 })
-export class ItemChildrenEditListComponent implements OnChanges {
-  @Input() itemData?: ItemData;
-  @Input() type: ItemTypeCategory = 'activity';
-  @Input() data: PossiblyInvisibleChildData[] = [];
-  @Output() childrenChanges = new EventEmitter<PossiblyInvisibleChildData[]>();
+export class ItemChildrenEditListComponent {
+  itemData = input.required<ItemData>();
+  type = input<ItemTypeCategory>('activity');
+  data = input.required<PossiblyInvisibleChildData[]>();
+
+  childrenChanges = output<PossiblyInvisibleChildData[]>();
 
   private dialogService = inject(Dialog);
+  private destroyRef = inject(DestroyRef);
 
-  selectedRows: PossiblyInvisibleChildData[] = [];
-  scoreWeightEnabled = signal(false);
-  propagationEditItemIdx?: number;
-  addedItemIds: string[] = [];
+  selectedRows = signal<PossiblyInvisibleChildData[]>([]);
+  scoreWeightEnabled = linkedSignal(() => this.data().some(c => c.scoreWeight !== 1));
+  propagationEditItemIdx = signal<number | undefined>(undefined);
+  addedItemIds = computed(() => this.data().map(item => item.id).filter(isNotUndefined));
 
   propagationEditMenuPositions = signal<ConnectedPosition[]>([
     {
@@ -123,11 +123,6 @@ export class ItemChildrenEditListComponent implements OnChanges {
     this.baseColumns().filter(c => ![ 'type', 'title' ].includes(c))
   );
 
-  ngOnChanges(): void {
-    this.addedItemIds = this.data.map(item => item.id).filter(isNotUndefined);
-    this.scoreWeightEnabled.set(this.data.some(c => c.scoreWeight !== 1));
-  }
-
   addChild(child: AddedContent<ItemType>): void {
     const permissionsForCreatedItem: ItemCorePerm = {
       canView: itemViewPermMax,
@@ -137,7 +132,7 @@ export class ItemChildrenEditListComponent implements OnChanges {
       isOwner: true,
     };
     this.childrenChanges.emit([
-      ...this.data,
+      ...this.data(),
       {
         ...child,
         scoreWeight: DEFAULT_SCORE_WEIGHT,
@@ -149,50 +144,57 @@ export class ItemChildrenEditListComponent implements OnChanges {
   }
 
   onSelect(item: PossiblyInvisibleChildData): void {
-    if (this.selectedRows.includes(item)) {
-      const idx = this.selectedRows.indexOf(item);
-      this.selectedRows = [
-        ...this.selectedRows.slice(0, idx),
-        ...this.selectedRows.slice(idx + 1),
-      ];
-    } else {
-      this.selectedRows = [ ...this.selectedRows, item ];
-    }
+    this.selectedRows.update(rows => {
+      if (rows.includes(item)) {
+        const idx = rows.indexOf(item);
+        return [ ...rows.slice(0, idx), ...rows.slice(idx + 1) ];
+      }
+      return [ ...rows, item ];
+    });
   }
 
   onSelectAll(): void {
-    this.selectedRows = this.selectedRows.length === this.data.length ? [] : this.data;
+    const currentData = this.data();
+    this.selectedRows.update(rows => (rows.length === currentData.length ? [] : currentData));
   }
 
   onRemove(): void {
-    this.childrenChanges.emit(this.data.filter(elm => !this.selectedRows.includes(elm)));
-    this.selectedRows = [];
+    const selected = this.selectedRows();
+    this.childrenChanges.emit(this.data().filter(elm => !selected.includes(elm)));
+    this.selectedRows.set([]);
   }
 
   onEnableScoreWeightChange(event: boolean): void {
     if (!event) {
-      this.childrenChanges.emit(this.data.map(c => ({ ...c, scoreWeight: DEFAULT_SCORE_WEIGHT })));
+      this.childrenChanges.emit(this.data().map(c => ({ ...c, scoreWeight: DEFAULT_SCORE_WEIGHT })));
     }
   }
 
   orderChanged(event: CdkDragDrop<PossiblyInvisibleChildData[]>): void {
-    const previousIndex = this.data.findIndex(d => d === event.item.data);
-    moveItemInArray(this.data, previousIndex, event.currentIndex);
-    this.data = [ ...this.data ];
-    this.childrenChanges.emit(this.data);
+    const reordered = [ ...this.data() ];
+    const previousIndex = reordered.findIndex(d => d === event.item.data);
+    moveItemInArray(reordered, previousIndex, event.currentIndex);
+    this.childrenChanges.emit(reordered);
   }
 
-  onScoreWeightChange(): void {
-    this.childrenChanges.emit(this.data);
+  onScoreWeightChange(rowData: PossiblyInvisibleChildData, scoreWeight: number | null): void {
+    const index = this.data().findIndex(c => c === rowData);
+    if (index === -1) {
+      return;
+    }
+    const weight = scoreWeight ?? DEFAULT_SCORE_WEIGHT;
+    this.childrenChanges.emit(
+      this.data().map((c, i) => (i === index ? { ...c, scoreWeight: weight } : c)),
+    );
   }
 
   openPropagationEditMenu(rowData: PossiblyInvisibleChildData): void {
-    this.propagationEditItemIdx = this.data.indexOf(rowData);
+    this.propagationEditItemIdx.set(this.data().indexOf(rowData));
   }
 
   emitChildPermPropagations(propagations: Partial<ItemPermPropagations>, childIdx: number): void {
     this.childrenChanges.emit(
-      this.data.map((c, index) => {
+      this.data().map((c, index) => {
         if (index === childIdx) {
           return {
             ...c,
@@ -206,13 +208,12 @@ export class ItemChildrenEditListComponent implements OnChanges {
 
   onContentViewPropagationChanged(contentViewPropagation: 'none' | 'as_info' | 'as_content', childIdx: number): void {
     this.emitChildPermPropagations({ contentViewPropagation }, childIdx);
-    this.propagationEditItemIdx = undefined;
+    this.propagationEditItemIdx.set(undefined);
   }
 
   openAdvancedPermPropagationConfigurationDialog(child: PossiblyInvisibleChildData, childIdx: number): void {
     if (!child.permissions) throw new Error('Unexpected: missed permissions');
-    const item = this.itemData?.item;
-    if (!item) throw new Error('Unexpected: missed item');
+    const item = this.itemData().item;
     const title = item.string.title;
     if (!title) throw new Error('Unexpected: missed title');
     const childTitle = child.isVisible ? child.title : undefined;
@@ -235,7 +236,9 @@ export class ItemChildrenEditListComponent implements OnChanges {
           watchPropagation: child.watchPropagation,
         },
       },
-    }).closed.subscribe(result => {
+    }).closed.pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(result => {
       if (result) {
         this.emitChildPermPropagations(result, childIdx);
       }

--- a/src/app/items/containers/item-children-edit/item-children-edit.component.html
+++ b/src/app/items/containers/item-children-edit/item-children-edit.component.html
@@ -1,41 +1,39 @@
 @if (state$ | async; as state) {
-  @if (itemData(); as itemDataValue) {
-    @if (state.isReady) {
-      @if (itemDataValue.item.type === 'Skill') {
-        <h2 class="alg-h2 alg-text-normal alg-base-title-primary-space" i18n>Sub-skills</h2>
-        <alg-item-children-edit-list
-          type="skill"
-          [data]="skills()"
-          [itemData]="itemDataValue"
-          (childrenChanges)="onDataChange($event, 'skill')"
-        ></alg-item-children-edit-list>
+  @if (state.isReady) {
+    @if (itemData().item.type === 'Skill') {
+      <h2 class="alg-h2 alg-text-normal alg-base-title-primary-space" i18n>Sub-skills</h2>
+      <alg-item-children-edit-list
+        type="skill"
+        [data]="skills()"
+        [itemData]="itemData()"
+        (childrenChanges)="onDataChange($event, 'skill')"
+      ></alg-item-children-edit-list>
 
-        <h2 class="alg-h2 alg-text-normal alg-base-title-space" i18n>
-          Activities to learn or reinforce this skill
-        </h2>
-        <alg-item-children-edit-list
-          [data]="activities()"
-          [itemData]="itemDataValue"
-          (childrenChanges)="onDataChange($event)"
-        ></alg-item-children-edit-list>
-      } @else {
-        <alg-item-children-edit-list
-          [data]="activities()"
-          [itemData]="itemDataValue"
-          (childrenChanges)="onDataChange($event)"
-        ></alg-item-children-edit-list>
-      }
+      <h2 class="alg-h2 alg-text-normal alg-base-title-space" i18n>
+        Activities to learn or reinforce this skill
+      </h2>
+      <alg-item-children-edit-list
+        [data]="activities()"
+        [itemData]="itemData()"
+        (childrenChanges)="onDataChange($event)"
+      ></alg-item-children-edit-list>
+    } @else {
+      <alg-item-children-edit-list
+        [data]="activities()"
+        [itemData]="itemData()"
+        (childrenChanges)="onDataChange($event)"
+      ></alg-item-children-edit-list>
     }
-    @if (state.isFetching) {
-      <alg-loading></alg-loading>
-    }
-    @if (state.isError) {
-      <alg-error
-        class="dark"
-        i18n-message message="Error while loading the children items"
-        [showRefreshButton]="true"
-        (refresh)="reloadData()"
-      ></alg-error>
-    }
+  }
+  @if (state.isFetching) {
+    <alg-loading></alg-loading>
+  }
+  @if (state.isError) {
+    <alg-error
+      class="dark"
+      i18n-message message="Error while loading the children items"
+      [showRefreshButton]="true"
+      (refresh)="reloadData()"
+    ></alg-error>
   }
 }

--- a/src/app/items/containers/item-children-edit/item-children-edit.component.html
+++ b/src/app/items/containers/item-children-edit/item-children-edit.component.html
@@ -1,12 +1,12 @@
 @if (state$ | async; as state) {
-  @if (itemData) {
+  @if (itemData(); as itemDataValue) {
     @if (state.isReady) {
-      @if (itemData.item.type === 'Skill') {
+      @if (itemDataValue.item.type === 'Skill') {
         <h2 class="alg-h2 alg-text-normal alg-base-title-primary-space" i18n>Sub-skills</h2>
         <alg-item-children-edit-list
           type="skill"
-          [data]="skills"
-          [itemData]="itemData"
+          [data]="skills()"
+          [itemData]="itemDataValue"
           (childrenChanges)="onDataChange($event, 'skill')"
         ></alg-item-children-edit-list>
 
@@ -14,14 +14,14 @@
           Activities to learn or reinforce this skill
         </h2>
         <alg-item-children-edit-list
-          [data]="activities"
-          [itemData]="itemData"
+          [data]="activities()"
+          [itemData]="itemDataValue"
           (childrenChanges)="onDataChange($event)"
         ></alg-item-children-edit-list>
       } @else {
         <alg-item-children-edit-list
-          [data]="activities"
-          [itemData]="itemData"
+          [data]="activities()"
+          [itemData]="itemDataValue"
           (childrenChanges)="onDataChange($event)"
         ></alg-item-children-edit-list>
       }
@@ -39,4 +39,3 @@
     }
   }
 }
-

--- a/src/app/items/containers/item-children-edit/item-children-edit.component.ts
+++ b/src/app/items/containers/item-children-edit/item-children-edit.component.ts
@@ -3,7 +3,7 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ItemData } from '../../models/item-data';
 import { GetItemChildrenService, isVisibleItemChild } from '../../../data-access/get-item-children.service';
 import { Observable, Subject } from 'rxjs';
-import { filter, map, share, switchMap } from 'rxjs/operators';
+import { distinctUntilChanged, filter, map, share, switchMap } from 'rxjs/operators';
 import { isASkill, ItemType, ItemTypeCategory, itemTypeCategoryEnum as c } from 'src/app/items/models/item-type';
 import { bestAttemptFromResults } from 'src/app/items/models/attempts';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
@@ -70,6 +70,9 @@ export class ItemChildrenEditComponent {
       ? { id: itemData.item.id, attemptId: itemData.currentResult.attemptId }
       : undefined)),
     filter(isNotUndefined),
+    // Avoid re-fetching (which would reset pending local edits) when `itemData` re-emits a new
+    // object reference without an actual change of item/attempt, e.g. on a cancelled navigation.
+    distinctUntilChanged((a, b) => a.id === b.id && a.attemptId === b.attemptId),
   );
 
   readonly state$: Observable<FetchState<PossiblyInvisibleChildData[]>> = this.params$.pipe(

--- a/src/app/items/containers/item-children-edit/item-children-edit.component.ts
+++ b/src/app/items/containers/item-children-edit/item-children-edit.component.ts
@@ -1,13 +1,15 @@
-import { Component, Input, OnChanges, Output, EventEmitter, OnInit, OnDestroy, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DestroyRef, inject, input, output, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { ItemData } from '../../models/item-data';
 import { GetItemChildrenService, isVisibleItemChild } from '../../../data-access/get-item-children.service';
-import { Observable, ReplaySubject, Subject, Subscription } from 'rxjs';
-import { distinctUntilChanged, map, share, switchMap } from 'rxjs/operators';
+import { Observable, Subject } from 'rxjs';
+import { filter, map, share, switchMap } from 'rxjs/operators';
 import { isASkill, ItemType, ItemTypeCategory, itemTypeCategoryEnum as c } from 'src/app/items/models/item-type';
 import { bestAttemptFromResults } from 'src/app/items/models/attempts';
 import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { FetchState } from 'src/app/utils/state';
 import { ItemCorePerm } from 'src/app/items/models/item-permissions';
+import { isNotUndefined } from 'src/app/utils/null-undefined-predicates';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
 import { ItemChildrenEditListComponent } from '../item-children-edit-list/item-children-edit-list.component';
@@ -49,24 +51,28 @@ export const DEFAULT_SCORE_WEIGHT = 1;
   selector: 'alg-item-children-edit',
   templateUrl: './item-children-edit.component.html',
   styleUrls: [ './item-children-edit.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ ItemChildrenEditListComponent, LoadingComponent, ErrorComponent, AsyncPipe ]
 })
-export class ItemChildrenEditComponent implements OnInit, OnDestroy, OnChanges {
+export class ItemChildrenEditComponent {
   private getItemChildrenService = inject(GetItemChildrenService);
+  private destroyRef = inject(DestroyRef);
 
-  @Input() itemData?: ItemData;
+  itemData = input.required<ItemData>();
+  childrenChanges = output<PossiblyInvisibleChildData[]>();
 
-  activities: PossiblyInvisibleChildData[] = [];
-  skills: PossiblyInvisibleChildData[] = [];
+  activities = signal<PossiblyInvisibleChildData[]>([]);
+  skills = signal<PossiblyInvisibleChildData[]>([]);
 
-  private subscription?: Subscription;
-  @Output() childrenChanges = new EventEmitter<PossiblyInvisibleChildData[]>();
-
-  private readonly params$ = new ReplaySubject<{ id: string, attemptId: string }>(1);
   private readonly refresh$ = new Subject<void>();
+
+  private readonly params$ = toObservable(this.itemData).pipe(
+    map(itemData => (itemData.currentResult
+      ? { id: itemData.item.id, attemptId: itemData.currentResult.attemptId }
+      : undefined)),
+    filter(isNotUndefined),
+  );
+
   readonly state$: Observable<FetchState<PossiblyInvisibleChildData[]>> = this.params$.pipe(
-    distinctUntilChanged((a, b) => a.id === b.id && a.attemptId === b.attemptId),
     switchMap(({ id, attemptId }) => this.getItemChildrenService.getWithInvisibleItems(id, attemptId)),
     map(children => children
       .sort((a, b) => a.order - b.order)
@@ -108,26 +114,16 @@ export class ItemChildrenEditComponent implements OnInit, OnDestroy, OnChanges {
     share(),
   );
 
-  ngOnInit(): void {
-    this.subscription = this.state$.pipe(readyData()).subscribe(data => {
-      this.skills = data.filter(item => isASkill(item));
-      this.activities = data.filter(item => !isASkill(item));
+  constructor() {
+    this.destroyRef.onDestroy(() => this.refresh$.complete());
+
+    this.state$.pipe(
+      readyData(),
+      takeUntilDestroyed(),
+    ).subscribe(data => {
+      this.skills.set(data.filter(item => isASkill(item)));
+      this.activities.set(data.filter(item => !isASkill(item)));
     });
-  }
-
-  ngOnDestroy(): void {
-    this.refresh$.complete();
-    this.params$.complete();
-    this.subscription?.unsubscribe();
-  }
-
-  ngOnChanges(): void {
-    if (this.itemData?.currentResult) {
-      this.params$.next({
-        id: this.itemData.item.id,
-        attemptId: this.itemData.currentResult.attemptId,
-      });
-    }
   }
 
   reloadData(): void {
@@ -140,10 +136,10 @@ export class ItemChildrenEditComponent implements OnInit, OnDestroy, OnChanges {
 
   onDataChange(children: PossiblyInvisibleChildData[], type: ItemTypeCategory = c.activity): void {
     if (type === c.skill) {
-      this.skills = children;
+      this.skills.set(children);
     } else {
-      this.activities = children;
+      this.activities.set(children);
     }
-    this.childrenChanges.emit([ ...this.skills, ...this.activities ]);
+    this.childrenChanges.emit([ ...this.skills(), ...this.activities() ]);
   }
 }

--- a/src/app/items/containers/item-content/item-content.component.ts
+++ b/src/app/items/containers/item-content/item-content.component.ts
@@ -122,7 +122,7 @@ export class ItemContentComponent implements PendingChangesComponent {
   hasPrerequisites: boolean|undefined = undefined; // undefined while not known
 
   isDirty(): boolean {
-    return !!this.itemChildrenEditFormComponent?.dirty;
+    return !!this.itemChildrenEditFormComponent?.dirty();
   }
 
   onEditModeEnableChange(editModeEnabled: boolean): void {


### PR DESCRIPTION
## Summary
- Modernize `item-children-edit-list`, `item-children-edit`, and `item-children-edit-form` to Angular 22 patterns; stop in-place array mutation; update `item-content.isDirty()` for signal `dirty()`.
- Batch 19 from `.cursor/plans/modernize-batch-19-children-edit.md`.

## Scope
- **item-children-edit-list** — signal inputs/outputs; `linkedSignal` for score weights; copy-on-emit for reorder/add/remove/propagation; `takeUntilDestroyed` on dialog
- **item-children-edit** — `toObservable(itemData)` fetch; `activities`/`skills` → signals
- **item-children-edit-form** — `dirty`/`disabled` → signals; `viewChild` for reset
- **item-content** — minimal touch: `isDirty()` reads `?.dirty()`

## Risks / manual checks
- **Array-copy change** is the main behavioral risk — every edit must round-trip through `childrenChanges`
- E2E: `item-children-list-edit`, `chapter-children-edit`, `propagation-edit-menu`, `lost-changes-confirmation`
- Manual smoke: chapter edit (add/remove/reorder/weight/propagation/save/cancel); skill with sub-skills + activities

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-19/en/

## Verification
- [x] `npm run lint`
- [x] `ng build algorea --configuration=e2e`
- [x] CI E2E (children edit, propagation, lost-changes)
- [x] Manual smoke (see above)