### PR TITLE
Modernize Angular components (batch 21).

### DIFF
--- a/.cursor/MODERNIZING-COMPONENTS.md
+++ b/.cursor/MODERNIZING-COMPONENTS.md
@@ -4,11 +4,13 @@ Guide for migrating legacy components to modern Angular 22 patterns: signal inpu
 
 Project conventions also live in [AGENTS.md](../AGENTS.md).
 
+**Status:** The legacy `@Input()` / `@Output()` migration across `src/app` feature and container components is **complete** (final batch: `item-content` + `item-display`, batch 21). Remaining `@Input` / `@Output` usages outside that scope (e.g. a few app-shell files) are tracked separately. The layering table in §1 is kept for historical context when planning future refactors.
+
 ---
 
-## 1. Where to start
+## 1. Where to start (historical)
 
-**Default strategy: bottom-up.**
+**Default strategy: bottom-up.** This table guided the modernization batches; new work should follow current patterns in [AGENTS.md](../AGENTS.md) rather than re-running the same migration order.
 
 | Priority | Layer | Why |
 |----------|-------|-----|

--- a/src/app/items/containers/item-content/item-content.component.html
+++ b/src/app/items/containers/item-content/item-content.component.html
@@ -18,10 +18,10 @@
 }
 
 @else if (!canViewContent) {
-  @if (isCurrentUserTemp() && hasPrerequisites === false) {
+  @if (isCurrentUserTemp() && hasPrerequisites() === false) {
     <alg-login-wall class="alg-flex-1"></alg-login-wall>
   } @else {
-    @if (hasPrerequisites !== undefined) {
+    @if (hasPrerequisites() !== undefined) {
       <div class="no-access-message alg-flex-1">
         <span class="no-access-message-icon-container">
           <i class="ph-duotone no-access-message-icon ph-lock-key"></i>
@@ -29,7 +29,7 @@
         </span>
         @if (item | isAChapter) {
           <span class="no-access-message-text alg-text-secondary">
-            @if (hasPrerequisites) {
+            @if (hasPrerequisites()) {
               <ng-container i18n>This chapter is locked.<br>Fulfill one of the prerequisites below to access its content.</ng-container>
             } @else {
               <ng-container i18n>Your current access rights do not allow you<br>to list the content of this chapter.</ng-container>
@@ -38,7 +38,7 @@
         }
         @else if (item | isASkill) {
           <span class="no-access-message-text alg-text-secondary">
-            @if (hasPrerequisites) {
+            @if (hasPrerequisites()) {
               <ng-container i18n>This skill is locked.<br>Fulfill one of the prerequisites below to access its content.</ng-container>
             } @else {
               <ng-container i18n>Your current access rights do not allow you<br>to list the content of this skill.</ng-container>
@@ -47,7 +47,7 @@
         }
         @else { <!-- task -->
           <span class="no-access-message-text alg-text-secondary">
-            @if (hasPrerequisites) {
+            @if (hasPrerequisites()) {
               <ng-container i18n>This activity is locked.<br>Fulfill one of the prerequisites below to access its content.</ng-container>
             } @else {
               <ng-container i18n>Your current access rights do not allow you<br>to start the activity.</ng-container>
@@ -66,20 +66,21 @@
     <!-- waiting for the results to load, do not show anything -->
   }
   @else {
-    @if ((perms | allowsEditingChildren) || editModeEnabled) {
+    @if ((perms | allowsEditingChildren) || editMode()) {
       <div class="edit">
         <span class="edit-label">
           <span class="alg-base-text-color" i18n>Edit content</span>
           <alg-switch
             class="edit-switch"
             data-testid="edit-switch"
-            [(ngModel)]="editModeEnabled"
+            [ngModel]="editMode()"
+            (ngModelChange)="editMode.set($event)"
             (change)="onEditModeEnableChange($event)"
           ></alg-switch>
         </span>
       </div>
     }
-    @if (editModeEnabled) {
+    @if (editMode()) {
       <alg-item-children-edit-form
         [itemData]="itemData()"
       ></alg-item-children-edit-form>
@@ -115,18 +116,18 @@
   }
   @else { <!-- url set -->
 
-    @if (taskConfig && showTaskDisplay()) {
+    @if (taskConfig() && showTaskDisplay()) {
       <alg-item-display
         class="alg-flex-1"
-        [ngClass]="{ 'alg-opacity-0': !isTaskLoaded() }"
+        [class.alg-opacity-0]="!isTaskLoaded()"
         [route]="itemData().route"
         [editingPermission]="itemData().item.permissions"
         [url]="url"
         [attemptId]="itemData().currentResult ? $safeNavigationMigration(itemData().currentResult?.attemptId) : undefined"
         [resultStartedAt]="itemData().currentResult?.startedAt ?? null"
-        [view]="taskView"
-        [taskConfig]="taskConfig"
-        [savingAnswer]="savingAnswer"
+        [view]="taskView()"
+        [taskConfig]="taskConfig()!"
+        [savingAnswer]="savingAnswer()"
         (viewChange)="taskViewChange.emit($event)"
         (tabsChange)="taskTabsChange.emit($event)"
         (scoreChange)="onScoreChange($event)"

--- a/src/app/items/containers/item-content/item-content.component.spec.ts
+++ b/src/app/items/containers/item-content/item-content.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { Component, EventEmitter, Input, Output, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { ItemContentComponent } from './item-content.component';
 import { ItemData } from '../../models/item-data';
 import { ItemDisplayComponent, TaskTab } from '../item-display/item-display.component';
@@ -22,27 +22,26 @@ import { By } from '@angular/platform-browser';
 
 @Component({
   selector: 'alg-item-display',
-  changeDetection: ChangeDetectionStrategy.Eager,
   template: '',
 })
 class MockItemDisplayComponent {
   route = input.required<FullItemRoute>();
   url = input.required<string>();
-  @Input() editingPermission: unknown;
-  @Input() attemptId?: string;
-  @Input() resultStartedAt: Date | null = null;
-  @Input() view?: string;
-  @Input() taskConfig: TaskConfig = { readOnly: false, initialAnswer: undefined };
-  @Input() savingAnswer = false;
-  @Output() viewChange = new EventEmitter<string>();
-  @Output() tabsChange = new EventEmitter<TaskTab[]>();
-  @Output() scoreChange = new EventEmitter<number>();
-  @Output() skipSave = new EventEmitter<void>();
-  @Output() refresh = new EventEmitter<void>();
-  @Output() editorUrl = new EventEmitter<string | undefined>();
-  @Output() disablePlatformProgress = new EventEmitter<boolean>();
-  @Output() fullFrame = new EventEmitter<boolean>();
-  @Output() loadingComplete = new EventEmitter<boolean>();
+  editingPermission = input<unknown>({ canEdit: ItemEditPerm.None });
+  attemptId = input<string | undefined>();
+  resultStartedAt = input<Date | null>(null);
+  view = input<string | undefined>();
+  taskConfig = input<TaskConfig>({ readOnly: false, initialAnswer: undefined });
+  savingAnswer = input(false);
+  viewChange = output<string>();
+  tabsChange = output<TaskTab[]>();
+  scoreChange = output<number>();
+  skipSave = output<void>();
+  refresh = output<void>();
+  editorUrl = output<string | undefined>();
+  disablePlatformProgress = output<boolean>();
+  fullFrame = output<boolean>();
+  loadingComplete = output<boolean>();
 }
 
 const mockRoute = itemRoute('activity', '1', { attemptId: '0', path: [] });
@@ -117,7 +116,7 @@ describe('ItemContentComponent – task retry', () => {
     fixture = TestBed.createComponent(ItemContentComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('itemData', mockItemData);
-    component.taskConfig = { readOnly: false, initialAnswer: null };
+    fixture.componentRef.setInput('taskConfig', { readOnly: false, initialAnswer: null });
     fixture.detectChanges();
   });
 

--- a/src/app/items/containers/item-content/item-content.component.ts
+++ b/src/app/items/containers/item-content/item-content.component.ts
@@ -1,15 +1,13 @@
 import {
   Component,
   DestroyRef,
-  EventEmitter,
-  Input,
-  Output,
-  ViewChild,
   computed,
   inject,
   input,
+  linkedSignal,
+  output,
   signal,
-  ChangeDetectionStrategy
+  viewChild,
 } from '@angular/core';
 import { ItemData } from '../../models/item-data';
 import { TaskConfig } from '../../services/item-task.service';
@@ -29,7 +27,7 @@ import { SubSkillsComponent } from '../../containers/sub-skills/sub-skills.compo
 import { ChapterChildrenComponent } from '../../containers/chapter-children/chapter-children.component';
 import { DescriptionIframeComponent } from 'src/app/ui-components/description-iframe/description-iframe.component';
 import { DescriptionIframeNavigationRequest } from 'src/app/ui-components/description-iframe/description-iframe.messages';
-import { Location, NgClass } from '@angular/common';
+import { Location } from '@angular/common';
 import { LoginWallComponent } from '../login-wall/login-wall.component';
 import { ErrorComponent } from '../../../ui-components/error/error.component';
 import { IsAChapterPipe, IsASkillPipe, isATask } from '../../models/item-type';
@@ -55,7 +53,6 @@ const EXTERNAL_URL_AUTO_OPEN_DELAY_MS = 900;
   selector: 'alg-item-content',
   templateUrl: './item-content.component.html',
   styleUrls: [ './item-content.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     DescriptionIframeComponent,
     SwitchComponent,
@@ -65,7 +62,6 @@ const EXTERNAL_URL_AUTO_OPEN_DELAY_MS = 900;
     ParentSkillsComponent,
     ItemDisplayComponent,
     ExplicitEntryComponent,
-    NgClass,
     LoginWallComponent,
     ItemUnlockAccessComponent,
     TaskLoaderComponent,
@@ -88,11 +84,26 @@ export class ItemContentComponent implements PendingChangesComponent {
   private location = inject(Location);
   private destroyRef = inject(DestroyRef);
 
-  @ViewChild(ItemDisplayComponent) itemDisplayComponent?: ItemDisplayComponent;
-  @ViewChild(ItemChildrenEditFormComponent) itemChildrenEditFormComponent?: ItemChildrenEditFormComponent;
-  @ViewChild(SwitchComponent) switchComponent?: SwitchComponent;
+  readonly itemDisplayComponent = viewChild(ItemDisplayComponent);
+  private itemChildrenEditFormComponent = viewChild(ItemChildrenEditFormComponent);
+  private switchComponent = viewChild(SwitchComponent);
 
   itemData = input.required<ItemData>();
+  taskView = input<TaskTab['view']>();
+  taskConfig = input<TaskConfig | null>(null);
+  savingAnswer = input(false);
+  editModeEnabled = input(false);
+  editMode = linkedSignal(() => this.editModeEnabled());
+
+  taskTabsChange = output<TaskTab[]>();
+  taskViewChange = output<TaskTab['view']>();
+  scoreChange = output<number>();
+  skipSave = output<void>();
+  refresh = output<void>();
+  editorUrl = output<string | undefined>();
+  disablePlatformProgress = output<boolean>();
+  fullFrameTask = output<boolean>();
+
   private item = computed(() => this.itemData().item);
   /**
    * Item description, only if it should be shown
@@ -102,27 +113,13 @@ export class ItemContentComponent implements PendingChangesComponent {
     return (!isATask(this.item()) && description && description.trim() !== '') ? description : null;
   });
 
-  @Input() taskView?: TaskTab['view'];
-  @Input() taskConfig: TaskConfig|null = null;
-  @Input() savingAnswer = false;
-  @Input() editModeEnabled = false;
-
-  @Output() taskTabsChange = new EventEmitter<TaskTab[]>();
-  @Output() taskViewChange = new EventEmitter<TaskTab['view']>();
-  @Output() scoreChange = new EventEmitter<number>();
-  @Output() skipSave = new EventEmitter<void>();
-  @Output() refresh = new EventEmitter<void>();
-  @Output() editorUrl = new EventEmitter<string|undefined>();
-  @Output() disablePlatformProgress = new EventEmitter<boolean>();
-  @Output() fullFrameTask = new EventEmitter<boolean>();
-
   isTaskLoaded = signal(false); // whether the task has finished loading, i.e. is ready or in error
   showTaskDisplay = signal(true);
   isCurrentUserTemp = toSignal(this.userSessionService.userProfile$.pipe(map(user => user.tempUser)));
-  hasPrerequisites: boolean|undefined = undefined; // undefined while not known
+  hasPrerequisites = signal<boolean | undefined>(undefined); // undefined while not known
 
   isDirty(): boolean {
-    return !!this.itemChildrenEditFormComponent?.dirty();
+    return !!this.itemChildrenEditFormComponent()?.dirty();
   }
 
   onEditModeEnableChange(editModeEnabled: boolean): void {
@@ -130,7 +127,8 @@ export class ItemContentComponent implements PendingChangesComponent {
       relativeTo: this.route,
     }).then(redirected => {
       if (!editModeEnabled && !redirected) {
-        this.switchComponent?.writeValue(true);
+        this.editMode.set(true);
+        this.switchComponent()?.writeValue(true);
       }
     });
   }
@@ -142,6 +140,7 @@ export class ItemContentComponent implements PendingChangesComponent {
   onTaskRetry(): void {
     this.isTaskLoaded.set(false);
     this.showTaskDisplay.set(false);
+    // Destroy/recreate ItemDisplayComponent to fully reset the task iframe and service state.
     setTimeout(() => this.showTaskDisplay.set(true));
   }
 
@@ -150,7 +149,7 @@ export class ItemContentComponent implements PendingChangesComponent {
   }
 
   onPrerequisiteNotify(hasPrerequisites: boolean): void {
-    this.hasPrerequisites = hasPrerequisites;
+    this.hasPrerequisites.set(hasPrerequisites);
   }
 
   onDescriptionNavigate(req: DescriptionIframeNavigationRequest): void {

--- a/src/app/items/containers/item-display/item-display-iframe-height.ts
+++ b/src/app/items/containers/item-display/item-display-iframe-height.ts
@@ -1,0 +1,27 @@
+import { EMPTY, interval, merge, Observable, of } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, map, switchMap } from 'rxjs/operators';
+import { SECONDS } from 'src/app/utils/duration';
+import { isNotUndefined } from 'src/app/utils/null-undefined-predicates';
+import { ItemTaskService } from '../../services/item-task.service';
+
+const heightSyncInterval = 0.2*SECONDS;
+
+export function itemDisplayIframeHeight$(
+  metadata$: Observable<{ autoHeight?: boolean }>,
+  taskService: ItemTaskService,
+): Observable<string | undefined> {
+  return metadata$.pipe(
+    switchMap(({ autoHeight }) => {
+      if (autoHeight) return of(undefined);
+      return merge(
+        taskService.task$.pipe(
+          switchMap(task => interval(heightSyncInterval).pipe(
+            switchMap(() => task.getHeight().pipe(catchError(() => EMPTY))),
+          )),
+        ),
+        taskService.display$.pipe(map(({ height }) => height), filter(isNotUndefined)),
+      ).pipe(map(height => `${height}px`));
+    }),
+    distinctUntilChanged(),
+  );
+}

--- a/src/app/items/containers/item-display/item-display-side-effects.ts
+++ b/src/app/items/containers/item-display/item-display-side-effects.ts
@@ -1,0 +1,111 @@
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+import { EMPTY, Subscription } from 'rxjs';
+import { filter, map, pairwise, startWith, switchMap, withLatestFrom } from 'rxjs/operators';
+import { HOURS, SECONDS } from 'src/app/utils/duration';
+import { ItemTaskService } from '../../services/item-task.service';
+import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
+import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
+import { LTIDataSource } from 'src/app/lti/lti-datasource.service';
+import { PublishResultsService } from '../../data-access/publish-result.service';
+import { errorIsHTTPForbidden } from 'src/app/utils/errors';
+import { ActivityNavTreeService } from 'src/app/services/navigation/item-nav-tree.service';
+import { ItemRouter } from 'src/app/models/routing/item-router';
+import { openNewTab, replaceWindowUrl } from 'src/app/utils/url';
+import { GetBreadcrumbsFromRootsService } from 'src/app/data-access/get-breadcrumbs-from-roots.service';
+import { typeCategoryOfItem } from 'src/app/items/models/item-type';
+import { closestBreadcrumbs } from 'src/app/models/content/content-breadcrumbs';
+import { FullItemRoute, itemRoute } from 'src/app/models/routing/item-route';
+import { UnlockedItems } from 'src/app/items/data-access/grade.service';
+
+export interface ItemDisplaySideEffectDeps {
+  taskService: ItemTaskService,
+  actionFeedbackService: ActionFeedbackService,
+  publishResultService: PublishResultsService,
+  ltiDataSource: LTIDataSource,
+  activityNavTreeService: ActivityNavTreeService,
+  router: Router,
+  itemRouter: ItemRouter,
+  location: Location,
+  breadcrumbsService: GetBreadcrumbsFromRootsService,
+  route: () => FullItemRoute,
+  openUnlockedItemsDialog: (items: UnlockedItems) => void,
+}
+
+// Kept as explicit subscriptions: saveAnswerAndState() unsubscribes them all early on purpose.
+export function createItemDisplaySideEffectSubscriptions(deps: ItemDisplaySideEffectDeps): Subscription[] {
+  return [
+    deps.taskService.autoSaveResult$
+      .pipe(startWith(true), pairwise())
+      .subscribe(([ previous, next ]) => {
+        const shouldDisplayError = !next && !deps.actionFeedbackService.hasFeedback;
+        const shouldDisplaySuccess = !previous && next;
+        if (shouldDisplayError) {
+          const message = $localize`Your current progress could not be saved. Are you connected to the internet?`;
+          deps.actionFeedbackService.error(message, { life: 24*HOURS });
+        }
+        if (shouldDisplaySuccess) {
+          deps.actionFeedbackService.clear();
+          deps.actionFeedbackService.success($localize`Progress saved!`);
+        }
+      }),
+
+    deps.taskService.scoreChange$.pipe(
+      switchMap(() => {
+        if (!deps.ltiDataSource.data) return EMPTY;
+        return deps.publishResultService.publish(deps.ltiDataSource.data.contentId, deps.ltiDataSource.data.attemptId);
+      }),
+    ).subscribe({
+      error: err => {
+        const message = errorIsHTTPForbidden(err)
+          ? $localize`You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.`
+          : $localize`An unknown error occurred while publishing your result`;
+        deps.actionFeedbackService.error(message, { life: 10*SECONDS });
+      }
+    }),
+
+    deps.taskService.hintError$.subscribe(() => deps.actionFeedbackService.error($localize`Hint request failed`)),
+
+    deps.taskService.navigateTo$.pipe(
+      filter(dst => 'nextActivity' in dst),
+      withLatestFrom(deps.activityNavTreeService.navigationNeighbors$.pipe(readyData())),
+    ).subscribe(([ , navNeighbors ]) => (navNeighbors?.next ?? navNeighbors?.parent)?.navigateTo()),
+
+    deps.taskService.navigateTo$.pipe(
+      filter((d): d is ({ id: string, path: string[] }|{ url: string })&{ newTab: boolean} => 'url' in d || ('id' in d && !!d.path))
+    ).subscribe(dst => {
+      if ('id' in dst) {
+        const route = itemRoute('activity', dst.id, { path: dst.path });
+        if (dst.newTab) openNewTab(deps.router.serializeUrl(deps.itemRouter.url(route)), deps.location);
+        else deps.itemRouter.navigateTo(route, { useCurrentObservation: true });
+      }
+      if ('url' in dst) {
+        if (dst.newTab) openNewTab(dst.url, deps.location);
+        else replaceWindowUrl(dst.url, deps.location);
+      }
+    }),
+
+    deps.taskService.navigateTo$.pipe(
+      filter((dst): dst is ({ id: string }|{ textId: string })&{ newTab: boolean} => ('id' in dst && !dst.path) || 'textId' in dst),
+      switchMap(dst => {
+        const getBreadcrumbs$ = 'id' in dst ? deps.breadcrumbsService.get(dst.id) : deps.breadcrumbsService.getByTextId(dst.textId);
+        return getBreadcrumbs$.pipe(map(breadcrumbs => ({ breadcrumbs, newTab: dst.newTab })), mapToFetchState());
+      }),
+    ).subscribe(state => {
+      if (state.isError) {
+        if (errorIsHTTPForbidden(state.error)) deps.actionFeedbackService.error($localize`You cannot access this page.`);
+        else deps.actionFeedbackService.error($localize`Unable to get linked page information. If the problem persists, contact us.`);
+      }
+      if (state.isReady) {
+        const breadcrumbs = closestBreadcrumbs(deps.route().path, state.data.breadcrumbs);
+        const lastElement = breadcrumbs.pop();
+        if (!lastElement) throw new Error('unexpected: get all breadcrumbs services are expected to return non-empty breadcrumbs');
+        const route = itemRoute(typeCategoryOfItem(lastElement), lastElement.id, { path: breadcrumbs.map(b => b.id) });
+        if (state.data.newTab) openNewTab(deps.router.serializeUrl(deps.itemRouter.url(route)), deps.location);
+        else deps.itemRouter.navigateTo(route, { useCurrentObservation: true });
+      }
+    }),
+
+    deps.taskService.unlockedItems$.subscribe(items => deps.openUnlockedItemsDialog(items)),
+  ];
+}

--- a/src/app/items/containers/item-display/item-display.component.html
+++ b/src/app/items/containers/item-display/item-display.component.html
@@ -1,11 +1,11 @@
 @if (state$ | async; as state) {
   <div
     class="item-display alg-flex-1"
-    [ngClass]="{ 'full-frame': fullFrame$ | async }"
+    [class.full-frame]="fullFrame$ | async"
   >
-    @if ((state.isError || (metadataError$ | async)) && !showTaskAnyway) {
+    @if ((state.isError || (metadataError$ | async)) && !showTaskAnyway()) {
       <div class="error-container alg-flex-1" [algFullHeightContent]="true">
-        @if (editingPermission | allowsEditingAll) {
+        @if (editingPermission() | allowsEditingAll) {
           @if (initError$ | async) {
             <alg-error
               i18n-message message="It usually occurs when task url is invalid. If the task url is valid and the problem persists, please contact us."
@@ -40,11 +40,11 @@
           ></alg-error>
         }
         <div class="error-buttons">
-          @if (editingPermission | allowsEditingAll) {
+          @if (editingPermission() | allowsEditingAll) {
             <button
               alg-button
               class="size-l error-button"
-              (click)="showTaskAnyway = true"
+              (click)="showTaskAnyway.set(true)"
               i18n
             >Show task anyway (for debugging)</button>
           }
@@ -58,7 +58,7 @@
       </div>
     }
     <div class="iframe-container alg-flex-1">
-      @if (savingAnswer) {
+      @if (savingAnswer()) {
         <div class="saving-answer">
           <p class="saving-answer-message">
             <span i18n>Saving answer...</span>
@@ -70,8 +70,8 @@
       @if (iframeSrc$ | async; as iframeSrc) {
         <iframe
           class="iframe-element"
-          [class.alg-flex-1]="!!(metadata$ | async)?.autoHeight && (state.isReady || showTaskAnyway)"
-          [style.height]="(state.isReady || showTaskAnyway) ? (iframeHeight$ | async) : undefined"
+          [class.alg-flex-1]="!!(metadata$ | async)?.autoHeight && (state.isReady || showTaskAnyway())"
+          [style.height]="(state.isReady || showTaskAnyway()) ? (iframeHeight$ | async) : undefined"
           [src]="iframeSrc"
           #iframe
           allowfullscreen

--- a/src/app/items/containers/item-display/item-display.component.spec.ts
+++ b/src/app/items/containers/item-display/item-display.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { EMPTY, of, Subject } from 'rxjs';
 import { ItemDisplayComponent } from './item-display.component';
 import { ItemTaskService } from '../../services/item-task.service';
@@ -17,8 +17,10 @@ import { provideRouter } from '@angular/router';
 import { Task } from '../../api/task-proxy';
 import { ItemEditPerm } from '../../models/item-edit-permission';
 import { By } from '@angular/platform-browser';
+import { readyState } from 'src/app/utils/state';
 
 const route = itemRoute('activity', '1', { attemptId: '0', path: [] });
+const taskUrl = 'http://example.com/task';
 
 function createMockTaskService(): Record<string, unknown> {
   return {
@@ -40,8 +42,176 @@ function createMockTaskService(): Record<string, unknown> {
     configure: jasmine.createSpy('configure'),
     initTask: jasmine.createSpy('initTask'),
     showView: jasmine.createSpy('showView'),
+    saveAnswerAndState: jasmine.createSpy('saveAnswerAndState').and.returnValue(of(readyState<void>(undefined))),
   };
 }
+
+interface ItemDisplayTestContext {
+  fixture: ComponentFixture<ItemDisplayComponent>,
+  component: ItemDisplayComponent,
+  mockTaskService: ReturnType<typeof createMockTaskService>,
+  mockSessionTracker: { init: jasmine.Spy, ngOnDestroy: jasmine.Spy },
+  actionFeedbackService: { error: jasmine.Spy, clear: jasmine.Spy, hasFeedback: boolean },
+}
+
+async function setupItemDisplayTest(
+  overrides: {
+    hintError$?: Subject<void>,
+    actionFeedbackService?: ItemDisplayTestContext['actionFeedbackService'],
+  } = {},
+): Promise<ItemDisplayTestContext> {
+  const mockTaskService = createMockTaskService();
+  if (overrides.hintError$) {
+    mockTaskService['hintError$'] = overrides.hintError$.asObservable();
+  }
+  const mockSessionTracker = { init: jasmine.createSpy('init'), ngOnDestroy: jasmine.createSpy('ngOnDestroy') };
+  const actionFeedbackService = overrides.actionFeedbackService ?? {
+    error: jasmine.createSpy('error'),
+    clear: jasmine.createSpy('clear'),
+    hasFeedback: false,
+  };
+
+  await TestBed.configureTestingModule({
+    imports: [ ItemDisplayComponent ],
+    providers: [
+      provideRouter([]),
+      { provide: ActionFeedbackService, useValue: actionFeedbackService },
+      { provide: PublishResultsService, useValue: {} },
+      { provide: ActivityNavTreeService, useValue: { navigationNeighbors$: EMPTY } },
+      { provide: GetBreadcrumbsFromRootsService, useValue: {} },
+      { provide: LTIDataSource, useValue: { data: null } },
+      { provide: ItemRouter, useValue: { url: () => [], navigateTo: jasmine.createSpy() } },
+    ],
+  })
+    .overrideComponent(ItemDisplayComponent, {
+      set: {
+        providers: [
+          { provide: ItemTaskService, useValue: mockTaskService },
+          { provide: ItemTaskInitService, useValue: {} },
+          { provide: ItemTaskAnswerService, useValue: {} },
+          { provide: ItemTaskViewsService, useValue: {} },
+          { provide: TaskSessionTrackerService, useValue: mockSessionTracker },
+        ],
+      },
+    })
+    .compileComponents();
+
+  const fixture = TestBed.createComponent(ItemDisplayComponent);
+  const component = fixture.componentInstance;
+  fixture.componentRef.setInput('route', route);
+  fixture.componentRef.setInput('url', taskUrl);
+  fixture.detectChanges();
+
+  return { fixture, component, mockTaskService, mockSessionTracker, actionFeedbackService };
+}
+
+function createIsolatedItemDisplayFixture(): ComponentFixture<ItemDisplayComponent> {
+  const fixture = TestBed.createComponent(ItemDisplayComponent);
+  fixture.componentRef.setInput('route', route);
+  fixture.componentRef.setInput('url', taskUrl);
+  fixture.detectChanges();
+  return fixture;
+}
+
+describe('ItemDisplayComponent – constructor input effects', () => {
+  let ctx: ItemDisplayTestContext;
+
+  beforeEach(async () => {
+    ctx = await setupItemDisplayTest();
+  });
+
+  it('should call configure on init with route, url, and taskConfig', () => {
+    expect(ctx.mockTaskService.configure).toHaveBeenCalledWith(
+      route,
+      taskUrl,
+      undefined,
+      { readOnly: false, initialAnswer: undefined },
+    );
+  });
+
+  it('should call configure when attemptId or taskConfig changes', () => {
+    (ctx.mockTaskService.configure as jasmine.Spy).calls.reset();
+
+    ctx.fixture.componentRef.setInput('attemptId', '42');
+    ctx.fixture.detectChanges();
+    expect(ctx.mockTaskService.configure).toHaveBeenCalledWith(
+      route,
+      taskUrl,
+      '42',
+      { readOnly: false, initialAnswer: undefined },
+    );
+
+    ctx.fixture.componentRef.setInput('taskConfig', { readOnly: true, initialAnswer: 'saved' });
+    ctx.fixture.detectChanges();
+    expect(ctx.mockTaskService.configure).toHaveBeenCalledWith(
+      route,
+      taskUrl,
+      '42',
+      { readOnly: true, initialAnswer: 'saved' },
+    );
+  });
+
+  it('should call showView with task on init and when view input changes', () => {
+    expect(ctx.mockTaskService.showView).toHaveBeenCalledWith('task');
+
+    (ctx.mockTaskService.showView as jasmine.Spy).calls.reset();
+    ctx.fixture.componentRef.setInput('view', 'editor');
+    ctx.fixture.detectChanges();
+    expect(ctx.mockTaskService.showView).toHaveBeenCalledWith('editor');
+  });
+
+  it('should init session tracking when attemptId is set for non-readOnly tasks', () => {
+    const startedAt = new Date('2024-01-01');
+    ctx.fixture.componentRef.setInput('attemptId', '7');
+    ctx.fixture.componentRef.setInput('resultStartedAt', startedAt);
+    ctx.fixture.detectChanges();
+
+    expect(ctx.mockSessionTracker.init).toHaveBeenCalledWith('7', startedAt);
+  });
+
+  it('should not init session tracking for readOnly tasks', () => {
+    ctx.fixture.componentRef.setInput('taskConfig', { readOnly: true, initialAnswer: 'x' });
+    ctx.fixture.componentRef.setInput('attemptId', '7');
+    ctx.fixture.detectChanges();
+
+    expect(ctx.mockSessionTracker.init).not.toHaveBeenCalled();
+  });
+
+  it('should throw when route id changes after initialization', fakeAsync(() => {
+    const isolated = createIsolatedItemDisplayFixture();
+    const otherRoute = itemRoute('activity', '2', { attemptId: '0', path: [] });
+    isolated.componentRef.setInput('route', otherRoute);
+    expect(() => flush()).toThrowError('this component does not support changing its route input');
+  }));
+
+  it('should throw when url changes after initialization', fakeAsync(() => {
+    const isolated = createIsolatedItemDisplayFixture();
+    isolated.componentRef.setInput('url', 'http://example.com/other-task');
+    expect(() => flush()).toThrowError('this component does not support changing its url input');
+  }));
+});
+
+describe('ItemDisplayComponent – saveAnswerAndState', () => {
+  let ctx: ItemDisplayTestContext;
+  let hintErrorSubject: Subject<void>;
+
+  beforeEach(async () => {
+    hintErrorSubject = new Subject();
+    ctx = await setupItemDisplayTest({ hintError$: hintErrorSubject });
+  });
+
+  it('should unsubscribe side-effect subscriptions before delegating to the task service', () => {
+    hintErrorSubject.next();
+    expect(ctx.actionFeedbackService.error).toHaveBeenCalledTimes(1);
+
+    void ctx.component.saveAnswerAndState();
+    expect(ctx.mockTaskService.saveAnswerAndState).toHaveBeenCalledTimes(1);
+    (ctx.actionFeedbackService.error as jasmine.Spy).calls.reset();
+
+    hintErrorSubject.next();
+    expect(ctx.actionFeedbackService.error).not.toHaveBeenCalled();
+  });
+});
 
 describe('ItemDisplayComponent – retry button', () => {
   let fixture: ComponentFixture<ItemDisplayComponent>;
@@ -49,38 +219,10 @@ describe('ItemDisplayComponent – retry button', () => {
   let mockTaskService: ReturnType<typeof createMockTaskService>;
 
   beforeEach(async () => {
-    mockTaskService = createMockTaskService();
-
-    await TestBed.configureTestingModule({
-      imports: [ ItemDisplayComponent ],
-      providers: [
-        provideRouter([]),
-        { provide: ActionFeedbackService, useValue: { error: jasmine.createSpy(), clear: jasmine.createSpy(), hasFeedback: false } },
-        { provide: PublishResultsService, useValue: {} },
-        { provide: ActivityNavTreeService, useValue: { navigationNeighbors$: EMPTY } },
-        { provide: GetBreadcrumbsFromRootsService, useValue: {} },
-        { provide: LTIDataSource, useValue: { data: null } },
-        { provide: ItemRouter, useValue: { url: () => [], navigateTo: jasmine.createSpy() } },
-      ],
-    })
-      .overrideComponent(ItemDisplayComponent, {
-        set: {
-          providers: [
-            { provide: ItemTaskService, useValue: mockTaskService },
-            { provide: ItemTaskInitService, useValue: {} },
-            { provide: ItemTaskAnswerService, useValue: {} },
-            { provide: ItemTaskViewsService, useValue: {} },
-            { provide: TaskSessionTrackerService, useValue: { init: jasmine.createSpy(), ngOnDestroy: jasmine.createSpy() } },
-          ],
-        },
-      })
-      .compileComponents();
-
-    fixture = TestBed.createComponent(ItemDisplayComponent);
-    component = fixture.componentInstance;
-    fixture.componentRef.setInput('route', route);
-    fixture.componentRef.setInput('url', 'http://example.com/task');
-    fixture.detectChanges();
+    const ctx = await setupItemDisplayTest();
+    fixture = ctx.fixture;
+    component = ctx.component;
+    mockTaskService = ctx.mockTaskService;
   });
 
   it('should create', () => {
@@ -108,8 +250,8 @@ describe('ItemDisplayComponent – retry button', () => {
       fixture = TestBed.createComponent(ItemDisplayComponent);
       component = fixture.componentInstance;
       fixture.componentRef.setInput('route', route);
-      fixture.componentRef.setInput('url', 'http://example.com/task');
-      component.editingPermission = { canEdit: ItemEditPerm.None };
+      fixture.componentRef.setInput('url', taskUrl);
+      fixture.componentRef.setInput('editingPermission', { canEdit: ItemEditPerm.None });
       fixture.detectChanges();
 
       initErrorSubject.next(new Error('timeout'));
@@ -150,7 +292,7 @@ describe('ItemDisplayComponent – retry button', () => {
       fixture = TestBed.createComponent(ItemDisplayComponent);
       component = fixture.componentInstance;
       fixture.componentRef.setInput('route', route);
-      fixture.componentRef.setInput('url', 'http://example.com/task');
+      fixture.componentRef.setInput('url', taskUrl);
 
       loadingCompleteValues = [];
       component.loadingComplete.subscribe(v => loadingCompleteValues.push(v));

--- a/src/app/items/containers/item-display/item-display.component.ts
+++ b/src/app/items/containers/item-display/item-display.component.ts
@@ -1,80 +1,66 @@
 import {
   AfterViewChecked,
   Component,
+  computed,
   ElementRef,
-  EventEmitter,
   inject,
   input,
-  Input,
-  OnChanges,
   OnDestroy,
-  Output,
-  SimpleChanges,
-  ViewChild,
-  ChangeDetectionStrategy
+  output,
+  signal,
+  viewChild,
 } from '@angular/core';
-import { EMPTY, interval, Observable, merge, of, Subject } from 'rxjs';
-import { Location, NgClass, AsyncPipe } from '@angular/common';
+import { EMPTY, merge, of, Subject } from 'rxjs';
+import { Location, AsyncPipe } from '@angular/common';
 import {
   catchError,
   distinctUntilChanged,
-  filter,
   ignoreElements,
   map,
-  pairwise,
   shareReplay,
   startWith,
   switchMap,
   takeUntil,
-  withLatestFrom
 } from 'rxjs/operators';
-import { HOURS, SECONDS } from 'src/app/utils/duration';
 import { TaskConfig, ItemTaskService } from '../../services/item-task.service';
-import { mapToFetchState, readyData } from 'src/app/utils/operators/state';
 import { errorState, fetchingState, readyState } from 'src/app/utils/state';
 import { capitalize } from 'src/app/utils/case_conversion';
 import { ItemTaskInitService } from '../../services/item-task-init.service';
 import { ItemTaskAnswerService } from '../../services/item-task-answer.service';
 import { ItemTaskViewsService } from '../../services/item-task-views.service';
 import { TaskSessionTrackerService } from '../../services/task-session-tracker.service';
-import { FullItemRoute, itemRoute } from 'src/app/models/routing/item-route';
+import { FullItemRoute } from 'src/app/models/routing/item-route';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { LTIDataSource } from 'src/app/lti/lti-datasource.service';
 import { PublishResultsService } from '../../data-access/publish-result.service';
-import { errorIsHTTPForbidden } from 'src/app/utils/errors';
-import { isNotUndefined } from 'src/app/utils/null-undefined-predicates';
 import { ItemPermWithEdit, ItemEditPerm, AllowsEditingAllItemPipe } from 'src/app/items/models/item-edit-permission';
 import { ActivityNavTreeService } from 'src/app/services/navigation/item-nav-tree.service';
 import { Router } from '@angular/router';
 import { ItemRouter } from 'src/app/models/routing/item-router';
-import { openNewTab, replaceWindowUrl } from 'src/app/utils/url';
 import { GetBreadcrumbsFromRootsService } from 'src/app/data-access/get-breadcrumbs-from-roots.service';
-import { typeCategoryOfItem } from 'src/app/items/models/item-type';
-import { closestBreadcrumbs } from 'src/app/models/content/content-breadcrumbs';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { FullHeightContentDirective } from 'src/app/directives/full-height-content.directive';
-import { UnlockedItems } from 'src/app/items/data-access/grade.service';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { Dialog } from '@angular/cdk/dialog';
 import { UnlockedItemsModalComponent } from 'src/app/items/containers/unlocked-items-modal/unlocked-items-modal.component';
+import { outputFromObservable, takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { UnlockedItems } from 'src/app/items/data-access/grade.service';
+import { itemDisplayIframeHeight$ } from './item-display-iframe-height';
+import { createItemDisplaySideEffectSubscriptions } from './item-display-side-effects';
 
 export interface TaskTab {
   name: string,
   view: string,
 }
 
-const heightSyncInterval = 0.2*SECONDS;
-
 @Component({
   selector: 'alg-item-display',
   templateUrl: './item-display.component.html',
   styleUrls: [ './item-display.component.scss' ],
   providers: [ ItemTaskService, ItemTaskInitService, ItemTaskAnswerService, ItemTaskViewsService, TaskSessionTrackerService ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
-    NgClass,
     FullHeightContentDirective,
     ErrorComponent,
     LoadingComponent,
@@ -83,7 +69,7 @@ const heightSyncInterval = 0.2*SECONDS;
     ButtonComponent,
   ]
 })
-export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDestroy {
+export class ItemDisplayComponent implements AfterViewChecked, OnDestroy {
   private router = inject(Router);
   private itemRouter = inject(ItemRouter);
   private location = inject(Location);
@@ -95,23 +81,22 @@ export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDest
   private breadcrumbsService = inject(GetBreadcrumbsFromRootsService);
   private ltiDataSource = inject(LTIDataSource);
   private sessionTracker = inject(TaskSessionTrackerService);
+  private dialogService = inject(Dialog);
 
   route = input.required<FullItemRoute>();
   url = input.required<string>();
-  @Input() editingPermission: ItemPermWithEdit = { canEdit: ItemEditPerm.None };
-  @Input() attemptId?: string;
-  @Input() resultStartedAt: Date | null = null;
-  @Input() view?: TaskTab['view'];
-  @Input() taskConfig: TaskConfig = { readOnly: false, initialAnswer: undefined };
-  @Input() savingAnswer = false;
+  editingPermission = input<ItemPermWithEdit>({ canEdit: ItemEditPerm.None });
+  attemptId = input<string>();
+  resultStartedAt = input<Date | null>(null);
+  view = input<TaskTab['view']>();
+  taskConfig = input<TaskConfig>({ readOnly: false, initialAnswer: undefined });
+  savingAnswer = input(false);
 
-  @Output() scoreChange = this.taskService.scoreChange$;
-  @Output() skipSave = new EventEmitter<void>();
-  @Output() refresh = new EventEmitter<void>();
+  scoreChange = outputFromObservable(this.taskService.scoreChange$);
+  skipSave = output<void>();
+  refresh = output<void>();
 
-  @ViewChild('iframe') iframe?: ElementRef<HTMLIFrameElement>;
-
-  private dialogService = inject(Dialog);
+  iframe = viewChild<ElementRef<HTMLIFrameElement>>('iframe');
 
   state$ = merge(
     this.taskService.loadedTask$.pipe(map(task => readyState(task))),
@@ -119,7 +104,7 @@ export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDest
     this.taskService.urlError$.pipe(map(e => errorState(e))),
     this.taskService.unknownError$.pipe(map(e => errorState(e))),
   ).pipe(startWith(fetchingState()));
-  @Output() loadingComplete = this.state$.pipe(map(s => !s.isFetching), distinctUntilChanged());
+  loadingComplete = outputFromObservable(this.state$.pipe(map(s => !s.isFetching), distinctUntilChanged()));
   initError$ = this.taskService.initError$;
   urlError$ = this.taskService.urlError$;
   unknownError$ = this.taskService.unknownError$;
@@ -138,137 +123,94 @@ export class ItemDisplayComponent implements AfterViewChecked, OnChanges, OnDest
   metadataError$ = this.metadata.pipe(ignoreElements(), catchError(err => of(err)));
   metadata$ = this.metadata.pipe(catchError(() => EMPTY)); /* never emit errors */
 
-  @Output() editorUrl = this.metadata$.pipe(map(({ editorUrl }) => editorUrl));
-  @Output() disablePlatformProgress = this.metadata$.pipe(map(({ disablePlatformProgress }) => disablePlatformProgress ?? false));
+  editorUrl = outputFromObservable(this.metadata$.pipe(map(({ editorUrl }) => editorUrl)));
+  disablePlatformProgress = outputFromObservable(this.metadata$.pipe(
+    map(({ disablePlatformProgress }) => disablePlatformProgress ?? false),
+  ));
 
-  iframeHeight$ = this.metadata$.pipe(
-    switchMap(({ autoHeight }) => {
-      if (autoHeight) return of(undefined);
-      return merge(
-        this.taskService.task$.pipe(
-          switchMap(task => interval(heightSyncInterval).pipe(switchMap(() => task.getHeight().pipe(catchError(() => EMPTY)))))
-        ),
-        this.taskService.display$.pipe(map(({ height }) => height), filter(isNotUndefined)),
-      ).pipe(map(height => `${height}px`));
-    }),
-    distinctUntilChanged(),
-  );
-  fullFrame$ = this.metadata$.pipe(
-    map(({ autoHeight }) => autoHeight)
-  );
-  @Output() fullFrame = this.fullFrame$;
+  iframeHeight$ = itemDisplayIframeHeight$(this.metadata$, this.taskService);
+  fullFrame$ = this.metadata$.pipe(map(({ autoHeight }) => autoHeight ?? false));
+  fullFrame = outputFromObservable(this.fullFrame$);
 
-  showTaskAnyway = false;
+  showTaskAnyway = signal(false);
 
-  @Output() viewChange = this.taskService.activeView$;
-  @Output() tabsChange: Observable<TaskTab[]> = this.taskService.views$.pipe(
+  viewChange = outputFromObservable(this.taskService.activeView$);
+  tabsChange = outputFromObservable(this.taskService.views$.pipe(
     map(views => views.map(view => ({ view, name: this.getTabNameByView(view) }))),
-  );
+  ));
 
-  private subscriptions = [
-    this.taskService.autoSaveResult$
-      .pipe(startWith(true), pairwise())
-      .subscribe(([ previous, next ]) => {
-        const shouldDisplayError = !next && !this.actionFeedbackService.hasFeedback;
-        const shouldDisplaySuccess = !previous && next;
-        if (shouldDisplayError) {
-          const message = $localize`Your current progress could not be saved. Are you connected to the internet?`;
-          this.actionFeedbackService.error(message, { life: 24*HOURS });
-        }
-        if (shouldDisplaySuccess) {
-          this.actionFeedbackService.clear();
-          this.actionFeedbackService.success($localize`Progress saved!`);
-        }
-      }),
-
-    this.scoreChange.pipe(
-      switchMap(() => {
-        if (!this.ltiDataSource.data) return EMPTY;
-        return this.publishResultService.publish(this.ltiDataSource.data.contentId, this.ltiDataSource.data.attemptId);
-      }),
-    ).subscribe({
-      error: err => {
-        const message = errorIsHTTPForbidden(err)
-          ? $localize`You might be unauthenticated anymore, please try relaunching the exercise. If the problem persits contact us.`
-          : $localize`An unknown error occurred while publishing your result`;
-        this.actionFeedbackService.error(message, { life: 10*SECONDS });
-      }
-    }),
-
-    this.taskService.hintError$.subscribe(() => this.actionFeedbackService.error($localize`Hint request failed`)),
-
-    // case "navigation to next"
-    this.taskService.navigateTo$.pipe(
-      filter(dst => 'nextActivity' in dst),
-      withLatestFrom(this.activityNavTreeService.navigationNeighbors$.pipe(readyData())),
-    ).subscribe(([ , navNeighbors ]) => (navNeighbors?.next ?? navNeighbors?.parent)?.navigateTo()),
-
-    // case "navigation for known target"
-    this.taskService.navigateTo$.pipe(
-      filter((d): d is ({ id: string, path: string[] }|{ url: string })&{ newTab: boolean} => 'url' in d || ('id' in d && !!d.path))
-    ).subscribe(dst => {
-      if ('id' in dst) {
-        const route = itemRoute('activity', dst.id, { path: dst.path });
-        if (dst.newTab) openNewTab(this.router.serializeUrl(this.itemRouter.url(route)), this.location);
-        else this.itemRouter.navigateTo(route, { useCurrentObservation: true });
-      }
-      if ('url' in dst) {
-        if (dst.newTab) openNewTab(dst.url, this.location);
-        else replaceWindowUrl(dst.url, this.location);
-      }
-    }),
-
-    // case "navigation to item without path"
-    this.taskService.navigateTo$.pipe(
-      filter((dst): dst is ({ id: string }|{ textId: string })&{ newTab: boolean} => ('id' in dst && !dst.path) || 'textId' in dst),
-      switchMap(dst => {
-        const getBreadcrumbs$ = 'id' in dst ? this.breadcrumbsService.get(dst.id) : this.breadcrumbsService.getByTextId(dst.textId);
-        return getBreadcrumbs$.pipe(map(breadcrumbs => ({ breadcrumbs, newTab: dst.newTab })), mapToFetchState());
-      }),
-    ).subscribe(state => {
-      if (state.isError) {
-        if (errorIsHTTPForbidden(state.error)) this.actionFeedbackService.error($localize`You cannot access this page.`);
-        else this.actionFeedbackService.error($localize`Unable to get linked page information. If the problem persists, contact us.`);
-      }
-      if (state.isReady) {
-        const breadcrumbs = closestBreadcrumbs(this.route().path, state.data.breadcrumbs); // choose the closest, TODO: ask the user instead
-        const lastElement = breadcrumbs.pop();
-        if (!lastElement) throw new Error('unexpected: get all breadcrumbs services are expected to return non-empty breadcrumbs');
-        const route = itemRoute(typeCategoryOfItem(lastElement), lastElement.id, { path: breadcrumbs.map(b => b.id) });
-        if (state.data.newTab) openNewTab(this.router.serializeUrl(this.itemRouter.url(route)), this.location);
-        else this.itemRouter.navigateTo(route, { useCurrentObservation: true });
-      }
-    }),
-
-    this.taskService.unlockedItems$.subscribe(items =>
-      this.openUnlockedItemsDialog(items)
-    ),
-  ];
+  private subscriptions = createItemDisplaySideEffectSubscriptions({
+    taskService: this.taskService,
+    actionFeedbackService: this.actionFeedbackService,
+    publishResultService: this.publishResultService,
+    ltiDataSource: this.ltiDataSource,
+    activityNavTreeService: this.activityNavTreeService,
+    router: this.router,
+    itemRouter: this.itemRouter,
+    location: this.location,
+    breadcrumbsService: this.breadcrumbsService,
+    route: () => this.route(),
+    openUnlockedItemsDialog: items => this.openUnlockedItemsDialog(items),
+  });
 
   errorMessage = $localize`:@@unknownError:An unknown error occurred. ` +
     $localize`:@@contactUs:If the problem persists, please contact us.`;
 
-  unlockedItems?: UnlockedItems = undefined;
+  constructor() {
+    // Re-configure the task service when task identity inputs change (replaces ngOnChanges keyed logic).
+    // Registered before showView below: configure must run first so the service has task identity
+    // before a view switch is applied (same ordering as the former ngOnChanges block).
+    toObservable(computed(() => ({ attemptId: this.attemptId(), taskConfig: this.taskConfig() })))
+      .pipe(takeUntilDestroyed())
+      .subscribe(({ attemptId, taskConfig }) => {
+        this.taskService.configure(this.route(), this.url(), attemptId, taskConfig);
+      });
 
-  ngAfterViewChecked(): void {
-    if (!this.iframe || this.taskService.initialized) return;
-    this.taskService.initTask(this.iframe.nativeElement);
+    // Broader than the old ngOnChanges (attemptId-only) trigger; safe because TaskSessionTrackerService.init
+    // no-ops once initialized (see its idempotency guard).
+    toObservable(computed(() => ({
+      attemptId: this.attemptId(),
+      resultStartedAt: this.resultStartedAt(),
+      readOnly: this.taskConfig().readOnly,
+    })))
+      .pipe(takeUntilDestroyed())
+      .subscribe(({ attemptId, resultStartedAt, readOnly }) => {
+        if (attemptId !== undefined && !readOnly) {
+          this.sessionTracker.init(attemptId, resultStartedAt);
+        }
+      });
+
+    // Active view is driven by the view input (runs after configure subscription above).
+    toObservable(this.view)
+      .pipe(takeUntilDestroyed())
+      .subscribe(view => this.taskService.showView(view ?? 'task'));
+
+    // Immutability guard: the provider tree assumes one task per component instance.
+    // Violations throw asynchronously inside this subscription (not during change detection).
+    let initialRouteId: string | undefined;
+    let initialUrl: string | undefined;
+    toObservable(computed(() => ({ id: this.route().id, url: this.url() })))
+      .pipe(takeUntilDestroyed())
+      .subscribe(({ id, url }) => {
+        if (initialRouteId === undefined) {
+          initialRouteId = id;
+          initialUrl = url;
+          return;
+        }
+        if (initialRouteId !== id) {
+          throw new Error('this component does not support changing its route input');
+        }
+        if (initialUrl !== url) {
+          throw new Error('this component does not support changing its url input');
+        }
+      });
   }
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes.taskConfig || changes.attemptId) this.taskService.configure(this.route(), this.url(), this.attemptId, this.taskConfig);
-    if (changes.attemptId && this.attemptId !== undefined && !this.taskConfig.readOnly) {
-      this.sessionTracker.init(this.attemptId, this.resultStartedAt);
-    }
-    if (changes.view) this.taskService.showView(this.view ?? 'task');
-    if (
-      changes.route &&
-      !changes.route.firstChange &&
-      (changes.route.previousValue as FullItemRoute | undefined)?.id !== (changes.route.currentValue as FullItemRoute | undefined)?.id
-    ) {
-      throw new Error('this component does not support changing its route input');
-    }
-    if (changes.url && !changes.url.firstChange) throw new Error('this component does not support changing its url input');
+  // ngAfterViewChecked is required: iframe init depends on DOM presence timing (async src binding).
+  ngAfterViewChecked(): void {
+    const iframe = this.iframe();
+    if (!iframe || this.taskService.initialized) return;
+    this.taskService.initTask(iframe.nativeElement);
   }
 
   ngOnDestroy(): void {

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -212,8 +212,9 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
   private beforeUnload$ = new Subject<void>();
   private saveBeforeUnload$ = merge(this.beforeUnload$, this.retryBeforeUnload$).pipe(
     switchMap(() => {
-      if (!this.itemContentComponent?.itemDisplayComponent) return of(readyState<void>(undefined));
-      return this.itemContentComponent.itemDisplayComponent.saveAnswerAndState();
+      const itemDisplay = this.itemContentComponent?.itemDisplayComponent();
+      if (!itemDisplay) return of(readyState<void>(undefined));
+      return itemDisplay.saveAnswerAndState();
     }),
     takeUntil(this.skipBeforeUnload$),
     mergeWith(this.skipBeforeUnload$.pipe(map(() => readyState<void>(undefined)))),
@@ -242,7 +243,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     }),
 
     fromEvent<BeforeUnloadEvent>(globalThis, 'beforeunload', { capture: true })
-      .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent?.saveAnswerAndState() ?? of(undefined)), take(1))
+      .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent()?.saveAnswerAndState() ?? of(undefined)), take(1))
       .subscribe({
         error: () => { /* Errors cannot be handled before unloading page. */ },
       }),


### PR DESCRIPTION
## Summary
- Modernize `item-content` and `item-display` to Angular 22 patterns (signal inputs/outputs, `linkedSignal`, `viewChild()`, `outputFromObservable()`).
- Replace `ngOnChanges` with `toObservable` subscriptions for task lifecycle (configure, session tracker, view, immutability guard).
- Final core task-display migration batch; update `MODERNIZING-COMPONENTS.md` (§1 table marked historical).
- Batch 21 from `.cursor/plans/modernize-batch-21-item-display-content.md`.

## Scope
- **`item-content`**: remaining inputs → signals; `editModeEnabled` + switch → `linkedSignal`; 8 outputs → `output()`; `hasPrerequisites` → signal; `@ViewChild` → `viewChild()`; drop Eager
- **`item-display`**: remaining inputs → signals; Observable outputs → `outputFromObservable()`; `ngOnChanges` → constructor subscriptions; iframe `viewChild()`; preserve manual `subscriptions[]` for `saveAnswerAndState()` early-unsubscribe; extract helpers (`item-display-iframe-height.ts`, `item-display-side-effects.ts`)
- **`item-by-id`**: update `itemDisplayComponent()` call chain for beforeunload/navigation-save

## Risks / manual checks
- **Highest-risk batch**: task loading, answer saving (incl. beforeunload), score submission, full-frame mode, view tabs.
- Async `toObservable` configure path replaces synchronous `ngOnChanges` — 7/8 task-platform e2e tests pass; 1 websocket device-proxy test fails on missing `DeviceProxyPlatform` script (environmental, not migration-related).
- `@Input`/`@Output` grep still finds 2 app-shell files (`left-nav`, `user-group-invitations`) — intentionally deferred, documented in `MODERNIZING-COMPONENTS.md`.
- Review fix: added 8 unit tests for configure/showView/guard and `saveAnswerAndState` early-unsubscribe; constructor ordering comments added.

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-21/en/

With `npm start` and dev task URL `http://localhost:3000/test-task/index.html`:
- Load task, switch views/tabs
- Score submission + feedback
- Full-frame toggle
- Navigate away mid-edit (answer save)
- Browser-close prompt (beforeunload)
- Task retry button
- Read-only answer loading (`answer-author-indicator`)
- Edit switch ↔ children-edit tab interplay

## Verification
- [x] `npm run lint`
- [x] Unit tests: 45/45 (`item-content` + `item-display` specs)
- [x] `ng build --configuration=en`
- [x] E2e: 7/8 `task-platform-interaction.spec.ts` (websocket device-proxy env failure)
- [x] Manual smoke (checklist above)