### PR TITLE
Modernize Angular components (batch 28).

### DIFF
--- a/src/app/items/containers/chapter-user-progress/chapter-user-progress.component.html
+++ b/src/app/items/containers/chapter-user-progress/chapter-user-progress.component.html
@@ -39,7 +39,9 @@
                       <div>
                         <a
                           class="alg-link"
-                          [ngClass]="{ 'disabled font-bold text-black': rowData.id === itemData().item.id }"
+                          [class.disabled]="rowData.id === itemData().item.id"
+                          [class.font-bold]="rowData.id === itemData().item.id"
+                          [class.text-black]="rowData.id === itemData().item.id"
                           [routerLink]="rowData | itemRoute: { path: itemData().route.path.concat([ itemData().item.id ]), parentAttemptId } | url"
                         >
                           {{ rowData.title }}

--- a/src/app/items/containers/chapter-user-progress/chapter-user-progress.component.ts
+++ b/src/app/items/containers/chapter-user-progress/chapter-user-progress.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, OnDestroy, inject, input, ChangeDetectionStrategy } from '@angular/core';
+import { Component, computed, OnDestroy, inject, input } from '@angular/core';
 import { GetParticipantProgressService } from '../../data-access/get-participant-progress.service';
 import { Observable, Subject } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
@@ -14,7 +14,7 @@ import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.
 import { RouterLink } from '@angular/router';
 import { ErrorComponent } from 'src/app/ui-components/error/error.component';
 import { LoadingComponent } from 'src/app/ui-components/loading/loading.component';
