### PR TITLE
dedupe sync effects

### DIFF
--- a/src/app/groups/group-by-id.component.ts
+++ b/src/app/groups/group-by-id.component.ts
@@ -64,11 +64,6 @@ export class GroupByIdComponent implements OnDestroy, PendingChangesComponent {
   private hasRedirected = false;
 
   constructor() {
-    // Field-initializer subscriptions ran synchronously; effects defer to the first CD flush.
-    this.applyGroupToCurrentContentSync();
-    this.applyActiveRouteToCurrentContentSync();
-    this.applyBreadcrumbsErrorHandling();
-
     effect(() => {
       this.applyGroupToCurrentContentSync();
     });

--- a/src/app/items/item-content-sync.service.spec.ts
+++ b/src/app/items/item-content-sync.service.spec.ts
@@ -1,0 +1,123 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Item } from 'src/app/data-access/get-item-by-id.service';
+import { FullItemRoute, itemRoute } from 'src/app/models/routing/item-route';
+import { ItemRouter } from 'src/app/models/routing/item-router';
+import { CurrentContentService } from 'src/app/services/current-content.service';
+import { ContentDisplayType, LayoutService } from 'src/app/services/layout.service';
+import { displaySettingsSchema } from 'src/app/items/models/display-settings';
+import { ItemEditPerm } from 'src/app/items/models/item-edit-permission';
+import { ItemGrantViewPerm } from 'src/app/items/models/item-grant-view-permission';
+import { ItemViewPerm } from 'src/app/items/models/item-view-permission';
+import { ItemWatchPerm } from 'src/app/items/models/item-watch-permission';
+import { readyState } from 'src/app/utils/state';
+import { ItemContentSyncService } from './item-content-sync.service';
+import { ItemData } from './models/item-data';
+import { ItemTabs } from './item-tabs';
+import { fromItemContent } from './store';
+
+const mockItemBase: Item = {
+  id: '1',
+  requiresExplicitEntry: false,
+  string: { title: 'Test', description: null, imageUrl: null, subtitle: null, languageTag: 'en' },
+  bestScore: 0,
+  permissions: {
+    canView: ItemViewPerm.Content,
+    canGrantView: ItemGrantViewPerm.None,
+    canEdit: ItemEditPerm.None,
+    canWatch: ItemWatchPerm.None,
+    isOwner: false,
+    canRequestHelp: false,
+  },
+  type: 'Task',
+  displaySettings: displaySettingsSchema.parse({}),
+  textId: null,
+  validationType: 'None',
+  noScore: false,
+  allowsMultipleAttempts: false,
+  duration: null,
+  enteringTimeMin: new Date(),
+  enteringTimeMax: new Date(),
+  entryParticipantType: 'User',
+  entryFrozenTeams: false,
+  entryMaxTeamSize: 0,
+  entryMinAdmittedMembersRatio: 'None',
+  url: 'http://example.com/task',
+  usesApi: false,
+  defaultLanguageTag: 'en',
+  supportedLanguageTags: [ 'en' ],
+};
+
+function createItemData(route: FullItemRoute, itemOverrides?: Partial<Item>): ItemData {
+  return {
+    route,
+    item: { ...mockItemBase, id: route.id, ...itemOverrides },
+    breadcrumbs: [],
+  };
+}
+
+describe('ItemContentSyncService', () => {
+  let store: MockStore;
+  let currentContent: jasmine.SpyObj<Pick<CurrentContentService, 'replace' | 'clear'>>;
+  let layoutService: jasmine.SpyObj<Pick<LayoutService, 'configure'>>;
+  let itemTabs: jasmine.SpyObj<Pick<ItemTabs, 'itemChanged'>>;
+
+  const route1 = itemRoute('activity', '1', { attemptId: '0', path: [] });
+  const route2 = itemRoute('activity', '2', { attemptId: '0', path: [] });
+
+  beforeEach(() => {
+    currentContent = jasmine.createSpyObj('CurrentContentService', [ 'replace', 'clear' ]);
+    layoutService = jasmine.createSpyObj('LayoutService', [ 'configure' ]);
+    itemTabs = jasmine.createSpyObj('ItemTabs', [ 'itemChanged' ]);
+
+    TestBed.configureTestingModule({
+      providers: [
+        ItemContentSyncService,
+        provideMockStore({
+          selectors: [
+            { selector: fromItemContent.selectActiveContentData, value: readyState(createItemData(route1)) },
+            { selector: fromItemContent.selectActiveContentBreadcrumbsState, value: readyState([], route1) },
+          ],
+        }),
+        { provide: CurrentContentService, useValue: currentContent },
+        { provide: LayoutService, useValue: layoutService },
+        { provide: ItemTabs, useValue: itemTabs },
+        { provide: ItemRouter, useValue: jasmine.createSpyObj('ItemRouter', [ 'navigateTo' ]) },
+      ],
+    });
+
+    store = TestBed.inject(MockStore);
+    TestBed.inject(ItemContentSyncService);
+  });
+
+  it('runs each sync side effect once on init', () => {
+    TestBed.flushEffects();
+
+    expect(currentContent.replace).toHaveBeenCalledTimes(1);
+    expect(layoutService.configure).toHaveBeenCalledTimes(1);
+    expect(layoutService.configure).toHaveBeenCalledWith({ contentDisplayType: ContentDisplayType.Show });
+    expect(itemTabs.itemChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs item reset sync once when item id changes', () => {
+    TestBed.flushEffects();
+    itemTabs.itemChanged.calls.reset();
+
+    store.overrideSelector(fromItemContent.selectActiveContentData, readyState(createItemData(route2)));
+    store.refreshState();
+    TestBed.flushEffects();
+
+    expect(itemTabs.itemChanged).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates current content once when item data changes to a new item', () => {
+    TestBed.flushEffects();
+    currentContent.replace.calls.reset();
+
+    store.overrideSelector(fromItemContent.selectActiveContentData, readyState(createItemData(route2)));
+    store.refreshState();
+    TestBed.flushEffects();
+
+    expect(currentContent.replace).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/items/item-content-sync.service.ts
+++ b/src/app/items/item-content-sync.service.ts
@@ -39,12 +39,6 @@ export class ItemContentSyncService {
   private lastLayoutConfig: { id: string, display: ContentDisplayType } | undefined;
 
   constructor() {
-    // Field-initializer subscriptions ran synchronously; effects defer to the first CD flush.
-    this.applyResetOnItemChange();
-    this.applyItemToCurrentContentSync();
-    this.applyBreadcrumbsErrorHandling();
-    this.applyLayoutDisplaySync();
-
     effect(() => {
       this.applyResetOnItemChange();
     });

--- a/src/app/items/item-task-flow.service.spec.ts
+++ b/src/app/items/item-task-flow.service.spec.ts
@@ -1,0 +1,124 @@
+import { TestBed } from '@angular/core/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { EMPTY } from 'rxjs';
+import { APPCONFIG } from 'src/app/config';
+import { Item } from 'src/app/data-access/get-item-by-id.service';
+import { FullItemRoute, itemRoute } from 'src/app/models/routing/item-route';
+import { ItemRouter } from 'src/app/models/routing/item-router';
+import { ConfirmationModalService } from 'src/app/services/confirmation-modal.service';
+import { LocaleService } from 'src/app/services/localeService';
+import { displaySettingsSchema } from 'src/app/items/models/display-settings';
+import { ItemEditPerm } from 'src/app/items/models/item-edit-permission';
+import { ItemGrantViewPerm } from 'src/app/items/models/item-grant-view-permission';
+import { ItemViewPerm } from 'src/app/items/models/item-view-permission';
+import { ItemWatchPerm } from 'src/app/items/models/item-watch-permission';
+import { readyState } from 'src/app/utils/state';
+import { ItemTaskFlowService } from './item-task-flow.service';
+import { ItemData } from './models/item-data';
+import { InitialAnswerDataSource } from './services/initial-answer-datasource';
+import { fromItemContent } from './store';
+
+const mockItemBase: Item = {
+  id: '1',
+  requiresExplicitEntry: false,
+  string: { title: 'Test', description: null, imageUrl: null, subtitle: null, languageTag: 'en' },
+  bestScore: 0,
+  permissions: {
+    canView: ItemViewPerm.Content,
+    canGrantView: ItemGrantViewPerm.None,
+    canEdit: ItemEditPerm.None,
+    canWatch: ItemWatchPerm.None,
+    isOwner: false,
+    canRequestHelp: false,
+  },
+  type: 'Task',
+  displaySettings: displaySettingsSchema.parse({}),
+  textId: null,
+  validationType: 'None',
+  noScore: false,
+  allowsMultipleAttempts: false,
+  duration: null,
+  enteringTimeMin: new Date(),
+  enteringTimeMax: new Date(),
+  entryParticipantType: 'User',
+  entryFrozenTeams: false,
+  entryMaxTeamSize: 0,
+  entryMinAdmittedMembersRatio: 'None',
+  url: 'http://example.com/task',
+  usesApi: false,
+  defaultLanguageTag: 'en',
+  supportedLanguageTags: [ 'en' ],
+};
+
+function createItemData(route: FullItemRoute): ItemData {
+  return {
+    route,
+    item: { ...mockItemBase, id: route.id },
+    breadcrumbs: [],
+  };
+}
+
+describe('ItemTaskFlowService', () => {
+  let store: MockStore;
+  let setInfo: jasmine.Spy;
+
+  const route1 = itemRoute('activity', '1', { attemptId: '0', path: [] });
+  const route2 = itemRoute('activity', '2', { attemptId: '0', path: [] });
+
+  beforeEach(() => {
+    setInfo = jasmine.createSpy('setInfo');
+
+    TestBed.configureTestingModule({
+      providers: [
+        ItemTaskFlowService,
+        provideMockStore({
+          selectors: [
+            { selector: fromItemContent.selectActiveContentRoute, value: route1 },
+            { selector: fromItemContent.selectActiveContentData, value: readyState(createItemData(route1)) },
+          ],
+        }),
+        {
+          provide: InitialAnswerDataSource,
+          useValue: { setInfo, error$: EMPTY },
+        },
+        { provide: LocaleService, useValue: { currentLang: { tag: 'en' } } },
+        { provide: ConfirmationModalService, useValue: { open: (): typeof EMPTY => EMPTY } },
+        { provide: ItemRouter, useValue: jasmine.createSpyObj('ItemRouter', [ 'navigateTo' ]) },
+        { provide: APPCONFIG, useValue: { redirects: {} } },
+      ],
+    });
+
+    store = TestBed.inject(MockStore);
+    TestBed.inject(ItemTaskFlowService);
+  });
+
+  afterEach(() => {
+    TestBed.inject(ItemTaskFlowService).ngOnDestroy();
+  });
+
+  it('calls setInfo exactly once on init', () => {
+    TestBed.flushEffects();
+
+    expect(setInfo).toHaveBeenCalledTimes(1);
+    expect(setInfo).toHaveBeenCalledWith(
+      jasmine.objectContaining({ id: '1' }),
+      true,
+    );
+  });
+
+  it('calls setInfo once when route and item data change', () => {
+    TestBed.flushEffects();
+    setInfo.calls.reset();
+
+    store.overrideSelector(fromItemContent.selectActiveContentRoute, route2);
+    store.overrideSelector(fromItemContent.selectActiveContentData, readyState(createItemData(route2)));
+    store.refreshState();
+    TestBed.flushEffects();
+
+    expect(setInfo).toHaveBeenCalledTimes(1);
+    expect(setInfo).toHaveBeenCalledWith(
+      jasmine.objectContaining({ id: '2' }),
+      true,
+    );
+  });
+});

--- a/src/app/items/item-task-flow.service.ts
+++ b/src/app/items/item-task-flow.service.ts
@@ -97,8 +97,6 @@ export class ItemTaskFlowService implements OnDestroy {
   );
 
   constructor() {
-    this.applyInitialAnswerInfoSync();
-
     effect(() => {
       this.applyInitialAnswerInfoSync();
     });


### PR DESCRIPTION
Remove the redundant constructor-time imperative calls that duplicate each effect()'s initial run in the two item sync services and group-by-id.component, so each sync method runs exactly once on init and once per signal change. Add spec files locking in single-execution behavior.

Code written with the help of AI, already reviewed locally.