### PR TITLE
Modernize Angular components (batch 24).

### DIFF
--- a/src/app/containers/fatal-error-modal/fatal-error-modal.component.ts
+++ b/src/app/containers/fatal-error-modal/fatal-error-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { DIALOG_DATA } from '@angular/cdk/dialog';
 import { NotificationModalComponent } from 'src/app/ui-components/notification-modal/notification-modal.component';
@@ -7,7 +7,6 @@ import { NotificationModalComponent } from 'src/app/ui-components/notification-m
   selector: 'alg-fatal-error-modal',
   templateUrl: './fatal-error-modal.component.html',
   styleUrls: [ './fatal-error-modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ ButtonComponent, NotificationModalComponent ]
 })
 export class FatalErrorModalComponent {

--- a/src/app/containers/group-observation-error-modal/group-observation-error-modal.component.ts
+++ b/src/app/containers/group-observation-error-modal/group-observation-error-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { NotificationModalComponent } from 'src/app/ui-components/notification-modal/notification-modal.component';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 
@@ -6,7 +6,6 @@ import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
   selector: 'alg-group-observation-error-modal',
   templateUrl: './group-observation-error-modal.component.html',
   styleUrls: [ './group-observation-error-modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ NotificationModalComponent ]
 })
 export class GroupObservationErrorModalComponent {

--- a/src/app/containers/language-mismatch/language-mismatch-modal/language-mismatch-modal.component.html
+++ b/src/app/containers/language-mismatch/language-mismatch-modal/language-mismatch-modal.component.html
@@ -2,7 +2,7 @@
   @if (currentLanguage) {
     @let languageMismatch = params();
 
-    @if (updating) {
+    @if (updating()) {
       <div class="spinner-overlay">
         <alg-loading></alg-loading>
       </div>

--- a/src/app/containers/language-mismatch/language-mismatch-modal/language-mismatch-modal.component.ts
+++ b/src/app/containers/language-mismatch/language-mismatch-modal/language-mismatch-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnDestroy, signal } from '@angular/core';
 import { NotificationModalComponent } from 'src/app/ui-components/notification-modal/notification-modal.component';
 import { catchError, filter, retry, switchMap } from 'rxjs/operators';
 import { EMPTY } from 'rxjs';
@@ -18,7 +18,6 @@ export interface LanguageMismatchModalParams {
   selector: 'alg-language-mismatch-modal',
   templateUrl: './language-mismatch-modal.component.html',
   styleUrls: [ './language-mismatch-modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     NotificationModalComponent,
     LoadingComponent,
@@ -35,7 +34,7 @@ export class LanguageMismatchModalComponent implements OnDestroy {
 
   readonly currentLanguage = this.localeService.currentLang?.tag;
 
-  updating = false;
+  protected readonly updating = signal(false);
 
   private updateTempUserLanguage = this.sessionService.userProfile$.pipe(
     filter(profile => profile.tempUser && profile.defaultLanguage !== this.currentLanguage),
@@ -50,7 +49,7 @@ export class LanguageMismatchModalComponent implements OnDestroy {
     this.sessionService.updateCurrentUser({ default_language: language })
       .pipe(mapPending())
       .subscribe(updating => {
-        this.updating = updating;
+        this.updating.set(updating);
         if (!updating) {
           this.dialogRef.close();
         }

--- a/src/app/containers/language-mismatch/language-mismatch.component.ts
+++ b/src/app/containers/language-mismatch/language-mismatch.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, effect, inject } from '@angular/core';
 import { filter, map, takeUntil } from 'rxjs/operators';
 import { UserSessionService } from '../../services/user-session.service';
 import { LocaleService } from '../../services/localeService';
@@ -12,8 +12,6 @@ import {
   selector: 'alg-language-mismatch',
   templateUrl: './language-mismatch.component.html',
   styleUrls: [ './language-mismatch.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  standalone: true,
 })
 export class LanguageMismatchComponent {
   private localeService = inject(LocaleService);

--- a/src/app/groups/containers/confirm-approval-modal/confirm-approval-modal.component.ts
+++ b/src/app/groups/containers/confirm-approval-modal/confirm-approval-modal.component.ts
@@ -1,7 +1,7 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { NotificationModalComponent } from 'src/app/ui-components/notification-modal/notification-modal.component';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
-import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { DialogRef } from '@angular/cdk/dialog';
 
 export type ConfirmApprovalModalResult = 'empty' | 'reinvite' | undefined;
 
@@ -9,14 +9,11 @@ export type ConfirmApprovalModalResult = 'empty' | 'reinvite' | undefined;
   selector: 'alg-confirm-approval-modal',
   templateUrl: './confirm-approval-modal.component.html',
   styleUrls: [ './confirm-approval-modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     NotificationModalComponent,
     ButtonComponent,
   ]
 })
 export class ConfirmApprovalModalComponent {
-  name = inject<string>(DIALOG_DATA);
-
   dialogRef = inject(DialogRef<ConfirmApprovalModalResult>);
 }

--- a/src/app/groups/containers/join-group-confirmation-dialog/join-group-confirmation-dialog.component.ts
+++ b/src/app/groups/containers/join-group-confirmation-dialog/join-group-confirmation-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnInit, signal } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { SwitchFieldComponent } from 'src/app/ui-components/collapsible-section/switch-field/switch-field.component';
 import { DatePipe } from '@angular/common';
@@ -13,7 +13,6 @@ export type JoinGroupConfirmationDialogResult = { confirmed: true } | undefined;
   selector: 'alg-join-group-confirmation-dialog',
   templateUrl: './join-group-confirmation-dialog.component.html',
   styleUrls: [ './join-group-confirmation-dialog.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     SwitchFieldComponent,
     ReactiveFormsModule,

--- a/src/app/groups/containers/manager-permission-dialog/manager-permission-dialog.component.html
+++ b/src/app/groups/containers/manager-permission-dialog/manager-permission-dialog.component.html
@@ -1,4 +1,4 @@
-<alg-modal i18n-modalTitle modalTitle="{{ params().group.name }}: manager access given to {{ userCaption }}" (closeEvent)="onClose()">
+<alg-modal i18n-modalTitle modalTitle="{{ params().group.name }}: manager access given to {{ userCaption() }}" (closeEvent)="onClose()">
   <div class="dialog-container">
     <div class="dialog-content">
       <p class="dialog-description" i18n>
@@ -61,7 +61,7 @@
 
   <footer>
     <div class="footer">
-      @if (isUpdating) {
+      @if (isUpdating()) {
         <alg-loading></alg-loading>
       } @else {
         <button

--- a/src/app/groups/containers/manager-permission-dialog/manager-permission-dialog.component.ts
+++ b/src/app/groups/containers/manager-permission-dialog/manager-permission-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnInit, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { Group } from '../../models/group';
 import { Manager } from '../../data-access/get-group-managers.service';
 import { ProgressSelectValue, ProgressSelectComponent } from
@@ -14,7 +14,7 @@ import { CollapsibleSectionComponent } from 'src/app/ui-components/collapsible-s
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { ConfirmationModalService } from 'src/app/services/confirmation-modal.service';
 import { Observable, of } from 'rxjs';
-import { filter, switchMap } from 'rxjs/operators';
+import { filter, switchMap, finalize } from 'rxjs/operators';
 import { groupManagershipLevelEnum as l } from '../../models/group-management';
 import { ModalComponent } from 'src/app/ui-components/modal/modal.component';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
@@ -32,7 +32,6 @@ export interface ManagerPermissionDialogResult {
   selector: 'alg-manager-permission-dialog',
   templateUrl: './manager-permission-dialog.component.html',
   styleUrls: [ './manager-permission-dialog.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     FormsModule,
     ReactiveFormsModule,
@@ -72,8 +71,16 @@ export class ManagerPermissionDialogComponent implements OnInit {
     },
   ];
 
-  userCaption?: string;
-  isUpdating = false;
+  protected readonly userCaption = computed(() => {
+    const manager = this.params().manager;
+    return manager.login ? formatUser({
+      login: manager.login,
+      firstName: manager.firstName,
+      lastName: manager.lastName,
+    }) : manager.name;
+  });
+
+  protected readonly isUpdating = signal(false);
 
   form = this.fb.group({
     canManage: [ 'none' ],
@@ -89,12 +96,6 @@ export class ManagerPermissionDialogComponent implements OnInit {
       canGrantGroupAccess: manager.canGrantGroupAccess,
       canWatchMembers: manager.canWatchMembers,
     }, { emitEvent: false });
-
-    this.userCaption = manager.login ? formatUser({
-      login: manager.login,
-      firstName: manager.firstName,
-      lastName: manager.lastName,
-    }) : manager.name;
   }
 
   onClose(): void {
@@ -130,9 +131,10 @@ export class ManagerPermissionDialogComponent implements OnInit {
       canWatchMembers: this.form.get('canWatchMembers')?.value as GroupManagerPermissionChanges['canWatchMembers'],
     };
 
-    this.isUpdating = true;
+    this.isUpdating.set(true);
     proceedSaving$.pipe(
       switchMap(() => this.updateGroupManagersService.update(group.id, manager.id, managerPermissions)),
+      finalize(() => this.isUpdating.set(false)),
     ).subscribe({
       next: () => {
         this.actionFeedbackService.success($localize`New permissions successfully saved.`);
@@ -141,7 +143,6 @@ export class ManagerPermissionDialogComponent implements OnInit {
       error: () => {
         this.actionFeedbackService.error($localize`Failed to save permissions.`);
       },
-      complete: () => this.isUpdating = false,
     });
   }
 }

--- a/src/app/items/containers/permissions-edit-dialog/permissions-edit-dialog.component.html
+++ b/src/app/items/containers/permissions-edit-dialog/permissions-edit-dialog.component.html
@@ -31,11 +31,11 @@
             <alg-permissions-edit-form
               (save)="onPermissionsDialogSave($event)"
               (cancel)="closeDialog()"
-              [targetType]="targetType"
+              [targetType]="targetType()"
               [permissions]="state.data.granted"
               [computedPermissions]="state.data.computed"
               [giverPermissions]="params().currentUserPermissions"
-              [acceptButtonDisabled]="updateInProcess"
+              [acceptButtonDisabled]="updateInProcess()"
               [requiresExplicitEntry]="params().item.requiresExplicitEntry"
             ></alg-permissions-edit-form>
           </div>

--- a/src/app/items/containers/permissions-edit-dialog/permissions-edit-dialog.component.ts
+++ b/src/app/items/containers/permissions-edit-dialog/permissions-edit-dialog.component.ts
@@ -1,5 +1,4 @@
-import { Component, inject, OnDestroy, OnInit, signal, ChangeDetectionStrategy } from '@angular/core';
-import { ItemCorePerm } from 'src/app/items/models/item-permissions';
+import { Component, computed, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { RawGroupRoute, isUser } from 'src/app/models/routing/group-route';
 import { GroupPermissions, GroupPermissionsService } from 'src/app/data-access/group-permissions.service';
 import { ReplaySubject, switchMap } from 'rxjs';
@@ -16,6 +15,7 @@ import { AsyncPipe } from '@angular/common';
 import { GroupIsUserPipe } from 'src/app/pipes/groupIsUser';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { ModalComponent } from 'src/app/ui-components/modal/modal.component';
+import { ItemCorePerm } from 'src/app/items/models/item-permissions';
 
 export interface PermissionsEditDialogParams {
   currentUserPermissions: ItemCorePerm,
@@ -30,7 +30,6 @@ export interface PermissionsEditDialogParams {
   selector: 'alg-permissions-edit-dialog',
   templateUrl: './permissions-edit-dialog.component.html',
   styleUrls: [ './permissions-edit-dialog.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ErrorComponent,
     LoadingComponent,
@@ -57,9 +56,8 @@ export class PermissionsEditDialogComponent implements OnDestroy, OnInit {
     shareReplay(1),
   );
 
-  permissions?: Omit<GroupPermissions,'canEnterFrom'|'canEnterUntil'>;
-  updateInProcess = false;
-  targetType: TypeFilter = 'Users';
+  protected readonly updateInProcess = signal(false);
+  targetType = computed((): TypeFilter => (isUser(this.params().group) ? 'Users' : 'Groups'));
 
   ngOnDestroy(): void {
     this.params$.complete();
@@ -75,7 +73,6 @@ export class PermissionsEditDialogComponent implements OnDestroy, OnInit {
       throw new Error('Unexpected: Source group must not be a user');
     }
 
-    this.targetType = isUser(this.params().group) ? 'Users' : 'Groups';
     this.params$.next({
       sourceGroupId: this.params().sourceGroup?.id ?? this.params().group.id,
       groupId: this.params().group.id,
@@ -93,7 +90,7 @@ export class PermissionsEditDialogComponent implements OnDestroy, OnInit {
       throw new Error('Unexpected: A user group must be provided with source group');
     }
 
-    this.updateInProcess = true;
+    this.updateInProcess.set(true);
     this.groupPermissionsService.updatePermissions(
       this.params().sourceGroup?.id ?? this.params().group.id,
       this.params().group.id,
@@ -102,13 +99,13 @@ export class PermissionsEditDialogComponent implements OnDestroy, OnInit {
     )
       .subscribe({
         next: () => {
-          this.updateInProcess = false;
+          this.updateInProcess.set(false);
           this.actionFeedbackService.success($localize`:@@permissionsUpdated:Permissions successfully updated.`);
           this.currentContentService.forceNavMenuReload();
           this.closeDialog(true);
         },
         error: err => {
-          this.updateInProcess = false;
+          this.updateInProcess.set(false);
           this.actionFeedbackService.unexpectedError();
           this.currentContentService.forceNavMenuReload();
           if (!(err instanceof HttpErrorResponse)) throw err;

--- a/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.ts
+++ b/src/app/items/containers/propagation-advanced-configuration-dialog/propagation-advanced-configuration-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import {
   PropagationAdvancedConfigurationFormComponent
 } from 'src/app/items/containers/propagation-advanced-configuration-form/propagation-advanced-configuration-form.component';
@@ -21,7 +21,6 @@ export interface PropagationAdvancedConfigurationDialogData {
   selector: 'alg-propagation-advanced-configuration-dialog',
   templateUrl: 'propagation-advanced-configuration-dialog.component.html',
   styleUrls: [ 'propagation-advanced-configuration-dialog.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     PropagationAdvancedConfigurationFormComponent,
     ModalComponent,

--- a/src/app/items/containers/propagation-advanced-configuration-form/propagation-advanced-configuration-form.component.ts
+++ b/src/app/items/containers/propagation-advanced-configuration-form/propagation-advanced-configuration-form.component.ts
@@ -1,4 +1,5 @@
-import { Component, computed, input, OnChanges, output, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, input, output, inject } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
 import { CollapsibleSectionComponent } from 'src/app/ui-components/collapsible-section/collapsible-section.component';
 import { ProgressSelectComponent } from 'src/app/ui-components/collapsible-section/progress-select/progress-select.component';
@@ -17,7 +18,6 @@ import { propagationsConstraintsValidator } from 'src/app/items/models/propagati
   selector: 'alg-propagation-advanced-configuration-form',
   templateUrl: './propagation-advanced-configuration-form.component.html',
   styleUrls: [ './propagation-advanced-configuration-form.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ReactiveFormsModule,
     CollapsibleSectionComponent,
@@ -26,7 +26,7 @@ import { propagationsConstraintsValidator } from 'src/app/items/models/propagati
     ButtonComponent,
   ]
 })
-export class PropagationAdvancedConfigurationFormComponent implements OnChanges {
+export class PropagationAdvancedConfigurationFormComponent {
   private fb = inject(FormBuilder);
 
   closeEvent = output<ItemPermPropagations | undefined>();
@@ -49,7 +49,19 @@ export class PropagationAdvancedConfigurationFormComponent implements OnChanges 
     editPropagation: this.fb.nonNullable.control<ItemPermPropagations['editPropagation']>(false),
   });
 
-  ngOnChanges(): void {
+  constructor() {
+    toObservable(computed(() => ({
+      p: this.itemPropagations(),
+      g: this.giverPermissions(),
+    }))).pipe(takeUntilDestroyed()).subscribe(() => this.resetForm());
+  }
+
+  onSubmit(): void {
+    if (!this.form.dirty || this.form.invalid) return;
+    this.closeEvent.emit(this.form.getRawValue());
+  }
+
+  private resetForm(): void {
     const {
       contentViewPropagation,
       upperViewLevelsPropagation,
@@ -66,10 +78,5 @@ export class PropagationAdvancedConfigurationFormComponent implements OnChanges 
       ...(watchPropagation ? { watchPropagation } : {}),
       ...(editPropagation ? { editPropagation } : {}),
     });
-  }
-
-  onSubmit(): void {
-    if (!this.form.dirty || this.form.invalid) return;
-    this.closeEvent.emit(this.form.getRawValue());
   }
 }

--- a/src/app/items/containers/unlocked-items-modal/unlocked-items-modal.component.html
+++ b/src/app/items/containers/unlocked-items-modal/unlocked-items-modal.component.html
@@ -8,11 +8,12 @@
   <div class="unlocked-items">
     @for (item of items(); track $index) {
       <div class="unlocked-item">
-        <span class="alg-primary-color ph" [ngClass]="{
-          'ph-files': item.type === 'Task',
-          'ph-folder': item.type === 'Chapter',
-          'ph-graduation-cap': item.type === 'Skill'
-        }"></span>
+        <span
+          class="alg-primary-color ph"
+          [class.ph-files]="item.type === 'Task'"
+          [class.ph-folder]="item.type === 'Chapter'"
+          [class.ph-graduation-cap]="item.type === 'Skill'"
+        ></span>
         <a
           class="alg-link unlocked-item-title"
           [routerLink]="{

--- a/src/app/items/containers/unlocked-items-modal/unlocked-items-modal.component.ts
+++ b/src/app/items/containers/unlocked-items-modal/unlocked-items-modal.component.ts
@@ -1,9 +1,8 @@
-import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { ItemRoutePipe } from 'src/app/pipes/itemRoute';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
 import { RouterLink } from '@angular/router';
-import { NgClass } from '@angular/common';
 import { UnlockedItems } from 'src/app/items/data-access/grade.service';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
 import { NotificationModalComponent } from 'src/app/ui-components/notification-modal/notification-modal.component';
@@ -12,13 +11,11 @@ import { NotificationModalComponent } from 'src/app/ui-components/notification-m
   selector: 'alg-unlocked-items-modal',
   templateUrl: './unlocked-items-modal.component.html',
   styleUrls: [ './unlocked-items-modal.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ButtonComponent,
     ItemRoutePipe,
     RouteUrlPipe,
     RouterLink,
-    NgClass,
     NotificationModalComponent,
   ]
 })


### PR DESCRIPTION
## Summary
- Modernize 11 CDK dialog/modal components to Angular 22 patterns (drop Eager CD, signal inputs for async state, computed() for derived fields, template cleanup).
- Batch 24 from `.cursor/plans/modernize-batch-24-dialogs.md`.

## Scope
- `unlocked-items-modal` — NgClass → `[class.*]` bindings
- `join-group-confirmation-dialog` — drop Eager
- `confirm-approval-modal` — remove unused `DIALOG_DATA` / `name` inject
- `manager-permission-dialog` — `isUpdating` → signal; `userCaption` → computed(); reset spinner on save error via `finalize`
- `language-mismatch-modal` — `updating` → signal
- `language-mismatch` — remove `standalone: true`
- `group-observation-error-modal` — drop Eager
- `fatal-error-modal` — drop Eager
- `permissions-edit-dialog` — `updateInProcess` → signal; `targetType` → computed(); remove dead `permissions?` field
- `propagation-advanced-configuration-dialog` — drop Eager
- `propagation-advanced-configuration-form` — fix broken ngOnChanges/signal hybrid with `toObservable(computed(...))`

## Risks / manual checks
- Dialog components re-instantiate per open — verify **during-action** states (spinners, disabled buttons) after the Eager removal.
- E2e coverage exists for: permissions edit, manager permission, propagation config, approval/join-group, unlocked items.
- No e2e for: language mismatch, fatal error, group observation error — manual smoke required.
- Review fix: manager permission save spinner now clears on API error (pre-existing bug).

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-24/en/

## Verification
- [x] `npm run lint`
- [x] `ng build --configuration=en` (default `ng build` fails locally due to missing locale XLF files)
- [x] Manual smoke: unlocked items, manager permission save (incl. error path), permissions edit save, propagation config save, join-group confirmation, approval confirmation, language mismatch, fatal error, group observation error