### PR TITLE
Modernize Angular components (batch 25).

### DIFF
--- a/src/app/groups/containers/add-group/add-group.component.html
+++ b/src/app/groups/containers/add-group/add-group.component.html
@@ -3,7 +3,7 @@
     [isLight]="true"
     [allowedTypesForNewContent]="allowedNewGroupTypes"
     (contentAdded)="addChild($event)"
-    [loading]="state === 'addingGroup'"
+    [loading]="state() === 'addingGroup'"
     [showSearchUI]="false"
     i18n-inputCreatePlaceholder inputCreatePlaceholder="Enter a title to create a new group"
   ></alg-add-content>

--- a/src/app/groups/containers/add-group/add-group.component.ts
+++ b/src/app/groups/containers/add-group/add-group.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { AddedContent, NewContentType } from 'src/app/ui-components/add-content/add-content.component';
 import { GroupCreationService } from '../../data-access/group-creation.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
@@ -15,7 +15,6 @@ type GroupType = 'Class'|'Team'|'Club'|'Friends'|'Other'|'Session';
   selector: 'alg-add-group',
   templateUrl: 'add-group.component.html',
   styleUrls: [ 'add-group.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ AddContentComponent, SubSectionComponent ]
 })
 export class AddGroupComponent {
@@ -51,19 +50,19 @@ export class AddGroupComponent {
     },
   ];
 
