### PR TITLE
Modernize Angular components (batch 22).

### DIFF
--- a/src/app/directives/auto-resize.directive.ts
+++ b/src/app/directives/auto-resize.directive.ts
@@ -1,14 +1,16 @@
-import { AfterViewInit, Directive, ElementRef, HostListener, inject, Renderer2 } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, inject, Renderer2 } from '@angular/core';
 
 @Directive({
   selector: 'textarea[algAutoResize]',
-  standalone: true,
+  host: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Angular host event binding
+    '(input)': 'onInput($event)',
+  },
 })
 export class AutoResizeDirective implements AfterViewInit {
   private el = inject(ElementRef);
   private renderer = inject(Renderer2);
 
-  @HostListener('input', [ '$event' ])
   onInput(event: Event): void {
     if (event.target instanceof HTMLTextAreaElement) {
       this.renderer.setStyle(this.el.nativeElement, 'height', 'auto');

--- a/src/app/directives/html-el-loaded.directive.ts
+++ b/src/app/directives/html-el-loaded.directive.ts
@@ -1,13 +1,12 @@
-import { AfterViewInit, Directive, ElementRef, EventEmitter, inject, Output } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, inject, output } from '@angular/core';
 
 @Directive({
   selector: '[algHtmlElLoaded]',
-  standalone: true,
 })
 export class HtmlElLoadedDirective implements AfterViewInit {
   private el = inject<ElementRef<HTMLElement>>(ElementRef);
 
-  @Output() elLoaded = new EventEmitter<HTMLElement>();
+  elLoaded = output<HTMLElement>();
 
   ngAfterViewInit(): void {
     this.elLoaded.emit(this.el.nativeElement);

--- a/src/app/forum/models/thread-events.ts
+++ b/src/app/forum/models/thread-events.ts
@@ -79,15 +79,15 @@ export function mergeEvents(eventLists: ThreadEvent[][]): ThreadEvent[] {
 /**
  * Pipes for type assertion
  */
-@Pipe({ name: 'isMessageEvent', pure: true, standalone: true })
+@Pipe({ name: 'isMessageEvent', pure: true })
 export class IsMessageEventPipe implements PipeTransform {
   transform = isMessageEvent;
 }
-@Pipe({ name: 'isAttemptStartedEvent', pure: true, standalone: true })
+@Pipe({ name: 'isAttemptStartedEvent', pure: true })
 export class IsAttemptStartedEventPipe implements PipeTransform {
   transform = isAttemptStartedEvent;
 }
-@Pipe({ name: 'isSubmissionEvent', pure: true, standalone: true })
+@Pipe({ name: 'isSubmissionEvent', pure: true })
 export class IsSubmissionEventPipe implements PipeTransform {
   transform = isSubmissionEvent;
 }

--- a/src/app/groups/containers/group-manager-list/management-level-as-text.pipe.ts
+++ b/src/app/groups/containers/group-manager-list/management-level-as-text.pipe.ts
@@ -13,7 +13,7 @@ function managementLevelAsText(level: GroupManagershipLevel): string {
   }
 }
 
-@Pipe({ name: 'managementLevelAsText', pure: true, standalone: true })
+@Pipe({ name: 'managementLevelAsText', pure: true })
 export class ManagementLevelAsTextPipe implements PipeTransform {
   transform = managementLevelAsText;
 }

--- a/src/app/groups/models/group-management.ts
+++ b/src/app/groups/models/group-management.ts
@@ -53,27 +53,27 @@ export function compareManagershipLevel(l1: GroupManagershipLevel, l2: GroupMana
 // Pipes for templates
 // ********************************************
 
-@Pipe({ name: 'isCurrentUserManager', pure: true, standalone: true })
+@Pipe({ name: 'isCurrentUserManager', pure: true })
 export class IsCurrentUserManagerPipe implements PipeTransform {
   transform = isCurrentUserManager;
 }
 
-@Pipe({ name: 'canCurrentUserGrantGroupAccess', pure: true, standalone: true })
+@Pipe({ name: 'canCurrentUserGrantGroupAccess', pure: true })
 export class CanCurrentUserGrantGroupAccessPipe implements PipeTransform {
   transform = canCurrentUserGrantGroupAccess;
 }
 
-@Pipe({ name: 'canCurrentUserWatchMembers', pure: true, standalone: true })
+@Pipe({ name: 'canCurrentUserWatchMembers', pure: true })
 export class CanCurrentUserWatchMembersPipe implements PipeTransform {
   transform = canCurrentUserWatchMembers;
 }
 
-@Pipe({ name: 'canCurrentUserManageMembers', pure: true, standalone: true })
+@Pipe({ name: 'canCurrentUserManageMembers', pure: true })
 export class CanCurrentUserManageMembersPipe implements PipeTransform {
   transform = canCurrentUserManageMembers;
 }
 
-@Pipe({ name: 'canCurrentUserManageMembersAndGroup', pure: true, standalone: true })
+@Pipe({ name: 'canCurrentUserManageMembersAndGroup', pure: true })
 export class CanCurrentUserManageMembersAndGroupPipe implements PipeTransform {
   transform = canCurrentUserManageMembersAndGroup;
 }
@@ -82,7 +82,7 @@ export class CanCurrentUserManageMembersAndGroupPipe implements PipeTransform {
  * Compares two managership levels.
  * @returns A negative number if l1 is less than l2, a positive number if l1 is greater than l2, or zero if they are equal.
  */
-@Pipe({ name: 'compareManagershipLevel', pure: true, standalone: true })
+@Pipe({ name: 'compareManagershipLevel', pure: true })
 export class CompareManagershipLevelPipe implements PipeTransform {
   transform = compareManagershipLevel;
 }

--- a/src/app/groups/models/group-membership.ts
+++ b/src/app/groups/models/group-membership.ts
@@ -13,7 +13,7 @@ export function isCurrentUserMember<T extends { currentUserMembership: GroupMemb
 // Pipes for templates
 // ********************************************
 
-@Pipe({ name: 'isCurrentUserMember', pure: true, standalone: true })
+@Pipe({ name: 'isCurrentUserMember', pure: true })
 export class IsCurrentUserMemberPipe implements PipeTransform {
   transform = isCurrentUserMember;
 }

--- a/src/app/groups/models/user.ts
+++ b/src/app/groups/models/user.ts
@@ -66,12 +66,12 @@ export function canEditPersonalInfo(user: User): boolean {
     || user.personalInfoAccessApprovalToCurrentUser === RequirePersonalInfoAccessApproval.Edit;
 }
 
-@Pipe({ name: 'canViewPersonalInfo', pure: true, standalone: true })
+@Pipe({ name: 'canViewPersonalInfo', pure: true })
 export class CanViewPersonalInfoPipe implements PipeTransform {
   transform = canViewPersonalInfo;
 }
 
-@Pipe({ name: 'canEditPersonalInfo', pure: true, standalone: true })
+@Pipe({ name: 'canEditPersonalInfo', pure: true })
 export class CanEditPersonalInfoPipe implements PipeTransform {
   transform = canEditPersonalInfo;
 }

--- a/src/app/items/models/attempts.ts
+++ b/src/app/items/models/attempts.ts
@@ -61,8 +61,7 @@ export function implicitResultStart(item: Item): boolean {
  * Returns true if the user can (still) submit on this result.
  */
 @Pipe({
-  name: 'isActive', pure: true,
-  standalone: true
+  name: 'isActive', pure: true
 })
 export class ResultIsActivePipe implements PipeTransform {
 

--- a/src/app/items/models/item-edit-permission.ts
+++ b/src/app/items/models/item-edit-permission.ts
@@ -41,16 +41,14 @@ export function allowsGrantingEdition(p: ItemPermWithEdit): boolean {
 // ********************************************
 
 @Pipe({
-  name: 'allowsEditingChildren', pure: true,
-  standalone: true
+  name: 'allowsEditingChildren', pure: true
 })
 export class AllowsEditingChildrenItemPipe implements PipeTransform {
   transform = allowsEditingChildren;
 }
 
 @Pipe({
-  name: 'allowsEditingAll', pure: true,
-  standalone: true
+  name: 'allowsEditingAll', pure: true
 })
 export class AllowsEditingAllItemPipe implements PipeTransform {
   transform = allowsEditingAll;

--- a/src/app/items/models/item-entry.ts
+++ b/src/app/items/models/item-entry.ts
@@ -22,8 +22,7 @@ export function hasAlreadyStated(entryState: EntryState): boolean {
 
 @Pipe({
   name: 'canEnterNow',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class CanEnterNowPipe implements PipeTransform {
   transform = canEnterNow;
@@ -31,8 +30,7 @@ export class CanEnterNowPipe implements PipeTransform {
 
 @Pipe({
   name: 'hasAlreadyStated',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class HasAlreadyStatedPipe implements PipeTransform {
   transform = hasAlreadyStated;

--- a/src/app/items/models/item-grant-view-permission.ts
+++ b/src/app/items/models/item-grant-view-permission.ts
@@ -42,15 +42,13 @@ export function canCurrentUserGrantView(i: ItemWithGrantViewPerm): boolean {
 // ********************************************
 
 @Pipe({
-  name: 'allowsGrantingView', pure: true,
-  standalone: true
+  name: 'allowsGrantingView', pure: true
 })
 export class AllowsGrantingViewItemPipe implements PipeTransform {
   transform = allowsGrantingView;
 }
 @Pipe({
-  name: 'allowsGrantingContentView', pure: true,
-  standalone: true
+  name: 'allowsGrantingContentView', pure: true
 })
 export class AllowsGrantingContentViewItemPipe implements PipeTransform {
   transform = allowsGrantingContentView;

--- a/src/app/items/models/item-type.ts
+++ b/src/app/items/models/item-type.ts
@@ -52,32 +52,28 @@ export function isAnActivity(item: ItemWithType): boolean {
 // ********************************************
 
 @Pipe({
-  name: 'isASkill', pure: true,
-  standalone: true
+  name: 'isASkill', pure: true
 })
 export class IsASkillPipe implements PipeTransform {
   transform = isASkill;
 }
 
 @Pipe({
-  name: 'isATask', pure: true,
-  standalone: true
+  name: 'isATask', pure: true
 })
 export class IsATaskPipe implements PipeTransform {
   transform = isATask;
 }
 
 @Pipe({
-  name: 'isAChapter', pure: true,
-  standalone: true
+  name: 'isAChapter', pure: true
 })
 export class IsAChapterPipe implements PipeTransform {
   transform = isAChapter;
 }
 
 @Pipe({
-  name: 'mayHaveChildren', pure: true,
-  standalone: true
+  name: 'mayHaveChildren', pure: true
 })
 export class MayHaveChildrenPipe implements PipeTransform {
   transform = mayHaveChildren;

--- a/src/app/items/models/item-view-permission.ts
+++ b/src/app/items/models/item-view-permission.ts
@@ -50,15 +50,13 @@ export function canCurrentUserViewContent(i: ItemWithViewPerm): boolean {
 // ********************************************
 
 @Pipe({
-  name: 'allowsViewingInfo', pure: true,
-  standalone: true
+  name: 'allowsViewingInfo', pure: true
 })
 export class AllowsViewingItemInfoPipe implements PipeTransform {
   transform = allowsViewingInfo;
 }
 @Pipe({
-  name: 'allowsViewingContent', pure: true,
-  standalone: true
+  name: 'allowsViewingContent', pure: true
 })
 export class AllowsViewingItemContentPipe implements PipeTransform {
   transform = allowsViewingContent;

--- a/src/app/items/models/item-watch-permission.ts
+++ b/src/app/items/models/item-watch-permission.ts
@@ -51,16 +51,14 @@ export function canCurrentUserWatchResult(i: ItemWithWatchPerm): boolean {
 // ********************************************
 
 @Pipe({
-  name: 'allowsWatchingResults', pure: true,
-  standalone: true
+  name: 'allowsWatchingResults', pure: true
 })
 export class AllowsWatchingItemResultsPipe implements PipeTransform {
   transform = allowsWatchingResults;
 }
 
 @Pipe({
-  name: 'allowsWatchingAnswers', pure: true,
-  standalone: true
+  name: 'allowsWatchingAnswers', pure: true
 })
 export class AllowsWatchingItemAnswersPipe implements PipeTransform {
   transform = allowsWatchingAnswers;

--- a/src/app/items/models/team-activity.ts
+++ b/src/app/items/models/team-activity.ts
@@ -13,8 +13,7 @@ export function isTeamActivity(item: { type: ItemType, entryParticipantType: z.i
 // ********************************************
 
 @Pipe({
-  name: 'isTeamActivity', pure: true,
-  standalone: true
+  name: 'isTeamActivity', pure: true
 })
 export class IsTeamActivityPipe implements PipeTransform {
   transform = isTeamActivity;

--- a/src/app/items/models/time-limited-activity.ts
+++ b/src/app/items/models/time-limited-activity.ts
@@ -29,8 +29,7 @@ export function canCurrentUserSetExtraTime(item: Pick<Item, 'permissions'>): boo
 
 @Pipe({
   name: 'isTimeLimitedActivity',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class IsTimeLimitedActivityPipe implements PipeTransform {
   transform = isTimeLimitedActivity;
@@ -38,8 +37,7 @@ export class IsTimeLimitedActivityPipe implements PipeTransform {
 
 @Pipe({
   name: 'canCurrentUserSetExtraTime',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class CanCurrentUserSetExtraTimePipe implements PipeTransform {
   transform = canCurrentUserSetExtraTime;

--- a/src/app/pipes/allowDisplayCodeSnippet.ts
+++ b/src/app/pipes/allowDisplayCodeSnippet.ts
@@ -5,8 +5,7 @@ function replaceHTML(text: string): string {
 }
 
 @Pipe({
-  name: 'allowDisplayCodeSnippet', pure: true,
-  standalone: true
+  name: 'allowDisplayCodeSnippet', pure: true
 })
 export class AllowDisplayCodeSnippet implements PipeTransform {
 

--- a/src/app/pipes/breakLines.ts
+++ b/src/app/pipes/breakLines.ts
@@ -2,8 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'breakLines',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class BreakLinesPipe implements PipeTransform {
 

--- a/src/app/pipes/duration.ts
+++ b/src/app/pipes/duration.ts
@@ -2,8 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { Duration } from '../utils/duration';
 
 @Pipe({
-  name: 'toMin',
-  standalone: true
+  name: 'toMin'
 })
 export class DurationToMinPipe implements PipeTransform {
   transform(duration: Duration): number {
@@ -12,8 +11,7 @@ export class DurationToMinPipe implements PipeTransform {
 }
 
 @Pipe({
-  name: 'secToDuration',
-  standalone: true
+  name: 'secToDuration'
 })
 export class SecondsToDurationPipe implements PipeTransform {
   transform(seconds: number): Duration {
@@ -22,8 +20,7 @@ export class SecondsToDurationPipe implements PipeTransform {
 }
 
 @Pipe({
-  name: 'readable',
-  standalone: true
+  name: 'readable'
 })
 export class DurationToReadablePipe implements PipeTransform {
   transform(duration: Duration): string {
@@ -32,8 +29,7 @@ export class DurationToReadablePipe implements PipeTransform {
 }
 
 @Pipe({
-  name: 'asCountdown',
-  standalone: true
+  name: 'asCountdown'
 })
 export class DurationAsCountdownPipe implements PipeTransform {
   transform(duration: Duration): string {

--- a/src/app/pipes/findInArray.ts
+++ b/src/app/pipes/findInArray.ts
@@ -2,8 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
   name: 'findInArray',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class FindInArray implements PipeTransform {
 

--- a/src/app/pipes/groupIsUser.ts
+++ b/src/app/pipes/groupIsUser.ts
@@ -2,8 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { GroupLike, isUser } from '../models/routing/group-route';
 
 @Pipe({
-  name: 'isUser', pure: true,
-  standalone: true
+  name: 'isUser', pure: true
 })
 export class GroupIsUserPipe implements PipeTransform {
 

--- a/src/app/pipes/groupLink.ts
+++ b/src/app/pipes/groupLink.ts
@@ -7,8 +7,7 @@ import { GroupRouter } from '../models/routing/group-router';
  * Pipe to format group links from a group object, a user/profile object or a group route object.
  */
 @Pipe({
-  name: 'groupLink', pure: true,
-  standalone: true
+  name: 'groupLink', pure: true
 })
 export class GroupLinkPipe implements PipeTransform {
   private groupRouter = inject(GroupRouter);

--- a/src/app/pipes/groupPermissionCaption.ts
+++ b/src/app/pipes/groupPermissionCaption.ts
@@ -17,8 +17,7 @@ const PERMISSION_CAPTIONS = {
 };
 
 @Pipe({
-  name: 'groupPermissionCaption', pure: true,
-  standalone: true
+  name: 'groupPermissionCaption', pure: true
 })
 export class GroupPermissionCaptionPipe implements PipeTransform {
   transform(value: keyof typeof PERMISSION_CAPTIONS): string {

--- a/src/app/pipes/itemRoute.ts
+++ b/src/app/pipes/itemRoute.ts
@@ -14,8 +14,7 @@ import { Store } from '@ngrx/store';
  */
 @Pipe({
   name: 'itemRoute',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class ItemRoutePipe implements PipeTransform {
 
@@ -33,8 +32,7 @@ export class ItemRoutePipe implements PipeTransform {
  */
 @Pipe({
   name: 'with',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class ItemRouteWithExtraPipe implements PipeTransform {
   transform<T extends RawItemRoute>(route: T, attrs: Partial<ItemRoute>): T {

--- a/src/app/pipes/logActionDisplay.ts
+++ b/src/app/pipes/logActionDisplay.ts
@@ -13,8 +13,7 @@ function formatLogAction (type: ActivityLogs[number]['activityType'], score?: nu
 }
 
 @Pipe({
-  name: 'logActionDisplay',
-  standalone: true
+  name: 'logActionDisplay'
 })
 export class LogActionDisplayPipe implements PipeTransform {
   transform = formatLogAction;

--- a/src/app/pipes/logActivityTypeIcon.ts
+++ b/src/app/pipes/logActivityTypeIcon.ts
@@ -3,8 +3,7 @@ import { ActivityLogs } from 'src/app/data-access/activity-log.service';
 
 @Pipe({
   name: 'logActivityTypeIcon',
-  pure: true,
-  standalone: true
+  pure: true
 })
 export class LogActivityTypeIconPipe implements PipeTransform {
   transform(activity: ActivityLogs[number]['activityType']): string {

--- a/src/app/pipes/routeUrl.ts
+++ b/src/app/pipes/routeUrl.ts
@@ -6,8 +6,7 @@ import { GroupRouter } from '../models/routing/group-router';
 import { UrlTree } from '@angular/router';
 
 @Pipe({
-  name: 'url', pure: true,
-  standalone: true
+  name: 'url', pure: true
 })
 export class RouteUrlPipe implements PipeTransform {
   private itemRouter = inject(ItemRouter);

--- a/src/app/pipes/userCaption.ts
+++ b/src/app/pipes/userCaption.ts
@@ -2,8 +2,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 import { UserBase, formatUser } from '../groups/models/user';
 
 @Pipe({
-  name: 'userCaption', pure: true,
-  standalone: true
+  name: 'userCaption', pure: true
 })
 export class UserCaptionPipe implements PipeTransform {
   transform(user: UserBase): string {

--- a/src/app/ui-components/overlay/show-overlay-hover-target.directive.ts
+++ b/src/app/ui-components/overlay/show-overlay-hover-target.directive.ts
@@ -2,7 +2,6 @@ import { Directive, ElementRef, inject } from '@angular/core';
 
 @Directive({
   selector: '[algShowOverlayHoverTarget]',
-  standalone: true,
 })
 export class ShowOverlayHoverTargetDirective {
   nativeElement = inject<ElementRef<HTMLElement>>(ElementRef).nativeElement;

--- a/src/app/ui-components/overlay/show-overlay.directive.ts
+++ b/src/app/ui-components/overlay/show-overlay.directive.ts
@@ -2,7 +2,6 @@ import {
   AfterViewInit,
   contentChild,
   Directive,
-  HostListener,
   inject,
   input,
   OnDestroy,
@@ -19,8 +18,11 @@ import { TemplatePortal } from '@angular/cdk/portal';
 
 @Directive({
   selector: '[algShowOverlay]',
-  standalone: true,
   exportAs: 'algShowOverlay',
+  host: {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Angular host event binding
+    '(mouseleave)': 'onHover($event)',
+  },
 })
 export class ShowOverlayDirective implements OnDestroy, AfterViewInit {
   overlayOpenEvent = output<Event>();
@@ -44,7 +46,7 @@ export class ShowOverlayDirective implements OnDestroy, AfterViewInit {
     panelClass: 'alg-path-suggestion-overlay',
   });
 
-  @HostListener('mouseleave', [ '$event' ]) onHover(event: MouseEvent): void {
+  onHover(event: MouseEvent): void {
     if (canCloseOverlay(event)) {
       this.showOverlaySubject$.next(undefined);
     }

--- a/src/app/ui-components/table-sort/table-sort.directive.ts
+++ b/src/app/ui-components/table-sort/table-sort.directive.ts
@@ -4,7 +4,6 @@ import { SortEvent, TableSortHeaderComponent } from 'src/app/ui-components/table
 
 @Directive({
   selector: '[algTableSort]',
-  standalone: true,
 })
 export class TableSortDirective {
   sortChange = output<SortEvent[]>();

--- a/src/app/ui-components/tooltip/tooltip.directive.ts
+++ b/src/app/ui-components/tooltip/tooltip.directive.ts
@@ -58,7 +58,6 @@ const positions = new Map<TooltipPosition, ConnectedPosition[]>([
 
 @Directive({
   selector: '[algTooltip]',
-  standalone: true,
 })
 export class TooltipDirective implements AfterViewInit, OnDestroy {
   private overlay = inject(Overlay);


### PR DESCRIPTION
## Summary
- Remove redundant `standalone: true` from ~40 pipes and 6 directives; modernize `ShowOverlayDirective`, `HtmlElLoadedDirective`, and `AutoResizeDirective` host bindings / outputs.
- Batch 22 from `.cursor/plans/modernize-batch-22-pipes-directives.md`.

## Scope
- **Pipes (26 files):** `src/app/pipes/`, `items/models/`, `groups/models/`, `forum/models/thread-events.ts`, `management-level-as-text.pipe.ts`
- **Directives:** `TooltipDirective`, `TableSortDirective`, `ShowOverlay*` (host binding), `HtmlElLoadedDirective` (`output()`), `AutoResizeDirective` (host binding)
- No template or call-site changes

## Risks / manual checks
- No functional change expected
- Remaining `standalone: true`: deferred components (`pending-join-requests`, `group-no-permission`, `language-mismatch`)
- Smoke-load app once (tooltips, table sort, overlay hover, forum textarea resize)

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-22/en/

## Verification
- [x] `npm run lint`
- [x] `rg 'standalone: true' src/app` — only expected deferred hits
- [x] `rg '@HostListener|@HostBinding' src/app` — zero matches
- [x] `ng build --configuration=e2e`