-import { NgClass, AsyncPipe, DatePipe } from '@angular/common';
+import { AsyncPipe, DatePipe } from '@angular/common';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import {
   CdkCell,
@@ -46,11 +46,9 @@ interface RowData {
   selector: 'alg-chapter-user-progress',
   templateUrl: './chapter-user-progress.component.html',
   styleUrls: [ './chapter-user-progress.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
-    NgClass,
     RouterLink,
     ScoreRingComponent,
     AsyncPipe,

--- a/src/app/items/containers/item-extra-time/item-extra-time-for-descendants/item-extra-time-for-descendants.component.ts
+++ b/src/app/items/containers/item-extra-time/item-extra-time-for-descendants/item-extra-time-for-descendants.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, OnDestroy, signal, inject } from '@angular/core';
+import { Component, input, OnDestroy, signal, inject } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { combineLatest, Subject, switchMap } from 'rxjs';
 import { ExtraTimeService } from 'src/app/items/data-access/extra-time.service';
@@ -50,7 +50,6 @@ import {
   ],
   templateUrl: './item-extra-time-for-descendants.component.html',
   styleUrl: './item-extra-time-for-descendants.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ItemExtraTimeForDescendantsComponent implements OnDestroy {
   private extraTimeService = inject(ExtraTimeService);

--- a/src/app/items/containers/item-extra-time/item-extra-time-input/item-extra-time-input.component.ts
+++ b/src/app/items/containers/item-extra-time/item-extra-time-input/item-extra-time-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, effect, input, output, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, effect, input, output, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 import { InputNumberComponent } from 'src/app/ui-components/input-number/input-number.component';
@@ -7,7 +7,6 @@ import { InputNumberComponent } from 'src/app/ui-components/input-number/input-n
   selector: 'alg-item-extra-time-input',
   templateUrl: './item-extra-time-input.component.html',
   styleUrls: [ './item-extra-time-input.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     FormsModule,
     ButtonIconComponent,

--- a/src/app/items/containers/item-extra-time/item-extra-time.component.ts
+++ b/src/app/items/containers/item-extra-time/item-extra-time.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, input, OnDestroy, signal, ViewChild, inject } from '@angular/core';
+import { Component, input, OnDestroy, signal, viewChild, inject } from '@angular/core';
 import { ItemData } from '../../models/item-data';
 import { CanCurrentUserSetExtraTimePipe, IsTimeLimitedActivityPipe } from '../../models/time-limited-activity';
 import { DurationToReadablePipe } from 'src/app/pipes/duration';
@@ -33,7 +33,6 @@ import { ActionFeedbackService } from 'src/app/services/action-feedback.service'
   ],
   templateUrl: './item-extra-time.component.html',
   styleUrl: './item-extra-time.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ItemExtraTimeComponent implements OnDestroy {
   private store = inject(Store);
@@ -41,7 +40,7 @@ export class ItemExtraTimeComponent implements OnDestroy {
   private setExtraTimeService = inject(SetExtraTimeService);
   private actionFeedbackService = inject(ActionFeedbackService);
 
-  @ViewChild(ItemExtraTimeForDescendantsComponent) itemExtraTimeForDescendantsComponent?: ItemExtraTimeForDescendantsComponent;
+  readonly itemExtraTimeForDescendantsComponent = viewChild(ItemExtraTimeForDescendantsComponent);
 
   itemData = input.required<ItemData>();
 
@@ -71,7 +70,7 @@ export class ItemExtraTimeComponent implements OnDestroy {
   }
 
   onExtraTimeSave(additionalTime: number, groupId: string): void {
-    const extraTimeForDescendantsComponent = this.itemExtraTimeForDescendantsComponent;
+    const extraTimeForDescendantsComponent = this.itemExtraTimeForDescendantsComponent();
     if (!extraTimeForDescendantsComponent) throw new Error('Unexpected: extraTimeForDescendantsComponent');
     this.updating.set(true);
     this.setExtraTimeService.set(this.itemData().item.id, groupId, additionalTime).subscribe({

--- a/src/app/items/containers/user-progress/user-progress.component.html
+++ b/src/app/items/containers/user-progress/user-progress.component.html
@@ -1,15 +1,15 @@
 <div
   class="group-situation-data"
-  [ngClass]="state"
-  [class.pointer]="state !== 'not-started'"
+  [class]="state()"
+  [class.pointer]="state() !== 'not-started'"
 >
-  @if (state !== 'success' && state !== 'not-started') {
+  @if (state() !== 'success' && state() !== 'not-started') {
     <alg-score-ring
       [currentScore]="userProgress().score"
       [diameter]="32"
     ></alg-score-ring>
   }
-  @if (state === 'success') {
+  @if (state() === 'success') {
     <span class="situation-check">
       <i class="ph-bold ph-check"></i>
     </span>

--- a/src/app/items/containers/user-progress/user-progress.component.ts
+++ b/src/app/items/containers/user-progress/user-progress.component.ts
@@ -1,35 +1,23 @@
-import { Component, input, OnChanges, OnInit, SimpleChanges, ChangeDetectionStrategy } from '@angular/core';
-import { mustNotBeUndefined } from 'src/app/utils/assert';
+import { Component, computed, input } from '@angular/core';
 import { ParticipantProgresses } from 'src/app/data-access/get-group-progress.service';
 import { ScoreRingComponent } from 'src/app/ui-components/score-ring/score-ring.component';
-import { NgClass } from '@angular/common';
 
 @Component({
   selector: 'alg-user-progress',
   templateUrl: './user-progress.component.html',
   styleUrls: [ './user-progress.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
-  imports: [ NgClass, ScoreRingComponent ]
+  imports: [ ScoreRingComponent ]
 })
-export class UserProgressComponent implements OnInit, OnChanges {
+export class UserProgressComponent {
 
   userProgress = input.required<ParticipantProgresses[number]>();
 
-  state: 'success'|'in-progress'|'no-score'|'not-started' = 'no-score';
-
-  ngOnInit(): void {
-    // When the component has no inputs, the hook onChange is not executed.
-    // Therefore, the user progress assertion must be declared also at init.
-    mustNotBeUndefined(this.userProgress(), 'user progress must be defined');
-  }
-
-  ngOnChanges(_changes: SimpleChanges): void {
-    mustNotBeUndefined(this.userProgress(), 'user progress must be defined');
-
-    if (this.userProgress().validated || this.userProgress().score === 100) this.state = 'success';
-    else if (this.userProgress().score > 0) this.state = 'in-progress';
-    else if (this.userProgress().score === 0 && this.userProgress().latestActivityAt !== null) this.state = 'no-score';
-    else this.state = 'not-started';
-  }
+  protected readonly state = computed((): 'success' | 'in-progress' | 'no-score' | 'not-started' => {
+    const progress = this.userProgress();
+    if (progress.validated || progress.score === 100) return 'success';
+    if (progress.score > 0) return 'in-progress';
+    if (progress.score === 0 && progress.latestActivityAt !== null) return 'no-score';
+    return 'not-started';
+  });
 
 }

--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -16,7 +16,8 @@
         @if (observedGroup$ | async; as observedGroup) {
           <alg-item-permissions
             class="item-permissions"
-            [ngClass]="{ 'with-margin': fullFrameContentDisplayed, 'with-right-margin': !!(withLeftPaddingContentDisplayed$ | async) }"
+            [class.with-margin]="fullFrameContentDisplayed"
+            [class.with-right-margin]="!!(withLeftPaddingContentDisplayed$ | async)"
             [itemData]="itemData"
             [observedGroup]="observedGroup"
             (changed)="reloadItem()"
@@ -27,15 +28,12 @@
         }
         <div
           class="content-container"
-          [ngClass]="{
-            'no-top-padding': itemData.item.type === 'Task' && !!currentTab?.isTaskTab,
-            'side-padding': itemData.item.type === 'Task' && !currentTab?.isTaskTab && fullFrameContentDisplayed,
-            'right-padding': itemData.item.type === 'Task' && !currentTab?.isTaskTab && !fullFrameContentDisplayed
-          }"
-          #contentContainer
+          [class.no-top-padding]="itemData.item.type === 'Task' && !!currentTab?.isTaskTab"
+          [class.side-padding]="itemData.item.type === 'Task' && !currentTab?.isTaskTab && fullFrameContentDisplayed"
+          [class.right-padding]="itemData.item.type === 'Task' && !currentTab?.isTaskTab && !fullFrameContentDisplayed"
           *ngrxLet="currentTab$ as currentTab"
           >
-          @if (currentTab?.isTaskTab || itemContentComponent?.isTaskLoaded() || currentTab?.tag === 'alg-content' || currentTab?.tag === 'alg-children-edit') {
+          @if (currentTab?.isTaskTab || itemContentComponent()?.isTaskLoaded() || currentTab?.tag === 'alg-content' || currentTab?.tag === 'alg-children-edit') {
             @if (answerLoadingError$ | async; as error) {
               <alg-error>
                 @if (!error.fallbackLink) {
@@ -54,7 +52,7 @@
                 @if (taskConfig && taskConfig.readOnly && taskConfig.initialAnswer && currentTab && currentTab?.isTaskTab) {
                   <div
                     class="indicator"
-                    [ngClass]="{ 'no-left-padding': !fullFrameContentDisplayed }"
+                    [class.no-left-padding]="!fullFrameContentDisplayed"
                     >
                       <alg-answer-author-indicator
                         [answer]="taskConfig.initialAnswer"
@@ -84,7 +82,7 @@
           }
           @if (currentTab?.tag ==='alg-task-edit') {
             <alg-item-task-edit
-              [editorUrl]="editorUrl"
+              [editorUrl]="editorUrl()"
               (redirectToDefaultTab)="navigateToDefaultTab(itemData.route)"
             ></alg-item-task-edit>
           }

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -1,6 +1,6 @@
-import { Component, ElementRef, inject, OnDestroy, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, OnDestroy, signal, viewChild } from '@angular/core';
 import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
-import { combineLatest, of, Subscription, EMPTY, fromEvent, merge, Observable, Subject, BehaviorSubject } from 'rxjs';
+import { combineLatest, of, EMPTY, fromEvent, merge, Observable, Subject, BehaviorSubject } from 'rxjs';
 import {
   delay,
   distinctUntilChanged,
@@ -54,7 +54,8 @@ import { TabBarComponent } from 'src/app/ui-components/tab-bar/tab-bar.component
 import { ItemPermissionsComponent } from './containers/item-permissions/item-permissions.component';
 import { AccessCodeViewComponent } from 'src/app/containers/access-code-view/access-code-view.component';
 import { ItemHeaderComponent } from './containers/item-header/item-header.component';
-import { AsyncPipe, NgClass } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Store } from '@ngrx/store';
 import { fromForum, isThreadInline } from '../forum/store';
 import { isNotNull } from '../utils/null-undefined-predicates';
@@ -85,9 +86,7 @@ const selectState = createSelector(
   templateUrl: './item-by-id.component.html',
   styleUrls: [ './item-by-id.component.scss' ],
   providers: [ InitialAnswerDataSource, ItemTabs ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
-    NgClass,
     ItemHeaderComponent,
     AccessCodeViewComponent,
     ItemPermissionsComponent,
@@ -134,11 +133,10 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
   private config = inject(APPCONFIG);
   private confirmationModalService = inject(ConfirmationModalService);
 
-  @ViewChild(ItemContentComponent) itemContentComponent?: ItemContentComponent;
-  @ViewChild(ItemEditWrapperComponent) itemEditWrapperComponent?: ItemEditWrapperComponent;
-  @ViewChild('contentContainer') contentContainer?: ElementRef<HTMLDivElement>;
+  readonly itemContentComponent = viewChild(ItemContentComponent);
+  readonly itemEditWrapperComponent = viewChild(ItemEditWrapperComponent);
 
-  private destroyed$ = new Subject<void>();
+  readonly editorUrl = signal<string | undefined>(undefined);
   private itemRoute$ = this.store.select(fromItemContent.selectActiveContentRoute).pipe(filter(isNotNull));
 
   private itemState$ = this.store.select(fromItemContent.selectActiveContentData).pipe(
@@ -212,7 +210,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
   private beforeUnload$ = new Subject<void>();
   private saveBeforeUnload$ = merge(this.beforeUnload$, this.retryBeforeUnload$).pipe(
     switchMap(() => {
-      const itemDisplay = this.itemContentComponent?.itemDisplayComponent();
+      const itemDisplay = this.itemContentComponent()?.itemDisplayComponent();
       if (!itemDisplay) return of(readyState<void>(undefined));
       return itemDisplay.saveAnswerAndState();
     }),
@@ -234,22 +232,25 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
   fullFrameContentDisplayed$ = this.layoutService.fullFrameContentDisplayed$;
   withLeftPaddingContentDisplayed$ = this.layoutService.withLeftPaddingContentDisplayed$;
 
-  private subscriptions: Subscription[] = [
-
-    this.itemChanged$.subscribe(() => {
+  constructor() {
+    this.itemChanged$.pipe(takeUntilDestroyed()).subscribe(() => {
       this.fullFrameContent$.next(false);
-      this.editorUrl = undefined;
+      this.editorUrl.set(undefined);
       this.itemTabs.itemChanged();
-    }),
+    });
 
     fromEvent<BeforeUnloadEvent>(globalThis, 'beforeunload', { capture: true })
-      .pipe(switchMap(() => this.itemContentComponent?.itemDisplayComponent()?.saveAnswerAndState() ?? of(undefined)), take(1))
+      .pipe(
+        switchMap(() => this.itemContentComponent()?.itemDisplayComponent()?.saveAnswerAndState() ?? of(undefined)),
+        take(1),
+        takeUntilDestroyed(),
+      )
       .subscribe({
         error: () => { /* Errors cannot be handled before unloading page. */ },
-      }),
+      });
 
     // on datasource state change, update the current content page info
-    this.itemState$.pipe(readyData<ItemData>()).subscribe(data => {
+    this.itemState$.pipe(readyData<ItemData>(), takeUntilDestroyed()).subscribe(data => {
       this.currentContent.replace(itemInfo({
         route: routeWithSelfAttempt(data.route, data.currentResult?.attemptId),
         details: {
@@ -265,11 +266,11 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
           leftNavIcon: data.item.displaySettings.leftNavIcon ?? undefined,
         },
       }));
-    }),
+    });
 
-    this.breadcrumbService.resultPathStarted$.subscribe(() => this.currentContent.forceNavMenuReload()),
+    this.breadcrumbService.resultPathStarted$.pipe(takeUntilDestroyed()).subscribe(() => this.currentContent.forceNavMenuReload());
 
-    this.store.select(fromItemContent.selectActiveContentBreadcrumbsState).subscribe(state => {
+    this.store.select(fromItemContent.selectActiveContentBreadcrumbsState).pipe(takeUntilDestroyed()).subscribe(state => {
       if (state.isError) this.currentContent.clear();
 
       // If path is incorrect, redirect to same page without path to trigger the solve missing path at next navigation
@@ -286,7 +287,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
         this.itemRouter.navigateTo(routeWithoutPath, { navExtras: { replaceUrl: true }, useCurrentObservation: true });
       }
       if (state.isReady) this.hasRedirected = false;
-    }),
+    });
 
     combineLatest([ this.itemRoute$, this.itemState$.pipe(startWith(undefined)) ]).pipe(
       map(([ route, itemState ]) => (itemState && route.id === itemState.data?.item.id ?
@@ -296,9 +297,9 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
         } :
         { route, isTask: undefined }
       ))
-    ).subscribe(({ route, isTask }) => {
+    ).pipe(takeUntilDestroyed()).subscribe(({ route, isTask }) => {
       this.initialAnswerDataSource.setInfo(route, isTask);
-    }),
+    });
 
     combineLatest([ this.itemState$.pipe(readyData<ItemData>()), this.fullFrameContent$ ]).pipe(
       map(([ data, fullFrame ]) => {
@@ -307,7 +308,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
       }),
       distinctUntilChanged((x, y) => x.id === y.id && x.display === y.display), // emit once per item for a same display
       map(({ display }) => display),
-    ).subscribe(display => this.layoutService.configure({ contentDisplayType: display })),
+    ).pipe(takeUntilDestroyed()).subscribe(display => this.layoutService.configure({ contentDisplayType: display }));
 
     this.saveBeforeUnloadError$.pipe(
       filter(isError => isError),
@@ -321,16 +322,14 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
         rejectButtonStyleClass: 'primary',
         allowToClose: false,
       }, { maxWidth: '34rem', disableClose: true }))
-    ).subscribe(confirmed => {
+    ).pipe(takeUntilDestroyed()).subscribe(confirmed => {
       if (confirmed) {
         this.skipBeforeUnload();
       } else {
         this.retryBeforeUnload();
       }
-    }),
-  ];
-
-  editorUrl?: string;
+    });
+  }
 
   errorMessageContactUs = $localize`:@@contactUs:If the problem persists, please contact us.`;
 
@@ -339,18 +338,15 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
   ngOnDestroy(): void {
     this.tabService.setTabs([]);
     this.currentContent.clear();
-    this.subscriptions.forEach(s => s.unsubscribe());
     this.layoutService.configure({ contentDisplayType: ContentDisplayType.Default });
     this.skipBeforeUnload$.complete();
     this.retryBeforeUnload$.complete();
     this.beforeUnload$.complete();
-    this.destroyed$.next();
-    this.destroyed$.complete();
   }
 
 
   isDirty(): boolean {
-    return !!this.itemContentComponent?.isDirty() || !!this.itemEditWrapperComponent?.isDirty();
+    return !!this.itemContentComponent()?.isDirty() || !!this.itemEditWrapperComponent()?.isDirty();
   }
 
 
@@ -394,7 +390,7 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
 
   editorUrlChanged(url: string|undefined): void {
     this.itemTabs.editTabEnabledChange(!!url);
-    this.editorUrl = url;
+    this.editorUrl.set(url);
   }
 
   disablePlatformProgressChanged(value: boolean): void {

--- a/src/app/lti/lti.component.ts
+++ b/src/app/lti/lti.component.ts
@@ -1,7 +1,8 @@
-import { Component, inject, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { combineLatest, EMPTY, forkJoin, Observable } from 'rxjs';
 import { catchError, filter, map, retry, shareReplay, switchMap, withLatestFrom } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivityNavTreeService } from 'src/app/services/navigation/item-nav-tree.service';
 import { GetItemChildrenService, ItemChildren } from 'src/app/data-access/get-item-children.service';
 import { GetItemPathService } from 'src/app/data-access/get-item-path.service';
@@ -45,14 +46,13 @@ const loginIdParam = 'user_id';
   selector: 'alg-lti',
   templateUrl: './lti.component.html',
   styleUrls: [ './lti.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     LoadingComponent,
     ErrorComponent,
     AsyncPipe,
   ]
 })
-export class LTIComponent implements OnDestroy {
+export class LTIComponent {
   private activatedRoute = inject(ActivatedRoute);
   private itemRouter = inject(ItemRouter);
   private router = inject(Router);
@@ -117,24 +117,27 @@ export class LTIComponent implements OnDestroy {
     })
   );
 
-  private subscriptions = [
+  constructor() {
+    this.layoutService.configure({ showTopRightControls: false, canShowLeftMenu: false, canShowBreadcrumbs: false });
+
     combineLatest([
       this.contentId$,
       this.loginId$.pipe(filter(isNotNull)),
-    ]).subscribe(([ contentId, loginId ]) => {
+    ]).pipe(takeUntilDestroyed()).subscribe(([ contentId, loginId ]) => {
       setRedirectToSubPathAtInit(`/lti/${contentId}?${loginIdParam}=${loginId}&${isRedirectionParam}=${boolToQueryParamValue(true)}`);
       this.activityNavTreeService.navigationNeighborsRestrictedToDescendantOfElementId = contentId;
-    }),
+    });
 
     combineLatest([
       this.isLoggedIn$.pipe(catchError(() => EMPTY)), // error is handled elsewhere
       this.isRedirection$,
     ]).pipe(
       filter(([ isLoggedIn, isRedirection ]) => !isLoggedIn && !isRedirection),
-    ).subscribe(() => this.userSession.login()), // will redirect outside the platform
+      takeUntilDestroyed(),
+    ).subscribe(() => this.userSession.login()); // will redirect outside the platform
 
     this.navigationData$
-      .pipe(readyData(), withLatestFrom(this.contentId$, this.fromPath$))
+      .pipe(readyData(), withLatestFrom(this.contentId$, this.fromPath$), takeUntilDestroyed())
       .subscribe(([{ firstChild, path, attemptId }, contentId, fromPath ]) => {
         this.ltiDataSource.data = { contentId, attemptId };
 
@@ -148,15 +151,7 @@ export class LTIComponent implements OnDestroy {
         }
         const route = itemRoute('activity', firstChild.id, { path, parentAttemptId: attemptId });
         this.itemRouter.navigateTo(route, { navExtras: { replaceUrl: true }, useCurrentObservation: true });
-      }),
-  ];
-
-  constructor() {
-    this.layoutService.configure({ showTopRightControls: false, canShowLeftMenu: false, canShowBreadcrumbs: false });
-  }
-
-  ngOnDestroy(): void {
-    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+      });
   }
 
   private getNavigationData(itemId: string): Observable<{ firstChild: ItemChildren[number], path: string[], attemptId: string }> {

--- a/src/app/ui-page/ui-page.component.ts
+++ b/src/app/ui-page/ui-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal, ChangeDetectionStrategy } from '@angular/core';
+import { Component, inject, signal } from '@angular/core';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
 import { TooltipDirective } from 'src/app/ui-components/tooltip/tooltip.directive';
@@ -8,7 +8,6 @@ import { ActionFeedbackService } from 'src/app/services/action-feedback.service'
   selector: 'alg-ui-page',
   templateUrl: './ui-page.component.html',
   styleUrls: [ './ui-page.component.scss' ],
-  changeDetection: ChangeDetectionStrategy.Eager,
   imports: [
     ButtonComponent,
     ButtonIconComponent,


### PR DESCRIPTION
## Summary
- Modernize 8 components on the items page shell and progress/extra-time leftovers: drop Eager, migrate viewChild/signals, fix user-progress broken ngOnChanges hybrid.
- Batch 28 from `.cursor/plans/modernize-batch-28-items-pages.md`.

## Scope
- **`item-by-id`**: `editorUrl` → signal; `@ViewChild` → `viewChild()`; delete dead `contentContainer` ViewChild; NgClass → class bindings; subscriptions → constructor + `takeUntilDestroyed()`
- **`user-progress`**: `state` → `computed()` from `userProgress()` (fixes stuck state bug); remove ngOnChanges/ngOnInit
- **`chapter-user-progress`**: NgClass → split class bindings
- **`item-extra-time` trio**: viewChild migration; remove redundant explicit OnPush; drop Eager on input
- **`ui-page`**, **`lti`**: drop Eager; lti subscriptions → `takeUntilDestroyed()`

## Risks / manual checks
- `item-by-id` is app-breaking if CD regresses — e2e: 221/248 passed locally; batch-critical specs all green
- Editor tab (`editorUrl` signal), full-frame margin classes, chapter progress, extra time flow
- **LTI**: no e2e — untested without LTI environment

## Manual testing
https://dev.algorea.org/branch/modernize-ng-comp-28/en/

## Verification
- [x] `npm run lint`
- [x] `ng build --configuration=en`
- [x] Items e2e (221 passed; 20 failures appear pre-existing/flaky)
- [x] Manual smoke: tabs, editor URL, full-frame margins, chapter progress, extra time