### PR TITLE
Modernize Angular components (batch 23).

### DIFF
--- a/src/app/ui-components/button-icon/button-icon.component.html
+++ b/src/app/ui-components/button-icon/button-icon.component.html
@@ -1,3 +1,3 @@
 <span class="wrapper">
-  <span class="icon" [ngClass]="icon()"></span>
+  <span class="icon" [class]="icon()"></span>
 </span>

--- a/src/app/ui-components/button-icon/button-icon.component.ts
+++ b/src/app/ui-components/button-icon/button-icon.component.ts
@@ -1,14 +1,9 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { Component, input } from '@angular/core';
 
 @Component({
   selector: 'button[alg-button-icon], a[alg-button-icon]',
   templateUrl: './button-icon.component.html',
   styleUrls: [ './button-icon.component.scss' ],
-  imports: [
-    NgClass,
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ButtonIconComponent {
   icon = input.required<string>();

--- a/src/app/ui-components/button/button.component.html
+++ b/src/app/ui-components/button/button.component.html
@@ -5,5 +5,5 @@
 }
 
 @if (icon(); as icon) {
-  <span class="icon" [ngClass]="icon"></span>
+  <span class="icon" [class]="icon"></span>
 }

--- a/src/app/ui-components/button/button.component.ts
+++ b/src/app/ui-components/button/button.component.ts
@@ -1,15 +1,10 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { Component, input } from '@angular/core';
 import { style, trigger, transition, animate } from '@angular/animations';
 
 @Component({
   selector: 'button[alg-button], a[alg-button]',
   templateUrl: './button.component.html',
   styleUrls: [ './button.component.scss' ],
-  imports: [
-    NgClass
-  ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('captionAnimation', [
       transition(':enter', [

--- a/src/app/ui-components/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/ui-components/confirmation-modal/confirmation-modal.component.html
@@ -4,7 +4,7 @@
       <button class="secondary" alg-button-icon icon="ph ph-x" (click)="dialogRef.close()"></button>
     </div>
   }
-  <div class="body" [ngClass]="{ 'without-close-padding': !data().allowToClose }">
+  <div class="body" [class.without-close-padding]="!data().allowToClose">
     @if (data().title; as title) {
       <div class="title alg-h4">{{ title }}</div>
     }

--- a/src/app/ui-components/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/ui-components/confirmation-modal/confirmation-modal.component.ts
@@ -1,19 +1,16 @@
-import { Component, inject, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { ConfirmationModalData } from 'src/app/services/confirmation-modal.service';
-import { NgClass } from '@angular/common';
 
 @Component({
   selector: 'alg-confirmation-modal',
   templateUrl: './confirmation-modal.component.html',
   styleUrls: [ './confirmation-modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ButtonIconComponent,
     ButtonComponent,
-    NgClass,
   ]
 })
 export class ConfirmationModalComponent {

--- a/src/app/ui-components/input-number/input-number.component.ts
+++ b/src/app/ui-components/input-number/input-number.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, input, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, forwardRef, input, signal } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MaskDirective } from '../mask/mask.directive';
 import { isString } from 'src/app/utils/type-checkers';
@@ -14,7 +14,6 @@ import { isString } from 'src/app/utils/type-checkers';
       multi: true,
     },
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     FormsModule,
     MaskDirective,

--- a/src/app/ui-components/left-menu-search/left-menu-search.component.ts
+++ b/src/app/ui-components/left-menu-search/left-menu-search.component.ts
@@ -6,7 +6,6 @@ import {
   inject,
   input,
   output,
-  ChangeDetectionStrategy
 } from '@angular/core';
 import { outputFromObservable } from '@angular/core/rxjs-interop';
 import { FormBuilder } from '@angular/forms';
@@ -18,7 +17,6 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
   selector: 'alg-left-menu-search',
   templateUrl: 'left-menu-search.component.html',
   styleUrls: [ 'left-menu-search.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ InputComponent, ButtonIconComponent ],
 })
 export class LeftMenuSearchComponent {

--- a/src/app/ui-components/modal/modal.component.ts
+++ b/src/app/ui-components/modal/modal.component.ts
@@ -1,11 +1,10 @@
-import { Component, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 
 @Component({
   selector: 'alg-modal',
   templateUrl: './modal.component.html',
   styleUrls: [ './modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ButtonIconComponent,
   ]

--- a/src/app/ui-components/notification-modal/notification-modal.component.ts
+++ b/src/app/ui-components/notification-modal/notification-modal.component.ts
@@ -1,11 +1,10 @@
-import { Component, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 
 @Component({
   selector: 'alg-notification-modal',
   templateUrl: './notification-modal.component.html',
   styleUrls: [ './notification-modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ ButtonIconComponent ]
 })
 export class NotificationModalComponent {

--- a/src/app/ui-components/select/select-option/select-option.component.html
+++ b/src/app/ui-components/select/select-option/select-option.component.html
@@ -1,6 +1,6 @@
 <button
   class="button alg-select-option"
-  [ngClass]="{ 'selected': selected() }"
+  [class.selected]="selected()"
   type="button"
   (click)="select(value())"
 >

--- a/src/app/ui-components/select/select-option/select-option.component.ts
+++ b/src/app/ui-components/select/select-option/select-option.component.ts
@@ -1,15 +1,10 @@
-import { Component, computed, inject, input, ChangeDetectionStrategy } from '@angular/core';
-import { NgClass } from '@angular/common';
+import { Component, computed, inject, input } from '@angular/core';
 import { SelectedOptionService, SelectOption } from 'src/app/ui-components/select/select-option/selected-option.service';
 
 @Component({
   selector: 'alg-select-option',
   templateUrl: './select-option.component.html',
   styleUrls: [ './select-option.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [
-    NgClass
-  ]
 })
 export class SelectOptionComponent {
   value = input.required<SelectOption>();

--- a/src/app/ui-components/select/select.component.ts
+++ b/src/app/ui-components/select/select.component.ts
@@ -10,7 +10,6 @@ import {
   output,
   signal,
   viewChild,
-  ChangeDetectionStrategy
 } from '@angular/core';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import {
@@ -35,7 +34,6 @@ import { SelectedOptionService, SelectOption } from 'src/app/ui-components/selec
     CdkOverlayOrigin,
     CdkConnectedOverlay,
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/src/app/ui-components/switch/switch.component.ts
+++ b/src/app/ui-components/switch/switch.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, forwardRef, output, signal } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, FormsModule } from '@angular/forms';
 
 /**
@@ -22,7 +22,6 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, FormsModule } from '@angular/f
       multi: true,
     }
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ FormsModule ]
 })
 export class SwitchComponent implements ControlValueAccessor {

--- a/src/app/ui-components/tab-bar/tab-bar.component.html
+++ b/src/app/ui-components/tab-bar/tab-bar.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  @if (showPrevButton) {
+  @if (showPrevButton()) {
     <button
       class="size-s primary no-bg tab-arrow tab-prev prev-button"
       type="button"
@@ -23,7 +23,7 @@
       }
     </ul>
   </ng-scrollbar>
-  @if (showNextButton) {
+  @if (showNextButton()) {
     <button
       class="size-s primary no-bg tab-arrow tab-next next-button"
       type="button"

--- a/src/app/ui-components/tab-bar/tab-bar.component.ts
+++ b/src/app/ui-components/tab-bar/tab-bar.component.ts
@@ -1,6 +1,6 @@
 import {
-  AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef,
-  input, OnDestroy, ViewChild, inject,
+  AfterViewInit, Component, ElementRef,
+  input, OnDestroy, inject, signal, viewChild,
 } from '@angular/core';
 import { combineLatest, map, Subscription, Subject, merge, fromEvent } from 'rxjs';
 import { TabService } from '../../services/tab.service';
@@ -14,7 +14,6 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
   selector: 'alg-tab-bar',
   templateUrl: './tab-bar.component.html',
   styleUrls: [ './tab-bar.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   host: {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     '(window:resize)': 'resize()',
@@ -24,13 +23,12 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
 export class TabBarComponent implements AfterViewInit, OnDestroy {
   private tabService = inject(TabService);
   private elementRef = inject<ElementRef<HTMLDivElement>>(ElementRef);
-  private cd = inject(ChangeDetectorRef);
 
-  @ViewChild(NgScrollbar, { static: false }) scrollbarRef?: NgScrollbar;
+  scrollbarRef = viewChild(NgScrollbar);
   styleClass = input<string>();
 
-  showPrevButton = false;
-  showNextButton = false;
+  showPrevButton = signal(false);
+  showNextButton = signal(false);
 
   tabs$ = combineLatest([ this.tabService.tabs$, this.tabService.activeTab$ ]).pipe(
     map(([ tabs, active ]) => tabs.map(tab => ({
@@ -53,12 +51,13 @@ export class TabBarComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
-    if (!this.scrollbarRef) return;
+    const scrollbar = this.scrollbarRef();
+    if (!scrollbar) return;
     this.resizeObserver.observe(this.elementRef.nativeElement);
     this.subscriptions.add(
       merge(
         this.resizeEvent.asObservable(),
-        fromEvent(this.scrollbarRef.nativeElement, 'scroll'),
+        fromEvent(scrollbar.nativeElement, 'scroll'),
         this.tabs$,
       ).pipe(
         debounceTime(50),
@@ -79,31 +78,33 @@ export class TabBarComponent implements AfterViewInit, OnDestroy {
   }
 
   handleArrows(): void {
-    if (!this.scrollbarRef) throw new Error('Unexpected: Missed scrollbar');
-    const scrollLeft = this.scrollbarRef.nativeElement.scrollLeft;
-    const scrollWidth = this.scrollbarRef.nativeElement.scrollWidth;
-    const clientWidth = this.scrollbarRef.nativeElement.clientWidth;
+    const scrollbar = this.scrollbarRef();
+    if (!scrollbar) throw new Error('Unexpected: Missed scrollbar');
+    const scrollLeft = scrollbar.nativeElement.scrollLeft;
+    const scrollWidth = scrollbar.nativeElement.scrollWidth;
+    const clientWidth = scrollbar.nativeElement.clientWidth;
     const gap = 5;
-    this.showPrevButton = clientWidth !== Math.round(scrollWidth) && scrollLeft > gap;
-    this.showNextButton = clientWidth !== Math.round(scrollWidth)
-      && (scrollLeft + clientWidth) < (Math.round(scrollWidth) - gap);
-    this.cd.detectChanges();
+    this.showPrevButton.set(clientWidth !== Math.round(scrollWidth) && scrollLeft > gap);
+    this.showNextButton.set(clientWidth !== Math.round(scrollWidth)
+      && (scrollLeft + clientWidth) < (Math.round(scrollWidth) - gap));
   }
 
   onPrev(): void {
-    if (!this.scrollbarRef) throw new Error('Unexpected: Missed scrollbar');
-    const scrollLeft = this.scrollbarRef.nativeElement.scrollLeft;
-    const clientWidth = this.scrollbarRef.nativeElement.clientWidth;
-    void this.scrollbarRef.scrollTo({
+    const scrollbar = this.scrollbarRef();
+    if (!scrollbar) throw new Error('Unexpected: Missed scrollbar');
+    const scrollLeft = scrollbar.nativeElement.scrollLeft;
+    const clientWidth = scrollbar.nativeElement.clientWidth;
+    void scrollbar.scrollTo({
       left: scrollLeft - (clientWidth / 2),
     });
   }
 
   onNext(): void {
-    if (!this.scrollbarRef) throw new Error('Unexpected: Missed scrollbar');
-    const scrollLeft = this.scrollbarRef.nativeElement.scrollLeft;
-    const clientWidth = this.scrollbarRef.nativeElement.clientWidth;
-    void this.scrollbarRef.scrollTo({
+    const scrollbar = this.scrollbarRef();
+    if (!scrollbar) throw new Error('Unexpected: Missed scrollbar');
+    const scrollLeft = scrollbar.nativeElement.scrollLeft;
+    const clientWidth = scrollbar.nativeElement.clientWidth;
+    void scrollbar.scrollTo({
       left: scrollLeft + (clientWidth / 2),
     });
   }

--- a/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.html
+++ b/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.html
@@ -1,4 +1,4 @@
-<label class="label" [ngClass]="{ 'cursor-pointer': sortEnabled() }">
+<label class="label" [class.cursor-pointer]="sortEnabled()">
   <ng-content></ng-content>
   @if (sortEnabled()) {
     @let icon = sortOrder() === 1

--- a/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.ts
+++ b/src/app/ui-components/table-sort/table-sort-header/table-sort-header.component.ts
@@ -1,6 +1,5 @@
-import { Component, input, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
-import { NgClass } from '@angular/common';
 
 export interface SortEvent {
   field: string,
@@ -11,8 +10,7 @@ export interface SortEvent {
   selector: 'th[alg-table-sort-header]',
   templateUrl: './table-sort-header.component.html',
   styleUrls: [ './table-sort-header.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ ButtonIconComponent, NgClass ]
+  imports: [ ButtonIconComponent ]
 })
 export class TableSortHeaderComponent {
   sortField = input.required<string>({ alias: 'alg-table-sort-header' });

--- a/src/app/ui-components/toast-messages/toast-messages.component.ts
+++ b/src/app/ui-components/toast-messages/toast-messages.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MessageV2, MessageService } from 'src/app/services/message.service';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
@@ -8,7 +8,6 @@ import { Subscription } from 'rxjs';
   selector: 'alg-toast-messages',
   templateUrl: './toast-messages.component.html',
   styleUrls: [ './toast-messages.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ButtonIconComponent,
   ]

--- a/src/app/ui-components/tooltip/tooltip.component.ts
+++ b/src/app/ui-components/tooltip/tooltip.component.ts
@@ -1,11 +1,10 @@
-import { Component, signal, TemplateRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, signal, TemplateRef } from '@angular/core';
 import { NgTemplateOutlet } from '@angular/common';
 
 @Component({
   selector: 'alg-tooltip',
   templateUrl: './tooltip.component.html',
   styleUrls: [ './tooltip.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     NgTemplateOutlet
   ]


### PR DESCRIPTION
## Summary
- Drop explicit `ChangeDetectionStrategy.Eager` (12 components) and redundant `OnPush` (2); replace remaining `NgClass` with class bindings; convert `tab-bar` arrow state to signals.
- Batch 23 from `.cursor/plans/modernize-batch-23-ui-cd-cleanup.md`.

## Scope
- **Trivial (13 components):** tooltip, toast-messages, table-sort-header, switch, select, select-option, notification-modal, modal, left-menu-search, input-number, confirmation-modal, button, button-icon
- **Non-trivial:** `tab-bar` — `showPrevButton`/`showNextButton` → signals; remove manual `detectChanges()`; `@ViewChild` → `viewChild(NgScrollbar)`

## Risks / manual checks
- High-reuse components (`button` ~100 usages, `switch` 17, `select` 13)
- **Tab bar arrows** on narrow window + resize (main behavioral change)
- Manual smoke: select dropdown, switch toggle, toast on save, left-menu search, confirmation modal

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-23/en/

## Verification
- [x] `npm run lint`
- [x] ui-components unit tests (97/97)
- [x] No `NgClass` in `ui-components` TS files
- [x] `ng build algorea --configuration=en`
- [x] Manual smoke (tab-bar arrows especially)