-  state: 'addingGroup' | 'ready' = 'ready';
+  state = signal<'addingGroup' | 'ready'>('ready');
 
   addChild(group: AddedContent<GroupType>): void {
-    this.state = 'addingGroup';
+    this.state.set('addingGroup');
     this.groupCreationService.create(group.title, group.type).subscribe({
       next: createdId => {
-        this.state = 'ready';
+        this.state.set('ready');
         this.actionFeedbackService.success($localize`Group successfully created`);
         this.currentContentService.forceNavMenuReload();
         this.groupRouter.navigateTo(rawGroupRoute({ ...group, id: createdId }));
       },
       error: err => {
-        this.state = 'ready';
+        this.state.set('ready');
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       }

--- a/src/app/groups/containers/group-manager-list/group-manager-list.component.html
+++ b/src/app/groups/containers/group-manager-list/group-manager-list.component.html
@@ -26,7 +26,7 @@
             <ng-container cdkColumnDef="checkbox">
               <th class="alg-table-th alg-table-selection-col" cdk-header-cell *cdkHeaderCellDef></th>
               <td class="alg-table-td" cdk-cell *cdkCellDef="let rowData">
-                @let isSelected = !!(selection | findInArray: rowData);
+                @let isSelected = !!(selection() | findInArray: rowData);
                 <input type="checkbox" [checked]="isSelected" (change)="onSelect(rowData)" [disabled]="rowData.canManage === null" />
               </td>
             </ng-container>
@@ -132,7 +132,7 @@
                 class="alg-table-footer-checkbox"
                 id="select-all-checkbox"
                 (change)="onSelectAll(managers)"
-                [checked]="managers.length === selection.length"
+                [checked]="managers.length === selection().length"
               />
               <span class="alg-table-footer-select-all" i18n>
                 Select all
@@ -144,7 +144,7 @@
             type="button"
             icon="ph-duotone ph-trash"
             (click)="onRemove()"
-            [disabled]="removalInProgress || !state.isReady || selection.length === 0"
+            [disabled]="removalInProgress() || !state.isReady || selection().length === 0"
             alg-button-icon
             data-testid="remove-group-managers"
           ></button>

--- a/src/app/groups/containers/group-manager-list/group-manager-list.component.ts
+++ b/src/app/groups/containers/group-manager-list/group-manager-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, inject, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, input, signal } from '@angular/core';
 import { Observable, of, switchMap } from 'rxjs';
 import { GetGroupManagersService, Manager } from '../../data-access/get-group-managers.service';
 import { RemoveGroupManagerService } from '../../data-access/remove-group-manager.service';
@@ -45,6 +45,7 @@ import {
 } from '@angular/cdk/table';
 import { FindInArray } from 'src/app/pipes/findInArray';
 import { Dialog } from '@angular/cdk/dialog';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 const managersLimit = 25;
 
@@ -52,7 +53,6 @@ const managersLimit = 25;
   selector: 'alg-group-manager-list',
   templateUrl: './group-manager-list.component.html',
   styleUrls: [ './group-manager-list.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -86,13 +86,14 @@ export class GroupManagerListComponent {
   private actionFeedbackService = inject(ActionFeedbackService);
   private userService = inject(UserSessionService);
   private confirmationModalService = inject(ConfirmationModalService);
+  private destroyRef = inject(DestroyRef);
 
   group = input.required<Group>();
 
   private dialogService = inject(Dialog);
 
-  selection: Manager[] = [];
-  removalInProgress = false;
+  selection = signal<Manager[]>([]);
+  removalInProgress = signal(false);
 
   readonly datapager = new DataPager({
     fetch: (pageSize, latestManager?: Manager): Observable<Manager[]> => this.getGroupManagersService.getGroupManagers(
@@ -136,27 +137,28 @@ export class GroupManagerListComponent {
   }
 
   onSelectAll(managers: Manager[]): void {
-    if (this.selection.length === managers.length) {
-      this.selection = [];
+    if (this.selection().length === managers.length) {
+      this.selection.set([]);
       return;
     }
-    this.selection = managers;
+    this.selection.set(managers);
   }
 
   onSelect(item: Manager): void {
-    if (this.selection.includes(item)) {
-      const idx = this.selection.indexOf(item);
-      this.selection = [
-        ...this.selection.slice(0, idx),
-        ...this.selection.slice(idx + 1),
-      ];
+    const currentSelection = this.selection();
+    if (currentSelection.includes(item)) {
+      const idx = currentSelection.indexOf(item);
+      this.selection.set([
+        ...currentSelection.slice(0, idx),
+        ...currentSelection.slice(idx + 1),
+      ]);
     } else {
-      this.selection = [ ...this.selection, item ];
+      this.selection.set([ ...currentSelection, item ]);
     }
   }
 
   onRemove(): void {
-    if (this.selection.length === 0) {
+    if (this.selection().length === 0) {
       return;
     }
 
@@ -177,9 +179,9 @@ export class GroupManagerListComponent {
     }
 
     const groupId = this.group().id;
-    const ownManagerId = this.selection.find(manager => manager.id === currentUserId)?.id;
+    const ownManagerId = this.selection().find(manager => manager.id === currentUserId)?.id;
 
-    this.removalInProgress = true;
+    this.removalInProgress.set(true);
 
     const proceedRemoving$: Observable<true | undefined> = ownManagerId ? this.confirmationModalService.open({
       messageIconStyleClass: 'ph-duotone ph-warning-circle alg-validation-error',
@@ -194,26 +196,26 @@ export class GroupManagerListComponent {
       switchMap(() =>
         this.removeGroupManagerService.removeBatch(
           groupId,
-          this.selection.filter(manager => manager.id !== ownManagerId).map(manager => manager.id),
+          this.selection().filter(manager => manager.id !== ownManagerId).map(manager => manager.id),
           ownManagerId,
         )
       )
     ).subscribe({
       next: result => {
         displayGroupManagerRemovalResponseToast(this.actionFeedbackService, result);
-        this.removalInProgress = false;
+        this.removalInProgress.set(false);
 
         if (result.countSuccess > 0) {
-          this.selection = [];
+          this.selection.set([]);
           this.fetchData();
         }
       },
       error: err => {
-        this.removalInProgress = false;
+        this.removalInProgress.set(false);
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       },
-      complete: () => this.removalInProgress = false,
+      complete: () => this.removalInProgress.set(false),
     });
   }
 
@@ -224,7 +226,9 @@ export class GroupManagerListComponent {
         manager,
       },
       disableClose: true,
-    }).closed.subscribe(result => {
+    }).closed.pipe(
+      takeUntilDestroyed(this.destroyRef),
+    ).subscribe(result => {
       if (result?.updated) {
         this.fetchData();
         this.store.dispatch(fromGroupContent.groupPageActions.refresh());

--- a/src/app/groups/containers/group-managers/group-managers.component.ts
+++ b/src/app/groups/containers/group-managers/group-managers.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { IsCurrentUserManagerPipe } from '../../models/group-management';
 import { GroupManagerListComponent } from '../group-manager-list/group-manager-list.component';
 import { IsCurrentUserMemberPipe } from '../../models/group-membership';
@@ -8,7 +8,6 @@ import { Group } from '../../models/group';
   selector: 'alg-group-managers',
   templateUrl: './group-managers.component.html',
   styleUrls: [ './group-managers.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [ GroupManagerListComponent, IsCurrentUserManagerPipe, IsCurrentUserMemberPipe ]
 })
 export class GroupManagersComponent {

--- a/src/app/groups/containers/joined-group-list/joined-group-list.component.html
+++ b/src/app/groups/containers/joined-group-list/joined-group-list.component.html
@@ -115,7 +115,7 @@
         </ng-container>
         <tr
           class="alg-table-header-tr"
-          [ngClass]="{ 'alg-display-none': !state.isReady || state.data.length === 0 }"
+          [class.alg-display-none]="!state.isReady || state.data.length === 0"
           cdk-header-row
           *cdkHeaderRowDef="displayedColumns()"
         ></tr>

--- a/src/app/groups/containers/joined-group-list/joined-group-list.component.ts
+++ b/src/app/groups/containers/joined-group-list/joined-group-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, signal, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, signal, inject } from '@angular/core';
 import { ReplaySubject, Subject } from 'rxjs';
 import { distinctUntilChanged, filter, startWith, switchMap } from 'rxjs/operators';
 import { GroupMembership, JoinedGroupsService } from 'src/app/data-access/joined-groups.service';
@@ -8,7 +8,7 @@ import { GroupLeaveService } from 'src/app/data-access/group-leave.service';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { RouterLink } from '@angular/router';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
-import { AsyncPipe, DatePipe, NgClass } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 import { ConfirmationModalService } from 'src/app/services/confirmation-modal.service';
 import {
@@ -32,7 +32,6 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
   selector: 'alg-joined-group-list',
   templateUrl: './joined-group-list.component.html',
   styleUrls: [ './joined-group-list.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ErrorComponent,
     RouterLink,
@@ -52,7 +51,6 @@ import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directiv
     CdkHeaderCell,
     CdkHeaderCellDef,
     TableSortHeaderComponent,
-    NgClass,
     TooltipDirective
   ]
 })

--- a/src/app/groups/containers/manage-groups/manage-groups.component.ts
+++ b/src/app/groups/containers/manage-groups/manage-groups.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { UserSessionService } from 'src/app/services/user-session.service';
 import { delay } from 'rxjs/operators';
 import { AsyncPipe } from '@angular/common';
@@ -15,7 +15,6 @@ import { managedGroupsPage } from 'src/app/models/routing/group-route';
   selector: 'alg-manage-groups',
   templateUrl: './manage-groups.component.html',
   styleUrls: [ './manage-groups.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     AsyncPipe,
     AddGroupComponent,

--- a/src/app/groups/containers/managed-group-list/managed-group-list.component.html
+++ b/src/app/groups/containers/managed-group-list/managed-group-list.component.html
@@ -1,4 +1,4 @@
-@if (state === 'error') {
+@if (state() === 'error') {
   <alg-error
     class="dark"
     icon="ph-duotone ph-warning-circle"
@@ -7,12 +7,12 @@
     (refresh)="fetchData()"
   ></alg-error>
 } @else {
-  @if (state === 'fetching') {
+  @if (state() === 'fetching') {
     <alg-loading></alg-loading>
   } @else {
     <div class="alg-table-page-wrapper">
       <div class="alg-table-horizontal-scroll">
-        <table class="alg-table-v2" cdk-table [dataSource]="data">
+        <table class="alg-table-v2" cdk-table [dataSource]="data()">
           <ng-container cdkColumnDef="name">
             <th class="alg-table-th" cdk-header-cell *cdkHeaderCellDef i18n>Name</th>
             <td class="alg-table-td" cdk-cell *cdkCellDef="let group">
@@ -35,10 +35,8 @@
             <td class="alg-table-td" cdk-cell *cdkCellDef="let group">
               <span
                 class="table-icon"
-                [ngClass]="{
-                  locked: group.canWatchMembers,
-                  unlocked: !group.canWatchMembers
-                }"
+                [class.locked]="group.canWatchMembers"
+                [class.unlocked]="!group.canWatchMembers"
               >
                 @if (!group.canWatchMembers) {
                   <i class="ph-bold ph-x"></i>
@@ -55,10 +53,8 @@
             <td class="alg-table-td" cdk-cell *cdkCellDef="let group">
               <span
                 class="table-icon"
-                [ngClass]="{
-                  locked: group.canGrantGroupAccess,
-                  unlocked: !group.canGrantGroupAccess
-                }"
+                [class.locked]="group.canGrantGroupAccess"
+                [class.unlocked]="!group.canGrantGroupAccess"
               >
                 @if (!group.canGrantGroupAccess) {
                   <i class="ph-bold ph-x"></i>
@@ -70,7 +66,7 @@
             </td>
           </ng-container>
 
-          @if (data.length > 0) {
+          @if (data().length > 0) {
             <tr class="alg-table-header-tr" cdk-header-row *cdkHeaderRowDef="displayedColumns()"></tr>
           }
           <tr class="alg-table-body-tr" cdk-row *cdkRowDef="let row; columns: displayedColumns()"></tr>
@@ -84,4 +80,3 @@
     </div>
   }
 }
-

--- a/src/app/groups/containers/managed-group-list/managed-group-list.component.ts
+++ b/src/app/groups/containers/managed-group-list/managed-group-list.component.ts
@@ -1,8 +1,7 @@
-import { Component, OnInit, signal, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, signal, inject } from '@angular/core';
 import { Group, GroupType, ManagedGroupsService } from 'src/app/data-access/managed-groups.service';
 import { RouterLink } from '@angular/router';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
-import { NgClass } from '@angular/common';
 import { GroupManagershipLevel, groupManagershipLevelEnum as l } from '../../models/group-management';
 import {
   CdkCell,
@@ -23,11 +22,9 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
   selector: 'alg-managed-group-list',
   templateUrl: './managed-group-list.component.html',
   styleUrls: [ './managed-group-list.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ErrorComponent,
     RouterLink,
-    NgClass,
     CdkTable,
     CdkRow,
     CdkRowDef,
@@ -45,9 +42,9 @@ import { LoadingComponent } from 'src/app/ui-components/loading/loading.componen
 export class ManagedGroupListComponent implements OnInit {
   private managedGroupService = inject(ManagedGroupsService);
 
-  state: 'error' | 'ready' | 'fetching' = 'fetching';
+  state = signal<'error' | 'ready' | 'fetching'>('fetching');
 
-  data: Group[] = [];
+  data = signal<Group[]>([]);
 
   displayedColumns = signal([ 'name', 'type', 'canManage', 'canWatchMembers', 'canGrantGroupAccess' ]);
 
@@ -56,13 +53,13 @@ export class ManagedGroupListComponent implements OnInit {
   }
 
   fetchData(): void {
-    this.state = 'fetching';
+    this.state.set('fetching');
     this.managedGroupService.getManagedGroups().subscribe({
       next: data => {
-        this.state = 'ready';
-        this.data = data;
+        this.state.set('ready');
+        this.data.set(data);
       },
-      error: _err => this.state = 'error',
+      error: _err => this.state.set('error'),
     });
   }
 

--- a/src/app/groups/containers/my-groups/my-groups.component.ts
+++ b/src/app/groups/containers/my-groups/my-groups.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, ViewChild, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject, viewChild } from '@angular/core';
 import { myGroupsInfo } from 'src/app/models/content/group-info';
 import { CurrentContentService } from 'src/app/services/current-content.service';
 import { JoinedGroupListComponent } from '../joined-group-list/joined-group-list.component';
@@ -16,7 +16,6 @@ import { fromCurrentContent } from 'src/app/store/navigation/current-content/cur
   selector: 'alg-my-groups',
   templateUrl: './my-groups.component.html',
   styleUrls: [ './my-groups.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     UserGroupInvitationsComponent,
     JoinedGroupListComponent,
@@ -30,7 +29,7 @@ export class MyGroupsComponent implements OnDestroy, OnInit {
   private currentContent = inject(CurrentContentService);
   private sessionService = inject(UserSessionService);
 
-  @ViewChild('joinedGroupList') joinedGroupList?: JoinedGroupListComponent;
+  joinedGroupList = viewChild('joinedGroupList', { read: JoinedGroupListComponent });
 
   currentUser$ = this.sessionService.userProfile$.pipe(delay(0));
 
@@ -47,7 +46,7 @@ export class MyGroupsComponent implements OnDestroy, OnInit {
   }
 
   onGroupJoined(): void {
-    this.joinedGroupList?.refresh();
+    this.joinedGroupList()?.refresh();
     this.currentContent.forceNavMenuReload();
   }
 

--- a/src/app/groups/containers/user-group-invitations/user-group-invitations.component.html
+++ b/src/app/groups/containers/user-group-invitations/user-group-invitations.component.html
@@ -43,7 +43,7 @@
                   type="button"
                   icon="ph-bold ph-check"
                   (click)="openJoinGroupConfirmationDialog(rowData)"
-                  [disabled]="processing"
+                  [disabled]="processing()"
                 ></button>
                 <button
                   class="stroke size-l"
@@ -52,7 +52,7 @@
                   type="button"
                   icon="ph-bold ph-x"
                   (click)="onReject(rowData)"
-                  [disabled]="processing"
+                  [disabled]="processing()"
                 ></button>
               </div>
             </td>

--- a/src/app/groups/containers/user-group-invitations/user-group-invitations.component.ts
+++ b/src/app/groups/containers/user-group-invitations/user-group-invitations.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, inject, OnDestroy, Output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnDestroy, output, signal } from '@angular/core';
 import { BehaviorSubject, EMPTY, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { GetRequestsService, GroupInvitation } from '../../data-access/get-requests.service';
@@ -36,7 +36,6 @@ import { Dialog } from '@angular/cdk/dialog';
   selector: 'alg-user-group-invitations',
   templateUrl: './user-group-invitations.component.html',
   styleUrls: [ './user-group-invitations.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -64,11 +63,11 @@ export class UserGroupInvitationsComponent implements OnDestroy {
   private currentContentService = inject(CurrentContentService);
   private processGroupInvitationService = inject(ProcessGroupInvitationService);
 
-  @Output() groupJoined = new EventEmitter<void>();
+  groupJoined = output<void>();
 
   private dialogService = inject(Dialog);
 
-  processing = false;
+  processing = signal(false);
 
   private sortSubject = new BehaviorSubject<string[]>([]);
   state$ = this.sortSubject.pipe(
@@ -112,7 +111,7 @@ export class UserGroupInvitationsComponent implements OnDestroy {
       switchMap(response => (response?.confirmed ? this.accept(groupInvitation.group.id, data.params) : EMPTY))
     ).subscribe({
       next: result => {
-        this.processing = false;
+        this.processing.set(false);
         if (!result.changed) {
           this.actionFeedbackService.error($localize`Unable to accept invitation to group "${ groupInvitation.group.name }"`);
           return;
@@ -122,7 +121,7 @@ export class UserGroupInvitationsComponent implements OnDestroy {
         this.groupJoined.emit();
       },
       error: err => {
-        this.processing = false;
+        this.processing.set(false);
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       },
@@ -130,15 +129,15 @@ export class UserGroupInvitationsComponent implements OnDestroy {
   }
 
   accept(groupId: string, params: GroupApprovals): Observable<{ changed: boolean }> {
-    this.processing = true;
+    this.processing.set(true);
     return this.processGroupInvitationService.accept(groupId, mapGroupApprovalParamsToValues(params));
   }
 
   onReject(groupInvitation: GroupInvitation): void {
-    this.processing = true;
+    this.processing.set(true);
     this.processGroupInvitationService.reject(groupInvitation.group.id).subscribe({
       next: result => {
-        this.processing = false;
+        this.processing.set(false);
         if (!result.changed) {
           this.actionFeedbackService.error($localize`Unable to reject invitation to group "${ groupInvitation.group.name }"`);
           return;
@@ -148,7 +147,7 @@ export class UserGroupInvitationsComponent implements OnDestroy {
         this.currentContentService.forceNavMenuReload();
       },
       error: err => {
-        this.processing = false;
+        this.processing.set(false);
         this.actionFeedbackService.unexpectedError();
         if (!(err instanceof HttpErrorResponse)) throw err;
       },


### PR DESCRIPTION
## Summary
- Modernize 8 groups list/page components to Angular 22 patterns (signals for async state, drop Eager CD, NgClass → class bindings, `@Output`/`@ViewChild` → modern APIs).
- Batch 25 from `.cursor/plans/modernize-batch-25-groups-lists.md`.

## Scope
- `managed-group-list` — `state`/`data` → signals; lock icon class bindings
- `joined-group-list` — `[class.alg-display-none]`; preserve public `refresh()`
- `user-group-invitations` — `groupJoined` → `output()`; `processing` → signal
- `group-manager-list` — `selection`/`removalInProgress` → signals; dialog subscription scoped with `takeUntilDestroyed`
- `group-managers`, `manage-groups` — drop Eager
- `my-groups` — `@ViewChild` → `viewChild`; refresh joined list on group join
- `add-group` — `state` → signal for loading indicator

## Risks / manual checks
- E2E coverage: `my-groups.spec.ts`, `user-group-invitations.spec.ts`, `delete-group-managers.spec.ts`, etc.
- Verify group-manager-list checkbox sync after bulk removal
- `group-manager-list` constructor `effect` is pre-existing (plan: keep as-is)

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-25/en/

- Mine page: accept/reject invitations (processing disabled state), joined list refresh after join, leave group
- Manage page: managed list lock icons, create group via add-group loading state
- Group managers tab: select managers, bulk remove with confirmation, add manager

## Verification
- [x] `npm run lint`
- [x] `ng build --configuration=en`
- [x] Manual smoke / CI e2e