### PR TITLE
scaffold item -> router-outlet migration

### DIFF
--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -152,6 +152,7 @@
               <alg-item-forum class="alg-flex-1" [itemData]="itemData!"></alg-item-forum>
             }
           }
+          <router-outlet></router-outlet>
         </div>
         @if (isThreadInline$ | async) {
           <div class="inline-thread-panel">

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject, OnDestroy, signal, viewChild } from '@angular/core';
-import { ActivatedRoute, RouterLink, RouterLinkActive } from '@angular/router';
+import { ActivatedRoute, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { combineLatest, of, EMPTY, fromEvent, merge, Observable, Subject, BehaviorSubject } from 'rxjs';
 import {
   delay,
@@ -107,6 +107,7 @@ const selectState = createSelector(
     ItemStatsComponent,
     ItemForumComponent,
     RouterLinkActive,
+    RouterOutlet,
     AsyncPipe,
     AllowsViewingItemContentPipe,
     AllowsWatchingItemResultsPipe,

--- a/src/app/items/item.routes.ts
+++ b/src/app/items/item.routes.ts
@@ -10,7 +10,9 @@ const routes: Routes = [
     path: ':idOrAlias',
     component: ItemByIdComponent,
     canDeactivate: [ BeforeUnloadGuard, PendingChangesGuard ],
-    // Children below do not use routing but there are defined here so that the router can validate the route exists
+    // Migration in progress (see .cursor/plans/item-tabs-outlet-*): secondary tabs are being moved
+    // from the @if chain in item-by-id to lazy routed components rendered in <router-outlet>.
+    // Routes still defined as `children: []` are validation-only stubs (rendered by the @if chain).
     children: [
       { path: '', pathMatch: 'full', children: [] },
       {


### PR DESCRIPTION
Scaffold for preparing the migration of item tabs (those not related to task, having their own component) to using router-outlet.