### PR TITLE
Improve error handling in template 1

### DIFF
--- a/src/app/containers/path-suggestion/path-suggestion.component.html
+++ b/src/app/containers/path-suggestion/path-suggestion.component.html
@@ -9,11 +9,11 @@
       class="alg-flex-1 light"
       icon="ph-duotone ph-warning-circle"
       i18n-buttonCaption buttonCaption="Retry"
-      [showRefreshButton]="$any(state.error).status !== 403"
+      [showRefreshButton]="!(state.error | isHttpForbidden)"
       buttonStyleClass="size-l refresh-button light-border"
       (refresh)="refresh()"
     >
-      @if ($any(state.error).status === 403) {
+      @if (state.error | isHttpForbidden) {
         <span class="no-access" i18n>There is currently no way for you to access this content.</span>
       } @else {
         <span i18n>Error while loading path suggestion</span>

--- a/src/app/containers/path-suggestion/path-suggestion.component.ts
+++ b/src/app/containers/path-suggestion/path-suggestion.component.ts
@@ -13,6 +13,7 @@ import { AsyncPipe } from '@angular/common';
 import { mapBreadcrumbsWithPath } from 'src/app/models/content/content-breadcrumbs';
 import { ItemRoutePipe } from 'src/app/pipes/itemRoute';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
+import { IsHttpForbiddenPipe } from 'src/app/utils/error-handling/http-error.pipes';
 
 @Component({
   selector: 'alg-path-suggestion',
@@ -25,6 +26,7 @@ import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
     AsyncPipe,
     ItemRoutePipe,
     RouteUrlPipe,
+    IsHttpForbiddenPipe,
   ]
 })
 export class PathSuggestionComponent implements AfterViewInit, OnDestroy {

--- a/src/app/groups/containers/group-header/group-header.component.html
+++ b/src/app/groups/containers/group-header/group-header.component.html
@@ -8,7 +8,7 @@
             @if (state.isFetching) {
               <span i18n>loading...</span>
             } @else if (state.isError) {
-              @if ($any(state.error).status === 403 || $any(state.error).status === 404) {
+              @if ((state.error | isHttpForbidden) || (state.error | isHttpNotFound)) {
                 <span i18n>not visible to you</span>
               } @else {
                 <div class="error-container">

--- a/src/app/groups/containers/group-header/group-header.component.ts
+++ b/src/app/groups/containers/group-header/group-header.component.ts
@@ -10,6 +10,7 @@ import { RouterLink } from '@angular/router';
 import { ItemRoutePipe } from 'src/app/pipes/itemRoute';
 import { RouteUrlPipe } from 'src/app/pipes/routeUrl';
 import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-icon.component';
+import { IsHttpForbiddenPipe, IsHttpNotFoundPipe } from 'src/app/utils/error-handling/http-error.pipes';
 
 @Component({
   selector: 'alg-group-header',
@@ -21,6 +22,8 @@ import { ButtonIconComponent } from 'src/app/ui-components/button-icon/button-ic
     ItemRoutePipe,
     RouteUrlPipe,
     ButtonIconComponent,
+    IsHttpForbiddenPipe,
+    IsHttpNotFoundPipe,
   ]
 })
 export class GroupHeaderComponent implements OnDestroy {

--- a/src/app/groups/containers/group-log-view/group-log-view.component.html
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.html
@@ -5,12 +5,12 @@
   @if (state.isError) {
     <alg-error
       class="alg-flex-1"
-      [class.dark]="$any(state).error.status !== 403"
-      [icon]="$any(state).error.status !== 403 ? 'ph-duotone ph-warning-circle' : undefined"
-      [showRefreshButton]="$any(state).error.status !== 403"
+      [class.dark]="!(state.error | isHttpForbidden)"
+      [icon]="!(state.error | isHttpForbidden) ? 'ph-duotone ph-warning-circle' : undefined"
+      [showRefreshButton]="!(state.error | isHttpForbidden)"
       (refresh)="refresh()"
     >
-      @if ($any(state).error.status === 403) {
+      @if (state.error | isHttpForbidden) {
         <span i18n>
           You are not allowed to see activities of this user.
         </span>

--- a/src/app/groups/containers/group-log-view/group-log-view.component.ts
+++ b/src/app/groups/containers/group-log-view/group-log-view.component.ts
@@ -19,6 +19,7 @@ import { UserSessionService } from '../../../services/user-session.service';
 import { ShowOverlayHoverTargetDirective } from 'src/app/ui-components/overlay/show-overlay-hover-target.directive';
 import { ShowOverlayDirective } from 'src/app/ui-components/overlay/show-overlay.directive';
 import { LogActivityTypeIconPipe } from 'src/app/pipes/logActivityTypeIcon';
+import { IsHttpForbiddenPipe } from 'src/app/utils/error-handling/http-error.pipes';
 import { ButtonComponent } from 'src/app/ui-components/button/button.component';
 import { Store } from '@ngrx/store';
 import { fromItemContent } from 'src/app/items/store';
@@ -70,6 +71,7 @@ const logsLimit = 20;
     CdkRow,
     CdkRowDef,
     CdkNoDataRow,
+    IsHttpForbiddenPipe,
   ]
 })
 export class GroupLogViewComponent {

--- a/src/app/groups/group-by-id.component.html
+++ b/src/app/groups/group-by-id.component.html
@@ -84,10 +84,10 @@
 @if (state.isError) {
   <alg-error
     class="alg-flex-1"
-    [showRefreshButton]="$any(state.error).status !== 403"
+    [showRefreshButton]="!(state.error | isHttpForbidden)"
     (refresh)="onGroupRefreshRequired()"
   >
-    @if ($any(state.error).status === 403) {
+    @if (state.error | isHttpForbidden) {
       <ng-container i18n>
         You are not allowed to view this group page.
       </ng-container>

--- a/src/app/groups/group-by-id.component.ts
+++ b/src/app/groups/group-by-id.component.ts
@@ -22,6 +22,7 @@ import { errorHasTag, errorIsHTTPForbidden, errorIsHTTPNotFound } from '../utils
 import { GroupData, selectGroupData } from './models/group-data';
 import { readyData } from '../utils/operators/state';
 import { IsCurrentUserMemberPipe } from './models/group-membership';
+import { IsHttpForbiddenPipe } from '../utils/error-handling/http-error.pipes';
 import { PendingChangesComponent } from 'src/app/guards/pending-changes-guard';
 import { PendingChangesService } from 'src/app/services/pending-changes-service';
 
@@ -41,6 +42,7 @@ import { PendingChangesService } from 'src/app/services/pending-changes-service'
     IsCurrentUserMemberPipe,
     CanCurrentUserGrantGroupAccessPipe,
     CanCurrentUserManageMembersAndGroupPipe,
+    IsHttpForbiddenPipe,
   ]
 })
 export class GroupByIdComponent implements OnDestroy, PendingChangesComponent {

--- a/src/app/items/item-by-id.component.html
+++ b/src/app/items/item-by-id.component.html
@@ -111,7 +111,7 @@
     <alg-loading class="alg-flex-1" />
   }
   @if (state.isError) {
-    @if (state.error && ($any(state.error).status === 403 || $any(state.error).status === 404 || $any(state.error).name === 'NoSuchAliasError')) {
+    @if (isItemUnavailableError(state.error)) {
       <alg-restricted-content>
         @if ((userProfile$ | async)?.tempUser) {
           <alg-login-wall i18n-description

--- a/src/app/items/item-by-id.component.ts
+++ b/src/app/items/item-by-id.component.ts
@@ -19,6 +19,7 @@ import { CurrentContentService } from 'src/app/services/current-content.service'
 import { breadcrumbServiceTag } from './data-access/get-breadcrumb.service';
 import { ItemData } from './models/item-data';
 import { errorHasTag, errorIsHTTPForbidden, errorIsHTTPNotFound } from 'src/app/utils/errors';
+import { isItemUnavailableError } from './utils/item-unavailable-error';
 import { ItemRouter } from 'src/app/models/routing/item-router';
 import { isATask } from 'src/app/items/models/item-type';
 import { itemInfo } from 'src/app/models/content/item-info';
@@ -329,6 +330,10 @@ export class ItemByIdComponent implements OnDestroy, BeforeUnloadComponent, Pend
     return !!this.itemContentComponent()?.isDirty() || !!this.pendingChangesService.component?.isDirty();
   }
 
+
+  protected isItemUnavailableError(error: unknown): boolean {
+    return isItemUnavailableError(error);
+  }
 
   reloadItem(): void {
     this.store.dispatch(fromItemContent.itemByIdPageActions.refresh());

--- a/src/app/items/utils/item-route-validation.ts
+++ b/src/app/items/utils/item-route-validation.ts
@@ -6,10 +6,12 @@ import { defaultAttemptId } from '../models/attempts';
 import { loadAnswerAsCurrentFromNavigationState } from 'src/app/models/routing/item-navigation-state';
 import { ItemRouteError } from 'src/app/models/routing/item-route-serialization';
 
+export const NO_SUCH_ALIAS_ERROR_NAME = 'NoSuchAliasError';
+
 class NoSuchAliasError extends Error {
   constructor() {
     super('The given alias could not be resolved to an item id');
-    this.name = 'NoSuchAliasError';
+    this.name = NO_SUCH_ALIAS_ERROR_NAME;
   }
 }
 

--- a/src/app/items/utils/item-unavailable-error.spec.ts
+++ b/src/app/items/utils/item-unavailable-error.spec.ts
@@ -1,0 +1,27 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { isItemUnavailableError } from './item-unavailable-error';
+import { NO_SUCH_ALIAS_ERROR_NAME } from './item-route-validation';
+
+describe('isItemUnavailableError', () => {
+  it('should return true for HTTP 403', () => {
+    expect(isItemUnavailableError(new HttpErrorResponse({ status: 403 }))).toBe(true);
+  });
+
+  it('should return true for HTTP 404', () => {
+    expect(isItemUnavailableError(new HttpErrorResponse({ status: 404 }))).toBe(true);
+  });
+
+  it('should return true for an error whose name is the no-such-alias name', () => {
+    const error = new Error('boom');
+    error.name = NO_SUCH_ALIAS_ERROR_NAME;
+    expect(isItemUnavailableError(error)).toBe(true);
+  });
+
+  it('should return false (without throwing) for unrelated errors and edge inputs', () => {
+    expect(isItemUnavailableError(new HttpErrorResponse({ status: 500 }))).toBe(false);
+    expect(isItemUnavailableError({ status: 500 })).toBe(false);
+    expect(isItemUnavailableError(new Error('boom'))).toBe(false);
+    expect(isItemUnavailableError(null)).toBe(false);
+    expect(isItemUnavailableError(undefined)).toBe(false);
+  });
+});

--- a/src/app/items/utils/item-unavailable-error.ts
+++ b/src/app/items/utils/item-unavailable-error.ts
@@ -1,0 +1,10 @@
+import { errorHasName, errorIsHTTPForbidden, errorIsHTTPNotFound } from 'src/app/utils/errors';
+import { NO_SUCH_ALIAS_ERROR_NAME } from './item-route-validation';
+
+/**
+ * Whether an error means the item cannot be shown to the user (forbidden, not found or unresolvable alias),
+ * which should trigger the "restricted content" display rather than a generic error.
+ */
+export function isItemUnavailableError(error: unknown): boolean {
+  return errorIsHTTPForbidden(error) || errorIsHTTPNotFound(error) || errorHasName(error, NO_SUCH_ALIAS_ERROR_NAME);
+}

--- a/src/app/utils/error-handling/http-error.pipes.spec.ts
+++ b/src/app/utils/error-handling/http-error.pipes.spec.ts
@@ -1,0 +1,36 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { IsHttpForbiddenPipe, IsHttpNotFoundPipe } from './http-error.pipes';
+
+describe('http-error pipes', () => {
+  describe('IsHttpForbiddenPipe', () => {
+    const pipe = new IsHttpForbiddenPipe();
+
+    it('should return true only for a 403 error', () => {
+      expect(pipe.transform(new HttpErrorResponse({ status: 403 }))).toBe(true);
+      expect(pipe.transform({ status: 403 })).toBe(true);
+    });
+
+    it('should return false for other statuses and non-HTTP errors', () => {
+      expect(pipe.transform(new HttpErrorResponse({ status: 404 }))).toBe(false);
+      expect(pipe.transform(new Error('boom'))).toBe(false);
+      expect(pipe.transform(null)).toBe(false);
+      expect(pipe.transform(undefined)).toBe(false);
+    });
+  });
+
+  describe('IsHttpNotFoundPipe', () => {
+    const pipe = new IsHttpNotFoundPipe();
+
+    it('should return true only for a 404 error', () => {
+      expect(pipe.transform(new HttpErrorResponse({ status: 404 }))).toBe(true);
+      expect(pipe.transform({ status: 404 })).toBe(true);
+    });
+
+    it('should return false for other statuses and non-HTTP errors', () => {
+      expect(pipe.transform(new HttpErrorResponse({ status: 403 }))).toBe(false);
+      expect(pipe.transform(new Error('boom'))).toBe(false);
+      expect(pipe.transform(null)).toBe(false);
+      expect(pipe.transform(undefined)).toBe(false);
+    });
+  });
+});

--- a/src/app/utils/error-handling/http-error.pipes.ts
+++ b/src/app/utils/error-handling/http-error.pipes.ts
@@ -1,0 +1,16 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { errorIsHTTPForbidden, errorIsHTTPNotFound } from '../errors';
+
+@Pipe({ name: 'isHttpForbidden' })
+export class IsHttpForbiddenPipe implements PipeTransform {
+  transform(error: unknown): boolean {
+    return errorIsHTTPForbidden(error);
+  }
+}
+
+@Pipe({ name: 'isHttpNotFound' })
+export class IsHttpNotFoundPipe implements PipeTransform {
+  transform(error: unknown): boolean {
+    return errorIsHTTPNotFound(error);
+  }
+}

--- a/src/app/utils/errors.spec.ts
+++ b/src/app/utils/errors.spec.ts
@@ -1,5 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import {
+  errorHasName,
   errorHasTag,
   errorIsBadRequest,
   errorIsHTTPForbidden,
@@ -82,6 +83,29 @@ describe('errors utils', () => {
       expect(errorHasTag('some string', 'my-tag')).toBe(false);
       expect(errorHasTag(42, 'my-tag')).toBe(false);
       expect(errorHasTag({}, 'my-tag')).toBe(false);
+    });
+  });
+
+  describe('errorHasName', () => {
+    it('should match an error whose name equals the given name', () => {
+      const error = new Error('boom');
+      error.name = 'NoSuchAliasError';
+      expect(errorHasName(error, 'NoSuchAliasError')).toBe(true);
+      expect(errorHasName({ name: 'NoSuchAliasError' }, 'NoSuchAliasError')).toBe(true);
+    });
+
+    it('should return false for a non-matching name', () => {
+      expect(errorHasName(new Error('boom'), 'NoSuchAliasError')).toBe(false);
+      expect(errorHasName({ name: 'OtherError' }, 'NoSuchAliasError')).toBe(false);
+      expect(errorHasName({ name: 123 }, 'NoSuchAliasError')).toBe(false);
+    });
+
+    it('should return false (without throwing) for edge inputs', () => {
+      expect(errorHasName(null, 'NoSuchAliasError')).toBe(false);
+      expect(errorHasName(undefined, 'NoSuchAliasError')).toBe(false);
+      expect(errorHasName('some string', 'NoSuchAliasError')).toBe(false);
+      expect(errorHasName(42, 'NoSuchAliasError')).toBe(false);
+      expect(errorHasName({}, 'NoSuchAliasError')).toBe(false);
     });
   });
 });

--- a/src/app/utils/errors.spec.ts
+++ b/src/app/utils/errors.spec.ts
@@ -1,0 +1,87 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import {
+  errorHasTag,
+  errorIsBadRequest,
+  errorIsHTTPForbidden,
+  errorIsHTTPInternalServer,
+  errorIsHTTPNotFound,
+  errorIsHTTPUnauthenticated,
+  isHttpErrorResponse,
+  tagError,
+} from './errors';
+
+describe('errors utils', () => {
+  describe('isHttpErrorResponse', () => {
+    it('should return true for an HttpErrorResponse', () => {
+      expect(isHttpErrorResponse(new HttpErrorResponse({ status: 403 }))).toBe(true);
+    });
+
+    it('should return true for a duck-typed object with a numeric status', () => {
+      expect(isHttpErrorResponse({ status: 404 })).toBe(true);
+    });
+
+    it('should return false for non-HTTP errors and edge inputs without throwing', () => {
+      expect(isHttpErrorResponse(new Error('boom'))).toBe(false);
+      expect(isHttpErrorResponse({ message: 'no status' })).toBe(false);
+      expect(isHttpErrorResponse({ status: 'not-a-number' })).toBe(false);
+      expect(isHttpErrorResponse(null)).toBe(false);
+      expect(isHttpErrorResponse(undefined)).toBe(false);
+      expect(isHttpErrorResponse('some string')).toBe(false);
+      expect(isHttpErrorResponse(42)).toBe(false);
+    });
+
+    it('should not throw on null/undefined inputs', () => {
+      expect(() => isHttpErrorResponse(null)).not.toThrow();
+      expect(() => isHttpErrorResponse(undefined)).not.toThrow();
+    });
+  });
+
+  describe('errorIsHTTP* helpers', () => {
+    const cases: { name: string, status: number, fn: (error: unknown) => boolean }[] = [
+      { name: 'errorIsHTTPUnauthenticated', status: 401, fn: errorIsHTTPUnauthenticated },
+      { name: 'errorIsHTTPForbidden', status: 403, fn: errorIsHTTPForbidden },
+      { name: 'errorIsHTTPNotFound', status: 404, fn: errorIsHTTPNotFound },
+      { name: 'errorIsBadRequest', status: 400, fn: errorIsBadRequest },
+      { name: 'errorIsHTTPInternalServer', status: 500, fn: errorIsHTTPInternalServer },
+    ];
+
+    cases.forEach(({ name, status, fn }) => {
+      describe(name, () => {
+        it(`should return true for an HttpErrorResponse with status ${status}`, () => {
+          expect(fn(new HttpErrorResponse({ status }))).toBe(true);
+          expect(fn({ status })).toBe(true);
+        });
+
+        it('should return false for a non-matching status', () => {
+          expect(fn(new HttpErrorResponse({ status: 418 }))).toBe(false);
+          expect(fn({ status: 418 })).toBe(false);
+        });
+
+        it('should return false (without throwing) for non-HTTP and edge inputs', () => {
+          expect(fn(new Error('boom'))).toBe(false);
+          expect(fn({ message: 'no status' })).toBe(false);
+          expect(fn(null)).toBe(false);
+          expect(fn(undefined)).toBe(false);
+          expect(fn('some string')).toBe(false);
+          expect(fn(42)).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe('tagError / errorHasTag', () => {
+    it('should tag an error and recognize it', () => {
+      const error = tagError(new Error('boom'), 'my-tag');
+      expect(errorHasTag(error, 'my-tag')).toBe(true);
+      expect(errorHasTag(error, 'other-tag')).toBe(false);
+    });
+
+    it('should return false (without throwing) for edge inputs', () => {
+      expect(errorHasTag(null, 'my-tag')).toBe(false);
+      expect(errorHasTag(undefined, 'my-tag')).toBe(false);
+      expect(errorHasTag('some string', 'my-tag')).toBe(false);
+      expect(errorHasTag(42, 'my-tag')).toBe(false);
+      expect(errorHasTag({}, 'my-tag')).toBe(false);
+    });
+  });
+});

--- a/src/app/utils/errors.ts
+++ b/src/app/utils/errors.ts
@@ -23,6 +23,10 @@ export function errorHasTag(error: unknown, tag: string): boolean {
   return typeof error === 'object' && error !== null && 'errorTag' in error && error.errorTag === tag;
 }
 
+export function errorHasName(error: unknown, name: string): boolean {
+  return typeof error === 'object' && error !== null && 'name' in error && error.name === name;
+}
+
 export function errorIsHTTPUnauthenticated(error: unknown): boolean {
   return isHttpErrorResponse(error) && error.status === 401;
 }

--- a/src/app/utils/errors.ts
+++ b/src/app/utils/errors.ts
@@ -9,26 +9,36 @@ export function tagError<T extends object>(error: T, tag: string): T & WithError
   return Object.assign(error, { errorTag: tag });
 }
 
-export function errorHasTag(error: any, tag: string): boolean {
-  return (error as WithErrorTag).errorTag === tag;
+/**
+ * Duck-typed guard for HTTP errors: matches any non-null object exposing a numeric `status`.
+ * We intentionally avoid `instanceof HttpErrorResponse` because some errors reaching these helpers
+ * are plain objects (e.g. serialized errors) rather than actual HttpErrorResponse instances.
+ */
+export function isHttpErrorResponse(error: unknown): error is HttpErrorResponse {
+  return typeof error === 'object' && error !== null && 'status' in error
+    && typeof error.status === 'number';
 }
 
-export function errorIsHTTPUnauthenticated(error: any): boolean {
-  return 'status' in error && (error as HttpErrorResponse).status === 401;
+export function errorHasTag(error: unknown, tag: string): boolean {
+  return typeof error === 'object' && error !== null && 'errorTag' in error && error.errorTag === tag;
 }
 
-export function errorIsHTTPForbidden(error: any): boolean {
-  return 'status' in error && (error as HttpErrorResponse).status === 403;
+export function errorIsHTTPUnauthenticated(error: unknown): boolean {
+  return isHttpErrorResponse(error) && error.status === 401;
 }
 
-export function errorIsHTTPNotFound(error: any): boolean {
-  return 'status' in error && (error as HttpErrorResponse).status === 404;
+export function errorIsHTTPForbidden(error: unknown): boolean {
+  return isHttpErrorResponse(error) && error.status === 403;
 }
 
-export function errorIsBadRequest(error: any): boolean {
-  return 'status' in error && (error as HttpErrorResponse).status === 400;
+export function errorIsHTTPNotFound(error: unknown): boolean {
+  return isHttpErrorResponse(error) && error.status === 404;
 }
 
-export function errorIsHTTPInternalServer(error: any): boolean {
-  return 'status' in error && (error as HttpErrorResponse).status === 500;
+export function errorIsBadRequest(error: unknown): boolean {
+  return isHttpErrorResponse(error) && error.status === 400;
+}
+
+export function errorIsHTTPInternalServer(error: unknown): boolean {
+  return isHttpErrorResponse(error) && error.status === 500;
 }


### PR DESCRIPTION
Remove `$any()` template casts and `any` typings around HTTP error handling

**Why:** Type safety. Templates use `$any(state.error)` (e.g. `group-by-id.component.html`)
and there are ~30 `any` usages in `src/app/**`. The recurring case is narrowing
`FetchState.error` to `HttpErrorResponse` to read `.status`.

Code written with the help of AI, already reviewed locally.