### PR TITLE
Modernize Angular components (batch 26).

### DIFF
--- a/src/app/groups/containers/associated-item/associated-item.component.ts
+++ b/src/app/groups/containers/associated-item/associated-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, forwardRef, input, OnDestroy, signal, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, forwardRef, input, OnDestroy, signal, inject } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { Observable, of, Subject } from 'rxjs';
 import { catchError, filter, map, switchMap } from 'rxjs/operators';
@@ -42,7 +42,6 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
       multi: true,
     }
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,

--- a/src/app/groups/containers/group-edit/group-edit.component.html
+++ b/src/app/groups/containers/group-edit/group-edit.component.html
@@ -49,7 +49,7 @@
               <div class="datepicker">
                 <alg-input-date
                   formControlName="requireLockMembershipApprovalUntil"
-                  [minDate]="minLockMembershipApprovalUntilDate"
+                  [minDate]="minLockMembershipApprovalUntilDate()"
                 ></alg-input-date>
               </div>
             }

--- a/src/app/groups/containers/group-edit/group-edit.component.ts
+++ b/src/app/groups/containers/group-edit/group-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { UntypedFormBuilder, Validators, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { readyData } from 'src/app/utils/operators/state';
 import { of, Subscription, combineLatest, switchMap, EMPTY } from 'rxjs';
@@ -41,7 +41,6 @@ import {
   selector: 'alg-group-edit',
   templateUrl: './group-edit.component.html',
   styleUrls: [ './group-edit.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
@@ -98,7 +97,7 @@ export class GroupEditComponent implements OnInit, OnDestroy, PendingChangesComp
     rootSkill: [ '', [] ],
   });
   initialFormData?: Group;
-  minLockMembershipApprovalUntilDate?: Date;
+  minLockMembershipApprovalUntilDate = signal<Date | undefined>(undefined);
 
   state$ = this.store.select(fromGroupContent.selectActiveContentGroupState);
 
@@ -268,8 +267,8 @@ export class GroupEditComponent implements OnInit, OnDestroy, PendingChangesComp
     if (enabled) {
       const initialRequireLockMembershipApprovalUntil = this.initialFormData?.requireLockMembershipApprovalUntil;
       const currentDate = new Date();
-      this.minLockMembershipApprovalUntilDate = initialRequireLockMembershipApprovalUntil && initialRequireLockMembershipApprovalUntil
-        < currentDate ? initialRequireLockMembershipApprovalUntil : currentDate;
+      this.minLockMembershipApprovalUntilDate.set(initialRequireLockMembershipApprovalUntil && initialRequireLockMembershipApprovalUntil
+        < currentDate ? initialRequireLockMembershipApprovalUntil : currentDate);
       requireLockMembershipApprovalUntilControl.addValidators(Validators.required);
     } else {
       requireLockMembershipApprovalUntilControl.removeValidators(Validators.required);

--- a/src/app/groups/containers/group-header/group-header.component.ts
+++ b/src/app/groups/containers/group-header/group-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, OnDestroy, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, OnDestroy, inject } from '@angular/core';
 import { GroupData } from '../../models/group-data';
 import { AsyncPipe } from '@angular/common';
 import { GetItemByIdService } from 'src/app/data-access/get-item-by-id.service';
@@ -15,7 +15,6 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
   selector: 'alg-group-header',
   templateUrl: './group-header.component.html',
   styleUrls: [ './group-header.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     AsyncPipe,
     RouterLink,

--- a/src/app/groups/containers/group-indicator/group-indicator.component.ts
+++ b/src/app/groups/containers/group-indicator/group-indicator.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { Group } from '../../models/group';
 import { GroupLinksComponent } from '../group-links/group-links.component';
 import { NgScrollbar } from 'ngx-scrollbar';
@@ -8,7 +8,6 @@ import { RouterLink } from '@angular/router';
   selector: 'alg-group-indicator',
   templateUrl: './group-indicator.component.html',
   styleUrls: [ './group-indicator.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     GroupLinksComponent,
     NgScrollbar,

--- a/src/app/groups/containers/group-links/group-links.component.ts
+++ b/src/app/groups/containers/group-links/group-links.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { GroupShortInfo } from '../../models/group';
 import { GroupLinkPipe } from 'src/app/pipes/groupLink';
 import { RouterLink } from '@angular/router';
@@ -10,7 +10,6 @@ const defaultMaxItemsDisplay = 4;
   selector: 'alg-group-links',
   templateUrl: './group-links.component.html',
   styleUrls: [ './group-links.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     RouterLink,
     SlicePipe,

--- a/src/app/groups/containers/group-no-permission/group-no-permission.component.ts
+++ b/src/app/groups/containers/group-no-permission/group-no-permission.component.ts
@@ -1,11 +1,9 @@
-import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   selector: 'alg-group-no-permission',
   templateUrl: './group-no-permission.component.html',
   styleUrls: [ './group-no-permission.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  standalone: true
 })
 export class GroupNoPermissionComponent {
 

--- a/src/app/groups/containers/platform-settings/platform-settings.component.ts
+++ b/src/app/groups/containers/platform-settings/platform-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ActionFeedbackService } from 'src/app/services/action-feedback.service';
 import { LocaleService } from 'src/app/services/localeService';
 import { UserSessionService } from 'src/app/services/user-session.service';
@@ -10,7 +10,6 @@ import { AsyncPipe } from '@angular/common';
   selector: 'alg-platform-settings',
   templateUrl: './platform-settings.component.html',
   styleUrls: [ './platform-settings.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LanguagePickerComponent,
     AsyncPipe,

--- a/src/app/groups/containers/user-groups-with-grants/user-groups-with-grants.component.ts
+++ b/src/app/groups/containers/user-groups-with-grants/user-groups-with-grants.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { JoinedGroupsService } from 'src/app/data-access/joined-groups.service';
 import { mapStateData, mapToFetchState } from 'src/app/utils/operators/state';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
@@ -11,7 +11,6 @@ import { GroupLinksComponent } from '../group-links/group-links.component';
   selector: 'alg-user-groups-with-grants',
   templateUrl: './user-groups-with-grants.component.html',
   styleUrls: [ './user-groups-with-grants.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,

--- a/src/app/groups/containers/user-header/user-header.component.ts
+++ b/src/app/groups/containers/user-header/user-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input } from '@angular/core';
 import { User } from '../../models/user';
 import { RawGroupRoute } from 'src/app/models/routing/group-route';
 import { UserCaptionPipe } from 'src/app/pipes/userCaption';
@@ -7,7 +7,6 @@ import { UserCaptionPipe } from 'src/app/pipes/userCaption';
   selector: 'alg-user-header',
   templateUrl: './user-header.component.html',
   styleUrls: [ './user-header.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     UserCaptionPipe,
   ]

--- a/src/app/groups/containers/user-info/user-info.component.ts
+++ b/src/app/groups/containers/user-info/user-info.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
 import { CanEditPersonalInfoPipe, CanViewPersonalInfoPipe, User } from 'src/app/groups/models/user';
 import { GenerateProfileEditTokenService } from 'src/app/groups/data-access/generate-profile-edit-token.service';
 import { Location } from '@angular/common';
@@ -11,7 +11,6 @@ import { UserGroupsWithGrantsComponent } from '../user-groups-with-grants/user-g
   selector: 'alg-user-info',
   templateUrl: './user-info.component.html',
   styleUrls: [ './user-info.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ButtonComponent,
     UserGroupsWithGrantsComponent,

--- a/src/app/groups/containers/user/user.component.ts
+++ b/src/app/groups/containers/user/user.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnDestroy, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { combineLatest, Observable, Subscription } from 'rxjs';
 import { NavigationEnd, Router, RouterLinkActive, RouterLink } from '@angular/router';
 import { map, startWith, filter, distinctUntilChanged } from 'rxjs/operators';
@@ -24,7 +24,6 @@ import { fromCurrentContent } from 'src/app/store/navigation/current-content/cur
   selector: 'alg-user',
   templateUrl: './user.component.html',
   styleUrls: [ './user.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,

--- a/src/app/groups/group-by-id.component.ts
+++ b/src/app/groups/group-by-id.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, OnDestroy, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnDestroy, viewChild } from '@angular/core';
 import { RouterLinkActive, RouterLink } from '@angular/router';
 import { APPCONFIG } from 'src/app/config';
 import { groupInfo } from 'src/app/models/content/group-info';
@@ -33,7 +33,6 @@ import { IsCurrentUserMemberPipe } from './models/group-membership';
   selector: 'alg-group-by-id',
   templateUrl: './group-by-id.component.html',
   styleUrls: [ './group-by-id.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     GroupHeaderComponent,
     GroupIndicatorComponent,
@@ -65,13 +64,7 @@ export class GroupByIdComponent implements OnDestroy {
 
   hideAccessTab = !this.config.featureFlags.showGroupAccessTab;
 
-  // use of ViewChild required as these elements are shown under some conditions, so may be undefined
-  @ViewChild('overviewTab') overviewTab?: RouterLinkActive;
-  @ViewChild('compositionTab') compositionTab?: RouterLinkActive;
-  @ViewChild('adminTab') adminTab?: RouterLinkActive;
-  @ViewChild('settingsTab') settingsTab?: RouterLinkActive;
-  @ViewChild('accessTab') accessTab?: RouterLinkActive;
-  @ViewChild('groupEdit') groupEdit?: GroupEditComponent;
+  groupEdit = viewChild<GroupEditComponent>('groupEdit');
 
   // on state change, update current content page info (for breadcrumb)
   private groupToCurrentContentSubscription = this.state$.pipe(readyData<GroupData>()).subscribe(({ route }) => {
@@ -119,7 +112,7 @@ export class GroupByIdComponent implements OnDestroy {
   }
 
   isDirty(): boolean {
-    return !!this.groupEdit?.isDirty();
+    return !!this.groupEdit()?.isDirty();
   }
 
   refreshNav(): void {


### PR DESCRIPTION
## Summary
- Modernize 12 group/user page components: drop Eager CD, delete 5 dead RouterLinkActive `@ViewChild`s, migrate `groupEdit` to `viewChild()`, convert `minLockMembershipApprovalUntilDate` to signal.
- Batch 26 from `.cursor/plans/modernize-batch-26-groups-pages.md`.

## Scope
- **`group-by-id`**: delete 5 unused TS `RouterLinkActive` ViewChilds; `groupEdit` → `viewChild()` for pending-changes guard
- **`group-edit`**: `minLockMembershipApprovalUntilDate` → signal (fixes unsafe OnPush mutation from constructor subscription)
- **`group-no-permission`**: remove `standalone: true`
- **`group-header`**, **`group-indicator`**, **`group-links`**, **`user`**, **`user-info`**, **`user-header`**, **`user-groups-with-grants`**, **`platform-settings`**, **`associated-item`**: drop Eager only

## Risks / manual checks
- Group page tab bar under OnPush (RouterLinkActive template refs) — e2e: `group-history.spec.ts`, `groups.spec.ts`
- Settings form pending-changes guard — e2e: `group-edit-requires-approval.spec.ts`, `strengthened-approval-conditions.spec.ts`
- Lock-membership min-date toggle when enabling approval switch
- User page — e2e: `user-data.spec.ts`

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-26/en/

- Group page tab bar (all tabs, including permission-hidden)
- Settings form edit + save + navigate away (pending changes)
- Lock-membership date switch (min date appears)
- Associated activity change
- User page (personal data, settings sub-tab, platform language)

## Verification
- [x] `npm run lint`
- [x] `group-no-permission` unit test (1/1)
- [x] `ng build --configuration=en`
- [ ] Manual smoke / CI e2e