### PR TITLE
Modernize Angular components (batch 27).

### DIFF
--- a/src/app/items/containers/item-parameters-form/item-parameters-form.component.ts
+++ b/src/app/items/containers/item-parameters-form/item-parameters-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, forwardRef, inject, input, output, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, forwardRef, inject, input, output } from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -47,7 +47,6 @@ import { createCvaEcho } from 'src/app/utils/cva-echo';
     ItemParametersTeamComponent,
     ItemRemoveButtonComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/src/app/items/containers/item-parameters-form/sections/item-parameters-participation.component.ts
+++ b/src/app/items/containers/item-parameters-form/sections/item-parameters-participation.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, forwardRef, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, forwardRef, inject, signal } from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -33,7 +33,6 @@ import {
     DurationComponent,
     InputDateComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/src/app/items/containers/item-parameters-form/sections/item-parameters-team.component.ts
+++ b/src/app/items/containers/item-parameters-form/sections/item-parameters-team.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, forwardRef, inject } from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder,
@@ -29,7 +29,6 @@ import { ItemEntryMinAdmittedMembersRatio, ItemParametersTeamValue } from 'src/a
     SelectOptionComponent,
     SwitchComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,

--- a/src/app/items/containers/item-strings-form-group/item-strings-control/item-strings-control.component.ts
+++ b/src/app/items/containers/item-strings-form-group/item-strings-control/item-strings-control.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, inject, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, forwardRef, inject, input } from '@angular/core';
 import {
   ControlValueAccessor,
   FormBuilder, NG_VALIDATORS,
@@ -36,7 +36,6 @@ export interface StringsValue {
     ItemEditContentComponent,
     TooltipDirective,
   ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   providers: [
     {
       provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
## Summary
- Drop `ChangeDetectionStrategy.Eager` on 4 CVA form components (strings/parameters); revert to default OnPush after e2e validation.
- Batch 27 from `.cursor/plans/modernize-batch-27-item-forms-cva.md`.

## Scope
- `item-strings-control`, `item-parameters-form`, `item-parameters-team`, `item-parameters-participation`
- Subscription hygiene (`takeUntilDestroyed`) was already in place; NG0100 comments preserved verbatim
- **Eager dropped on all 4** — no component kept Eager (e2e confirmed save-bar / pristine behavior)

## Risks / manual checks
- NG0100 regressions show as console errors or stale Save bar — watch browser console during manual smoke
- `item-edit-strings` e2e was flaky on first run (timeout); passed on chromium retry
- Post-init `writeValue` toggling team section visibility — covered by item-parameters e2e load path

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-27/en/

- Edit title/subtitle/description (dirty bar appears immediately)
- Team section toggles, entering fields min/max interplay
- Save then re-edit, navigate away with pending changes

## Verification
- [x] `npm run lint`
- [x] `ng build --configuration=en`
- [x] E2e: item-parameters (6/6), item-parameters-form-pristine (6/6), item-edit-strings (1/1 chromium retry)